### PR TITLE
Web specific locators for Appium

### DIFF
--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -218,7 +218,7 @@ It is often happen that mobile applications behave similarly on different platfo
 CodeceptJS provides a way to specify different locators for Android and iOS platforms:
 
 ```js
-I.click({android: 'android.widget.Button', ios: '//UIAApplication[1]/UIAWindow[1]/UIAButton[1]'});
+I.click({android: '//android.widget.Button', ios: '//UIAApplication[1]/UIAWindow[1]/UIAButton[1]'});
 ```
 
 In case some code should be executed on one platform and ignored on others use `runOnAndroid` and `runOnIOS` methods:
@@ -230,6 +230,23 @@ I.runOnAndroid(() => {
 I.runOnIOS(() => {
   I.click('Hello iOS');
 });
+```
+
+The same code can be shared for web applications as well. To execute some code in web browser only, use `I.runInWeb`:
+
+```js
+I.runInWeb(() => {
+  I.amOnPage('/login'); // not available for mobile
+  I.fillField('name', 'jon');
+  I.fillField('password', '123456');
+  I.click('Login');
+  I.waitForElement('#success'); // no available for mobile
+});
+```
+Just as you can specify android, and ios-specific locators, you can do so for web:
+
+```js
+I.click({web: '#login', ios: '//UIAApplication[1]/UIAWindow[1]/UIAButton[1]'});
 ```
 
 ## done()

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -9,6 +9,9 @@ const path = require('path');
 const requireg = require('requireg');
 const fs = require('fs');
 const recorder = require('../recorder');
+const isGenerator = require('../utils').isGenerator;
+const resumeTest = require('../scenario').resumeTest;
+
 
 const mobileRoot = '//*';
 const webRoot = 'body';
@@ -291,8 +294,14 @@ class Appium extends WebdriverIO {
   runInWeb(fn) {
     if (!this.isWeb) return;
     recorder.session.start('Web-only actions');
-    fn();
-    recorder.add('restore from Web session', () => recorder.session.restore());
+
+    let res = fn();
+    if (isGenerator(fn)) {
+      res.next();
+      resumeTest(res);
+    }
+
+    recorder.add('restore from Web session', () => recorder.session.restore(), true);
     return recorder.promise();
   }
 
@@ -308,7 +317,11 @@ class Appium extends WebdriverIO {
       fn = caps;
     }
 
-    return fn();
+    let res = fn();
+    if (isGenerator(fn)) {
+      res.next();
+      resumeTest(res);
+    }
   }
 
 
@@ -1207,8 +1220,6 @@ class Appium extends WebdriverIO {
     if (this.isWeb) return super.selectOption(select, option);
     throw new Error(`Should be used only in Web context. In native context use 'click' method instead`);
   }
-
-
 }
 
 function parseLocator(locator) {

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -216,7 +216,7 @@ class Appium extends WebdriverIO {
 
 
   /**
-   * Execute specific code only on iOS
+   * Execute code only on iOS
    *
    * ```js
    * I.runOnIOS(() => {
@@ -247,7 +247,7 @@ class Appium extends WebdriverIO {
   }
 
   /**
-   * Execute specific code only on iOS
+   * Execute code only on iOS
    *
    * ```js
    * I.runOnAndroid(() => {
@@ -273,6 +273,26 @@ class Appium extends WebdriverIO {
     recorder.session.start('Android-only actions');
     this._runWithCaps(caps, fn);
     recorder.add('restore from Android session', () => recorder.session.restore());
+    return recorder.promise();
+  }
+
+  /**
+   * Execute code only in Web mode.
+   *
+   * ```js
+   * I.runInWeb(() => {
+   *    I.waitForElement('#data');
+   *    I.seeInCurrentUrl('/data');
+   * });
+   * ```
+   *
+   * @param {*} fn
+   */
+  runInWeb(fn) {
+    if (!this.isWeb) return;
+    recorder.session.start('Web-only actions');
+    fn();
+    recorder.add('restore from Web session', () => recorder.session.restore());
     return recorder.promise();
   }
 
@@ -1207,6 +1227,10 @@ function parseLocator(locator) {
   }
 
   if (typeof locator !== 'object') return locator;
+
+  if (locator.web && this.isWeb) {
+    return parseLocator.call(this, locator.web);
+  }
 
   if (locator.android && this.platform == 'android') {
     return parseLocator.call(this, locator.android);

--- a/test/helper/Appium_test.js
+++ b/test/helper/Appium_test.js
@@ -532,7 +532,7 @@ describe('Appium', function () {
     });
   });
 
-  describe('#runOnIOS, #runOnAndroid', () => {
+  describe('#runOnIOS, #runOnAndroid, #runInWeb', () => {
 
     it('should use Android locators', () => {
       app.click({android: "~startUserRegistrationCD", ios: 'fake-element'}).then(() => {
@@ -553,6 +553,16 @@ describe('Appium', function () {
       });
 
       assert.equal('android', platform);
+    });
+
+
+    it('should execute only in Web', () => {
+      app.isWeb = true;
+      let executed = false;
+      app.runOnIOS(() => {
+        executed = true;
+      });
+      assert.ok(executed);
     });
   });
 


### PR DESCRIPTION
To have one test for mobile and web app.

* added `runInWeb` method to execute code only in web
* added `web` locator type similarly to `android` and `ios`