### PR TITLE
Added option to manually start the browser.

### DIFF
--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -23,6 +23,7 @@ This helper should be configured in codecept.json
 -   `url` - base url of website to be tested
 -   `browser` - browser in which perform testing
 -   `restart` - restart browser between tests (default: true), if set to false cookies will be cleaned but browser window will be kept.
+-   `manualStart` - start browser manually (default: false), if set to true the browser can be startet with `this.helpers["WebDriverIO"]._startBrowser()`
 -   `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
 -   `waitForTimeout`: (optional) sets default wait time in _ms_ for all `wait*` functions. 1000 by default;
 -   `desiredCapabilities`: Selenium capabilities

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -66,6 +66,7 @@ class SeleniumWebdriver extends Helper {
       seleniumAddress: 'http://localhost:4444/wd/hub',
       restart: true,
       waitforTimeout: 1000, // ms
+      manualStart: false,
       capabilities: {}
     };
     this.options = Object.assign(this.options, config);
@@ -109,14 +110,14 @@ class SeleniumWebdriver extends Helper {
   }
 
   _beforeSuite() {
-    if (!this.options.restart) {
+    if (!this.options.restart && !this.options.manualStart) {
       this.debugSection('Session','Starting singleton browser session');
       return this._startBrowser();
     }
   }
 
   _before() {
-   if (this.options.restart) return this._startBrowser();
+   if (this.options.restart && !this.options.manualStart) return this._startBrowser();
   }
 
   _after() {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -173,7 +173,7 @@ class WebDriverIO extends Helper {
       waitForTimeout: 1000, // ms
       desiredCapabilities: {},
       restart: true,
-      manual: false
+      manualStart: false
     };
 
     // override defaults with config
@@ -217,7 +217,7 @@ class WebDriverIO extends Helper {
   }
 
   _beforeSuite() {
-    if (!this.options.restart && !this.options.manual) {
+    if (!this.options.restart && !this.options.manualStart) {
       this.debugSection('Session','Starting singleton browser session');
       return this._startBrowser();
     }
@@ -241,7 +241,7 @@ class WebDriverIO extends Helper {
   }
 
   _before() {
-    if (this.options.restart && !this.options.manual) this._startBrowser();
+    if (this.options.restart && !this.options.manualStart) this._startBrowser();
     this.failedTestName = null;
     this.context = 'body';
     return this.browser;

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -172,7 +172,8 @@ class WebDriverIO extends Helper {
     this.options = {
       waitForTimeout: 1000, // ms
       desiredCapabilities: {},
-      restart: true
+      restart: true,
+      manual: false
     };
 
     // override defaults with config
@@ -216,7 +217,7 @@ class WebDriverIO extends Helper {
   }
 
   _beforeSuite() {
-    if (!this.options.restart) {
+    if (!this.options.restart && !this.options.manual) {
       this.debugSection('Session','Starting singleton browser session');
       return this._startBrowser();
     }
@@ -240,7 +241,7 @@ class WebDriverIO extends Helper {
   }
 
   _before() {
-    if (this.options.restart) this._startBrowser();
+    if (this.options.restart && !this.options.manual) this._startBrowser();
     this.failedTestName = null;
     this.context = 'body';
     return this.browser;


### PR DESCRIPTION
To work with cloud services like browserstack it can be beneficial to control when the session is started and therefore start the session manually.

One case in which this is useful is issue #190. You can set the `desiredCapability.name` and then start the session by executing `this.helpers['WebDriverIO']._startBrowser()` 

As the manual option is set to false by default the behavior doesn't change.