### PR TITLE
Fix typo in Page Objects documentation

### DIFF
--- a/docs/pageobjects.md
+++ b/docs/pageobjects.md
@@ -49,7 +49,7 @@ module.exports = {
   },
   submitButton: {css: '#new_user_basic input[type=submit]'},
 
-  // intorucing methods
+  // introducing methods
   sendForm(email, password) {
     I.fillField(this.fields.email, email);
     I.fillField(this.fields.password, password);


### PR DESCRIPTION
fixes small typo in documentation: 

![capture 2016-02-03 at 17 38 48](https://cloud.githubusercontent.com/assets/1375475/12954024/2dc85e36-d01d-11e5-9018-85800ef47f33.png)
