### PR TITLE
Added method to nightmare helper to trigger electron mouse events

### DIFF
--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -461,6 +461,14 @@ Can submit special keys like 'Enter', 'Backspace', etc
 
 -   `key`  
 
+## triggerMouseEvent
+
+Sends [input event](http://electron.atom.io/docs/api/web-contents/#contentssendinputeventevent) on a page.
+
+**Parameters**
+
+-   `event` event object, must contain `x` and `y` keys, others as needed from above link  
+
 ## resizeWindow
 
 Resize the current window to provided width and height.

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -158,6 +158,16 @@ class Nightmare extends Helper {
     }, function (key, done) {
       this.child.call('pressKey', key, done);
     });
+
+    this.Nightmare.action('triggerMouseEvent', function (ns, options, parent, win, renderer, done) {
+      parent.respondTo('triggerMouseEvent', function (evt, done) {
+        win.webContents.sendInputEvent(evt);
+        done();
+      });
+      done();
+    }, function (event, done) {
+      this.child.call('triggerMouseEvent', event, done);
+    });
   }
 
   _beforeSuite() {
@@ -565,6 +575,20 @@ class Nightmare extends Helper {
       key = specialKeys[key];
     }
     return this.browser.pressKey(key).wait(this.options.waitForAction);
+  }
+
+  /**
+   * Sends [input event](http://electron.atom.io/docs/api/web-contents/#contentssendinputeventevent) on a page.
+   * Should be a mouse event like:
+   *  {
+        type: 'mouseDown',
+        x: args.x,
+        y: args.y,
+        button: "left"
+      }
+   */
+  triggerMouseEvent(event) {
+    return this.browser.triggerMouseEvent(event).wait(this.options.waitForAction);
   }
 
   /**

--- a/translations/it-IT.js
+++ b/translations/it-IT.js
@@ -19,6 +19,7 @@ module.exports = {
         'selectOption': 'seleziono_la_opzione',
         'fillField': 'compilo_il_campo',
         'pressKey': 'premo_il_tasto',
+        'triggerMouseEvent': 'attivare_levento_del_mouse',
         'attachFile': 'allego_il_file',
         'seeInField': 'vedo_nel_campo',
         'dontSeeInField': 'non_vedo_nel_campo',

--- a/translations/pl-PL.js
+++ b/translations/pl-PL.js
@@ -19,6 +19,7 @@ module.exports = {
         'selectOption': 'wybieram_opcję',
         'fillField': 'wypełniam_pole',
         'pressKey': 'naciskam_przycisk',
+        'triggerMouseEvent': 'wywołaj_wydarzenie_myszki',
         'attachFile': 'załączam_plik',
         'seeInField': 'widzę_w_polu',
         'dontSeeInField': 'nie_widzę_w_polu',

--- a/translations/pt-BR.js
+++ b/translations/pt-BR.js
@@ -21,6 +21,7 @@ module.exports = {
         'selectOption': 'selecionoAOpcao',
         'fillField': 'preenchoOCampo',
         'pressKey': 'pressioneATecla',
+        'triggerMouseEvent': 'lançarEventoDoMouse',
         'attachFile': 'anexaOArquivo',
         'seeInField': 'vejoNoCampo',
         'dontSeeInField': 'naoVejoNoCampo',

--- a/translations/ru-RU.js
+++ b/translations/ru-RU.js
@@ -12,6 +12,7 @@ module.exports = {
         'selectOption': 'выбираю_опцию',
         'fillField': 'заполнаю_поле',
         'pressKey': 'нажимаю_кнопку',
+        'triggerMouseEvent': 'триггерное_событие_мыши',
         'attachFile': 'загружаю_файл',
         'seeInField': 'вижу_в_поле',
         'dontSeeInField': 'не_вижу_в_поле',


### PR DESCRIPTION
Currently the Nightmare helper exposes electron's `sendInputEvent`, but only for key presses. This PR passes `sendInputEvent` through to the Nightmare helper so that in tests you can trigger mouse events (move, drag, mousedown, etc) at specific x/y coordinates, like so:
`
I.triggerMouseEvent({ type: "mouseDown", x: 100, y: 100, button: "left" });
I.triggerMouseEvent({ type: "mouseMove", x: 200, y: 200, button: "left" });
I.triggerMouseEvent({ type: "mouseUp", x: 200, y: 200, button: "left" });
`