### PR TITLE
Fix TypeError when using babel-node or ts-node on node.js 7+

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -13,8 +13,8 @@ class Step {
     this.helperMethod = name; // helper method
     this.status = 'pending';
     this.prefix = this.suffix = '';
-    Error.captureStackTrace(this);
     this.args = [];
+    Error.captureStackTrace(this);
   }
 
   setArguments(args) {


### PR DESCRIPTION
Error.captureStackTrace() call in Step consturctor causes
Step.prototype.toString() to be called when step.args is not
initialized yet. This happens on node.js 7+ when
source-map-support is installed.

Fixes #576