### PR TITLE
Fix path resolution for the helpers config values to support absolute paths

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -8,7 +8,7 @@ function createHelpers(config) {
   for (let helperName in config) {
     try {
       module = config[helperName].require
-        ? path.join(global.codecept_dir, config[helperName].require) // custom helper
+        ? path.resolve(global.codecept_dir, config[helperName].require) // custom helper
         : './helper/' + helperName; // built-in helper
       let HelperClass = require(module);
       if (HelperClass._checkRequirements) {


### PR DESCRIPTION
Before the change, I could not set an absolute path as my helpers path.
`path.join` would always stick the project directory in front.
`path.resolve` will, however, check if the path is already absolute, in which case it won’t do anything.