### PR TITLE
Fix misprint in smart wait log message

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -393,7 +393,7 @@ class WebDriverIO extends Helper {
     let els;
 
     return this.defineTimeout({implicit: this.options.smartWait})
-      .then(() => this.debugSection('SmartWait', `Locating ${locator} in ${this.options.wait}`))
+      .then(() => this.debugSection('SmartWait', `Locating ${locator} in ${this.options.smartWait}`))
       .then(() => this.browser.elements(withStrictLocator(locator)));
   }
 


### PR DESCRIPTION
Fix misprint in smart wait log message -
[SmartWait] Locating //*['test'] in **undefined**