### PR TITLE
better support for webdriverio options

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1,4 +1,5 @@
 'use strict';
+let _ = require('lodash');
 let Helper = require('../helper');
 let webdriverio = require('webdriverio');
 let stringIncludes = require('../assert/include').includes;
@@ -35,8 +36,8 @@ let withinStore = {};
  *
  * This helper should be configured in codecept.json
  *
- * * `url` - base url of website to be tested
- * * `browser` - browser in which perform testing
+ * * `baseUrl` - base url of website to be tested
+ * * `desiredCapabilities.browserName` - browser in which perform testing
  * * `window_size`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
  *
  *
@@ -45,22 +46,24 @@ let withinStore = {};
  * ### Connect through proxy
  *
  * CodeceptJS also provides flexible options when you want to execute tests to Selenium servers through proxy. You will
- * need to update the `helpers.WebDriverIO.proxy` key.
+ * need to update the `helpers.WebDriverIO.desiredCapabilities.proxy` key.
  *
  * ```js
  * {
  *     "helpers": {
  *         "WebDriverIO": {
- *             "proxy": {
- *                 "proxyType": "manual|pac",
- *                 "proxyAutoconfigUrl": "URL TO PAC FILE",
- *                 "httpProxy": "PROXY SERVER",
- *                 "sslProxy": "PROXY SERVER",
- *                 "ftpProxy": "PROXY SERVER",
- *                 "socksProxy": "PROXY SERVER",
- *                 "socksUsername": "USERNAME",
- *                 "socksPassword": "PASSWORD",
- *                 "noProxy": "BYPASS ADDRESSES"
+ *             "desiredCapabilities": {
+ *                 "proxy": {
+ *                     "proxyType": "manual|pac",
+ *                     "proxyAutoconfigUrl": "URL TO PAC FILE",
+ *                     "httpProxy": "PROXY SERVER",
+ *                     "sslProxy": "PROXY SERVER",
+ *                     "ftpProxy": "PROXY SERVER",
+ *                     "socksProxy": "PROXY SERVER",
+ *                     "socksUsername": "USERNAME",
+ *                     "socksPassword": "PASSWORD",
+ *                     "noProxy": "BYPASS ADDRESSES"
+ *                 }
  *             }
  *         }
  *     }
@@ -73,12 +76,14 @@ let withinStore = {};
  * {
  *     "helpers": {
  *         "WebDriverIO": {
- *             "proxy": {
- *                 "proxyType": "manual",
- *                 "httpProxy": "http://corporate.proxy:8080",
- *                 "socksUsername": "codeceptjs",
- *                 "socksPassword": "secret",
- *                 "noProxy": "127.0.0.1,localhost"
+ *             "desiredCapabilities": {
+ *                 "proxy": {
+ *                     "proxyType": "manual",
+ *                     "httpProxy": "http://corporate.proxy:8080",
+ *                     "socksUsername": "codeceptjs",
+ *                     "socksPassword": "secret",
+ *                     "noProxy": "127.0.0.1,localhost"
+ *                 }
  *             }
  *         }
  *     }
@@ -86,6 +91,63 @@ let withinStore = {};
  * ```
  *
  * Please refer to [Selenium - Proxy Object](https://code.google.com/p/selenium/wiki/DesiredCapabilities#Proxy_JSON_Object) for more information.
+ *
+ * ## Cloud Providers
+ * WebDriverIO makes it possible to execute tests against services like `Sauce Labs` `BrowserStack` `TestingBot`
+ * Check out their documentation on [available parameters](http://webdriver.io/guide/testrunner/cloudservices.html)
+ *
+ * Connecting to `BrowserStack` and `Sauce Labs` is simple. All you need to do
+ * is set the `user` and `key` parameters. WebDriverIO authomatically know which
+ * service provider to connect to.
+ *
+ * ```js
+ * {
+ *     "helpers":{
+ *         "WebDriverIO": {
+ *             "baseUrl": "YOUR_DESIERED_HOST",
+ *             "user": "YOUR_BROWSERSTACK_USER",
+ *             "key": "YOUR_BROWSERSTACK_KEY",
+ *             "desiredCapabilities": {
+ *                 "browserName": "chrome",
+ *
+ *                 // only set this if you're using BrowserStackLocal to test a local domain
+ *                 // "browserstack.local": true,
+ *
+ *                 // set this option to tell browserstack to provide addition debugging info
+ *                 // "browserstack.debug": true,
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * ## Multiremote Capabilities
+ * This is a work in progress but you can control two browsers at a time right out of the box.
+ * Individual control is something that is planned for a later version.
+ *
+ * Here is the [webdriverio docs](http://webdriver.io/guide/usage/multiremote.html) on the subject
+ *
+ * ```js
+ * {
+ *     "helpers": {
+ *         "WebDriverIO": {
+ *             "multiremote": {
+ *                 "MyChrome": {
+ *                     "desiredCapabilities": {
+ *                         "browserName": "chrome"
+ *                      }
+ *                 },
+ *                 "MyFirefox": {
+ *                    "desiredCapabilities": {
+ *                        "browserName": "firefox"
+ *                    }
+ *                 }
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ *
  *
  * ## Access From Helpers
  *
@@ -100,12 +162,30 @@ class WebDriverIO extends Helper {
 
   constructor(config) {
     super(config);
-    this.options = config;
-    if (!this.options.desiredCapabilities) this.options.desiredCapabilities = {};
-    this.options.desiredCapabilities.browserName = config.browser;
-    this.options.baseUrl = config.url;
-    if (config.proxy) {
-      this.options.desiredCapabilities.proxy = config.proxy;
+
+    // set defaults
+    this.options = {
+      desiredCapabilities: {}
+    };
+
+    // override defaults with config
+    _.assign(this.options, config);
+
+    if (!this.options.baseUrl || !this.options.desiredCapabilities.browserName) {
+      throw new Error(`
+        WebDriverIO requires at least these parameters
+        Check your codeceptjs config file to ensure these are set properly
+          {
+            "helpers": {
+              "WebDriverIO": {
+                "baseUrl": "YOUR_HOST"
+                "desiredCapabilities": {
+                  "browserName": "YOUR_PREFERED_TESTING_BROWSER"
+                }
+              }
+            }
+          }
+      `)
     }
   }
 
@@ -117,8 +197,16 @@ class WebDriverIO extends Helper {
   }
 
   _before() {
-    this.browser = webdriverio.remote(this.options).init();
+
+    if (this.options.multiremote) {
+      this.browser = webdriverio.multiremote(this.options.multiremote);
+    } else {
+      this.browser = webdriverio.remote(this.options).init();
+    }
+
+
     let window_size = this.options.window_size;
+
     if (window_size === 'maximize') {
       this.browser.client.windowHandleMaximize(false);
     }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "escape-string-regexp": "^1.0.3",
     "glob": "^6.0.1",
     "inquirer": "^0.11.0",
+    "lodash": "^4.1.0",
     "mocha": "^2.4.2",
     "webdriverio": "~3.4.0"
   },


### PR DESCRIPTION
The original method of passing options to webdriverio caused some
confusion. If the user wanted to simply pass a webdriverio config
directly through the codeceptjs config some properties would get
overridden with undefined if they didn’t set `browser` or `url`.

It makes more sense to allow the passing of a webdriverio config rather
than attempting to map these properties and construct that object since
it can get extremely complex.


I.E

```js
// how you're currently doing it
{
  "helpers": {
    "WebDriverIO": {
      "proxy": {
        ...
      }
    }
  }
}

// it should be more like this
{
  "helpers": {
    "WebDriverIO": {
      "desieredCapabilities": {
        "proxy": {
          ...
        }
      }
    }
  }
}
```