### PR TITLE
Closes Codeception/CodeceptJS#16 , don't create the output folder if it exists

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -30,8 +30,6 @@ module.exports = function() {
 
   });
 }
-
-
 `;
 
 module.exports = function (initPath) {
@@ -41,8 +39,6 @@ module.exports = function (initPath) {
   print(`  Welcome to ${colors.magenta.bold('CodeceptJS')} initialization tool`);
   print("  It will prepare and configure a test environment for you");
   print();
-
-
   if (!path) {
     print(`No test root specified.`);
     print(`Test root is assumed to be ${colors.yellow.bold(testsPath)}`);
@@ -61,7 +57,6 @@ module.exports = function (initPath) {
     error(`Config is already created at ${configFile}`);
     return;
   }
-
 
   inquirer.prompt(
     [
@@ -150,9 +145,12 @@ module.exports = function (initPath) {
 
 
         if (config.output) {
-
-          fs.mkdirSync(path.join(testsPath, config.output));
-          success("Directory for temporaty output files created at `_output`");
+          if (!fileExists(config.output)) {
+            fs.mkdirSync(path.join(testsPath, config.output));
+            success("Directory for temporaty output files created at `_output`");
+          } else {
+            print("Directory for temporaty output files already presents at '" + config.output + "'. Don't create it!");
+          }
         }
 
         success("Almost done! Create your first test by executing `codeceptjs gt` (generate test) command");


### PR DESCRIPTION
If the output folder already exists when we run the  ```codeceptjs init``` command an exception is thrown.

Fixed that.