### PR TITLE
Fix attachFile on WebDriverIO helper

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -478,7 +478,7 @@ class WebDriverIO extends Helper {
     }
     return findFields(this.browser, locator).then((el) => {
       this.browser.uploadFile(file).then((res) => {
-        if (!el.value.length) {
+        if (!el.value || el.value.length === 0) {
           throw new Error(`File field ${locator} not found by name|text|CSS|XPath`);
         }
         return this.browser.elementIdValue(el.value[0].ELEMENT, res.value);

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -478,10 +478,10 @@ class WebDriverIO extends Helper {
     }
     return findFields(this.browser, locator).then((el) => {
       this.browser.uploadFile(file).then((res) => {
-        if (!el.length) {
+        if (!el.value.length) {
           throw new Error(`File field ${locator} not found by name|text|CSS|XPath`);
         }
-        return this.browser.elementIdValue(el[0].ELEMENT, res.value);
+        return this.browser.elementIdValue(el.value[0].ELEMENT, res.value);
       });
     });
   }


### PR DESCRIPTION
I noticed that attachFile has not been working as expected in the WebDriverIO helper. It seems there is a small bug in the code when using the object returned from findFields. This change should fix it (I've tested it and it's now working as expected).