### PR TITLE
Passing "suite" object to event.suite.before/after handlers

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -56,8 +56,8 @@ module.exports = function (suite) {
       suite.beforeEach('codeceptjs.before', scenario.setup);
       suite.afterEach('finialize codeceptjs', scenario.teardown);
 
-      suite.beforeAll('codeceptjs.beforeSuite', scenario.suiteSetup);
-      suite.afterAll('codeceptjs.afterSuite', scenario.suiteTeardown);
+      suite.beforeAll('codeceptjs.beforeSuite', () => scenario.suiteSetup(suite));
+      suite.afterAll('codeceptjs.afterSuite', () => scenario.suiteTeardown(suite));
 
       return suite;
     };

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -29,11 +29,11 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.suite.before, function (suite) {
-    runAsyncHelpersHook('_beforeSuite', null, true);
+    runAsyncHelpersHook('_beforeSuite', suite, true);
   });
 
   event.dispatcher.on(event.suite.after, function (suite) {
-    runAsyncHelpersHook('_afterSuite', null, true);
+    runAsyncHelpersHook('_afterSuite', suite, true);
   });
 
   event.dispatcher.on(event.test.started, function (test) {

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -98,14 +98,14 @@ module.exports.teardown = function () {
   event.emit(event.test.after);
 };
 
-module.exports.suiteSetup = function () {
+module.exports.suiteSetup = function (suite) {
   recorder.start();
-  event.emit(event.suite.before);
+  event.emit(event.suite.before, suite);
 };
 
-module.exports.suiteTeardown = function () {
+module.exports.suiteTeardown = function (suite) {
   recorder.start();
-  event.emit(event.suite.after);
+  event.emit(event.suite.after, suite);
 };
 
 function isGenerator(fn) {


### PR DESCRIPTION
Passing suite object to event.suite.before/after handlers and helper's _beforeSuite/_afterSuite. Fix #495.