### PR TITLE
Add seeNumberOfVisibleElements

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -770,7 +770,7 @@ class WebDriverIO extends Helper {
     return this.browser.isVisible(withStrictLocator(selector))
       .then(function(res) {
         res = res.filter((val) => val == true);
-        return assert.equal(res.length, num);
+        return truth(`elements of ${locator}`, 'to be seen').assert.equal(res.length, num);
       });
   }
 

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -757,6 +757,18 @@ class WebDriverIO extends Helper {
         return assert.equal(res.value.length, num);
       });
   }
+  
+  /**
+   * asserts that an element is visible a given number of times
+   * Element is located by CSS or XPath.
+   */
+  seeNumberOfVisibleElements(selector, num) {
+    return this.browser.isVisible(withStrictLocator(selector))
+      .then(function(res) {
+        res = res.filter((val) => val == true);
+        return assert.equal(res.length, num);
+      });
+  }
 
   /**
    * {{> ../webapi/seeInCurrentUrl }}

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -761,6 +761,10 @@ class WebDriverIO extends Helper {
   /**
    * asserts that an element is visible a given number of times
    * Element is located by CSS or XPath.
+   *
+   * ```js
+   * I.seeNumberOfVisibleElements('.buttons', 3);
+   * ```
    */
   seeNumberOfVisibleElements(selector, num) {
     return this.browser.isVisible(withStrictLocator(selector))


### PR DESCRIPTION
Give the ability to not only see how many times an element appears in the DOM but how many times an element is actually visible.

Had to build this function as a custom helper for my project. I believe this should be implemented. Very useful, especially when writing acceptance tests.