### PR TITLE
Fix 'fullTitle() is not a function' in exit.js

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -63,19 +63,19 @@ module.exports = function (suite) {
     };
 
     context.BeforeSuite = function (fn) {
-      suites[0].beforeAll('BeforeSuite', scenario.injected(fn));
+      suites[0].beforeAll('BeforeSuite', scenario.injected(fn, suites[0]));
     };
 
     context.AfterSuite = function (fn) {
-      suites[0].afterAll('AfterSuite', scenario.injected(fn));
+      suites[0].afterAll('AfterSuite', scenario.injected(fn, suites[0]));
     };
 
     context.Background = context.Before = function (fn) {
-      suites[0].beforeEach('Before', scenario.injected(fn));
+      suites[0].beforeEach('Before', scenario.injected(fn, suites[0]));
     };
 
     context.After = function (fn) {
-      suites[0].afterEach('After', scenario.injected(fn));
+      suites[0].afterEach('After', scenario.injected(fn, suites[0]));
     };
 
     /**

--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -6,13 +6,17 @@ let failed = false;
 
 let failedTests = [];
 
-event.dispatcher.on(event.test.failed, function (test) {
-  failedTests.push(test.fullTitle());
+event.dispatcher.on(event.test.failed, function (testOrSuite) {
+  // NOTE When an error happens in one of the hooks (BeforeAll/BeforeEach...) the event object
+  // is a suite and not a test
+  failedTests.push(testOrSuite.fullTitle());
 });
 
 // if test was successful after retries
-event.dispatcher.on(event.test.passed, function (test) {
-  failedTests = failedTests.filter((failed) => test.fullTitle() !== failed);
+event.dispatcher.on(event.test.passed, function (testOrSuite) {
+  // NOTE When an error happens in one of the hooks (BeforeAll/BeforeEach...) the event object
+  // is a suite and not a test
+  failedTests = failedTests.filter((failed) => testOrSuite.fullTitle() !== failed);
 });
 
 event.dispatcher.on(event.all.result, function () {

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -71,7 +71,7 @@ module.exports.test = (test) => {
 /**
  * Injects arguments to function from controller
  */
-module.exports.injected = function (fn) {
+module.exports.injected = function (fn, suite) {
   return function () {
     try {
       fn.apply(this, getInjectedArguments(fn));
@@ -79,7 +79,7 @@ module.exports.injected = function (fn) {
       recorder.throw(err);
     }
     recorder.catch((err) => {
-      event.emit(event.test.failed, {}, err); // emit
+      event.emit(event.test.failed, suite, err); // emit
       throw err;
     });
     return recorder.promise();


### PR DESCRIPTION
To reproduce create a test suite with beforeAll or beforeEach hooks. Then
run the tests without previously starting selenium/phantomjs. You should see the above error message which is also misleading since the actual error is 

```
 [1] Error | Error: Couldn't connect to selenium server
```