### PR TITLE
Nightmare restart fix

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -192,7 +192,9 @@ class Nightmare extends Helper {
       return this._stopBrowser();
     }
     if (this.options.keepCookies) return;
-    return Promise.all([this.browser.cookies.clearAll(), this.executeScript(function () {return localStorage.clear();})]);
+    return Promise.all([this.browser.cookies.clearAll(), this.executeScript(function () {
+      return localStorage.clear();
+    })]);
   }
 
   _afterSuite() {

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -192,7 +192,7 @@ class Nightmare extends Helper {
       return this._stopBrowser();
     }
     if (this.options.keepCookies) return;
-    return Promise.all([this.browser.cookies.clearAll(), this.executeScript('localStorage.clear();')]);
+    return Promise.all([this.browser.cookies.clearAll(), this.executeScript(function () {return localStorage.clear();})]);
   }
 
   _afterSuite() {


### PR DESCRIPTION
Fix 
`Error: .evaluate() fn should be a function` in after block for Nightmare when `restart:false`