### PR TITLE
Ignore errors from trying to delete non-existent file

### DIFF
--- a/test/runner/list_test.js
+++ b/test/runner/list_test.js
@@ -22,7 +22,9 @@ describe('list/def commands', () => {
 
 
   it('def should create definition file', (done) => {
-    require('fs').unlinkSync(codecept_dir + '/steps.d.ts');
+    try {
+      require('fs').unlinkSync(codecept_dir + '/steps.d.ts');
+    } catch (e) {}
     exec(`${runner} def ${codecept_dir}`, (err, stdout, stderr) => {
       stdout.should.include('Definitions were generated in steps.d.ts');
       stdout.should.include('<reference path="./steps.d.ts" />');


### PR DESCRIPTION
Test fails when run for the first time on a new clone because it attempts to delete a file that does not exist (it is created by the same test).

Additionally the same test is currently failing on the `master` travis build - https://travis-ci.org/Codeception/CodeceptJS/builds/191168878