### PR TITLE
Exit with non-zero code if init throws an error

### DIFF
--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -30,5 +30,6 @@ module.exports = function (suite, test, options) {
     output.error(err.message);
     output.print('');
     output.print(output.colors.grey(err.stack.replace(err.message, '')));
+    process.exit(1);
   }
 };


### PR DESCRIPTION
If an error is thrown by the `init` function on startup then the error is caught and the process exits with a zero exit code. This means that CI environments will yield a passing build, when in fact the test runner has suffered a catastrophic error.

Resolve this by exiting with a non-zero code if `init` throws an error.