### PR TITLE
Make debug taken precedence if specifed with steps

### DIFF
--- a/lib/reporter/cli.js
+++ b/lib/reporter/cli.js
@@ -15,8 +15,8 @@ class Cli extends Base {
   constructor(runner, opts) {
     super(runner);
     let level = 0;
-    if (opts.debug) level = 2;
     if (opts.steps) level = 1;
+    if (opts.debug) level = 2;
     output.level(level);
     let showSteps = level >= 1;
 
@@ -24,7 +24,6 @@ class Cli extends Base {
     function indent() {
       return Array(indents).join('  ');
     }
-
 
     runner.on('start', function () {
       console.log();


### PR DESCRIPTION
Just small change so that if both --debug and --steps are specified on the command line it will act as if both were applied. Previously only --steps would appear to take effect.