### PR TITLE
Add support for webdriver.io timeouts

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -229,6 +229,18 @@ class WebDriverIO extends Helper {
       this.browser = webdriverio.remote(this.options).init();
     }
 
+    if (this.options.timeouts) {
+      if (this.browser.timeouts.implicit) {
+        this.browser.timeouts('implicit', this.browser.timeouts.implicit);
+      }
+      if (this.browser.timeouts['page load']) {
+        this.browser.timeouts('page load', this.browser.timeouts['page load']);
+      }
+      if (this.browser.timeouts['script']) {
+        this.browser.timeouts('script', this.browser.timeouts['script']);
+      }
+    }
+
     if (this.options.windowSize === 'maximize') {
       this.browser.windowHandleMaximize(false);
     }


### PR DESCRIPTION
This adds support for each possible timeouts option in webdriver.io

In your codecept.conf.js you can express it like so:

```
  {
    timeouts: {
      implicit: 10000,
      'page load': 10000
      script: 10000
    }
  }
```