### PR TITLE
Fix for waitForElement of SeleniumWebdriver helper

### DIFF
--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -630,8 +630,7 @@ class SeleniumWebdriver extends Helper {
    */
   waitForElement(locator, sec) {
     sec = sec || this.options.waitforTimeout;
-    let el = this.browser.findElement(guessLocator(locator) || by.css(locator));
-    return this.browser.wait(this.webdriver.until.elementsLocated(el), sec*1000);
+    return this.browser.wait(this.webdriver.until.elementsLocated(guessLocator(locator) || by.css(locator)), sec*1000);
   }
 
   /**


### PR DESCRIPTION
Fixes "Invalid Locator" exception on calling waitForElement method of SeleniumWebdriver helper. 