### PR TITLE
Fix the "waitForTimeout" typo in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ exports.config = {
       key: process.env.CLOUDSERVICE_KEY,
 
       coloredLogs: true,
-      waitforTimeout: 10000
+      waitForTimeout: 10000
     }
   },
 


### PR DESCRIPTION
It should be capital 'F' instead of 'f' since the #387