### PR TITLE
Extend bootstrap/teardown configuration options behaviour

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,8 +13,18 @@ Here is an overview of available options with their defaults:
 * **helpers**: `{}` - list of enabled helpers
 * **mocha**: `{}` - mocha options, [reporters](http://codecept.io/reports/) can be configured here
 * **name**: `"tests"` - test suite name (not used)
-* **bootstrap**: `"./bootstrap.js"` - JS file to be executed before tests
-* **teardown**: - JS file to be executed after tests
+* **bootstrap**: `"./bootstrap.js"` - an option to run code _before_ tests are run. It can either be:
+  * a path to a js file that will be executed (via `require`) before tests. If the file exports a
+    function, the function is called right away with a callback function as the only parameter. When the
+    callback is called with no arguments, tests are executed. If instead the callback is called with an
+    error as first argument, test execution is aborted and the process stops
+  * a function (dynamic configuration only). The function is called before tests with a callback function
+    as the only parameter. When the callback is called with no arguments, tests are executed. If instead
+    the callback is called with an error as first argument, test execution is aborted and the process stops
+* **teardown**: - an option to run code _after_ tests are run. It can either be:
+  * a path to a js file that will be executed (via `require`) after tests. If the file exports a
+    function, the function is called right away
+  * a function (dynamic configuration only). The function is called after tests
 * **translation**: - [locale](http://codecept.io/translation/) to be used to print steps output, as well as used in source code.
 
 ## Dynamic Configuration

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -50,20 +50,27 @@ class Codecept {
 
   // loading bootstrap
   bootstrap(callback) {
-    if (this.config.bootstrap && fileExists(fsPath.join(codecept_dir, this.config.bootstrap))) {
+    if (typeof this.config.bootstrap === 'string' &&  fileExists(fsPath.join(codecept_dir, this.config.bootstrap))) {
       var bootstrap = require(fsPath.join(codecept_dir, this.config.bootstrap));
       if (typeof bootstrap === 'function') {
         bootstrap(callback);
         return;
       }
       callback();
+    } else if (typeof this.config.bootstrap === 'function') {
+      this.config.boostrap(callback);
     }
   }
 
   // loading teardown
   teardown() {
-    if (this.config.teardown && fileExists(fsPath.join(codecept_dir, this.config.teardown))) {
-      require(fsPath.join(codecept_dir, this.config.teardown));
+    if (typeof this.config.teardown === 'string' && fileExists(fsPath.join(codecept_dir, this.config.teardown))) {
+        var teardown = require(fsPath.join(codecept_dir, this.config.teardown));
+        if (typeof teardown === 'function') {
+          teardown();
+        }
+    } else if (typeof this.config.teardown === 'function') {
+      this.config.teardown();
     }
   }
 


### PR DESCRIPTION
### `bootstrap` config option
Current behaviour:
- when `bootstrap` is a path to a js file, the file is `require`d. If the file exports a function, the function is called with a callback

Proposed behaviour:
- when `bootstrap` is a path to a js file, the file is `require`d. If the file exports a function, the function is called with a callback
- when `bootstrap` is a function, it's called with a callback

### `teardown` config option
Current behaviour:
- when `teardown` is a path to a js file, the file is `require`d. If the file exports a function, the function is *not* called (inconsistent with the `bootstrap` behaviour)

Proposed behaviour:
- when `teardown` is a path to a js file, the file is `require`d. If the file exports a function, the function is called (consistent with the `bootstrap` behaviour, aside from the callback which is not necessary)
- when `teardown` is a function, it's called