### PR TITLE
Nightmare restart

### DIFF
--- a/docs/nightmare.md
+++ b/docs/nightmare.md
@@ -113,7 +113,8 @@ To enable Nightmare tests you should enable `Nightmare` helper in `codecept.json
   "helpers": {
     "Nightmare": {
       "url": "http://localhost",
-      "show": false
+      "show": false,
+      "restart": false
     }
   }
   // ..
@@ -121,6 +122,8 @@ To enable Nightmare tests you should enable `Nightmare` helper in `codecept.json
 ```
 Turn on the `show` option if you want to follow test progress in a window. This is very useful for debugging.
 All other options can be taken from [NightmareJS API](https://github.com/segmentio/nightmare#api).
+
+Turn off the `restart` option if you want to run your suite in a single browser instance.
 
 Option `waitForAction` defines how long to wait after a click, doubleClick or pressKey action is performed.
 Test execution may happen much faster than the response is rendered, so make sure you set a proper delay value.

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -46,7 +46,8 @@ class Nightmare extends Helper {
     this.options = {
       waitForAction: 500,
       waitForTimeout: 1000,
-      rootElement: 'body'
+      rootElement: 'body',
+      restart: true
     };
 
     // override defaults with config
@@ -156,7 +157,30 @@ class Nightmare extends Helper {
     });
   }
 
+  _beforeSuite() {
+    if (!this.options.restart)
+      this._startBrowser();
+  }
+
   _before() {
+    if (this.options.restart)
+        this._startBrowser();
+    return this.browser;
+  }
+
+  _after() {
+    if (this.options.restart)
+        return this._stopBrowser();
+    else
+        return this.browser.cookies.clearAll();
+  }
+
+  _afterSuite() {
+    if (!this.options.restart)
+        this._stopBrowser();
+  }
+
+  _startBrowser() {
     this.browser = this.Nightmare(this.options);
     this.browser.on('dom-ready', () => this._injectClientScripts());
     this.browser.on('console', (type, message) => {
@@ -169,13 +193,12 @@ class Nightmare extends Helper {
         this.browser.viewport(size[0], size[1]);
       }
     }
-    return this.browser;
   }
 
-  _after() {
+  _stopBrowser() {
     return this.browser.end().catch((error) => {
       this.debugSection('Error on End', error);
-    });
+    });;
   }
 
   _withinBegin(locator) {

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -28,6 +28,7 @@ describe('Nightmare', function () {
       show: false
     });
     I._init();
+    I._beforeSuite();
   });
 
   beforeEach(function() {


### PR DESCRIPTION
`restart` option for tests run using nightmare helper. Defaults to
`true`. Setting the option `false` with run all the scenario’s of a
suite in a single browser instance.