### PR TITLE
Test can be substring of filename

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -90,7 +90,7 @@ class Codecept {
   run(test) {
     this.mocha.files = this.testFiles;
     if (test) {
-      this.mocha.files = this.mocha.files.filter((t) => fsPath.basename(t, '_test.js') === test || fsPath.basename(t, '.js') === test || fsPath.basename(t) === test);
+      this.mocha.files = this.mocha.files.filter((t) => fsPath.basename(t).includes(test));
     }
     this.mocha.run(() => {
       event.emit(event.all.result, this);

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -90,7 +90,7 @@ class Codecept {
   run(test) {
     this.mocha.files = this.testFiles;
     if (test) {
-      this.mocha.files = this.mocha.files.filter((t) => fsPath.basename(t).includes(test));
+      this.mocha.files = this.mocha.files.filter((t) => fsPath.basename(t).match(`.*${test}.*\.js`));
     }
     this.mocha.run(() => {
       event.emit(event.all.result, this);


### PR DESCRIPTION
#### Current Situation
If you use `codeceptjs run . test`, `test` needs to be the filename exept .js or _test.js ending. `test` and the extension needs to be equal to a filename. Therefore only one single file can be run separatly.

#### Future Situation
`test` can match any substring of any testfile that meets the configured pattern. The filter can be used more flexible and to run multiple selected files.