### PR TITLE
fix WebDriverIO helper scrollTo

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -797,7 +797,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   scrollTo(locator, offsetX, offsetY) {
-    return this.browser.scrollTo(withStrictLocator(locator), offsetX, offsetY);
+    return this.browser.scroll(withStrictLocator(locator), offsetX, offsetY);
   }
 
   /**


### PR DESCRIPTION
```
  I.scrollTo('.selector', 1500, 400)
  **FAIL**  this.browser.scrollTo is not a function
```
WebDriverIO has no scrollTo function. I think it was typo.
Now, it's work.