### PR TITLE
Fix for Nightmare waitTimeout. Resolves #236

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -58,7 +58,7 @@ class Nightmare extends Helper {
     Object.assign(this.options, config);
 
     this.context = this.options.rootElement;
-    this.options.waitForTimeout /= 1000; // convert to seconds
+    this.options.waitForTimeout;
   }
 
   static _config() {
@@ -759,7 +759,7 @@ class Nightmare extends Helper {
       context = this.context;
     }
     let locator = guessLocator(context) || { css: context};
-    this.browser.optionWaitTimeout = sec * 1000 || this.options.waitForTimeout;
+    this.browser.options.waitTimeout = sec * 1000 || this.options.waitForTimeout;
 
     return this.browser.wait(function (by, locator, text) {
       return codeceptjs.findElement(by, locator).innerText.indexOf(text) > -1;
@@ -770,7 +770,7 @@ class Nightmare extends Helper {
    * {{> ../webapi/waitForVisible }}
    */
   waitForVisible(locator, sec) {
-    this.browser.optionWaitTimeout = sec * 1000 || this.options.waitForTimeout;
+    this.browser.options.waitTimeout = sec * 1000 || this.options.waitForTimeout;
     locator = guessLocator(locator) || { css: locator};
 
     return this.browser.wait(function (by, locator) {
@@ -784,7 +784,7 @@ class Nightmare extends Helper {
    * {{> ../webapi/waitForElement }}
    */
   waitForElement(locator, sec) {
-    this.browser.optionWaitTimeout = sec * 1000 || this.options.waitForTimeout;
+    this.browser.options.waitTimeout = sec * 1000 || this.options.waitForTimeout;
     locator = guessLocator(locator) || { css: locator};
 
     return this.browser.wait(function (by, locator) {

--- a/test/data/app/controllers.php
+++ b/test/data/app/controllers.php
@@ -244,3 +244,10 @@ class dynamic {
         include __DIR__.'/view/dynamic.php';
     }
 }
+
+class timeout {
+    public function GET()
+    {
+        include __DIR__.'/view/timeout.php';
+    }
+}

--- a/test/data/app/index.php
+++ b/test/data/app/index.php
@@ -38,6 +38,7 @@ $urls = array(
     '/external_url' => 'external_url',
     '/iframe' => 'iframe',
     '/dynamic' => 'dynamic',
+    '/timeout' => 'timeout',
 );
 
 glue::stick($urls);

--- a/test/data/app/view/timeout.php
+++ b/test/data/app/view/timeout.php
@@ -1,0 +1,12 @@
+<html>
+<body>
+
+<div id="text">Static text</div>
+
+<script>
+  setTimeout(function () {
+    document.querySelector('#text').textContent = 'Timeout text';
+  }, 30000);
+</script>
+</body>
+</html>

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -15,7 +15,7 @@ let webApiTests = require('./webapi');
 
 describe('Nightmare', function () {
   this.retries(3);
-  this.timeout(20000);
+  this.timeout(35000);
 
   before(function() {
     global.codecept_dir = path.join(__dirname, '/../data');

--- a/test/helper/SeleniumWebdriver_test.js
+++ b/test/helper/SeleniumWebdriver_test.js
@@ -14,7 +14,7 @@ require('co-mocha')(require('mocha'));
 let webApiTests = require('./webapi');
 
 describe('SeleniumWebdriver', function () {
-  this.timeout(10000);
+  this.timeout(35000);
 
   before(function() {
     global.codecept_dir = path.join(__dirname, '/../data');

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -15,7 +15,7 @@ let webApiTests = require('./webapi');
 
 
 describe('WebDriverIO', function () {
-  this.timeout(10000);
+  this.timeout(35000);
 
   before(() => {
     global.codecept_dir = path.join(__dirname, '/../data');

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -502,6 +502,13 @@ module.exports.tests = function() {
         .then(() => I.waitForText('Dynamic text', 2, '#text'))
         .then(() => I.see('Dynamic text'));
     });
+
+    it('should wait for text after timeout', () => {
+      return I.amOnPage('/timeout')
+        .then(() => I.dontSee('Timeout text'))
+        .then(() => I.waitForText('Timeout text', 31, '#text'))
+        .then(() => I.see('Timeout text'));
+    });
   });
 
   describe('window size #resizeWindow', () => {


### PR DESCRIPTION
Hi,

I spotted an issue with the waitFor functions in the Nightmare helper as mentioned in #236. 

In cases where the element you're waiting for takes longer than 30 seconds to appear, the default nightmare timeout is hit. The reason this is happening is that `optionWaitTimeout` isn't valid in Nightmare and was causing it to fall back to it's default of 30 seconds.

I've changed this to correctly set the Nightmare `options.waitTimeout` value. I also removed the /1000 on `waitForTimeout` as Nightmare requires milliuseconds and the functions below are the only place this was being used.

I added a test for for the timeout function on `waitForText`
