### PR TITLE
Implemented WebDriverIO frame() with new method switchTo() in helper

### DIFF
--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -882,3 +882,12 @@ Waits for a function to return true (waits for 1sec by default).
 
 -   `fn`  
 -   `sec`  
+
+## switchTo
+
+Switches context to the content within an IFrame element.
+A null locator will return the context to the current window.
+
+**Paramters**
+
+-   `locator`

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -911,6 +911,14 @@ class WebDriverIO extends Helper {
     sec = sec || this.options.waitForTimeout;
     return this.browser.waitUntil(fn, sec);
   }
+
+  /**
+   * Switches frame or in case of null locator reverts to parent.
+   */
+  switchTo(locator) {
+    locator = locator || null;
+    return this.browser.frame(locator);
+  }
 }
 
 function proceedSee(assertType, text, context) {

--- a/test/unit/helper/WebDriverIO_test.js
+++ b/test/unit/helper/WebDriverIO_test.js
@@ -226,7 +226,7 @@ describe('WebDriverIO', function () {
     });
   });
 
-  describe.only('#switchTo', () => {
+  describe('#switchTo', () => {
       it('should switch reference to iframe content', () => {
           return wd.amOnPage('/iframe')
             .then(() => wd.switchTo('content'))

--- a/test/unit/helper/WebDriverIO_test.js
+++ b/test/unit/helper/WebDriverIO_test.js
@@ -226,4 +226,29 @@ describe('WebDriverIO', function () {
     });
   });
 
+  describe.only('#switchTo', () => {
+      it('should switch reference to iframe content', () => {
+          return wd.amOnPage('/iframe')
+            .then(() => wd.switchTo('content'))
+            .then(() => wd.see('Information\nLots of valuable data here'));
+      });
+
+      it('should return error if iframe selector is invalid', () => {
+          return wd.amOnPage('/iframe')
+            .then(() => wd.switchTo('#invalidIframeSelector'))
+            .then(expectError)
+            .catch((e) => {
+                e.should.be.instanceOf(Error);
+                e.seleniumStack.type.should.be.equal('NoSuchFrame');
+            });
+      });
+
+      it('should return to parent frame given a null locator', () => {
+        return wd.amOnPage('/iframe')
+          .then(() => wd.switchTo('content'))
+          .then(() => wd.see('Information\nLots of valuable data here'))
+          .then(() => wd.switchTo(null))
+          .then(() => wd.see('Iframe test'));
+      });
+  });
 });


### PR DESCRIPTION
## Overview

I've been a big fan of CodeceptJS but missed support for IFrames since I switched from a Mocha & WebDriverIO testing stack to CodeceptJS. This merge implements the `frame()` method from https://github.com/webdriverio/webdriverio with a new method named `switchTo()` in the WebDriverIO helper.

`switchTo()` works the same as `frame()` by allowing the test case to change context to content inside an IFrame specified by a locator. Specifying a null locator (the default) will return the test case to the parent frame (usually the current window).

## What's in the merge?

In addition to the new method in the WebDriverIO helper, I've added three test cases and updated the helper specific documentation.