### PR TITLE
add custom steps to definition list

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -38,17 +38,30 @@ module.exports = function (genPath) {
     let codecept = new Codecept(config, {});
     codecept.init(testsPath);
     let helpers = container.helpers();
-    let methods = '';
+    let suppportI = container.support('I');
+    let methods = [];
+    let actions = [];
     for (let name in helpers) {
         let helper = helpers[name];
         methodsOfObject(helper).forEach((action) => {
             let params = getParamNames(helper[action]);
             if (params) params = params.join(', ');
             if (!params) params = '';
-            methods += `    ${(action)}: (${params}) => any; \n`;
+            methods.push(`    ${(action)}: (${params}) => any; \n`);
+            actions[action] = 1
         });
     }
-    let definitionsTemplate = template.replace('{{methods}}', methods);
+    for (let name in suppportI) {
+        if (actions[name]) {
+            continue
+        }
+        let actor = suppportI[name];
+        let params = getParamNames(actor);
+        if (params) params = params.join(', ');
+        if (!params) params = '';
+        methods.push(`    ${(name)}: (${params}) => any; \n`);
+    }
+    let definitionsTemplate = template.replace('{{methods}}', methods.join(''));
     fs.writeFileSync(path.join(testsPath, 'steps.d.ts'), definitionsTemplate);
     output.print('TypeScript Definitions provide autocompletion in Visual Studio Code and other IDEs');
     output.print('Definitions were generated in steps.d.ts');

--- a/lib/command/list.js
+++ b/lib/command/list.js
@@ -16,13 +16,26 @@ module.exports = function (path) {
   codecept.init(testsPath);
   output.print('List of test actions: -- ');
   let helpers = container.helpers();
+  let suppportI = container.support('I');
+  let actions = [];
   for (let name in helpers) {
     let helper = helpers[name];
     methodsOfObject(helper).forEach((action) => {
       let params = getParamNames(helper[action]);
       if (params) params = params.join(', ');
+      actions[action] = 1;
       output.print(` ${output.colors.grey(name)} I.${output.colors.bold(action)}(${params})`);
     });
+  }
+  for (let name in suppportI) {
+    if (actions[name]) {
+      continue
+    }
+    let actor = suppportI[name];
+    let params = getParamNames(actor);
+    if (params) params = params.join(', ');
+    if (!params) params = '';
+    output.print(` I.${output.colors.bold(name)}(${params})`);
   }
   output.print('PS: Actions are retrieved from enabled helpers. ')
   output.print('Implement custom actions in your helper classes.');


### PR DESCRIPTION
When generating a step definition file steps.d.ts the custom defined steps (e.g. form custom_steps.js) are not listed.

The PR gets all supported actions and adds them to the definition file as well as to the list command