### PR TITLE
Make function parameter name parsing more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Feature('CodeceptJS demo');
 Scenario('check Welcome page on site', (I) => {
   I.amOnPage('/');
   I.see('Welcome');
-}
+});
 ```
 
 Codeception tests are:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var getParameterNames = require('get-parameter-names');
 
 module.exports.fileExists = function (filePath) {
   try {
@@ -23,8 +24,7 @@ module.exports.isFile = function (filePath) {
 
 module.exports.getParamNames = function (fn) {
   if (fn.isSinonProxy) return [];
-  var funStr = fn.toString();
-  return funStr.slice(funStr.indexOf('(') + 1, funStr.indexOf(')')).match(/([^\s,]+)/g);
+  return getParameterNames(fn);
 };
 
 module.exports.installedLocally = function () {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "co": "^4.6.0",
     "commander": "^2.9.0",
     "escape-string-regexp": "^1.0.3",
+    "get-parameter-names": "^0.3.0",
     "glob": "^6.0.1",
     "inquirer": "^0.11.0",
     "mkdirp": "^0.5.1",

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -13,6 +13,7 @@ describe('utils', () => {
   describe('#getParamNames', () => {
     it('fn#1', () => utils.getParamNames(function (a, b) {}).should.eql(['a', 'b']));
     it('fn#2', () => utils.getParamNames((I, userPage) => { }).should.eql(['I', 'userPage']));
+    it('should handle single-param arrow functions with omitted parens', () => utils.getParamNames(I => {}).should.eql(['I']));
   });
 
   describe('#methodsOfObject', () => {


### PR DESCRIPTION
Use goatslacker/get-parameter-names to read function parameter names in a more robust way. With this, single-param arrow functions that omit the parentheses do not produce an error anymore.

Fixes #127