### PR TITLE
make seleniumAddress for SeleniumWebdriver

### DIFF
--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -42,7 +42,7 @@ let withinStore = {};
  * * `browser` - browser in which perform testing
  * * `driver` - which protrator driver to use (local, direct, session, hosted, sauce, browserstack). By default set to 'hosted' which requires selenium server to be started.
  * * `restart` - restart browser between tests (default: true), if set to false cookies will be cleaned but browser window will be kept.
- * * `seleniumAddress` - Selenium address to connect (default: http://localhost:4444/wd/hub)
+ * * `seleniumAddress` - Selenium address to connect (default: http://localhost:4444/wd/hub). Specify null to let selenium-webdriver handle this stuff.
  * * `waitForTimeout`: (optional) sets default wait time in _ms_ for all `wait*` functions. 1000 by default;
  * * `capabilities`: {} - list of [Desired Capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
  *
@@ -81,9 +81,9 @@ class SeleniumWebdriver extends Helper {
 
     this.browserBuilder = new this.webdriver.Builder()
       .withCapabilities(this.options.capabilities)
-      .forBrowser(this.options.browser)
-      .usingServer(this.options.seleniumAddress);
-
+      .forBrowser(this.options.browser);
+      
+    if (this.options.seleniumAddress) this.browserBuilder.usingServer(this.options.seleniumAddress);
     if (this.options.proxy) this.browserBuilder.setProxy(this.options.proxy);
   }
 


### PR DESCRIPTION
If you do not want to bother with selenium-standalone-server, SeleniumWebdriver can do it for you. You have just comment line `.usingServer(this.options.seleniumAddress);`