### PR TITLE
Fix path resolution for the output config value to support absolute paths

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -32,7 +32,7 @@ class Codecept {
   init(dir) {
     // preparing globals
     global.codecept_dir = dir;
-    global.output_dir = fsPath.join(dir, this.config.output);
+    global.output_dir = fsPath.resolve(dir, this.config.output);
     global.actor = global.codecept_actor = require('./actor');
     global.Helper = global.codecept_helper = require('./helper');
     global.pause = require('./pause');


### PR DESCRIPTION
Before the change, I could not set an absolute path as my output.
`path.join` would always stick the project directory in front.
`path.resolve` will, however, check if the path is already absolute, in which case it won’t do anything.