### PR TITLE
Add support for webdriver.io timeouts

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -229,6 +229,18 @@ class WebDriverIO extends Helper {
       this.browser = webdriverio.remote(this.options).init();
     }
 
+    if (this.options.timeouts) {
+      if (this.options.timeouts.implicit) {
+        this.browser.timeouts('implicit', this.options.timeouts.implicit);
+      }
+      if (this.options.timeouts['page load']) {
+        this.browser.timeouts('page load', this.options.timeouts['page load']);
+      }
+      if (this.options.timeouts.script) {
+        this.browser.timeouts('script', this.options.timeouts.script);
+      }
+    }
+
     if (this.options.windowSize === 'maximize') {
       this.browser.windowHandleMaximize(false);
     }


### PR DESCRIPTION
This adds support for each possible timeouts option in webdriver.io

In your codecept.conf.js you can express it something like:

```
{
  ...
  WebDriverIO: {
    url: 'http://localhost:8080',
    browser: 'phantomjs',
    timeouts: {
      implicit: 10000,
     'page load': 20000
      script: 5000
    }
  }
}
```