### PR TITLE
Smart Waits

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -172,10 +172,10 @@ Imagine, application generates a password and you want to ensure that user can l
 ```js
 I.fillField('email', 'miles@davis.com')
 I.click('Generate Password');
-$password = yield I.grabTextFrom('#password');
+let password = yield I.grabTextFrom('#password');
 I.click('Login');
 I.fillField('email', 'miles@davis.com');
-I.fillField('password', $password);
+I.fillField('password', password);
 I.click('Log in!');
 ```
 
@@ -200,8 +200,39 @@ I.waitForElement('#agree_button', 30); // secs
 // clicks a button only when it is visible
 I.click('#agree_button');
 ```
-
 More wait actions can be found in helper's reference.
+
+## SmartWait
+
+It is possible to wait for elements pragmatically. If a test uses element which is not on a page yet, CodeceptJS will wait for few extra seconds before failing. This feature is based on [Implicit Wait](http://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#implicit-waits) of Selenium. CodeceptJS enables implicit wait only when searching for a specific element and disables in all other cases. Thus, the performance of a test is not affected.
+
+SmartWait can be enabled by setting wait option in WebDriverIO config.
+Add `"smartWait": 5000` to wait for additional 5s.
+
+SmartWait works with a CSS/XPath locators in `click`, `seeElement` and other methods. See where it is enabled and where is not:
+
+```js
+I.click('Login'); // DISABLED, not a locator
+I.fillField('user', 'davert'); // DISABLED, not a specific locator
+I.fillField({name: 'password'}, '123456'); // ENABLED, strict locator
+I.click('#login'); // ENABLED, locator is CSS ID
+I.see('Hello, Davert'); // DISABLED, Not a locator
+I.seeElement('#userbar'); // ENABLED
+I.dontSeeElement('#login'); // DISABLED, can't wait for element to hide
+I.seeNumberOfElements('button.link', 5); // DISABLED, can wait only for one element
+
+```
+
+SmartWait doesn't check element for visibility, so tests may fail even element is on a page.
+
+Usage example:
+
+```js
+// we use smartWait: 5000 instead of
+// I.waitForElement('#click-me', 5);
+// to wait for element on page
+I.click('#click-me');
+```
 
 ## IFrames
 

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -100,7 +100,7 @@ class Nightmare extends Helper {
       let value = locator[by];
 
       this.evaluate_now(function (by, locator, contextEl) {
-        return window.codeceptjs.findAndStoreElements(by, locator);
+        return window.codeceptjs.findAndStoreElements(by, locator, contextEl);
       }, done, by, value, contextEl);
     });
 

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -114,7 +114,7 @@ class Nightmare extends Helper {
       let value = locator[by];
 
       this.evaluate_now(function (by, locator, contextEl) {
-        let res = window.codeceptjs.findAndStoreElement(by, locator);
+        let res = window.codeceptjs.findAndStoreElement(by, locator, contextEl);
         if (res === null) {
           throw new Error(`Element ${locator} couldn't be located by ${by}`);
         }

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -41,7 +41,7 @@ let withinStore = {};
  * * `browser` - browser in which perform testing
  * * `driver` - which protrator driver to use (local, direct, session, hosted, sauce, browserstack). By default set to 'hosted' which requires selenium server to be started.
  * * `restart` (optional, default: true) - restart browser between tests.
- * * `smartWait`: (optional) **enables SmartWait**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
+ * * `smartWait`: (optional) **enables [SmartWait](http://codecept.io/acceptance/#smartwait)**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
  * * `seleniumAddress` - Selenium address to connect (default: http://localhost:4444/wd/hub)
  * * `rootElement` - Root element of AngularJS application (default: body)
  * * `waitForTimeout`: (optional) sets default wait time in _ms_ for all `wait*` functions. 1000 by default.

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -41,6 +41,7 @@ let withinStore = {};
  * * `browser` - browser in which perform testing
  * * `driver` - which protrator driver to use (local, direct, session, hosted, sauce, browserstack). By default set to 'hosted' which requires selenium server to be started.
  * * `restart` (optional, default: true) - restart browser between tests.
+ * * `smartWait`: (optional) **enables SmartWait**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
  * * `seleniumAddress` - Selenium address to connect (default: http://localhost:4444/wd/hub)
  * * `rootElement` - Root element of AngularJS application (default: body)
  * * `waitForTimeout`: (optional) sets default wait time in _ms_ for all `wait*` functions. 1000 by default.
@@ -51,6 +52,21 @@ let withinStore = {};
  * * `proxy`: set proxy settings
  *
  * other options are the same as in [Protractor config](https://github.com/angular/protractor/blob/master/docs/referenceConf.js).
+ *
+ * Example:
+ *
+ * ```json
+ * {
+ *    "helpers": {
+ *      "Protractor" : {
+ *        "url": "http://localhost",
+ *        "browser": "chrome",
+ *        "smartWait": 5000,
+ *        "restart": false
+ *      }
+ *    }
+ * }
+ * ```
  *
  * ## Access From Helpers
  *
@@ -708,3 +724,21 @@ var _selectOption;
  * @scope instance
  */
 var _setCookie;
+
+
+/**
+ * ```js
+ * this.helpers['Protractor']._locate({name: 'password'}).then //...
+ * ```
+ * To use SmartWait and wait for element to appear on a page, add `true` as second arg:
+ *
+ * ```js
+ * this.helpers['Protractor']._locate({name: 'password'}, true).then //...
+ * ```
+ *
+ * @name _locate
+ * @kind function
+ * @memberof Protractor
+ * @scope instance
+ */
+var __locate;

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -227,7 +227,7 @@ class SeleniumWebdriver extends Helper {
 
   _smartWait(fn, enabled = true) {
     if (!this.options.smartWait || !enabled) return fn();
-    this.debugSection('SmartWait', 'Enabled for '+fn.toString());
+    this.debugSection('SmartWait', 'Enabled for ' + fn.toString());
     this.browser.manage().timeouts().implicitlyWait(this.options.smartWait);
     let res = fn();
     this.browser.manage().timeouts().implicitlyWait(0);

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -44,6 +44,7 @@ let withinStore = {};
  * * `browser` - browser in which perform testing
  * * `driver` - which protrator driver to use (local, direct, session, hosted, sauce, browserstack). By default set to 'hosted' which requires selenium server to be started.
  * * `restart` - restart browser between tests (default: true).
+ * * `smartWait`: (optional) **enables SmartWait**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
  * * `keepCookies` (optional, default: false)  - keep cookies between tests when `restart` set to false.*
  * * `seleniumAddress` - Selenium address to connect (default: http://localhost:4444/wd/hub)
  * * `waitForTimeout`: (optional) sets default wait time in _ms_ for all `wait*` functions. 1000 by default;
@@ -51,6 +52,21 @@ let withinStore = {};
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
  * * `manualStart` (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriverIO"]._startBrowser()`
  * * `capabilities`: {} - list of [Desired Capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
+ *
+ * Example:
+ *
+ * ```json
+ * {
+ *    "helpers": {
+ *      "SeleniumWebdriver" : {
+ *        "url": "http://localhost",
+ *        "browser": "chrome",
+ *        "smartWait": 5000,
+ *        "restart": false
+ *      }
+ *    }
+ * }
+ * ```
  *
  * ## Access From Helpers
  *
@@ -77,6 +93,7 @@ class SeleniumWebdriver extends Helper {
       waitForTimeout: 1000, // ms
       scriptTimeout: 1000, // ms
       manualStart: false,
+      smartWait: 0,
       capabilities: {}
     };
 
@@ -197,9 +214,24 @@ class SeleniumWebdriver extends Helper {
    * ```js
    * this.helpers['SeleniumWebdriver']._locate({name: 'password'}).then //...
    * ```
+   * To use SmartWait and wait for element to appear on a page, add `true` as second arg:
+   *
+   * ```js
+   * this.helpers['SeleniumWebdriver']._locate({name: 'password'}, true).then //...
+   * ```
+   *
    */
-  _locate(locator) {
-    return this.browser.findElements(guessLocator(locator));
+  _locate(locator, smartWait = false) {
+    return this._smartWait(() => this.browser.findElements(guessLocator(locator)), smartWait);
+  }
+
+  _smartWait(fn, enabled = true) {
+    if (!this.options.smartWait || !enabled) return fn();
+    this.debugSection('SmartWait', 'Enabled for '+fn.toString());
+    this.browser.manage().timeouts().implicitlyWait(this.options.smartWait);
+    let res = fn();
+    this.browser.manage().timeouts().implicitlyWait(0);
+    return res;
   }
 
   /**
@@ -218,9 +250,9 @@ class SeleniumWebdriver extends Helper {
   click(locator, context = null) {
     let matcher = this.browser;
     if (context) {
-      matcher = matcher.findElement(guessLocator(context) || by.css(context));
+      matcher = this._smartWait(() => matcher.findElement(guessLocator(context) || by.css(context)));
     }
-    return co(findClickable(matcher, locator)).then((el) => el.click());
+    return co(findClickable.call(this, matcher, locator)).then((el) => el.click());
   }
 
   /**
@@ -229,9 +261,9 @@ class SeleniumWebdriver extends Helper {
   doubleClick(locator, context = null) {
     let matcher = this.browser;
     if (context) {
-      matcher = matcher.findElement(guessLocator(context) || by.css(context));
+      matcher = this._smartWait(() => matcher.findElement(guessLocator(context) || by.css(context)));
     }
-    return co(findClickable(matcher, locator)).then((el) => this.browser.actions().doubleClick(el).perform());
+    return co(findClickable.call(this, matcher, locator)).then((el) => this.browser.actions().doubleClick(el).perform());
   }
 
   /**
@@ -473,7 +505,7 @@ class SeleniumWebdriver extends Helper {
    * {{> ../webapi/seeElement }}
    */
   seeElement(locator) {
-    return this.browser.findElements(guessLocator(locator) || by.css(locator)).then((els) => {
+    return this._smartWait(() => this.browser.findElements(guessLocator(locator) || by.css(locator))).then((els) => {
       return Promise.all(els.map((el) => el.isDisplayed())).then((els) => {
         return empty('elements').negate(els.filter((v) => v).fill('ELEMENT'));
       });
@@ -828,7 +860,8 @@ function proceedSee(assertType, text, context) {
     locator = guessLocator(context) || by.css(context);
     description = 'element ' + context;
   }
-  return this.browser.findElements(locator).then(co.wrap(function*(els) {
+  let enableSmartWait = !!this.context && assertType == 'assert';
+  return this._smartWait(() => this.browser.findElements(locator), enableSmartWait).then(co.wrap(function*(els) {
     let promises = [];
     let source = '';
     els.forEach(el => promises.push(el.getText().then((elText) => source += '| ' + elText)));
@@ -872,7 +905,7 @@ function *proceedIsChecked(assertType, option) {
 function *findClickable(matcher, locator) {
   let l = guessLocator(locator);
   if (guessLocator(locator)) {
-    return matcher.findElement(l);
+    return this._smartWait(() => matcher.findElement(l));
   }
 
   let literal = xpathLocator.literal(locator);

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1076,7 +1076,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   grabNumberOfVisibleElements(locator) {
-    return this.browser.elements(locator).then(function (res) {
+    return this.browser.elements(locator).then((res) => {
       if (!res.value || res.value.length === 0) {
         return 0;
       }
@@ -1423,7 +1423,7 @@ class WebDriverIO extends Helper {
         return this.elementIdLocation(elem.ELEMENT).then(function (location) {
           if (!location.value || location.value.length === 0) {
             throw new Error(
-              `Failed to recieve (${srcElement}) location`);
+              `Failed to receive (${srcElement}) location`);
           }
           return this.touchDown(location.value.x, location.value.y).then(function (res) {
             if (res.state !== 'success') throw new Error(`Failed to touch button down on (${srcElement})`);
@@ -1626,14 +1626,14 @@ class WebDriverIO extends Helper {
   waitForValue(context, value, sec = null) {
     let client = this.browser;
     sec = sec || this.options.waitForTimeout;
-    return client.waitUntil(function () {
-      return findFields(client, context).then(function (res) {
+    return client.waitUntil(() => {
+      return findFields.call(this, field).then((res) => {
         if (!res.value || res.value.length === 0) {
           return false;
         }
         let commands = [];
-        res.value.forEach((el) => commands.push(this.elementIdAttribute(el.ELEMENT, "value")));
-        return this.unify(commands, {
+        res.value.forEach((el) => commands.push(this.browser.elementIdAttribute(el.ELEMENT, "value")));
+        return this.browser.unify(commands, {
           extractValue: true
         }).then((selected) => {
           if (Array.isArray(selected)) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1620,10 +1620,14 @@ class WebDriverIO extends Helper {
    * Waits for the specified value to be in value attribute
    *
    * ```js
-   * I.waitForValue("GoodValue", '//input');
+   * I.waitForValue('//input', "GoodValue");
    * ```
+   *
+   * @param field input field
+   * @param value expcted value
+   * @param sec seconds to wait, 1 sec by default
    */
-  waitForValue(context, value, sec = null) {
+  waitForValue(field, value, sec = null) {
     let client = this.browser;
     sec = sec || this.options.waitForTimeout;
     return client.waitUntil(() => {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -44,9 +44,9 @@ let withinStore = {};
  * * `url` - base url of website to be tested
  * * `browser` - browser in which perform testing
  * * `restart` (optional, default: true) - restart browser between tests.
+ * * `smartWait`: (optional) **enables SmartWait**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
  * * `keepCookies` (optional, default: false)  - keep cookies between tests when `restart` set to false.
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
- * * `smartWait`: (optional) enables SmartWait; wait for additional milliseconds for element to appear. Disabled by default
  * * `waitForTimeout`: (option) sets default wait time in *ms* for all `wait*` functions. 1000 by default;
  * * `desiredCapabilities`: Selenium's [desired
  * capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
@@ -71,7 +71,6 @@ let withinStore = {};
  *      }
  *    }
  * }
- *
  * ```
  *
  * Additional configuration params can be used from [webdriverio
@@ -390,11 +389,7 @@ class WebDriverIO extends Helper {
 
     return this.defineTimeout({implicit: this.options.smartWait})
       .then(() => this.debugSection('SmartWait', `Locating ${locator} in ${this.options.wait}`))
-      .then(() => {
-        return els = this.browser.elements(withStrictLocator(locator));
-      })
-      .then(() => this.defineTimeout({implicit: this.options.timeouts.implicit || 0}))
-      .then(() => els);
+      .then(() => this.browser.elements(withStrictLocator(locator)));
   }
 
   /**
@@ -511,21 +506,20 @@ class WebDriverIO extends Helper {
    * Appium: support, but in apps works as usual click
    */
   rightClick(locator) {
-    let client = this.browser;
     /**
      * just press button if no selector is given
      */
     if (locator === undefined) {
-      return client.buttonPress("right");
+      return this.browser.buttonPress("right");
     }
-    return this._locate(locator, true).then(function (res) {
+    return this._locate(locator, true).then((res) => {
       if (!res.value || res.value.length === 0) {
         if (typeof locator === "object") locator = JSON.stringify(locator);
         throw new Error(`Clickable element ${locator.toString()} was not found by text|CSS|XPath`);
       }
       let elem = res.value[0];
-      if (client.isMobile) return this.touchClick(elem.ELEMENT);
-      return this.moveTo(elem.ELEMENT).buttonPress("right");
+      if (this.browser.isMobile) return this.browser.touchClick(elem.ELEMENT);
+      return this.browser.moveTo(elem.ELEMENT).buttonPress("right");
     });
   }
 
@@ -534,12 +528,12 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   fillField(field, value) {
-    return findFields.call(this, field).then(function (res) {
+    return findFields.call(this, field).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
       }
       let elem = res.value[0];
-      return this.elementIdClear(elem.ELEMENT).elementIdValue(elem.ELEMENT, value);
+      return this.browser.elementIdClear(elem.ELEMENT).elementIdValue(elem.ELEMENT, value);
     });
   }
 
@@ -548,12 +542,12 @@ class WebDriverIO extends Helper {
    * Appium: support, but it's clear a field before insert in apps
    */
   appendField(field, value) {
-    return findFields.call(this, field).then(function (res) {
+    return findFields.call(this, field).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
       }
       let elem = res.value[0];
-      return this.elementIdValue(elem.ELEMENT, value);
+      return this.browser.elementIdValue(elem.ELEMENT, value);
     });
   }
 
@@ -561,7 +555,7 @@ class WebDriverIO extends Helper {
    * {{> ../webapi/selectOption}}
    */
   selectOption(select, option) {
-    return findFields.call(this, select).then(function (res) {
+    return findFields.call(this, select).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Selectable field ${select} not found by name|text|CSS|XPath`);
       }
@@ -577,30 +571,30 @@ class WebDriverIO extends Helper {
       option.forEach((opt) => {
         normalized = `[normalize-space(.) = "${opt.trim() }"]`;
         byVisibleText = `./option${normalized}|./optgroup/option${normalized}`;
-        commands.push(this.elementIdElements(elem.ELEMENT, byVisibleText));
+        commands.push(this.browser.elementIdElements(elem.ELEMENT, byVisibleText));
       });
-      return this.unify(commands, {
+      return this.browser.unify(commands, {
         extractValue: true
       }).then((els) => {
         commands = [];
         let clickOptionFn = (el) => {
           if (el[0]) el = el[0];
-          if (el && el.ELEMENT) commands.push(this.elementIdClick(el.ELEMENT));
+          if (el && el.ELEMENT) commands.push(this.browser.elementIdClick(el.ELEMENT));
         };
 
         if (els.length) {
           els.forEach(clickOptionFn);
-          return this.unify(commands);
+          return this.browser.unify(commands);
         }
         let normalized, byValue;
 
         option.forEach((opt) => {
           normalized = `[normalize-space(@value) = "${opt.trim() }"]`;
           byValue = `./option${normalized}|./optgroup/option${normalized}`;
-          commands.push(this.elementIdElements(elem.ELEMENT, byValue));
+          commands.push(this.browser.elementIdElements(elem.ELEMENT, byValue));
         });
         // try by value
-        return this.unify(commands, {
+        return this.browser.unify(commands, {
           extractValue: true
         }).then((els) => {
           if (els.length === 0) {
@@ -608,7 +602,7 @@ class WebDriverIO extends Helper {
           }
           commands = [];
           els.forEach(clickOptionFn);
-          return this.unify(commands);
+          return this.browser.unify(commands);
         });
       });
     });
@@ -815,13 +809,13 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   seeElement(locator) {
-    return this._locate(locator, true).then(function (res) {
+    return this._locate(locator, true).then((res) => {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${locator}`, 'to be seen').assert(false);
       }
       let commands = [];
-      res.value.forEach((el) => commands.push(this.elementIdDisplayed(el.ELEMENT)));
-      return this.unify(commands, {
+      res.value.forEach((el) => commands.push(this.browser.elementIdDisplayed(el.ELEMENT)));
+      return this.browser.unify(commands, {
         extractValue: true
       }).then((selected) => {
         return truth(`elements of ${locator}`, 'to be seen').assert(selected);
@@ -834,13 +828,13 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   dontSeeElement(locator) {
-    return this.browser.elements(withStrictLocator(locator)).then(function (res) {
+    return this.browser.elements(withStrictLocator(locator)).then((res) => {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${locator}`, 'to be seen').negate(false);
       }
       let commands = [];
-      res.value.forEach((el) => commands.push(this.elementIdDisplayed(el.ELEMENT)));
-      return this.unify(commands, {
+      res.value.forEach((el) => commands.push(this.browser.elementIdDisplayed(el.ELEMENT)));
+      return this.browser.unify(commands, {
         extractValue: true
       }).then((selected) => {
         return truth(`elements of ${locator}`, 'to be seen').negate(selected);
@@ -921,13 +915,13 @@ class WebDriverIO extends Helper {
    * ```
    */
   seeNumberOfVisibleElements(locator, num) {
-    return this._locate(locator).then(function (res) {
+    return this._locate(locator).then((res) => {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${selector}`, 'to be seen').assert(false);
       }
       let commands = [];
-      res.value.forEach((el) => commands.push(this.elementIdDisplayed(el.ELEMENT)));
-      return this.unify(commands, {
+      res.value.forEach((el) => commands.push(this.browser.elementIdDisplayed(el.ELEMENT)));
+      return this.browser.unify(commands, {
         extractValue: true
       }).then((selected) => {
         if (!Array.isArray(selected)) selected = [selected];
@@ -1021,19 +1015,19 @@ class WebDriverIO extends Helper {
         }
         let elem = res.value[0];
         if (client.isMobile) return this.touchScroll(elem.ELEMENT, offsetX, offsetY);
-        return this.elementIdLocation(elem.ELEMENT).then(function (location) {
+        return client.elementIdLocation(elem.ELEMENT).then(function (location) {
           if (!location.value || location.value.length === 0) {
             throw new Error(
-            `Failed to recieve (${locator}) location`);
+            `Failed to receive (${locator}) location`);
           }
-          return this.execute(function scroll(x, y) {
+          return client.execute(function scroll(x, y) {
             return window.scrollTo(x, y);
           }, location.value.x + offsetX, location.value.y + offsetY);
         });
       });
     } else {
       if (client.isMobile) return client.touchScroll(locator, offsetX, offsetY);
-      return this.execute(function scroll(x, y) {
+      return client.execute(function scroll(x, y) {
         return window.scrollTo(x, y);
       }, offsetX, offsetY);
     }
@@ -1050,15 +1044,15 @@ class WebDriverIO extends Helper {
       hasOffsetParams = false;
     }
 
-    return this._locate(withStrictLocator(locator), true).then(function (res) {
+    return this._locate(withStrictLocator(locator), true).then((res) => {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${locator}`, 'to be seen').assert(false);
       }
       let elem = res.value[0];
       if (client.isMobile) {
-        return this.elementIdSize(elem.ELEMENT).then(function (size) {
+        return client.elementIdSize(elem.ELEMENT).then(function (size) {
           if (!size.value || size.value.length === 0) throw new Error(`Failed to recieve (${locator}) size`);
-          return this.elementIdLocation(elem.ELEMENT).then(function (location) {
+          return client.elementIdLocation(elem.ELEMENT).then(function (location) {
             if (!location.value || location.value.length === 0) {
               throw new Error(
               `Failed to recieve (${locator}) location`);
@@ -1070,12 +1064,12 @@ class WebDriverIO extends Helper {
               x = location.value.x + offsetX;
               y = location.value.y + offsetY;
             }
-            return this.touchMove(x, y);
+            return client.touchMove(x, y);
           });
         });
       }
 
-      return this.moveTo(elem.ELEMENT, offsetX, offsetY);
+      return client.moveTo(elem.ELEMENT, offsetX, offsetY);
     });
   }
 
@@ -1130,12 +1124,12 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   clearField(field) {
-    return findFields.call(this, field).then(function (res) {
+    return findFields.call(this, field).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
       }
       let elem = res.value[0];
-      return this.elementIdClear(elem.ELEMENT);
+      return this.browser.elementIdClear(elem.ELEMENT);
     });
 
   }
@@ -1281,7 +1275,7 @@ class WebDriverIO extends Helper {
               return this.elementIdLocation(elem.ELEMENT).then(function (location) {
                 if (!location.value || location.value.length === 0) {
                   throw new Error(
-                  `Failed to recieve (${destElement}) location`);
+                  `Failed to receive (${destElement}) location`);
                 }
                 return this.touchMove(location.value.x, location.value.y).then(function (res) {
                   if (res.state !== 'success') throw new Error(`Failed to touch move to (${destElement})`);
@@ -1346,8 +1340,8 @@ class WebDriverIO extends Helper {
           return false;
         }
         let commands = [];
-        res.value.forEach((el) => commands.push(this.elementIdEnabled(el.ELEMENT)));
-        return this.unify(commands, {
+        res.value.forEach((el) => commands.push(client.elementIdEnabled(el.ELEMENT)));
+        return client.unify(commands, {
           extractValue: true
         }).then((selected) => {
           if (Array.isArray(selected)) {
@@ -1389,8 +1383,8 @@ class WebDriverIO extends Helper {
           return false;
         }
         let commands = [];
-        res.value.forEach((el) => commands.push(this.elementIdText(el.ELEMENT)));
-        return this.unify(commands, {
+        res.value.forEach((el) => commands.push(client.elementIdText(el.ELEMENT)));
+        return client.unify(commands, {
           extractValue: true
         }).then((selected) => {
           if (Array.isArray(selected)) {
@@ -1416,8 +1410,8 @@ class WebDriverIO extends Helper {
           return false;
         }
         let commands = [];
-        res.value.forEach((el) => commands.push(this.elementIdDisplayed(el.ELEMENT)));
-        return this.unify(commands, {
+        res.value.forEach((el) => commands.push(client.elementIdDisplayed(el.ELEMENT)));
+        return client.unify(commands, {
           extractValue: true
         }).then((selected) => {
           if (Array.isArray(selected)) {
@@ -1442,8 +1436,8 @@ class WebDriverIO extends Helper {
           return true;
         }
         let commands = [];
-        res.value.forEach((el) => commands.push(this.elementIdDisplayed(el.ELEMENT)));
-        return this.unify(commands, {
+        res.value.forEach((el) => commands.push(client.elementIdDisplayed(el.ELEMENT)));
+        return client.unify(commands, {
           extractValue: true
         }).then((selected) => {
           if (Array.isArray(selected)) {
@@ -1496,11 +1490,11 @@ class WebDriverIO extends Helper {
   switchTo(locator = null) {
     if (Number.isInteger(locator)) return this.browser.frame(locator);
     if (typeof locator === 'undefined' || locator === null) return this.browser.frame(null);
-    return this.browser.element(withStrictLocator(locator)).then(function (res) {
+    return this.browser.element(withStrictLocator(locator)).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Element ${locator} not found by name|text|CSS|XPath`);
       }
-      return this.frame(res.value);
+      return this.browser.frame(res.value);
     });
   }
 
@@ -1522,14 +1516,13 @@ function proceedSee(assertType, text, context) {
 
   let smartWaitEnabled = assertType === 'assert';
 
-  return this._locate(withStrictLocator(context), smartWaitEnabled).then(function (res) {
+  return this._locate(withStrictLocator(context), smartWaitEnabled).then((res) => {
     if (!res.value || res.value.length === 0) {
       throw new Error(`${context} can't be located by name|text|CSS|XPath`);
     }
-
     let commands = [];
-    res.value.forEach((el) => commands.push(this.elementIdText(el.ELEMENT)));
-    return this.unify(commands, {
+    res.value.forEach((el) => commands.push(this.browser.elementIdText(el.ELEMENT)));
+    return this.browser.unify(commands, {
       extractValue: true
     }).then((selected) => {
       return stringIncludes(description)[assertType](text, selected);
@@ -1594,21 +1587,21 @@ function findFields(locator) {
 }
 
 function proceedSeeField(assertType, field, value) {
-  return findFields.call(this, field).then(function (res) {
+  return findFields.call(this, field).then((res) => {
     if (!res.value || res.value.length === 0) {
       throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
     }
 
     var proceedMultiple = (fields) => {
       let commands = [];
-      fields.forEach((el) => commands.push(this.elementIdSelected(el.ELEMENT)));
-      this.unify(commands).then(() => {
+      fields.forEach((el) => commands.push(this.browser.elementIdSelected(el.ELEMENT)));
+      this.browser.unify(commands).then(() => {
         commands = [];
         fields.forEach((el) => {
           if (el.value === false) return;
-          commands.push(this.elementIdAttribute(el.ELEMENT, 'value'));
+          commands.push(this.browser.elementIdAttribute(el.ELEMENT, 'value'));
         });
-        this.unify(commands, {
+        this.browser.unify(commands, {
           extractValue: true
         }).then((val) => {
           return stringIncludes('fields by ' + field)[assertType](value, val);
@@ -1617,18 +1610,18 @@ function proceedSeeField(assertType, field, value) {
     };
 
     var proceedSingle = (el) => {
-      return this.elementIdAttribute(el.ELEMENT, 'value').then((res) => {
+      return this.browser.elementIdAttribute(el.ELEMENT, 'value').then((res) => {
         return stringIncludes('fields by ' + field)[assertType](value, res.value);
       });
     };
 
-    return this.elementIdName(res.value[0].ELEMENT).then((tag) => {
+    return this.browser.elementIdName(res.value[0].ELEMENT).then((tag) => {
       if (tag.value === 'select') {
         return proceedMultiple(res.value);
       }
 
       if (tag.value === 'input') {
-        return this.elementIdAttribute(res.value[0].ELEMENT, 'type').then((type) => {
+        return this.browser.elementIdAttribute(res.value[0].ELEMENT, 'type').then((type) => {
           if (type.value === 'checkbox' || type.value === 'radio') {
             return proceedMultiple(res.value);
           }
@@ -1641,13 +1634,13 @@ function proceedSeeField(assertType, field, value) {
 }
 
 function proceedSeeCheckbox(assertType, field) {
-  return findFields.call(this, field).then(function (res) {
+  return findFields.call(this, field).then((res) => {
     if (!res.value || res.value.length === 0) {
       throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
     }
     let commands = [];
-    res.value.forEach((el) => commands.push(this.elementIdSelected(el.ELEMENT)));
-    return this.unify(commands, {
+    res.value.forEach((el) => commands.push(this.browser.elementIdSelected(el.ELEMENT)));
+    return this.browser.unify(commands, {
       extractValue: true
     }).then((selected) => {
       return truth(`checkable field ${field}`, 'to be checked')[assertType](selected);

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -9,7 +9,6 @@ const xpathLocator = require('../utils').xpathLocator;
 const hashCode = require('../utils').hashCode;
 const fileExists = require('../utils').fileExists;
 const clearString = require('../utils').clearString;
-const co = require('co');
 const assert = require('assert');
 const path = require('path');
 const requireg = require('requireg');

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -47,7 +47,7 @@ let withinStore = {};
  * * `restart` (optional, default: true) - restart browser between tests.
  * * `keepCookies` (optional, default: false)  - keep cookies between tests when `restart` set to false.
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
- * * `smartWait`: (optional) enables SmartWait; wait for more for element to appear. Default: 1000, set `null` to disable.
+ * * `smartWait`: (optional) enables SmartWait; wait for additional milliseconds for element to appear. Disabled by default
  * * `waitForTimeout`: (option) sets default wait time in *ms* for all `wait*` functions. 1000 by default;
  * * `desiredCapabilities`: Selenium's [desired
  * capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
@@ -208,7 +208,7 @@ class WebDriverIO extends Helper {
     this.root = webRoot;
 
     this.options = {
-      smarWait: 1000, // smart wait enabled
+      smartWait: 0, // smart wait enabled
       waitForTimeout: 1000, // ms
       desiredCapabilities: {},
       restart: true,

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1624,7 +1624,7 @@ class WebDriverIO extends Helper {
    * ```
    *
    * @param field input field
-   * @param value expcted value
+   * @param value expected value
    * @param sec seconds to wait, 1 sec by default
    */
   waitForValue(field, value, sec = null) {
@@ -1647,7 +1647,7 @@ class WebDriverIO extends Helper {
         });
       });
     }, sec * 1000,
-      `element (${context}) is not in DOM or there is no element(${context}) with value "${value}" after ${sec} sec`);
+      `element (${field}) is not in DOM or there is no element(${field}) with value "${value}" after ${sec} sec`);
   }
 
   /**

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -441,22 +441,22 @@ class WebDriverIO extends Helper {
    * ```
    */
   defineTimeout(timeouts) {
-    let p = Promise.resolve();
+    let p = [];
     if (timeouts.implicit) {
-      p = this.browser.timeouts('implicit', timeouts.implicit);
+      p.push(this.browser.timeouts('implicit', timeouts.implicit));
     }
     if (timeouts['page load']) {
-      p = this.browser.timeouts('page load', timeouts['page load']);
+      p.push(this.browser.timeouts('page load', timeouts['page load']));
     }
     // both pageLoad and page load are accepted
     // see http://webdriver.io/api/protocol/timeouts.html
     if (timeouts.pageLoad) {
-      p = this.browser.timeouts('pageLoad', timeouts.pageLoad);
+      p.push(this.browser.timeouts('pageLoad', timeouts.pageLoad));
     }
     if (timeouts.script) {
-      p = this.browser.timeouts('script', timeouts.script);
+      p.push(this.browser.timeouts('script', timeouts.script));
     }
-    return p; // return the last response
+    return Promise.all(p); // return the last response
   }
 
   /**

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -44,7 +44,7 @@ let withinStore = {};
  * * `url` - base url of website to be tested
  * * `browser` - browser in which perform testing
  * * `restart` (optional, default: true) - restart browser between tests.
- * * `smartWait`: (optional) **enables SmartWait**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
+ * * `smartWait`: (optional) **enables [SmartWait](http://codecept.io/acceptance/#smartwait)**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000
  * * `keepCookies` (optional, default: false)  - keep cookies between tests when `restart` set to false.
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
  * * `waitForTimeout`: (option) sets default wait time in *ms* for all `wait*` functions. 1000 by default;
@@ -206,7 +206,7 @@ class WebDriverIO extends Helper {
     this.root = webRoot;
 
     this.options = {
-      smartWait: 0, // smart wait enabled
+      smartWait: 0,
       waitForTimeout: 1000, // ms
       desiredCapabilities: {},
       restart: true,

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -813,7 +813,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   seeTextEquals(text, context = null) {
-    return proceedSeeEquals.call(this, 'assert', text, context);
+    return proceedSee.call(this, 'assert', text, context, true);
   }
 
   /**
@@ -1889,7 +1889,7 @@ class WebDriverIO extends Helper {
 
 }
 
-function proceedSee(assertType, text, context) {
+function proceedSee(assertType, text, context, strict = false) {
   let description;
   if (!context) {
     if (this.context === webRoot) {
@@ -1914,43 +1914,13 @@ function proceedSee(assertType, text, context) {
     return this.browser.unify(commands, {
       extractValue: true
     }).then((selected) => {
+      if (strict) return equals(description)[assertType](text, selected);
       return stringIncludes(description)[assertType](text, selected);
     });
   });
 }
 
-function proceedSeeEquals(assertType, text, context) {
-  let description;
-  if (!context) {
-    if (this.context === webRoot) {
-      context = this.context;
-      description = 'web page';
-    } else {
-      description = 'current context ' + this.context;
-      context = './/*';
-    }
-  } else {
-    description = 'element ' + context;
-  }
-
-  let client = this.browser;
-
-  return client.elements(withStrictLocator(context)).then(function (res) {
-    if (!res.value || res.value.length === 0) {
-      throw new Error(`${context} can't be located by name|text|CSS|XPath`);
-    }
-
-    let commands = [];
-    res.value.forEach((el) => commands.push(this.elementIdText(el.ELEMENT)));
-    return this.unify(commands, {
-      extractValue: true
-    }).then((selected) => {
-      return equals(description)[assertType](text, selected);
-    });
-  });
-}
-
-function findClickable(client, locator) {
+function findClickable(locator, locateFn) {
   if (typeof locator === 'object') return locateFn(withStrictLocator(locator), true);
   if (isCSSorXPathLocator(locator)) return locateFn(locator, true);
 

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -648,7 +648,7 @@ class WebDriverIO extends Helper {
         throw new Error(`Checkable ${field} cant be located by name|text|CSS|XPath`);
       }
       let elem = res.value[0];
-      return client.elementIdSelected(elem.ELEMENT).then(function (isSelected) {
+      return this.browser.elementIdSelected(elem.ELEMENT).then(function (isSelected) {
         if (isSelected.value) return true;
         return this[clickMethod](elem.ELEMENT);
       });

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -385,13 +385,13 @@ class WebDriverIO extends Helper {
    */
   _locate(locator, smartWait = false) {
 
-    if (!this.options.smartWait || !smartWait) return this.browser.elements(locator);
+    if (!this.options.smartWait || !smartWait) return this.browser.elements(withStrictLocator(locator));
     let els;
 
     return this.defineTimeout({implicit: this.options.smartWait})
       .then(() => this.debugSection('SmartWait', `Locating ${locator} in ${this.options.wait}`))
       .then(() => {
-        return els = this.browser.elements(locator);
+        return els = this.browser.elements(withStrictLocator(locator));
       })
       .then(() => this.defineTimeout({implicit: this.options.timeouts.implicit || 0}))
       .then(() => els);
@@ -502,7 +502,7 @@ class WebDriverIO extends Helper {
         throw new Error(`Clickable element ${locator.toString()} was not found by text|CSS|XPath`);
       }
       let elem = res.value[0];
-      return this.moveTo(elem.ELEMENT).doDoubleClick();
+      return this.browser.moveTo(elem.ELEMENT).doDoubleClick();
     });
   }
 
@@ -1655,7 +1655,7 @@ function proceedSeeCheckbox(assertType, field) {
   });
 }
 
-function findCheckable(locator) {
+function findCheckable(locator, locateFn) {
   if (typeof locator === 'object') return locateFn(withStrictLocator(locator), true);
   if (isCSSorXPathLocator(locator)) return locateFn(locator, true);
 

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -9,10 +9,12 @@ const xpathLocator = require('../utils').xpathLocator;
 const hashCode = require('../utils').hashCode;
 const fileExists = require('../utils').fileExists;
 const clearString = require('../utils').clearString;
+const co = require('co');
 const assert = require('assert');
 const path = require('path');
 const requireg = require('requireg');
 const webRoot = 'body';
+
 
 let withinStore = {};
 
@@ -45,6 +47,7 @@ let withinStore = {};
  * * `restart` (optional, default: true) - restart browser between tests.
  * * `keepCookies` (optional, default: false)  - keep cookies between tests when `restart` set to false.
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
+ * * `smartWait`: (optional) enables SmartWait; wait for more for element to appear. Default: 1000, set `null` to disable.
  * * `waitForTimeout`: (option) sets default wait time in *ms* for all `wait*` functions. 1000 by default;
  * * `desiredCapabilities`: Selenium's [desired
  * capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
@@ -58,13 +61,13 @@ let withinStore = {};
  * {
  *    "helpers": {
  *      "WebDriverIO" : {
+ *        "smartWait": 5000,
  *        "browser": "chrome",
  *        "restart": false,
  *        "windowSize": "maximize",
  *        "timeouts": {
  *          "script": 60000,
- *          "page load": 10000,
- *          "implicit" : 5000
+ *          "page load": 10000
  *        }
  *      }
  *    }
@@ -205,6 +208,7 @@ class WebDriverIO extends Helper {
     this.root = webRoot;
 
     this.options = {
+      smarWait: 1000, // smart wait enabled
       waitForTimeout: 1000, // ms
       desiredCapabilities: {},
       restart: true,
@@ -380,8 +384,18 @@ class WebDriverIO extends Helper {
    * this.helpers['WebDriverIO']._locate({name: 'password'}).then //...
    * ```
    */
-  _locate(locator) {
-    return this.browser.elements(withStrictLocator(locator));
+  _locate(locator, smartWait = false) {
+
+    if (!this.options.smartWait || !smartWait) return this.browser.elements(locator);
+    let els;
+
+    return this.defineTimeout({implicit: this.options.smartWait})
+      .then(() => this.debugSection('SmartWait', `Locating ${locator} in ${this.options.wait}`))
+      .then(() => {
+        return els = this.browser.elements(locator);
+      })
+      .then(() => this.defineTimeout({implicit: this.options.timeouts.implicit || 0}))
+      .then(() => els);
   }
 
   /**
@@ -392,9 +406,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   _locateCheckable(locator) {
-    return findCheckable(this.browser, locator).then(function (res) {
-      return res.value;
-    });
+    return findCheckable(locator, this.browser.elements.bind(this)).then((res) => res.value);
   }
 
   /**
@@ -405,9 +417,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   _locateClickable(locator) {
-    return findClickable(this.browser, locator).then(function (res) {
-      return res.value;
-    });
+    return findClickable(locator, this.browser.elements.bind(this)).then((res) => res.value);
   }
 
   /**
@@ -418,9 +428,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   _locateFields(locator) {
-    return findFields(this.browser, locator).then(function (res) {
-      return res.value;
-    });
+    return findFields.call(this, locator).then((res) => res.value);
   }
 
   /**
@@ -430,19 +438,26 @@ class WebDriverIO extends Helper {
    *
    * ```js
    * I.defineTimeout({ script: 5000 });
-   * I.defineTimeout({ implicit: 10000, "page load": 10000, script: 5000 });
+   * I.defineTimeout({ implicit: 10000, pageLoad: 10000, script: 5000 });
    * ```
    */
   defineTimeout(timeouts) {
+    let p = Promise.resolve();
     if (timeouts.implicit) {
-      this.browser.timeouts('implicit', timeouts.implicit);
+      p = this.browser.timeouts('implicit', timeouts.implicit);
     }
     if (timeouts['page load']) {
-      this.browser.timeouts('page load', timeouts['page load']);
+      p = this.browser.timeouts('page load', timeouts['page load']);
+    }
+    // both pageLoad and page load are accepted
+    // see http://webdriver.io/api/protocol/timeouts.html
+    if (timeouts.pageLoad) {
+      p = this.browser.timeouts('pageLoad', timeouts.pageLoad);
     }
     if (timeouts.script) {
-      this.browser.timeouts('script', timeouts.script);
+      p = this.browser.timeouts('script', timeouts.script);
     }
+    return p; // return the last response
   }
 
   /**
@@ -461,18 +476,16 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   click(locator, context = null) {
-    let client = this.browser;
     let clickMethod = this.browser.isMobile ? 'touchClick' : 'elementIdClick';
-    if (context) {
-      client = client.element(context);
-    }
-    return findClickable(client, locator).then(function (res) {
+    let locateFn = prepareLocateFn.call(this, context);
+
+    return findClickable(locator, locateFn).then((res) => {
       if (!res.value || res.value.length === 0) {
         if (typeof locator === "object") locator = JSON.stringify(locator);
-        throw new Error(`Clickable element ${locator.toString()} was not found by text|CSS|XPath`);
+        if (context) locator += ` inside ${context}`;
+        throw new Error(`Clickable element ${locator} was not found by text|CSS|XPath`);
       }
-      let elem = res.value[0];
-      return this[clickMethod](elem.ELEMENT);
+      return this.browser[clickMethod](res.value[0].ELEMENT);
     });
   }
 
@@ -481,11 +494,10 @@ class WebDriverIO extends Helper {
    * Appium: support only web testing
    */
   doubleClick(locator, context = null) {
-    let client = this.browser;
-    if (context) {
-      client = client.element(context);
-    }
-    return findClickable(client, locator).then(function (res) {
+    let clickMethod = this.browser.isMobile ? 'touchClick' : 'elementIdClick';
+    let locateFn = prepareLocateFn.call(this, context);
+
+    return findClickable(locator, locateFn).then((res) => {
       if (!res.value || res.value.length === 0) {
         if (typeof locator === "object") locator = JSON.stringify(locator);
         throw new Error(`Clickable element ${locator.toString()} was not found by text|CSS|XPath`);
@@ -507,7 +519,7 @@ class WebDriverIO extends Helper {
     if (locator === undefined) {
       return client.buttonPress("right");
     }
-    return this._locate(locator).then(function (res) {
+    return this._locate(locator, true).then(function (res) {
       if (!res.value || res.value.length === 0) {
         if (typeof locator === "object") locator = JSON.stringify(locator);
         throw new Error(`Clickable element ${locator.toString()} was not found by text|CSS|XPath`);
@@ -523,7 +535,7 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   fillField(field, value) {
-    return findFields(this.browser, field).then(function (res) {
+    return findFields.call(this, field).then(function (res) {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
       }
@@ -537,7 +549,7 @@ class WebDriverIO extends Helper {
    * Appium: support, but it's clear a field before insert in apps
    */
   appendField(field, value) {
-    return findFields(this.browser, field).then(function (res) {
+    return findFields.call(this, field).then(function (res) {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
       }
@@ -550,7 +562,7 @@ class WebDriverIO extends Helper {
    * {{> ../webapi/selectOption}}
    */
   selectOption(select, option) {
-    return findFields(this.browser, select).then(function (res) {
+    return findFields.call(this, select).then(function (res) {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Selectable field ${select} not found by name|text|CSS|XPath`);
       }
@@ -612,7 +624,7 @@ class WebDriverIO extends Helper {
     if (!fileExists(file)) {
       throw new Error(`File at ${file} can not be found on local system`);
     }
-    return findFields(this.browser, locator).then((el) => {
+    return findFields.call(this, locator).then((el) => {
       this.debug("Uploading " + file);
       return this.browser.uploadFile(file).then((res) => {
         if (!el.value || el.value.length === 0) {
@@ -628,12 +640,11 @@ class WebDriverIO extends Helper {
    * Appium: not tested
    */
   checkOption(field, context = null) {
-    let client = this.browser;
     let clickMethod = this.browser.isMobile ? 'touchClick' : 'elementIdClick';
-    if (context) {
-      client = client.element(withStrictLocator(context));
-    }
-    return findCheckable(client, field).then((res) => {
+
+    let locateFn = prepareLocateFn.call(this, context);
+
+    return findCheckable(field, locateFn).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Checkable ${field} cant be located by name|text|CSS|XPath`);
       }
@@ -651,7 +662,7 @@ class WebDriverIO extends Helper {
    */
   grabTextFrom(locator) {
     let client = this.browser;
-    return this._locate(locator).then((res) => {
+    return this._locate(locator, true).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`${locator} cant be located by name|text|CSS|XPath`);
       }
@@ -687,7 +698,7 @@ class WebDriverIO extends Helper {
    */
   grabValueFrom(locator) {
     let client = this.browser;
-    return this._locate(locator).then((res) => {
+    return this._locate(locator, true).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`${locator} cant be located by name|text|CSS|XPath`);
       }
@@ -707,7 +718,7 @@ class WebDriverIO extends Helper {
    */
   grabAttributeFrom(locator, attr) {
     let client = this.browser;
-    return this._locate(locator).then((res) => {
+    return this._locate(locator, true).then((res) => {
       if (!res.value || res.value.length === 0) {
         throw new Error(`${locator} cant be located by name|text|CSS|XPath`);
       }
@@ -805,7 +816,7 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   seeElement(locator) {
-    return this.browser.elements(withStrictLocator(locator)).then(function (res) {
+    return this._locate(locator, true).then(function (res) {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${locator}`, 'to be seen').assert(false);
       }
@@ -896,7 +907,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   seeNumberOfElements(selector, num) {
-    return this.browser.elements(withStrictLocator(selector))
+    return this._locate(withStrictLocator(selector))
       .then(function (res) {
         return assert.equal(res.value.length, num, `expected nummber of elements (${selector}) is ${num}, but found ${res.value.length}`);
       });
@@ -911,7 +922,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   seeNumberOfVisibleElements(locator, num) {
-    return this.browser.elements(locator).then(function (res) {
+    return this._locate(locator).then(function (res) {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${selector}`, 'to be seen').assert(false);
       }
@@ -1005,11 +1016,11 @@ class WebDriverIO extends Helper {
     }
 
     if (locator) {
-      return client.element(withStrictLocator(locator)).then(function (res) {
+      return this._locate(withStrictLocator(locator), true).then(function (res) {
         if (!res.value || res.value.length === 0) {
           return truth(`elements of ${locator}`, 'to be seen').assert(false);
         }
-        let elem = res.value;
+        let elem = res.value[0];
         if (client.isMobile) return this.touchScroll(elem.ELEMENT, offsetX, offsetY);
         return this.elementIdLocation(elem.ELEMENT).then(function (location) {
           if (!location.value || location.value.length === 0) {
@@ -1040,11 +1051,11 @@ class WebDriverIO extends Helper {
       hasOffsetParams = false;
     }
 
-    return client.element(withStrictLocator(locator)).then(function (res) {
+    return this._locate(withStrictLocator(locator), true).then(function (res) {
       if (!res.value || res.value.length === 0) {
         return truth(`elements of ${locator}`, 'to be seen').assert(false);
       }
-      let elem = res.value;
+      let elem = res.value[0];
       if (client.isMobile) {
         return this.elementIdSize(elem.ELEMENT).then(function (size) {
           if (!size.value || size.value.length === 0) throw new Error(`Failed to recieve (${locator}) size`);
@@ -1120,7 +1131,7 @@ class WebDriverIO extends Helper {
    * Appium: support
    */
   clearField(field) {
-    return findFields(this.browser, field).then(function (res) {
+    return findFields.call(this, field).then(function (res) {
       if (!res.value || res.value.length === 0) {
         throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
       }
@@ -1510,9 +1521,9 @@ function proceedSee(assertType, text, context) {
     description = 'element ' + context;
   }
 
-  let client = this.browser;
+  let smartWaitEnabled = assertType === 'assert';
 
-  return client.elements(withStrictLocator(context)).then(function (res) {
+  return this._locate(withStrictLocator(context), smartWaitEnabled).then(function (res) {
     if (!res.value || res.value.length === 0) {
       throw new Error(`${context} can't be located by name|text|CSS|XPath`);
     }
@@ -1527,9 +1538,9 @@ function proceedSee(assertType, text, context) {
   });
 }
 
-function findClickable(client, locator) {
-  if (typeof locator === 'object') return client.elements(withStrictLocator(locator));
-  if (isCSSorXPathLocator(locator)) return client.elements(locator);
+function findClickable(locator, locateFn) {
+  if (typeof locator === 'object') return locateFn(withStrictLocator(locator), true);
+  if (isCSSorXPathLocator(locator)) return locateFn(locator, true);
 
   let literal = xpathLocator.literal(locator);
 
@@ -1539,7 +1550,7 @@ function findClickable(client, locator) {
     `.//a/img[normalize-space(@alt)=${literal}]/ancestor::a`,
     `.//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][normalize-space(@value)=${literal}]`
   ]);
-  return client.elements(narrowLocator).then(function (els) {
+  return locateFn(narrowLocator).then(function (els) {
     if (els.value.length) {
       return els;
     }
@@ -1551,11 +1562,11 @@ function findClickable(client, locator) {
       `.//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][./@name = ${literal}]`,
       `.//button[./@name = ${literal}]`
     ]);
-    return client.elements(wideLocator).then(function (els) {
+    return locateFn(wideLocator).then(function (els) {
       if (els.value.length) {
         return els;
       }
-      return client.elements(locator); // by css or xpath
+      return locateFn(locator); // by css or xpath
     });
   });
 }
@@ -1564,27 +1575,27 @@ function toStrictLocator(locator) {
   if (locator[0] == '#') return;
 }
 
-function findFields(client, locator) {
-  if (typeof locator === 'object') return client.elements(withStrictLocator(locator));
-  if (isCSSorXPathLocator(locator)) return client.elements(locator);
+function findFields(locator) {
+  if (typeof locator === 'object') return this._locate(withStrictLocator(locator), true);
+  if (isCSSorXPathLocator(locator)) return this._locate(locator, true);
 
   let literal = xpathLocator.literal(locator);
   let byText = xpathLocator.combine([
     `.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@name = ${literal}) or ./@id = //label[contains(normalize-space(string(.)), ${literal})]/@for) or ./@placeholder = ${literal})]`,
     `.//label[contains(normalize-space(string(.)), ${literal})]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`
   ]);
-  return client.elements(byText).then((els) => {
+  return this._locate(byText).then((els) => {
     if (els.value.length) return els;
     let byName = `.//*[self::input | self::textarea | self::select][@name = ${literal}]`;
-    return client.elements(byName).then((els) => {
+    return this._locate(byName).then((els) => {
       if (els.value.length) return els;
-      return client.elements(locator); // by css or xpath
+      return this._locate(locator); // by css or xpath
     });
   });
 }
 
 function proceedSeeField(assertType, field, value) {
-  return findFields(this.browser, field).then(function (res) {
+  return findFields.call(this, field).then(function (res) {
     if (!res.value || res.value.length === 0) {
       throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
     }
@@ -1631,7 +1642,7 @@ function proceedSeeField(assertType, field, value) {
 }
 
 function proceedSeeCheckbox(assertType, field) {
-  return findFields(this.browser, field).then(function (res) {
+  return findFields.call(this, field).then(function (res) {
     if (!res.value || res.value.length === 0) {
       throw new Error(`Field ${field} not found by name|text|CSS|XPath`);
     }
@@ -1645,21 +1656,21 @@ function proceedSeeCheckbox(assertType, field) {
   });
 }
 
-function findCheckable(client, locator) {
-  if (typeof locator === 'object') return client.elements(withStrictLocator(locator));
-  if (isCSSorXPathLocator(locator)) return client.elements(locator);
+function findCheckable(locator) {
+  if (typeof locator === 'object') return locateFn(withStrictLocator(locator), true);
+  if (isCSSorXPathLocator(locator)) return locateFn(locator, true);
 
   let literal = xpathLocator.literal(locator);
   let byText = xpathLocator.combine([
     `.//input[@type = 'checkbox' or @type = 'radio'][(@id = //label[contains(normalize-space(string(.)), ${literal})]/@for) or @placeholder = ${literal}]`,
     `.//label[contains(normalize-space(string(.)), ${literal})]//input[@type = 'radio' or @type = 'checkbox']`
   ]);
-  return client.elements(byText).then(function (els) {
+  return locateFn(byText).then(function (els) {
     if (els.value.length) return els;
     let byName = `.//input[@type = 'checkbox' or @type = 'radio'][@name = ${literal}]`;
-    return client.elements(byName).then(function (els) {
+    return locateFn(byName).then(function (els) {
       if (els.value.length) return els;
-      return client.elements(locator); // by css or xpath
+      return locateFn(locator); // by css or xpath
     });
   });
 }
@@ -1700,6 +1711,20 @@ function isFrameLocator(locator) {
   let key = Object.keys(locator)[0];
   if (key !== 'frame') return false;
   return locator[key];
+}
+
+function prepareLocateFn(context) {
+  if (!context) return this._locate.bind(this);
+  let el;
+  return (l) => {
+    if (el) return this.browser.elementIdElements(el, l);
+    return this._locate(context, true).then((res) => {
+      if (!res.value || res.value.length === 0) {
+        throw new Error(`Context element ${context.toString()} was not found by CSS|XPath`);
+      }
+      return this.browser.elementIdElements(el = res.value[0].ELEMENT, l);
+    });
+  };
 }
 
 module.exports = WebDriverIO;

--- a/lib/helper/clientscripts/nightmare.js
+++ b/lib/helper/clientscripts/nightmare.js
@@ -37,7 +37,7 @@ if (!window.codeceptjs) {
 
   codeceptjs.findElements = function (by, locator, contextEl) {
     let context;
-    if (contextEl === null) {
+    if (typeof contextEl !== 'number') {
       context = this.within || document;
     } else {
       context = this.fetchElement(contextEl);

--- a/lib/helper/clientscripts/nightmare.js
+++ b/lib/helper/clientscripts/nightmare.js
@@ -37,7 +37,7 @@ if (!window.codeceptjs) {
 
   codeceptjs.findElements = function (by, locator, contextEl) {
     let context;
-    if (!contextEl) {
+    if (contextEl === null) {
       context = this.within || document;
     } else {
       context = this.fetchElement(contextEl);

--- a/test/data/app/view/form/wait_clickable.php
+++ b/test/data/app/view/form/wait_clickable.php
@@ -1,0 +1,25 @@
+<html>
+
+<body>
+
+<div id="context"></div>
+<div id="output"></div>
+<script>
+
+var newDiv = document.createElement("div");
+    newDiv.innerHTML = "<a onclick='print()' id='click'>Hello world</a>";
+    newDiv.id="linkContext";
+
+  setTimeout(function () {
+    document.getElementById('context').appendChild(newDiv);
+  }, 2000);
+
+  function print() {
+    document.getElementById('output').innerText = 'Hi!';
+  }
+
+
+</script>
+
+</body>
+</html>

--- a/test/helper/SeleniumWebdriver_test.js
+++ b/test/helper/SeleniumWebdriver_test.js
@@ -110,4 +110,37 @@ describe('SeleniumWebdriver', function () {
     });
   });
 
+  describe('SmartWait', () => {
+    before(() => I.options.smartWait = 3000);
+    after(() => I.options.smartWait = 0);
+
+    it('should wait for element to appear', () => {
+      return I.amOnPage('/form/wait_element')
+        .then(() => I.dontSeeElement('h1'))
+        .then(() => I.seeElement('h1'))
+    });
+
+    it('should wait for clickable element appear', () => {
+      return I.amOnPage('/form/wait_clickable')
+        .then(() => I.dontSeeElement('#click'))
+        .then(() => I.click('#click'))
+        .then(() => I.see('Hi!'))
+    });
+
+    it('should wait for clickable context to appear', () => {
+      return I.amOnPage('/form/wait_clickable')
+        .then(() => I.dontSeeElement('#linkContext'))
+        .then(() => I.click('Hello world', '#linkContext'))
+        .then(() => I.see('Hi!'))
+    });
+
+    it('should wait for text context to appear', () => {
+      return I.amOnPage('/form/wait_clickable')
+        .then(() => I.dontSee('Hello world'))
+        .then(() => I.see('Hello world', '#linkContext'))
+    });
+
+
+  });
+
 });

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -16,7 +16,7 @@ let within = require('../../lib/within')
 
 
 describe('WebDriverIO', function () {
-  // this.retries(4);
+  this.retries(4);
   this.timeout(35000);
 
   before(() => {

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -255,8 +255,8 @@ describe('WebDriverIO', function () {
 
 
   describe('SmartWait', () => {
-    before(() => wd.options.wait = 3000);
-    after(() => wd.options.wait = 0);
+    before(() => wd.options.smartWait = 3000);
+    after(() => wd.options.smartWait = 0);
 
     it('should wait for element to appear', () => {
       return wd.amOnPage('/form/wait_element')

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -253,6 +253,46 @@ describe('WebDriverIO', function () {
       });
   });
 
+
+  describe('SmartWait', () => {
+    before(() => wd.options.wait = 3000);
+    after(() => wd.options.wait = 0);
+
+    it('should wait for element to appear', () => {
+      return wd.amOnPage('/form/wait_element')
+        .then(() => wd.dontSeeElement('h1'))
+        .then(() => wd.seeElement('h1'))
+    });
+
+    it('should wait for clickable element appear', () => {
+      return wd.amOnPage('/form/wait_clickable')
+        .then(() => wd.dontSeeElement('#click'))
+        .then(() => wd.click('#click'))
+        .then(() => wd.see('Hi!'))
+    });
+
+    it('should wait for clickable context to appear', () => {
+      return wd.amOnPage('/form/wait_clickable')
+        .then(() => wd.dontSeeElement('#linkContext'))
+        .then(() => wd.click('Hello world', '#linkContext'))
+        .then(() => wd.see('Hi!'))
+    });
+
+    it('should wait for text context to appear', () => {
+      return wd.amOnPage('/form/wait_clickable')
+        .then(() => wd.dontSee('Hello world'))
+        .then(() => wd.see('Hello world', '#linkContext'))
+    });
+
+    it('should work with grabbers', () => {
+      return wd.amOnPage('/form/wait_clickable')
+        .then(() => wd.dontSee('Hello world'))
+        .then(() => wd.grabAttributeFrom('#click', 'id'))
+        .then((res) => assert.equal(res, 'click'))
+    });
+
+  });
+
   describe('#_locateClickable', () => {
     it('should locate a button to click', () => {
       return wd.amOnPage('/form/checkbox')
@@ -268,6 +308,7 @@ describe('WebDriverIO', function () {
         .then((res) => res.length.should.be.equal(0))
     });
   });
+
 
   describe('#_locateCheckable', () => {
     it('should locate a checkbox', () => {

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -16,7 +16,7 @@ let within = require('../../lib/within')
 
 
 describe('WebDriverIO', function () {
-  this.retries(4);
+  // this.retries(4);
   this.timeout(35000);
 
   before(() => {
@@ -28,7 +28,8 @@ describe('WebDriverIO', function () {
     wd = new WebDriverIO({
       url: site_url,
       browser: 'chrome',
-      windowSize: '500x400'
+      windowSize: '500x400',
+      smartWait: 10 // just to try
     });
   });
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -137,6 +137,14 @@ module.exports.tests = function() {
       return I.seeInCurrentUrl('/info');
     });
 
+    it('should not click wrong context', function*() {
+      let err = false;
+      yield I.amOnPage('/');
+      return I.click('More info', '#area1')
+        .catch((e) => err = true)
+        .then(() => assert.ok(err))
+    });
+
     it('should click link with inner span', function*() {
       yield I.amOnPage('/form/example7');
       yield I.click('Buy Chocolate Bar');


### PR DESCRIPTION
* fixed returning promise in `defineTimeout`
* fixed respecting context in `click`, `doubleClick`, `checkOption`
* added context test for `click`
* SmartWaits introduced. [What are SmartWaits](http://codeception.com/docs/03-AcceptanceTests#SmartWait)

If locator is defined and element is expected on page, we can wait for few more seconds before failing a test.

```js
I.click('#click');
I.click('Home', '#nav');
I.seeElement('#user');
```

Doesn't work with wide scope locators like:

```js
I.click('Hello');
```

Smart wait is disabled by default. 