### PR TITLE
Use mkdirp to create output directory

### DIFF
--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -4,7 +4,7 @@ const getTestRoot = require('./utils').getTestRoot;
 const deepMerge = require('./utils').deepMerge;
 const fileExists = require('../utils').fileExists;
 const path = require('path');
-const fs = require('fs');
+const mkdirp = require('mkdirp');
 const Config = require('../config');
 const Codecept = require('../codecept');
 const output = require('../output');
@@ -23,7 +23,7 @@ module.exports = function (test, options) {
 
   if (!fileExists(outputDir = path.join(testRoot, config.output))) {
     output.print('creating output directory: ' + outputDir);
-    fs.mkdirSync(outputDir);
+    mkdirp.sync(outputDir);
   }
 
   try {


### PR DESCRIPTION
fs.mkdirSync fails if config.output has subdirectories