### PR TITLE
Click only visible elements

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -110,8 +110,11 @@ AfterSuite((I) => {
 ## Within
 
 To specify the exact area on a page where actions can be performed you can use `within` function.
-Everything executed in its context will be narrowed to context specified by locator:
+Everything executed in its context will be narrowed to context specified by locator: 
 
+iFramesPath is optional, to be used for elements inside iframe or nested iframes. 
+
+Usage: within('section', ()=>{} , [iFrame_ID_1 , iFrame_ID_2.....] )
 ```js
 I.amOnPage('https://github.com');
 within('.form-signup-home', function () {
@@ -119,7 +122,7 @@ within('.form-signup-home', function () {
   I.fillField('user[email]', 'user@user.com');
   I.fillField('user[password]', 'user@user.com');
   I.click('button');
-});
+}, [iFrames] );
 I.see('There were problems creating your account.');
 ```
 

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -206,14 +206,15 @@ class Nightmare extends Helper {
     });
   }
 
-  _withinBegin(locator) {
+  _withinBegin(locator , optionalIframes) {
     this.context = locator;
     locator = guessLocator(locator) || {css: locator};
-    this.browser.evaluate(function (by, locator) {
-      var el = codeceptjs.findElement(by, locator);
+    this.browser.evaluate(function (by, locator, optionalIframes) {
+      var context = optionalIframes.reduce( (parentFrame , frame) => parentFrame.querySelector(frame.contentDocument) , window.document );
+      var el = codeceptjs.findElement(by, locator, context);
       if (!el) throw new Error(`Element by ${by}: ${locator} not found`);
       window.codeceptjs.within = el;
-    }, lctype(locator), lcval(locator));
+    }, lctype(locator), lcval(locator) , optionalIframes );
   }
 
   _withinEnd() {

--- a/lib/helper/clientscripts/nightmare.js
+++ b/lib/helper/clientscripts/nightmare.js
@@ -79,7 +79,12 @@ if (!window.codeceptjs) {
 
   // actions
   codeceptjs.clickEl = function (el) {
+    var elPostion = el.getBoundingClientRect();
+    var suspectElem = document.elementFromPoint(elPostion.left,elPostion.top)//not required
     document.activeElement.blur();
+    if(suspectElem!==el)
+      throw "Element not visible";
+
     var event = document.createEvent('MouseEvent');
     event.initEvent('click', true, true);
     return this.fetchElement(el).dispatchEvent(event);
@@ -110,4 +115,3 @@ if (!window.codeceptjs) {
 
   window.codeceptjs = codeceptjs;
 }
-

--- a/lib/within.js
+++ b/lib/within.js
@@ -4,7 +4,7 @@ let recorder = require('./recorder');
 let container = require('./container');
 let event = require('./event');
 
-function within(context, fn) {
+function within(context, fn, optionalIframes ) {
   recorder.add('register within wrapper', function () {
 
     recorder.session.start('within');
@@ -18,7 +18,7 @@ function within(context, fn) {
     output.stepShift = 2;
     if (output.level() > 0) output.print(`   Within ${output.colors.yellow.bold(locator)}:`);
     Object.keys(helpers).forEach((helper) => {
-      if (helpers[helper]._withinBegin) recorder.add('start within block', () => helpers[helper]._withinBegin(context));
+      if (helpers[helper]._withinBegin) recorder.add('start within block', () => helpers[helper]._withinBegin(context , optionalIframes));
     });
 
     fn();


### PR DESCRIPTION
Just a POC to throw error if the element is not visually present.

Idea here is to get the coordinates of the target element. Find the element in the document at the same coordinates. If the element doesnt match, its very likely that its not present on the view.

Based on the review comments, refactoring will be taken care.
