### PR TITLE
fix codeceptjs gt file extension and glob support

### DIFF
--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -49,7 +49,7 @@ module.exports.test = function (genPath) {
   output.print(`Creating a new test...`);
   output.print('----------------------');
 
-  let defaultExt = config.tests.match((/\*(.*?)$/)[1]) || '_test.js';
+  let defaultExt = config.tests.match((/\*(.*?)$/)[1])[0] || '_test.js';
 
   inquirer.prompt([
     {
@@ -66,7 +66,7 @@ module.exports.test = function (genPath) {
       }
     }
   ], (result) => {
-    let testFilePath = path.dirname(path.join(testsPath, config.tests));
+    let testFilePath = path.dirname(path.join(testsPath, config.tests)).replace(/\*\*$/, '');
     let testFile = path.join(testFilePath, result.filename);
     let ext = path.extname(testFile);
     if (!ext) testFile += defaultExt;


### PR DESCRIPTION
codeceptjs gt does not generate proper file without this, file has no extension. Also config.tests globs like `./test/folder/**/*.js` are not supported without this