### PR TITLE
Fixed step by step output

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -48,13 +48,23 @@ module.exports = function (obj) {
 function recordStep(step, args) {
   step.status = 'queued';
   step.setArguments(args);
+
+  // run async before step hooks
   event.emit(event.step.before, step);
 
-  let task = `${step.name}: ${Object.keys(args).map(key => args[key]).join(', ')}`;
-  recorder.add(task, () => val = step.run.apply(step, args));
-
+  let task = `${step.name}: ${step.humanizeArgs()}`;
   let val;
+
+  // run step inside promise
+  recorder.add(task, () => {
+    event.emit(event.step.started, step);
+    val = step.run.apply(step, args)
+  });
+
+  // run async after step hooks
   event.emit(event.step.after, step);
+
+  // ensure step result is passed to next step
   recorder.add('return step result', () => val);
   return recorder.promise();
 }

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -58,7 +58,7 @@ function recordStep(step, args) {
   // run step inside promise
   recorder.add(task, () => {
     event.emit(event.step.started, step);
-    val = step.run.apply(step, args)
+    val = step.run.apply(step, args);
   });
 
   // run async after step hooks

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -39,7 +39,7 @@ module.exports = function (obj) {
       });
     });
 
-  // add print comment method
+  // add print comment method`
   obj.say = (msg) => recorder.add(`say ${msg}`, () => output.say(msg));
 
   return obj;

--- a/lib/event.js
+++ b/lib/event.js
@@ -16,8 +16,8 @@ module.exports = {
     after: 'suite.after'
   },
   step: {
-    init: 'step.init',
     before: 'step.before',
+    started: 'step.start',
     after: 'step.after'
   },
   all: {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -73,19 +73,19 @@ class Helper {
    * Hook executed before each step
    *
    * @param step
+   * @override
+   *
+   * _beforeStep()
    */
-  _beforeStep() {
-
-  }
 
   /**
    * Hook executed after each step
    *
    * @param step
+   * @override
+   *
+   * _afterStep()
    */
-  _afterStep() {
-
-  }
 
   /**
    * Hook executed before each suite

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -15,7 +15,7 @@ let runHelpersHook = (hook, param) => {
 
 let runAsyncHelpersHook = (hook, param, force) => {
   Object.keys(helpers).forEach((key) => {
-    debug(`${key}.${hook}`);
+    if (!helpers[key][hook]) return;
     recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force);
   });
 };

--- a/lib/reporter/cli.js
+++ b/lib/reporter/cli.js
@@ -65,7 +65,7 @@ class Cli extends Base {
         }
       });
 
-      event.dispatcher.on(event.step.before, function (step) {
+      event.dispatcher.on(event.step.started, function (step) {
         output.step(step);
       });
     }

--- a/test/data/sandbox/fs_test.js
+++ b/test/data/sandbox/fs_test.js
@@ -2,5 +2,6 @@ Feature('Filesystem');
 
 Scenario('check current dir', (I) => {
   I.amInPath('.');
+  I.say('hello world');
   I.seeFile('codecept.json');
 });

--- a/test/runner/interface_test.js
+++ b/test/runner/interface_test.js
@@ -39,6 +39,7 @@ describe('CodeceptJS Interface', () => {
         `[2] Queued | hook FileSystem._before()`,
         `[2] Queued | amInPath: "."`,
         `[2] Queued | return step result`,
+        `[2] Queued | say hello world`,
         `[2] Queued | seeFile: "codecept.json"`,
         `[2] Queued | return step result`,
         `[2] Queued | fire test.passed`,
@@ -54,6 +55,7 @@ describe('CodeceptJS Interface', () => {
 
       let lines = stdout.match(/\S.+/g);
 
+      // before hooks
       let beforeStep = [
         `Emitted | step.before (I am in path ".")`,
         `[2] Queued | amInPath: "."`,
@@ -63,7 +65,17 @@ describe('CodeceptJS Interface', () => {
       ];
 
       lines.filter((l) => beforeStep.indexOf(l) > -1)
-        .should.eql(beforeStep, 'steps execution order should be equal');
+        .should.eql(beforeStep, 'check step hooks execution order');
+
+      // steps order
+      let step = [
+        `• I am in path "."`,
+        `hello world`,
+        `• I see file "codecept.json"`
+      ];
+
+      lines.filter((l) => step.indexOf(l) > -1)
+        .should.eql(step, 'check steps execution order');
 
       assert(!err);
       done();

--- a/test/runner/interface_test.js
+++ b/test/runner/interface_test.js
@@ -24,4 +24,50 @@ describe('CodeceptJS Interface', () => {
       done();
     });
   });
+
+  it('should execute expected promise chain', (done) => {
+    exec(codecept_run + ' --verbose', (err, stdout, stderr) => {
+      var queue1 = stdout.match(/\[1\] .+/g);
+      queue1.should.eql([
+        "[1] Starting recording promises",
+        "[1] Queued | hook FileSystem._beforeSuite()"
+      ]);
+
+      var queue2 = stdout.match(/\[2\] .+/g);
+      queue2.should.eql([
+        `[2] Starting recording promises`,
+        `[2] Queued | hook FileSystem._before()`,
+        `[2] Queued | amInPath: "."`,
+        `[2] Queued | return step result`,
+        `[2] Queued | seeFile: "codecept.json"`,
+        `[2] Queued | return step result`,
+        `[2] Queued | fire test.passed`,
+        `[2] Queued | finish test`,
+        `[2] Queued | hook FileSystem._after()`
+      ]);
+
+      var queue3 = stdout.match(/\[3\] .+/g);
+      queue3.should.eql([
+        `[3] Starting recording promises`,
+        `[3] Queued | hook FileSystem._afterSuite()`
+      ]);
+
+      let lines = stdout.match(/\S.+/g);
+
+      let beforeStep = [
+        `Emitted | step.before (I am in path ".")`,
+        `[2] Queued | amInPath: "."`,
+        `Emitted | step.after (I am in path ".")`,
+        `Emitted | step.start (I am in path ".")`,
+        `• I am in path "."`
+      ];
+
+      lines.filter((l) => beforeStep.indexOf(l) > -1)
+        .should.eql(beforeStep, 'steps execution order should be equal');
+
+      assert(!err);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
* Fixed async printing for step-by-step output (regression since 0.4.14)
* Added `step.started` event for running sync code before the step
* Removed `_beforeStep` and `_afterStep` dummy methods from Helper class, so they won't be added to promise chain. Nevertheless corresponding hooks can be implemened in custom helpers

Fixes #376 
Fixes #377 