### PR TITLE
Fix path resolution on the command line to support absolute paths

### DIFF
--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -6,7 +6,7 @@ let path = require('path');
 let colors = require('colors');
 
 module.exports.getTestRoot = function (currentPath) {
-  let testsPath = path.join(process.cwd(), currentPath || '.');
+  let testsPath = path.resolve(currentPath || '.');
 
   if (!currentPath) {
     output.print(`Test root is assumed to be ${colors.yellow.bold(testsPath)}`);


### PR DESCRIPTION
Before the change, I could not `codecept run /my/absolute/path`.
`path.join` would always stick the current working directory in front.
More proper path resolution is also simpler, as `path.resolve` will stick
the current working directory if the path is not already absolute.