### PR TITLE
Fix typo in attachFile documentation

### DIFF
--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -235,7 +235,7 @@ I.appendField('#myTextField', 'appended');
 
 Attaches a file to element located by label, name, CSS or XPath
 Path to file is relative current codecept directory (where codecept.json is located).
-File will be uploaded to remove system (if tests are running remotely).
+File will be uploaded to remote system (if tests are running remotely).
 
 ```js
 I.attachFile('Avatar', 'data/avatar.jpg');


### PR DESCRIPTION
There is a typo in the Webdriverio helper documentation, in function attachFile it mentions remove system instead of remote system