### PR TITLE
Add in loading config from a JS file

### DIFF
--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -23,8 +23,6 @@ module.exports.getConfig = function (testRoot) {
     jsonConfigFile = path.join(testRoot, 'codecept.json');
   if (fileExists(jsConfigFile)) {
     config = require(jsConfigFile).config;
-    console.log(config);
-
   } else if (fileExists(jsonConfigFile)) {
     config = JSON.parse(fs.readFileSync(jsonConfigFile, 'utf8'));
   } else {

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -16,13 +16,22 @@ module.exports.getTestRoot = function (currentPath) {
   return testsPath;
 };
 
-module.exports.getConfig = function (testsPath) {
-  let configFile = path.join(testsPath, 'codecept.json');
-  if (!fileExists(configFile)) {
-    output.error(`Can not load config from ${configFile}\nCodeceptJS is not initialized in this dir. Execute 'codeceptjs init' to start`);
+module.exports.getConfig = function (testRoot) {
+
+  let config,
+    jsConfigFile = path.join(testRoot, 'codecept.js'),
+    jsonConfigFile = path.join(testRoot, 'codecept.json');
+  if (fileExists(jsConfigFile)) {
+    config = require(jsConfigFile).config;
+    console.log(config);
+
+  } else if (fileExists(jsonConfigFile)) {
+    config = JSON.parse(fs.readFileSync(jsonConfigFile, 'utf8'));
+  } else {
+    output.error(`Can not load config from ${jsConfigFile} or ${jsonConfigFile}\nCodeceptJS is not initialized in this dir. Execute 'codeceptjs init' to start`);
     process.exit(1);
   }
-  let config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+
   if (!config.include) config.include = {};
   if (!config.helpers) config.helpers = {};
   return config;


### PR DESCRIPTION
Make it easier to configure CodeceptJS
- Not include keys in config files / source control
- Run on different browsers via env flags

RE Issue #59