### PR TITLE
Nightmare restart

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -46,7 +46,8 @@ class Nightmare extends Helper {
     this.options = {
       waitForAction: 500,
       waitForTimeout: 1000,
-      rootElement: 'body'
+      rootElement: 'body',
+      restart: true
     };
 
     // override defaults with config
@@ -156,7 +157,30 @@ class Nightmare extends Helper {
     });
   }
 
+  _beforeSuite() {
+    if (!this.options.restart)
+      this._startBrowser();
+  }
+
   _before() {
+    if (this.options.restart)
+        this._startBrowser();
+    return this.browser;
+  }
+
+  _after() {
+    if (this.options.restart)
+        return this._stopBrowser();
+    else
+        return this.browser.cookies.clearAll();
+  }
+
+  _afterSuite() {
+    if (!this.options.restart)
+        this._stopBrowser();
+  }
+
+  _startBrowser() {
     this.browser = this.Nightmare(this.options);
     this.browser.on('dom-ready', () => this._injectClientScripts());
     this.browser.on('console', (type, message) => {
@@ -169,13 +193,12 @@ class Nightmare extends Helper {
         this.browser.viewport(size[0], size[1]);
       }
     }
-    return this.browser;
   }
 
-  _after() {
+  _stopBrowser() {
     return this.browser.end().catch((error) => {
       this.debugSection('Error on End', error);
-    });
+    });;
   }
 
   _withinBegin(locator) {


### PR DESCRIPTION
Implemented restart option to run suites in a single instance of the browser. This feature is configuration driven similar to WD and Protractor.