### PR TITLE
Generators fix

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -29,23 +29,23 @@ program.command('def [path]')
   .description('List all actions for I.')
   .action(require('../lib/command/definitions'));
 
-program.command('generate test [path]')
+program.command('generate:test [path]')
   .alias('gt')
   .description('Generates an empty test')
   .action(require('../lib/command/generate').test);
 
-program.command('generate pageobject [path]')
+program.command('generate:pageobject [path]')
   .alias('gpo')
   .description('Generates an empty page object')
   .action(require('../lib/command/generate').pageObject);
 
-program.command('generate object [path]')
+program.command('generate:object [path]')
   .alias('go')
   .option('--type, -t [kind]', 'type of object to be created')
   .description('Generates an empty support object (page/step/fragment)')
   .action(require('../lib/command/generate').pageObject);
 
-program.command('generate helper [path]')
+program.command('generate:helper [path]')
   .alias('gh')
   .description('Generates a new helper')
   .action(require('../lib/command/generate').helper);

--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -9,6 +9,7 @@ let ucfirst = require('../utils').ucfirst;
 let lcfirst = require('../utils').lcfirst;
 let getConfig = require('./utils').getConfig;
 let getTestRoot = require('./utils').getTestRoot;
+let mkdirp = require('mkdirp');
 
 function updateConfig(testsPath, config) {
   let configFile = path.join(testsPath, 'codecept.json');
@@ -71,7 +72,7 @@ module.exports.test = function (genPath) {
     let ext = path.extname(testFile);
     if (!ext) testFile += defaultExt;
     let dir = path.dirname(testFile);
-    if (!fileExists(dir)) fs.mkdirSync(dir);
+    if (!fileExists(dir)) mkdirp.sync(dir);
     let testContent = testTemplate.replace('{{feature}}', result.feature);
 
     // can be confusing before translations are documented

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -9,6 +9,7 @@ let fileExists = require('../utils').fileExists;
 let inquirer = require("inquirer");
 let getTestRoot = require("./utils").getTestRoot;
 let isLocal = require('../utils').installedLocally();
+let mkdirp = require('mkdirp');
 
 let defaultConfig = {
   "tests": "./*_test.js",
@@ -61,7 +62,7 @@ module.exports = function (initPath) {
 
   if (!fileExists(testsPath)) {
     print(`Directory ${testsPath} does not exist, creating...`);
-    fs.mkdirSync(testsPath);
+    mkdirp.sync(testsPath);
   }
 
   let configFile = path.join(testsPath, 'codecept.json');
@@ -158,7 +159,7 @@ module.exports = function (initPath) {
 
       if (result.steps_file) {
         let stepFile = path.join(testsPath, result.steps_file);
-        if (!fileExists(path.dirname(stepFile))) fs.mkdirSync(path.dirname(stepFile));
+        if (!fileExists(path.dirname(stepFile))) mkdirp.sync(path.dirname(stepFile));
         fs.writeFileSync(stepFile, defaultActor);
         config.include.I = result.steps_file;
         success('Steps file created at ' + stepFile);
@@ -169,7 +170,7 @@ module.exports = function (initPath) {
 
       if (config.output) {
         if (!fileExists(config.output)) {
-          fs.mkdirSync(path.join(testsPath, config.output));
+          mkdirp.sync(path.join(testsPath, config.output));
           success("Directory for temporaty output files created at `_output`");
         } else {
           print(`Directory for temporaty output files is already created at '${config.output}'`);

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -116,7 +116,17 @@ module.exports = function (initPath) {
     let config = defaultConfig;
     config.name = testsPath.split(path.sep).pop();
     config.output = result.output;
+
     config.tests = result.tests;
+    // create a directory tests it is included in tests path
+    mkdirp.sync(path.join(testsPath, config.tests.match(/[^*.]+/)[0]));
+
+    // append file mask to the end of tests
+    if (!config.tests.match(/\*(.*?)$/)) {
+      config.tests = config.tests.replace(/\/+$/,'') + "/*_test.js";
+      console.log(`Adding default test mask: ${config.tests}`);
+    }
+
     if (result.translation !== noTranslation) config.translation = result.translation;
 
     result.helpers.forEach((helper) => config.helpers[helper] = {});
@@ -142,24 +152,12 @@ module.exports = function (initPath) {
       }
     });
 
-    if (result.helpers.length) {
-      print("Configure helpers...");
-    }
-
-    inquirer.prompt(helperConfigs, (helperResult) => {
-
-      Object.keys(helperResult).forEach((key) => {
-        let helperName, configName;
-        let parts = key.split('_');
-        helperName = parts[0];
-        configName = parts[1];
-        if (!configName) return;
-        config.helpers[helperName][configName] = helperResult[key];
-      });
-
+    let finish = () => {
       if (result.steps_file) {
         let stepFile = path.join(testsPath, result.steps_file);
-        if (!fileExists(path.dirname(stepFile))) mkdirp.sync(path.dirname(stepFile));
+        if (!fileExists(path.dirname(stepFile))) {
+          mkdirp.sync(path.dirname(stepFile));
+        }
         fs.writeFileSync(stepFile, defaultActor);
         config.include.I = result.steps_file;
         success('Steps file created at ' + stepFile);
@@ -171,9 +169,9 @@ module.exports = function (initPath) {
       if (config.output) {
         if (!fileExists(config.output)) {
           mkdirp.sync(path.join(testsPath, config.output));
-          success("Directory for temporaty output files created at `_output`");
+          success("Directory for temporary output files created at `_output`");
         } else {
-          print(`Directory for temporaty output files is already created at '${config.output}'`);
+          print(`Directory for temporary output files is already created at '${config.output}'`);
         }
       }
       success("Almost done! Create your first test by executing `codeceptjs gt` (generate test) command");
@@ -186,7 +184,27 @@ module.exports = function (initPath) {
           print("Please install dependent packages globally: [sudo] " + colors.bold('npm install -g '+packages.join(' ')));
         }
       }
+    }
 
+    if (!result.helpers.length) {
+      return finish();
+    }
+
+    print("Configure helpers...");
+    inquirer.prompt(helperConfigs, (helperResult) => {
+
+      Object.keys(helperResult).forEach((key) => {
+        let helperName, configName;
+        let parts = key.split('_');
+        helperName = parts[0];
+        configName = parts[1];
+        if (!configName) return;
+        config.helpers[helperName][configName] = helperResult[key];
+      });
+
+      finish();
     });
+
+
   });
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "escape-string-regexp": "^1.0.3",
     "glob": "^6.0.1",
     "inquirer": "^0.11.0",
+    "mkdirp": "^0.5.1",
     "mocha": "^2.4.2",
     "requireg": "^0.1.5"
   },


### PR DESCRIPTION
Fixes #259

Example:

```

  Welcome to CodeceptJS initialization tool
  It will prepare and configure a test environment for you

Installing to /home/davert/projects/codeceptjs/examples/output
? Where are your tests located? ./test/e2e
? What helpers do you want to use? WebDriverIO
? Where should logs, screenshots, and reports to be stored? ./test/e2e/errorShots
? Would you like to extend I object with custom steps? No
? Do you want to choose localization for tests? English (no localization)
Adding default test mask: ./test/e2e/*_test.js
Configure helpers...
? [WebDriverIO] Base url of site to be tested http://localhost
? [WebDriverIO] Browser in which testing will be performed firefox
Config created at /home/davert/projects/codeceptjs/examples/output/codecept.json
Directory for temporaty output files created at `_output`
Almost done! Create your first test by executing `codeceptjs gt` (generate test) command
➜  output git:(generators-fix) ✗ ../../bin/codecept.js gt  
Creating a new test...
----------------------
? Filename of a test notest
? Feature which is being tested Notest
Test for notest was created in /home/davert/projects/codeceptjs/examples/output/test/e2e/notest_test.js

```

---

also it handles cases like:

```

  Welcome to CodeceptJS initialization tool
  It will prepare and configure a test environment for you

Installing to /home/davert/projects/codeceptjs/examples/output
? Where are your tests located? user/**/*.js
? What helpers do you want to use? 
? Where should logs, screenshots, and reports to be stored? output/js
? Would you like to extend I object with custom steps? No
? Do you want to choose localization for tests? English (no localization)
Config created at /home/davert/projects/codeceptjs/examples/output/codecept.json
Directory for temporary output files created at `_output`
Almost done! Create your first test by executing `codeceptjs gt` (generate test) command
```

content of codecept.json:

```json
{
  "tests": "user/**/*.js",
  "timeout": 10000,
  "output": "output/js",
  "helpers": {},
  "include": {},
  "bootstrap": false,
  "mocha": {},
  "name": "output"
}
``` 