### PR TITLE
Apply an assertion to existence of definition file

### DIFF
--- a/test/runner/list_test.js
+++ b/test/runner/list_test.js
@@ -26,7 +26,7 @@ describe('list/def commands', () => {
     exec(`${runner} def ${codecept_dir}`, (err, stdout, stderr) => {
       stdout.should.include('Definitions were generated in steps.d.ts');
       stdout.should.include('<reference path="./steps.d.ts" />');
-      require('fs').existsSync(codecept_dir + '/steps.d.ts');
+      require('fs').existsSync(codecept_dir + '/steps.d.ts').should.be.ok;
       assert(!err);
       done();
     });


### PR DESCRIPTION
`fs.existsSync` will not throw if the file doesn't exist (it would probably not be much use if it did) so an assertion needs to be added to the return value for a meaningful test.