### PR TITLE
fix typo

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -89,7 +89,7 @@ let withinStore = {};
  *
  * ## Access From Helpers
  *
- * Receive a WebDriverIO client from a custom helper by accessing `brorwser` property:
+ * Receive a WebDriverIO client from a custom helper by accessing `browser` property:
  *
  * ```
  * this.helpers['WebDriverIO'].browser


### PR DESCRIPTION
Browser was misspelled as brorwser in lib/helper/WebDriverIO.js