### PR TITLE
Bootstrap - Default file to run phantomjs/selenium

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -11,8 +11,8 @@ Scenario('check Welcome page on site', (I) => {
 }
 ```
 
-Tests are expected to be written in ECMAScript 6. 
-Each test is described inside a `Scenario` function with `I` object passed into it. 
+Tests are expected to be written in ECMAScript 6.
+Each test is described inside a `Scenario` function with `I` object passed into it.
 I object is an **actor**, an abstraction for a testing user. I is a proxy object for currently enabled **Helpers**.
 
 ```json
@@ -24,13 +24,13 @@ I object is an **actor**, an abstraction for a testing user. I is a proxy object
   }
 ```
 
-For current config all methods of `I` will be taken from `WebDriverIO` helper. 
+For current config all methods of `I` will be taken from `WebDriverIO` helper.
 This is done to allow easy switching of running backends so you could replace WebDriverIO with Protractor or Nightmare helpers.
 
 ## How It Works
 
 Tests are written in synchronous way. Test scenarios should be linear, so tests by themseleves should not include promises or callbacks as well.
-However, behind the scene **all actions are wrapped in promises** inside the `I` object. 
+However, behind the scene **all actions are wrapped in promises** inside the `I` object.
 [Global promise](https://github.com/Codeception/CodeceptJS/blob/master/lib/recorder.js) chain is initialized before each test and all `I.*` calls will be appended to it as well as setup and teardown.
 
 If you want to get information from a running test you can use `yield` inside a **generator function** and special methods of helpers started with `grab` prefix.
@@ -40,9 +40,9 @@ Scenario('try grabbers', function* (I) {
   var title = yield I.grabTitle();
 });
 ```
- 
+
 then you can use those variables in assertions:
- 
+
 ```js
 var title = yield I.grabTitle();
 var assert = require('assert');
@@ -51,7 +51,7 @@ assert.equal(title, 'CodeceptJS');
 
 ## Pause
 
-Test execution can be paused in any place of a test with `pause()` call. 
+Test execution can be paused in any place of a test with `pause()` call.
 This also launches interactive console where you can call actions of `I` object.
 
 ![shell](/images/shell.png)
@@ -86,7 +86,7 @@ Scenario('test title', (I) => {
 });
 ```
 
-## Within 
+## Within
 
 To specify the exact area on a page where actions can be performed you can use `within` function.
 Everything executed in its context will be narrowed to context specified by locator:
@@ -117,7 +117,7 @@ Like in Mocha you can use `x` and `only` to skip tests or making a single test t
 
 CodeceptJS supports [Mocha Reporters](https://mochajs.org/#reporters).
 They can be used with `--reporter` options.
-By default a custom console reporter is enabled. 
+By default a custom console reporter is enabled.
 
 We are currently working on improving reporters support.
 
@@ -128,6 +128,14 @@ you can place it into your bootstrap file and provide a relative path to it in `
 
 ```json
 bootstrap: "./run_server.js"
+```
+
+> If you create `codecept.json` file using `codecept init` command, by default `bootstrap.js` file with automatic browser service startup ( [phantomjs](https://github.com/ariya/phantomjs) or selenium server), is copied to your project directory and defined like the default
+
+To run `bootstrap` async, add the extra key below:
+
+```json
+bootstrapAsync: true
 ```
 
 ---

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,0 +1,65 @@
+var spawn = require('child_process').spawn;
+var path = require('path');
+var sleep = require('sleep').sleep;
+
+function Bootstrap(codecept, callback) {
+
+  var phantomjs, seleniumPid, callbackCalled = false;
+
+  (function () {
+
+    var protractor = codecept.config.helpers.Protractor;
+    if (protractor && protractor.browser) {
+      if (/phantom/.test(protractor.browser)) {
+        var phantomPath = require('phantomjs').path || '/usr/local/bin/phantomjs';
+        phantomjs = spawn(phantomPath,['--webdriver=4444']);
+
+        phantomjs.stdout.on('data', function (data) {
+          if (!callbackCalled) {
+            callback();
+            callbackCalled = true;
+          }
+        });
+
+        process.on('exit', function () {
+          phantomjs.stdin.pause();
+          phantomjs.kill();
+        });
+
+      }else {
+
+        var binPath = path.join(path.dirname(require.resolve('protractor')),'..','..','.bin');
+        var webdriver = spawn(path.join(binPath,'webdriver-manager'),['start']);
+
+        webdriver.stdout.on('data', function (data) {
+
+          // Workaround to wait execution of selenium .jar
+          sleep(2);
+
+          var output = data.toString();
+          if (/seleniumProcess.pid/.test(output)) {
+            seleniumPid = output.match(/:\s\d{1,}/)[0].replace(/:\s/,'');
+          }
+          if (!callbackCalled) {
+            callback();
+            callbackCalled = true;
+          }
+        });
+
+        process.on('exit', function () {
+          webdriver.stdout.pause();
+          webdriver.kill();
+
+          if (seleniumPid) {
+            process.kill(seleniumPid, 'SIGINT');
+          }
+        });
+
+      }
+    }
+
+  })();
+
+}
+
+module.exports = Bootstrap;

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -29,7 +29,7 @@ class Codecept {
     this.testFiles = [];
   }
 
-  init(dir, cb) {
+  init(dir, callback) {
     // preparing globals
     global.codecept_dir = dir;
     global.output_dir = fsPath.resolve(dir, this.config.output);
@@ -45,11 +45,20 @@ class Codecept {
     require('./listener/exit');
 
     // loading bootstrap
-    // TODO: Add support for old use of bootstrap file
     if (this.config.bootstrap && fileExists(fsPath.join(dir, this.config.bootstrap))) {
-      require(fsPath.join(dir, this.config.bootstrap))(this, cb);
+      var bootstrap = require(fsPath.join(dir, this.config.bootstrap));
+      if (this.config.bootstrapAsync) {
+          if (typeof bootstrap == 'function') {
+            bootstrap(this, callback);
+          }
+      } else {
+        if (typeof bootstrap == 'function') {
+          bootstrap(this);
+        }
+        callback();
+      }
     } else {
-      cb();
+      callback();
     }
   }
 

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -29,7 +29,7 @@ class Codecept {
     this.testFiles = [];
   }
 
-  init(dir) {
+  init(dir, cb) {
     // preparing globals
     global.codecept_dir = dir;
     global.output_dir = fsPath.resolve(dir, this.config.output);
@@ -45,8 +45,11 @@ class Codecept {
     require('./listener/exit');
 
     // loading bootstrap
+    // TODO: Add support for old use of bootstrap file
     if (this.config.bootstrap && fileExists(fsPath.join(dir, this.config.bootstrap))) {
-      require(fsPath.join(dir, this.config.bootstrap));
+      require(fsPath.join(dir, this.config.bootstrap))(this, cb);
+    } else {
+      cb();
     }
   }
 

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -16,7 +16,7 @@ let defaultConfig = {
   "output": null,
   "helpers": {},
   "include": {},
-  "bootstrap": false,
+  "": false,
   "mocha": {}
 };
 
@@ -99,7 +99,12 @@ module.exports = function (initPath) {
         default: "./steps_file.js",
         when: function (answers) {
           return answers.steps;
-        }
+        },
+        {
+          name: "bootstrap_file",
+          type: "input",
+          message: "Do you want add a custom bootstrap file?",
+          default: "./bootstrap.js"
       }
     ], (result) => {
     let config = defaultConfig;
@@ -108,6 +113,11 @@ module.exports = function (initPath) {
     config.tests = result.tests;
     result.helpers.forEach((helper) => config.helpers[helper] = {});
     if (result.steps_file) config.include.I = result.steps_file;
+    if (result.bootstrap_file) {
+      // TODO: Copy the default bootstrap.js file to the generated codecept.json file
+      // TODO: Use fs-extra node module
+      config.bootstrap = result.bootstrap_file;
+    }
 
     let helperConfigs = [];
 

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -3,7 +3,7 @@ let print = require('../output').print;
 let success = require('../output').success;
 let error = require('../output').error;
 let colors = require('colors');
-let fs = require('fs');
+let fs = require('fs-extra');
 let path = require('path');
 let fileExists = require('../utils').fileExists;
 let inquirer = require("inquirer");
@@ -16,7 +16,7 @@ let defaultConfig = {
   "output": null,
   "helpers": {},
   "include": {},
-  "": false,
+  "bootstrap": './bootstrap.js',
   "mocha": {}
 };
 
@@ -100,11 +100,12 @@ module.exports = function (initPath) {
         when: function (answers) {
           return answers.steps;
         },
-        {
-          name: "bootstrap_file",
-          type: "input",
-          message: "Do you want add a custom bootstrap file?",
-          default: "./bootstrap.js"
+      },
+      {
+        name: "bootstrap_file",
+        type: "input",
+        message: "Do you want add a custom bootstrap file?",
+        default: "./bootstrap.js"
       }
     ], (result) => {
     let config = defaultConfig;
@@ -114,8 +115,16 @@ module.exports = function (initPath) {
     result.helpers.forEach((helper) => config.helpers[helper] = {});
     if (result.steps_file) config.include.I = result.steps_file;
     if (result.bootstrap_file) {
-      // TODO: Copy the default bootstrap.js file to the generated codecept.json file
-      // TODO: Use fs-extra node module
+      if (/bootstrap.js/.test(result.bootstrap_file)){
+        try {
+          var bootstrapDest = path.join(testsPath,result.bootstrap_file)
+          fs.copySync(require.resolve('../bootstrap.js'), bootstrapDest);
+          success(`Bootstrap file created at ${bootstrapDest}`);
+        } catch (err) {
+          error(`Error to copy ${result.bootstrap_file} to ${testsPath}`);
+          error(`[CAUSE]: ${err}`);
+        }
+      }
       config.bootstrap = result.bootstrap_file;
     }
 

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -7,11 +7,13 @@ module.exports = function (suite, test, options) {
   console.log('CodeceptJS v' + Codecept.version());
   let testRoot = getTestRoot(suite);
   let config = getConfig(testRoot);
-  try {    
+  try {
     let codecept = new Codecept(config, options);
-    codecept.init(testRoot);
-    codecept.loadTests();  
-    codecept.run(test);
+    codecept.init(testRoot, function() {
+      codecept.loadTests();
+      codecept.run(test);
+    });
+
   } catch (err) {
     let output = require('../output');
     output.print('');

--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -9,5 +9,9 @@ event.dispatcher.on(event.test.failed, function () {
 });
 
 event.dispatcher.on(event.all.result, function () {
-  if (failed) process.exit(1);
+  if (failed) {
+    process.exit(1);
+  }else {
+    process.exit();
+  }
 });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "glob": "^6.0.1",
     "inquirer": "^0.11.0",
     "mocha": "^2.4.2",
-    "requireg": "^0.1.5"
+    "requireg": "^0.1.5",
+    "fs-extra": "^0.30.0",
+    "sleep": "^3.0.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Added new `bootstrap.js` default file to start [phantomjs ](https://github.com/ariya/phantomjs) or selenium server using [webdriver-manager](https://github.com/bonigarcia/webdrivermanager). Now, the `codecept.json` can be configure with the keys:

``` js
{
 ...
  bootstrap: "bootstrap.js" //Added by default
  bootstrapAsync: true //Allow async tests execution
}
```

Added to a **async** execution to allow run tests only after run the bootstrap.

Some these adjusts were made with help of @abner 
