### PR TITLE
Updated Mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "glob": "^6.0.1",
     "inquirer": "^0.11.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.4.2",
+    "mocha": "^3.1.2",
     "requireg": "^0.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the version of Mocha in order to prevent this [security issue](https://nodesecurity.io/advisories/118).
You can verify this by running [nsp](https://github.com/nodesecurity/nsp).