### PR TITLE
Run arbitrary JS code after tests

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -11,8 +11,8 @@ Scenario('check Welcome page on site', (I) => {
 }
 ```
 
-Tests are expected to be written in ECMAScript 6. 
-Each test is described inside a `Scenario` function with `I` object passed into it. 
+Tests are expected to be written in ECMAScript 6.
+Each test is described inside a `Scenario` function with `I` object passed into it.
 I object is an **actor**, an abstraction for a testing user. I is a proxy object for currently enabled **Helpers**.
 
 ```json
@@ -24,13 +24,13 @@ I object is an **actor**, an abstraction for a testing user. I is a proxy object
   }
 ```
 
-For current config all methods of `I` will be taken from `WebDriverIO` helper. 
+For current config all methods of `I` will be taken from `WebDriverIO` helper.
 This is done to allow easy switching of running backends so you could replace WebDriverIO with Protractor or Nightmare helpers.
 
 ## How It Works
 
 Tests are written in synchronous way. Test scenarios should be linear, so tests by themseleves should not include promises or callbacks as well.
-However, behind the scene **all actions are wrapped in promises** inside the `I` object. 
+However, behind the scene **all actions are wrapped in promises** inside the `I` object.
 [Global promise](https://github.com/Codeception/CodeceptJS/blob/master/lib/recorder.js) chain is initialized before each test and all `I.*` calls will be appended to it as well as setup and teardown.
 
 If you want to get information from a running test you can use `yield` inside a **generator function** and special methods of helpers started with `grab` prefix.
@@ -40,9 +40,9 @@ Scenario('try grabbers', function* (I) {
   var title = yield I.grabTitle();
 });
 ```
- 
+
 then you can use those variables in assertions:
- 
+
 ```js
 var title = yield I.grabTitle();
 var assert = require('assert');
@@ -51,7 +51,7 @@ assert.equal(title, 'CodeceptJS');
 
 ## Pause
 
-Test execution can be paused in any place of a test with `pause()` call. 
+Test execution can be paused in any place of a test with `pause()` call.
 This also launches interactive console where you can call actions of `I` object.
 
 ![shell](/images/shell.png)
@@ -86,7 +86,7 @@ Scenario('test title', (I) => {
 });
 ```
 
-## Within 
+## Within
 
 To specify the exact area on a page where actions can be performed you can use `within` function.
 Everything executed in its context will be narrowed to context specified by locator:
@@ -117,7 +117,7 @@ Like in Mocha you can use `x` and `only` to skip tests or making a single test t
 
 CodeceptJS supports [Mocha Reporters](https://mochajs.org/#reporters).
 They can be used with `--reporter` options.
-By default a custom console reporter is enabled. 
+By default a custom console reporter is enabled.
 
 We are currently working on improving reporters support.
 
@@ -127,7 +127,16 @@ In case you need to execute arbitrary code before the tests,
 you can place it into your bootstrap file and provide a relative path to it in `codecept.json`
 
 ```json
-bootstrap: "./run_server.js"
+"bootstrap": "./run_server.js"
+```
+
+## teardown
+
+In case you need to execute arbitrary code after the tests have run,
+you can place it into your teardown file and provide a relative path to it in `codecept.json`
+
+```json
+"teardown": "./stop_server.js"
 ```
 
 ---

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -50,6 +50,13 @@ class Codecept {
     }
   }
 
+  teardown() {
+    // loading teardown
+    if (this.config.teardown && fileExists(fsPath.join(codecept_dir, this.config.teardown))) {
+      require(fsPath.join(codecept_dir, this.config.teardown));
+    }
+  }
+
   loadTests(pattern) {
     pattern = pattern || this.config.tests;
     glob.sync(fsPath.join(codecept_dir, pattern)).forEach((file) => {
@@ -64,8 +71,9 @@ class Codecept {
     }
     this.mocha.run(() => {
       event.emit(event.all.result, this);
+    }).on('end', () => {
+      this.teardown();
     });
-
   }
 
   static version() {


### PR DESCRIPTION
* added teardown method to Codecept class - this checks config for a teardown path the same way as bootstrap, and requires it if present
* call teardown when mocha fires `end` event