### PR TITLE
Fix typo in SeleniumWebdriver helper doc

### DIFF
--- a/docs/helpers/SeleniumWebdriver.md
+++ b/docs/helpers/SeleniumWebdriver.md
@@ -33,7 +33,7 @@ This helper should be configured in codecept.json
 Receive a WebDriverIO client from a custom helper by accessing `browser` property:
 
 ```js
-this.helpers['Protractor'].browser
+this.helpers['SeleniumWebdriver'].browser
 ```
 
 **Parameters**


### PR DESCRIPTION
Fixes doc issue reported in https://github.com/Codeception/CodeceptJS/issues/248