### PR TITLE
Typo: codecept.js ➡ json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-CodeceptJS configuration is set in `codecept.js` file.
+CodeceptJS configuration is set in `codecept.json` file.
 
 After running `codeceptjs init` it should be saved in test root.
 


### PR DESCRIPTION
The configuration is in a json file not in a js file.