### PR TITLE
Update guppy-pre-commit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-mocha": "^2.0.0",
     "gulp-mustache": "^2.2.0",
     "gulp-plumber": "^1.0.0",
-    "guppy-pre-commit": "^0.3.0",
+    "guppy-pre-commit": "^0.4.0",
     "nightmare": "^2.5.2",
     "nightmare-upload": "^0.1.1",
     "protractor": "^4.0.0",


### PR DESCRIPTION
Previous version installed a pre-commit hook which required a global install of gulp to be present. New version uses the locally installed binary.

See https://github.com/therealklanni/guppy-cli/commit/7ddf899b6943e46a328f79c8d24dbd37f015d7c1 (Note: `guppy-cli` version was updated in `guppy-pre-commit@0.4.0`)