### PR TITLE
Use `path.resolve` in favour of `path.join`

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -61,7 +61,7 @@ class Codecept {
 
   loadTests(pattern) {
     pattern = pattern || this.config.tests;
-    glob.sync(fsPath.join(codecept_dir, pattern)).forEach((file) => {
+    glob.sync(fsPath.resolve(codecept_dir, pattern)).forEach((file) => {
       this.testFiles.push(fsPath.resolve(file));
     });
   }


### PR DESCRIPTION
Using `join` to attach the configured test path to the project root prevents tests being loaded from an absolute path. Using `resolve` instead allows both relative and absolute paths to be used.

Fixes #361 