### PR TITLE
docs/quickstart.md: cross-culture translation fix + fix broken link 

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -56,7 +56,7 @@ This also launches interactive console where you can call actions of `I` object.
 
 ![shell](/images/shell.png)
 
-You can also the pause to check the web application in a browser. Press `ENTER` to resume test execution.   
+You can also use the pause to check the web application in a browser. Press `ENTER` to resume test execution.   
 
 Interactive shell can be started outside test context by running
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -56,7 +56,7 @@ This also launches interactive console where you can call actions of `I` object.
 
 ![shell](/images/shell.png)
 
-You can also use the pause to check the web application in a browser. Press `ENTER` to resume test execution.   
+You can also use `pause()` to check the web application in a browser. Press `ENTER` to resume test execution.   
 
 Interactive shell can be started outside test context by running
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ Scenario('test something', (I) => {
 });
 ```
 
-Before running this test we should ensure that [Selenium Web Server is running](./helpers/WebDriverIO/#selenium-installation). Then we can execute tests with
+Before running this test we should ensure that [Selenium Web Server is running](./helpers/WebDriverIO.md/#selenium-installation). Then we can execute tests with
 
 ```bash
 codeceptjs run --steps

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -136,4 +136,4 @@ method autocompletion while writing tests.
 
 ## Congrats! Your first test is running.
 
-Wasn't it hard, right?
+Wasn't so hard, right?

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ Scenario('test something', (I) => {
 });
 ```
 
-Before running this test we should ensure that [Selenium Web Server is running](/helpers/WebDriverIO/#selenium-installation). Then we can execute tests with
+Before running this test we should ensure that [Selenium Web Server is running](./helpers/WebDriverIO/#selenium-installation). Then we can execute tests with
 
 ```bash
 codeceptjs run --steps


### PR DESCRIPTION
The way it was written implies that it was hard, where you probably mean that it was simple
don't worry, it's a common error for post-soviet English speakers... :wink: 