### PR TITLE
Expand saveScreenshot() functionality

### DIFF
--- a/docs/webapi/saveScreenshot.mustache
+++ b/docs/webapi/saveScreenshot.mustache
@@ -1,10 +1,10 @@
 Saves a screenshot to ouput folder (set in codecept.json).
 Filename is relative to output folder. 
-Optionally resize the window to the full availible page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
+Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 
 ```js
 I.saveScreenshot('debug.png');
-I.saveScreenshot('debug.png',ture) \\resizes to availible scrollHeight and scrollWidth before taking screenshot
+I.saveScreenshot('debug.png',true) \\resizes to available scrollHeight and scrollWidth before taking screenshot
 ```
 @param fileName
 @param fullPage (optional)

--- a/docs/webapi/saveScreenshot.mustache
+++ b/docs/webapi/saveScreenshot.mustache
@@ -1,7 +1,10 @@
 Saves a screenshot to ouput folder (set in codecept.json).
-Filename is relative to output folder.
+Filename is relative to output folder. 
+Optionally resize the window to the full availible page height and width to capture the entire page by passing `true` in as the second argument.
 
 ```js
 I.saveScreenshot('debug.png');
+I.saveScreenshot('debug.png',ture) \\resizes to availible scrollHeight and scrollWidth before taking screenshot
 ```
 @param fileName
+@param fullPage (optional)

--- a/docs/webapi/saveScreenshot.mustache
+++ b/docs/webapi/saveScreenshot.mustache
@@ -1,6 +1,6 @@
 Saves a screenshot to ouput folder (set in codecept.json).
 Filename is relative to output folder. 
-Optionally resize the window to the full availible page height and width to capture the entire page by passing `true` in as the second argument.
+Optionally resize the window to the full availible page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 
 ```js
 I.saveScreenshot('debug.png');

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -800,27 +800,24 @@ class Nightmare extends Helper {
     /**
      * {{> ../webapi/saveScreenshot }}
      */
-    saveScreenshot(fileName, fullPage) {
-        fullPage = fullPage || false
-        let outputFile = path.join(global.output_dir, fileName);
-        this.debug('Screenshot is saving to ' + outputFile);
-        let recorder = require('../recorder');
+    saveScreenshot(fileName, fullPage = false) {
+      let outputFile = path.join(global.output_dir, fileName);
+      this.debug('Screenshot is saving to ' + outputFile);
+      let recorder = require('../recorder');
 
-        if (full === true) {
-            this.browser.evaluate(function () {
-                o = {
-                    height: document.body.scrollHeight,
-                    width: document.body.scrollWidth
-                }
-                return o
-            }).then(doc => {
-                console.log(doc.width, doc.height)
-                this.browser.viewport(doc.width, doc.width);
-                return this.browser.screenshot(outputFile)
-            })
-        }
-
+      if (!fullPage) {
         return this.browser.screenshot(outputFile);
+      }
+      return this.browser.evaluate(() => ({
+        height: document.body.scrollHeight,
+        width: document.body.scrollWidth
+      })).then(({
+        width,
+        height
+      }) => {
+        this.browser.viewport(width, height);
+        return this.browser.screenshot(outputFile)
+      })
     }
 
     _failed(test) {

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -797,20 +797,36 @@ class Nightmare extends Helper {
     }, lctype(locator), lcval(locator));
   }
 
-  /**
-   * {{> ../webapi/saveScreenshot }}
-   */
-  saveScreenshot(fileName) {
-    let outputFile = path.join(global.output_dir, fileName);
-    this.debug('Screenshot is saving to ' + outputFile);
-    let recorder = require('../recorder');
-    return this.browser.screenshot(outputFile);
-  }
+    /**
+     * {{> ../webapi/saveScreenshot }}
+     */
+    saveScreenshot(fileName, fullPage) {
+        fullPage = fullPage || false
+        let outputFile = path.join(global.output_dir, fileName);
+        this.debug('Screenshot is saving to ' + outputFile);
+        let recorder = require('../recorder');
 
-  _failed(test) {
-    let fileName = test.title.replace(/\W/g, '_') + '.failed.png';
-    return this.saveScreenshot(fileName);
-  }
+        if (full === true) {
+            this.browser.evaluate(function () {
+                o = {
+                    height: document.body.scrollHeight,
+                    width: document.body.scrollWidth
+                }
+                return o
+            }).then(doc => {
+                console.log(doc.width, doc.height)
+                this.browser.viewport(doc.width, doc.width);
+                return this.browser.screenshot(outputFile)
+            })
+        }
+
+        return this.browser.screenshot(outputFile);
+    }
+
+    _failed(test) {
+        let fileName = test.title.replace(/\W/g, '_') + '.failed.png';
+        return this.saveScreenshot(fileName, true);
+    }
 
   /**
    * Scrolls to element matched by locator.

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -800,30 +800,30 @@ class Nightmare extends Helper {
     /**
      * {{> ../webapi/saveScreenshot }}
      */
-    saveScreenshot(fileName, fullPage = false) {
-      let outputFile = path.join(global.output_dir, fileName);
-      this.debug('Screenshot is saving to ' + outputFile);
-      let recorder = require('../recorder');
+  saveScreenshot(fileName, fullPage = false) {
+    let outputFile = path.join(global.output_dir, fileName);
+    this.debug('Screenshot is saving to ' + outputFile);
+    let recorder = require('../recorder');
 
-      if (!fullPage) {
-        return this.browser.screenshot(outputFile);
-      }
-      return this.browser.evaluate(() => ({
-        height: document.body.scrollHeight,
-        width: document.body.scrollWidth
-      })).then(({
+    if (!fullPage) {
+      return this.browser.screenshot(outputFile);
+    }
+    return this.browser.evaluate(() => ({
+      height: document.body.scrollHeight,
+      width: document.body.scrollWidth
+    })).then(({
         width,
         height
       }) => {
-        this.browser.viewport(width, height);
-        return this.browser.screenshot(outputFile)
-      })
-    }
+      this.browser.viewport(width, height);
+      return this.browser.screenshot(outputFile);
+    });
+  }
 
-    _failed(test) {
-        let fileName = test.title.replace(/\W/g, '_') + '.failed.png';
-        return this.saveScreenshot(fileName, true);
-    }
+  _failed(test) {
+    let fileName = test.title.replace(/\W/g, '_') + '.failed.png';
+    return this.saveScreenshot(fileName, true);
+  }
 
   /**
    * Scrolls to element matched by locator.

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -159,7 +159,7 @@ class SeleniumWebdriver extends Helper {
 
   _failed(test) {
     let fileName = test.title.replace(/ /g, '_') + '.failed.png';
-    return this.saveScreenshot(fileName,true);
+    return this.saveScreenshot(fileName, true);
   }
 
   _withinBegin(locator) {
@@ -575,7 +575,7 @@ class SeleniumWebdriver extends Helper {
     let outputFile = path.join(global.output_dir, fileName);
     this.debug('Screenshot has been saved to ' + outputFile);
 
-    const writeFile = (png,outputFile) => {
+    const writeFile = (png, outputFile) => {
       let fs = require('fs');
       let stream = fs.createWriteStream(outputFile);
       stream.write(new Buffer(png, 'base64'));
@@ -583,11 +583,11 @@ class SeleniumWebdriver extends Helper {
       return new Promise(function (resolve) {
         return stream.on('finish', resolve);
       });
-    }
+    };
 
     if (!fullPage) {
       return this.browser.takeScreenshot()
-        .then(png => writeFile(png,outputFile));
+        .then(png => writeFile(png, outputFile));
     }
     return this.browser.executeScript(() => ({
       height: document.body.scrollHeight,
@@ -596,12 +596,11 @@ class SeleniumWebdriver extends Helper {
       width,
       height
     }) => {
-      this.browser.manage().window().setSize(width, height)
+      this.browser.manage().window().setSize(width, height);
       return this.browser.takeScreenshot()
-        .then(png => writeFile(png,outputFile));
-    })
+        .then(png => writeFile(png, outputFile));
+    });
   }
-
 
 
   /**

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -159,7 +159,7 @@ class SeleniumWebdriver extends Helper {
 
   _failed(test) {
     let fileName = test.title.replace(/ /g, '_') + '.failed.png';
-    return this.saveScreenshot(fileName);
+    return this.saveScreenshot(fileName,true);
   }
 
   _withinBegin(locator) {
@@ -571,19 +571,38 @@ class SeleniumWebdriver extends Helper {
   /**
    * {{> ../webapi/saveScreenshot }}
    */
-  saveScreenshot(fileName) {
+  saveScreenshot(fileName, fullPage = false) {
     let outputFile = path.join(global.output_dir, fileName);
     this.debug('Screenshot has been saved to ' + outputFile);
-    return this.browser.takeScreenshot().then(function (png) {
+
+    const writeFile = (png,outputFile) => {
       let fs = require('fs');
-      var stream = fs.createWriteStream(outputFile);
+      let stream = fs.createWriteStream(outputFile);
       stream.write(new Buffer(png, 'base64'));
       stream.end();
       return new Promise(function (resolve) {
         return stream.on('finish', resolve);
       });
-    });
+    }
+
+    if (!fullPage) {
+      return this.browser.takeScreenshot()
+        .then(png => writeFile(png,outputFile));
+    }
+    return this.browser.executeScript(() => ({
+      height: document.body.scrollHeight,
+      width: document.body.scrollWidth
+    })).then(({
+      width,
+      height
+    }) => {
+      this.browser.manage().window().setSize(width, height)
+      return this.browser.takeScreenshot()
+        .then(png => writeFile(png,outputFile));
+    })
   }
+
+
 
   /**
    * {{> ../webapi/setCookie}}

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -304,7 +304,7 @@ class WebDriverIO extends Helper {
     } else {
       fileName = test.title.replace(/ /g, '_') + '.failed.png';
     }
-    return this.saveScreenshot(fileName,true);
+    return this.saveScreenshot(fileName, true);
   }
 
   _withinBegin(locator) {
@@ -859,7 +859,7 @@ class WebDriverIO extends Helper {
   /**
    * {{> ../webapi/saveScreenshot}}
    */
-  saveScreenshot(fileName,fullPage = false) {
+  saveScreenshot(fileName, fullPage = false) {
     let outputFile = path.join(global.output_dir, fileName);
 
     if (!fullPage) {
@@ -875,8 +875,8 @@ class WebDriverIO extends Helper {
     }) => {
       this.browser.windowHandleSize(width, height);
       this.debug('Screenshot has been saved to ' + outputFile);
-      return this.browser.saveScreenshot(outputFile)
-    })
+      return this.browser.saveScreenshot(outputFile);
+    });
   }
 
 

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -304,7 +304,7 @@ class WebDriverIO extends Helper {
     } else {
       fileName = test.title.replace(/ /g, '_') + '.failed.png';
     }
-    return this.saveScreenshot(fileName);
+    return this.saveScreenshot(fileName,true);
   }
 
   _withinBegin(locator) {
@@ -859,11 +859,26 @@ class WebDriverIO extends Helper {
   /**
    * {{> ../webapi/saveScreenshot}}
    */
-  saveScreenshot(fileName) {
+  saveScreenshot(fileName,fullPage = false) {
     let outputFile = path.join(global.output_dir, fileName);
-    this.debug('Screenshot has been saved to ' + outputFile);
-    return this.browser.saveScreenshot(outputFile);
+
+    if (!fullPage) {
+      this.debug('Screenshot has been saved to ' + outputFile);
+      return this.browser.saveScreenshot(outputFile);
+    }
+    return this.browser.execute(() => ({
+      height: document.body.scrollHeight,
+      width: document.body.scrollWidth
+    })).then(({
+      width,
+      height
+    }) => {
+      this.browser.windowHandleSize(width, height);
+      this.debug('Screenshot has been saved to ' + outputFile);
+      return this.browser.saveScreenshot(outputFile)
+    })
   }
+
 
   /**
    * {{> ../webapi/setCookie}}

--- a/test/helper/Protractor_test.js
+++ b/test/helper/Protractor_test.js
@@ -372,6 +372,12 @@ describe('Protractor', function() {
       return assert.ok(fileExists(path.join(output_dir, 'protractor_user.png')), null, 'file does not exists');
     });
 
+    it('should create full page a screenshot file in output dir', function*() {
+      yield I.amOnPage('/');
+      yield I.saveScreenshot('protractor_user_full.png',true);
+      return assert.ok(fileExists(path.join(output_dir, 'protractor_user_full.png')), null, 'file does not exists');
+    });
+    
     it('should create a screenshot on fail', function*() {
       let test = { title: 'protractor should do smth' };
       yield I.amOnPage('/')

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -460,6 +460,23 @@ module.exports.tests = function() {
     });
   });
 
+  describe('window size #resizeWindow', () => {
+     it('should set initial window size', () => {
+       return I.amOnPage('/form/resize')
+         .then(() => I.click('Window Size'))
+         .then(() => I.see('Height 400', '#height'))
+         .then(() => I.see('Width 500', '#width'))
+     });
+
+     it('should resize window to specific dimensions', () => {
+       return I.amOnPage('/form/resize')
+         .then(() => I.resizeWindow(800, 600))
+         .then(() => I.click('Window Size'))
+         .then(() => I.see('Height 600', '#height'))
+         .then(() => I.see('Width 800', '#width'))
+     });
+   });
+
   describe('#saveScreenshot', () => {
     beforeEach(() => {
       global.output_dir = path.join(global.codecept_dir, 'output');
@@ -528,23 +545,6 @@ module.exports.tests = function() {
         .then(() => I.dontSee('Timeout text'))
         .then(() => I.waitForText('Timeout text', 31, '#text'))
         .then(() => I.see('Timeout text'));
-    });
-  });
-
-  describe('window size #resizeWindow', () => {
-    it('should set initial window size', () => {
-      return I.amOnPage('/form/resize')
-        .then(() => I.click('Window Size'))
-        .then(() => I.see('Height 400', '#height'))
-        .then(() => I.see('Width 500', '#width'))
-    });
-
-    it('should resize window to specific dimensions', () => {
-      return I.amOnPage('/form/resize')
-        .then(() => I.resizeWindow(800, 600))
-        .then(() => I.click('Window Size'))
-        .then(() => I.see('Height 600', '#height'))
-        .then(() => I.see('Width 800', '#width'))
     });
   });
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -472,6 +472,13 @@ module.exports.tests = function() {
         .then(() => assert.ok(fileExists(path.join(output_dir, 'screenshot_'+sec)), null, 'file does not exists'));
     });
 
+    it('should create a full page screenshot file in output dir', () => {
+      let sec = (new Date()).getUTCMilliseconds();
+      return I.amOnPage('/')
+        .then(() => I.saveScreenshot(`screenshot_full_${+sec}`,true))
+        .then(() => assert.ok(fileExists(path.join(output_dir, `screenshot_full_${+sec}`)), null, 'file does not exists'));
+    });
+
     it('should create a screenshot on fail', () => {
       let sec = (new Date()).getUTCMilliseconds().toString();
       let test = { title: 'sw should do smth '+sec };


### PR DESCRIPTION
Resolves #522.

##### Changes (all helpers):
-  `saveScreenshot()` - Takes a second argument of `true` to capture full page.
- `_failed` - Updated behaviour to take advantage of new functionality, failed tests now capture the full page.
- Documentation updated to reflect new functionality.
- Unit tests added for new functionality.