### PR TITLE
Nightmare re-inject scripts

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -120,6 +120,8 @@ class Appium extends WebdriverIO {
       }
     };
 
+    this.isRunning = false;
+
     // override defaults with config
     this.options = Object.assign(this.options, config);
 
@@ -167,7 +169,7 @@ class Appium extends WebdriverIO {
     } else {
       this.browser = webdriverio.remote(this.options).init();
     }
-
+    this.isRunning = true;
     let promisesList = [];
     if (this.options.timeouts && this.isWeb) {
       promisesList.push(this.defineTimeout(this.options.timeouts));
@@ -192,6 +194,7 @@ class Appium extends WebdriverIO {
 
   _after() {
     if (this.options.restart) return this.browser.end();
+    if (!this.isRunning) return;
     if (this.isWeb && !this.platform) {
       return super._after();
     }

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -169,32 +169,36 @@ class Appium extends WebdriverIO {
     } else {
       this.browser = webdriverio.remote(this.options).init();
     }
-    this.isRunning = true;
-    let promisesList = [];
-    if (this.options.timeouts && this.isWeb) {
-      promisesList.push(this.defineTimeout(this.options.timeouts));
-    }
-
-    if (this.options.windowSize === 'maximize' && !this.platform) {
-      promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
-        return this.browser.windowHandleSize({
-          width: res.value[0],
-          height: res.value[1]
-        });
-      }));
-    } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && !this.platform) {
-      let dimensions = this.options.windowSize.split('x');
-      promisesList.push(this.browser.windowHandleSize({
-        width: dimensions[0],
-        height: dimensions[1]
-      }));
-    }
-    return this.browser.then(() => Promise.all(promisesList));
+    return this.browser.then(() => {
+      this.isRunning = true;
+      let promisesList = [];
+      if (this.options.timeouts && this.isWeb) {
+        promisesList.push(this.defineTimeout(this.options.timeouts));
+      }
+      if (this.options.windowSize === 'maximize' && !this.platform) {
+        promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
+          return this.browser.windowHandleSize({
+            width: res.value[0],
+            height: res.value[1]
+          });
+        }));
+      } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && !this.platform) {
+        let dimensions = this.options.windowSize.split('x');
+        promisesList.push(this.browser.windowHandleSize({
+          width: dimensions[0],
+          height: dimensions[1]
+        }));
+      }
+      return Promise.all(promisesList);
+    });
   }
 
   _after() {
-    if (this.options.restart) return this.browser.end();
     if (!this.isRunning) return;
+    if (this.options.restart) {
+      this.isRunning = false;
+      return this.browser.end();
+    }
     if (this.isWeb && !this.platform) {
       return super._after();
     }

--- a/lib/helper/Mochawesome.js
+++ b/lib/helper/Mochawesome.js
@@ -45,11 +45,20 @@ class Mochawesome extends Helper {
 
   _failed(test) {
     if (this.options.disableScreenshots) return;
-    let fileName = clearString(test.title);
-    currentTest = {test: test};
+    let fileName;
+    // Get proper name if we are fail on hook
+    if (test.ctx.test.type == "hook") {
+      currentTest = {test: test.ctx.test};
+      // ignore retries if we are in hook
+      test._retries = -1;
+      fileName = clearString(`${test.title}_${currentTest.test.title}`);
+    } else {
+      currentTest = {test: test};
+      fileName = clearString(test.title);
+    }
     if (this.options.uniqueScreenshotNames) {
       fileName =
-        fileName.substring(0, 10) + '-' + hashCode(test.title) + '-' +
+        fileName.substring(0, 10) + '-' + hashCode(fileName) + '-' +
         hashCode(test.file);
     }
     if (test._retries < 1 || test._retries == test.retryNum) {

--- a/lib/helper/Mochawesome.js
+++ b/lib/helper/Mochawesome.js
@@ -46,6 +46,7 @@ class Mochawesome extends Helper {
   _failed(test) {
     if (this.options.disableScreenshots) return;
     let fileName = clearString(test.title);
+    currentTest = {test: test};
     if (this.options.uniqueScreenshotNames) {
       fileName =
         fileName.substring(0, 10) + '-' + hashCode(test.title) + '-' +

--- a/lib/helper/Mochawesome.js
+++ b/lib/helper/Mochawesome.js
@@ -54,7 +54,7 @@ class Mochawesome extends Helper {
     }
     if (test._retries < 1 || test._retries == test.retryNum) {
       fileName = `${fileName}.failed.png`;
-      return addMochawesomeContext(currentTest, path.join(global.output_dir, fileName));
+      return addMochawesomeContext(currentTest, fileName);
     }
   }
 

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -6,6 +6,7 @@ const urlEquals = require('../assert/equal').urlEquals;
 const equals = require('../assert/equal').equals;
 const empty = require('../assert/empty').empty;
 const truth = require('../assert/truth').truth;
+const hashCode = require('../utils').hashCode;
 const xpathLocator = require('../utils').xpathLocator;
 const fileExists = require('../utils').fileExists;
 const clearString = require('../utils').clearString;
@@ -897,10 +898,12 @@ class Nightmare extends Helper {
     let promisesList = [];
     if (withinStatus !== false) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {
-      let fileName = clearString(test.title) + '.failed.png';
+      let fileName = clearString(test.title);
+      if (test.ctx && test.ctx.test && test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
       if (this.options.uniqueScreenshotNames) {
-        fileName = test.title.substring(0, 10).replace(/ /g, '_') + '-' + hashCode(test.title) + '-' + hashCode(test.file) +
-          '.failed.png';
+        fileName = `${fileName.substring(0, 10)}-${hashCode(fileName)}-${hashCode(test.file)}.failed.png`;
+      } else {
+        fileName = fileName + '.failed.png';
       }
       promisesList.push(this.saveScreenshot(fileName, true));
     }

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -215,7 +215,7 @@ class Nightmare extends Helper {
   }
 
   _afterStep() {
-    return this._injectClientScripts()
+    return this._injectClientScripts();
   }
 
   _finishTest() {
@@ -823,11 +823,11 @@ class Nightmare extends Helper {
     return this.browser.wait(function (by, locator, text) {
       return codeceptjs.findElement(by, locator).innerText.indexOf(text) > -1;
     }, lctype(locator), lcval(locator), text).catch((err) => {
-      if (err.indexOf(`Cannot read property`) > -1)
-        throw new Error(`element (${JSON.stringify(context)}) is not in DOM. Unable to wait text.`)
-      else if (err.message.indexOf('.wait() timed out after') > -1)
-        throw new Error(`there is no element(${JSON.stringify(context)}) with text "${text}" after ${sec} sec`)
-      else throw err;
+      if (err.indexOf(`Cannot read property`) > -1) {
+        throw new Error(`element (${JSON.stringify(context)}) is not in DOM. Unable to wait text.`);
+      } else if (err.message.indexOf('.wait() timed out after') > -1) {
+        throw new Error(`there is no element(${JSON.stringify(context)}) with text "${text}" after ${sec} sec`);
+      } else throw err;
     });
   }
 
@@ -844,9 +844,9 @@ class Nightmare extends Helper {
       if (!el) return false;
       return el.offsetParent !== null;
     }, lctype(locator), lcval(locator)).catch((err) => {
-      if (err.message.indexOf('.wait() timed out after') > -1)
-        throw new Error(`element (${JSON.stringify(locator)}) still not visible on page after ${sec} sec`)
-      else throw err;
+      if (err.message.indexOf('.wait() timed out after') > -1) {
+        throw new Error(`element (${JSON.stringify(locator)}) still not visible on page after ${sec} sec`);
+      } else throw err;
     });
   }
 
@@ -861,9 +861,9 @@ class Nightmare extends Helper {
     return this.browser.wait(function (by, locator) {
       return window.codeceptjs.findElement(by, locator) !== null;
     }, lctype(locator), lcval(locator)).catch((err) => {
-      if (err.message.indexOf('.wait() timed out after') > -1)
-        throw new Error(`element (${JSON.stringify(locator)}) still not present on page after ${sec} sec`)
-      else throw err;
+      if (err.message.indexOf('.wait() timed out after') > -1) {
+        throw new Error(`element (${JSON.stringify(locator)}) still not present on page after ${sec} sec`);
+      } else throw err;
     });
   }
 

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -184,20 +184,21 @@ class Nightmare extends Helper {
 
   _beforeSuite() {
     if (!this.options.restart && !this.isRunning) {
-      this.isRunning = true;
+      this.debugSection('Session', 'Starting singleton browser session');
       return this._startBrowser();
     }
   }
 
   _before() {
-    if (this.options.restart) {
-      return this._startBrowser();
-    }
+    if (this.options.restart) return this._startBrowser();
+    if (!this.isRunning) return this._startBrowser();
     return this.browser;
   }
 
   _after() {
+    if (!this.isRunning) return;
     if (this.options.restart) {
+      this.isRunning = false;
       return this._stopBrowser();
     }
     if (this.options.keepBrowserState) return;
@@ -206,6 +207,7 @@ class Nightmare extends Helper {
         return localStorage.clear();
       })]);
     }
+    this.debugSection('Session', 'cleaning cookies and localStorage');
     return Promise.all([this.browser.cookies.clearAll(), this.executeScript(function () {
       return localStorage.clear();
     })]);
@@ -215,24 +217,27 @@ class Nightmare extends Helper {
   }
 
   _finishTest() {
-    if (!this.options.restart) {
+    if (!this.options.restart && this.isRunning) {
       this._stopBrowser();
     }
   }
 
   _startBrowser() {
     this.browser = this.Nightmare(this.options);
-    this.browser.on('dom-ready', () => this._injectClientScripts());
-    this.browser.on('did-start-loading', () => this._injectClientScripts());
-    this.browser.on('will-navigate', () => this._injectClientScripts());
-    this.browser.on('console', (type, message) => {
-      this.debug(`${type}: ${message}`);
-    });
+    return this.browser.then(() => {
+      this.isRunning = true;
+      this.browser.on('dom-ready', () => this._injectClientScripts());
+      this.browser.on('did-start-loading', () => this._injectClientScripts());
+      this.browser.on('will-navigate', () => this._injectClientScripts());
+      this.browser.on('console', (type, message) => {
+        this.debug(`${type}: ${message}`);
+      });
 
-    if (this.options.windowSize) {
-      let size = this.options.windowSize.split('x');
-      return this.browser.viewport(parseInt(size[0]), parseInt(size[1]));
-    }
+      if (this.options.windowSize) {
+        let size = this.options.windowSize.split('x');
+        return this.browser.viewport(parseInt(size[0]), parseInt(size[1]));
+      }
+    });
   }
 
   _stopBrowser() {

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -214,6 +214,10 @@ class Nightmare extends Helper {
   _afterSuite() {
   }
 
+  _afterStep() {
+    return this._injectClientScripts()
+  }
+
   _finishTest() {
     if (!this.options.restart) {
       this._stopBrowser();
@@ -814,10 +818,17 @@ class Nightmare extends Helper {
     }
     let locator = guessLocator(context) || { css: context};
     this.browser.options.waitTimeout = sec * 1000 || this.options.waitForTimeout;
+    sec = this.browser.options.waitForTimeout / 1000;
 
     return this.browser.wait(function (by, locator, text) {
       return codeceptjs.findElement(by, locator).innerText.indexOf(text) > -1;
-    }, lctype(locator), lcval(locator), text);
+    }, lctype(locator), lcval(locator), text).catch((err) => {
+      if (err.indexOf(`Cannot read property`) > -1)
+        throw new Error(`element (${JSON.stringify(context)}) is not in DOM. Unable to wait text.`)
+      else if (err.message.indexOf('.wait() timed out after') > -1)
+        throw new Error(`there is no element(${JSON.stringify(context)}) with text "${text}" after ${sec} sec`)
+      else throw err;
+    });
   }
 
   /**
@@ -825,13 +836,18 @@ class Nightmare extends Helper {
    */
   waitForVisible(locator, sec = null) {
     this.browser.options.waitTimeout = sec * 1000 || this.options.waitForTimeout;
+    sec = this.browser.options.waitForTimeout / 1000;
     locator = guessLocator(locator) || { css: locator};
 
     return this.browser.wait(function (by, locator) {
       var el = codeceptjs.findElement(by, locator);
       if (!el) return false;
       return el.offsetParent !== null;
-    }, lctype(locator), lcval(locator));
+    }, lctype(locator), lcval(locator)).catch((err) => {
+      if (err.message.indexOf('.wait() timed out after') > -1)
+        throw new Error(`element (${JSON.stringify(locator)}) still not visible on page after ${sec} sec`)
+      else throw err;
+    });
   }
 
   /**
@@ -839,11 +855,16 @@ class Nightmare extends Helper {
    */
   waitForElement(locator, sec = null) {
     this.browser.options.waitTimeout = sec * 1000 || this.options.waitForTimeout;
+    sec = this.browser.options.waitForTimeout / 1000;
     locator = guessLocator(locator) || { css: locator};
 
     return this.browser.wait(function (by, locator) {
-      return codeceptjs.findElement(by, locator) !== null;
-    }, lctype(locator), lcval(locator));
+      return window.codeceptjs.findElement(by, locator) !== null;
+    }, lctype(locator), lcval(locator)).catch((err) => {
+      if (err.message.indexOf('.wait() timed out after') > -1)
+        throw new Error(`element (${JSON.stringify(locator)}) still not present on page after ${sec} sec`)
+      else throw err;
+    });
   }
 
   /**

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -214,10 +214,6 @@ class Nightmare extends Helper {
   _afterSuite() {
   }
 
-  _afterStep() {
-    return this._injectClientScripts();
-  }
-
   _finishTest() {
     if (!this.options.restart) {
       this._stopBrowser();
@@ -227,6 +223,8 @@ class Nightmare extends Helper {
   _startBrowser() {
     this.browser = this.Nightmare(this.options);
     this.browser.on('dom-ready', () => this._injectClientScripts());
+    this.browser.on('did-start-loading', () => this._injectClientScripts());
+    this.browser.on('will-navigate', () => this._injectClientScripts());
     this.browser.on('console', (type, message) => {
       this.debug(`${type}: ${message}`);
     });
@@ -825,7 +823,7 @@ class Nightmare extends Helper {
     }, lctype(locator), lcval(locator), text).catch((err) => {
       if (err.indexOf(`Cannot read property`) > -1) {
         throw new Error(`element (${JSON.stringify(context)}) is not in DOM. Unable to wait text.`);
-      } else if (err.message.indexOf('.wait() timed out after') > -1) {
+      } else if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
         throw new Error(`there is no element(${JSON.stringify(context)}) with text "${text}" after ${sec} sec`);
       } else throw err;
     });
@@ -844,7 +842,7 @@ class Nightmare extends Helper {
       if (!el) return false;
       return el.offsetParent !== null;
     }, lctype(locator), lcval(locator)).catch((err) => {
-      if (err.message.indexOf('.wait() timed out after') > -1) {
+      if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
         throw new Error(`element (${JSON.stringify(locator)}) still not visible on page after ${sec} sec`);
       } else throw err;
     });
@@ -859,9 +857,9 @@ class Nightmare extends Helper {
     locator = guessLocator(locator) || { css: locator};
 
     return this.browser.wait(function (by, locator) {
-      return window.codeceptjs.findElement(by, locator) !== null;
+      return codeceptjs.findElement(by, locator) !== null;
     }, lctype(locator), lcval(locator)).catch((err) => {
-      if (err.message.indexOf('.wait() timed out after') > -1) {
+      if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
         throw new Error(`element (${JSON.stringify(locator)}) still not present on page after ${sec} sec`);
       } else throw err;
     });

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -116,6 +116,7 @@ class Protractor extends SeleniumWebdriver {
        // maybe it is installed as protractor dependency?
       this.webdriver = requireg('protractor/node_modules/selenium-webdriver');
     }
+    return Promise.resolve(Runner);
   }
 
   static _checkRequirements() {
@@ -145,8 +146,6 @@ class Protractor extends SeleniumWebdriver {
     global.element = this.browser.element;
     global.by = global.By = new By();
     global.ExpectedConditions = EC = this.browser.ExpectedConditions;
-    return this.browser.then(() => {
-      this.isRunning = true;
       let promisesList = [];
       if (this.options.windowSize == 'maximize') {
         promisesList.push(this.resizeWindow(this.options.windowSize));
@@ -156,8 +155,7 @@ class Protractor extends SeleniumWebdriver {
         promisesList.push(this.resizeWindow(parseInt(size[0]), parseInt(size[1])));
       }
 
-      return Promise.all(promisesList);
-    });
+      return Promise.all(promisesList).then(() => this.isRunning = true);
   }
 
   _before() {

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -157,7 +157,7 @@ class Protractor extends SeleniumWebdriver {
       }
 
       return Promise.all(promisesList);
-    })
+    });
   }
 
   _before() {

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -146,16 +146,16 @@ class Protractor extends SeleniumWebdriver {
     global.element = this.browser.element;
     global.by = global.By = new By();
     global.ExpectedConditions = EC = this.browser.ExpectedConditions;
-      let promisesList = [];
-      if (this.options.windowSize == 'maximize') {
-        promisesList.push(this.resizeWindow(this.options.windowSize));
-      }
-      if (this.options.windowSize) {
-        var size = this.options.windowSize.split('x');
-        promisesList.push(this.resizeWindow(parseInt(size[0]), parseInt(size[1])));
-      }
+    let promisesList = [];
+    if (this.options.windowSize == 'maximize') {
+      promisesList.push(this.resizeWindow(this.options.windowSize));
+    }
+    if (this.options.windowSize) {
+      var size = this.options.windowSize.split('x');
+      promisesList.push(this.resizeWindow(parseInt(size[0]), parseInt(size[1])));
+    }
 
-      return Promise.all(promisesList).then(() => this.isRunning = true);
+    return Promise.all(promisesList).then(() => this.isRunning = true);
   }
 
   _before() {

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -139,7 +139,7 @@ class Protractor extends SeleniumWebdriver {
   _startBrowser() {
     let runner = new Runner(this.options);
     this.browser = runner.createBrowser();
-
+    this.isRunning = true;
     global.browser = this.browser;
     global.$ = this.browser.$;
     global.$$ = this.browser.$$;

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -139,24 +139,25 @@ class Protractor extends SeleniumWebdriver {
   _startBrowser() {
     let runner = new Runner(this.options);
     this.browser = runner.createBrowser();
-    this.isRunning = true;
     global.browser = this.browser;
     global.$ = this.browser.$;
     global.$$ = this.browser.$$;
     global.element = this.browser.element;
     global.by = global.By = new By();
     global.ExpectedConditions = EC = this.browser.ExpectedConditions;
-    let promisesList = [];
-    if (this.options.windowSize == 'maximize') {
-      promisesList.push(this.resizeWindow(this.options.windowSize));
-    }
+    return this.browser.then(() => {
+      this.isRunning = true;
+      let promisesList = [];
+      if (this.options.windowSize == 'maximize') {
+        promisesList.push(this.resizeWindow(this.options.windowSize));
+      }
+      if (this.options.windowSize) {
+        var size = this.options.windowSize.split('x');
+        promisesList.push(this.resizeWindow(parseInt(size[0]), parseInt(size[1])));
+      }
 
-    if (this.options.windowSize) {
-      var size = this.options.windowSize.split('x');
-      promisesList.push(this.resizeWindow(parseInt(size[0]), parseInt(size[1])));
-    }
-
-    return Promise.all(promisesList);
+      return Promise.all(promisesList);
+    })
   }
 
   _before() {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -148,14 +148,14 @@ class SeleniumWebdriver extends Helper {
 
   _startBrowser() {
     this.browser = this.browserBuilder.build();
-      let promisesList = [];
-      if (this.options.windowSize == 'maximize') {
-        promisesList.push(this.resizeWindow(this.options.windowSize));
-      } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
-        var size = this.options.windowSize.split('x');
-        promisesList.push(this.resizeWindow(size[0], size[1]));
-      }
-      return Promise.all(promisesList).then(() => this.isRunning = true);
+    let promisesList = [];
+    if (this.options.windowSize == 'maximize') {
+      promisesList.push(this.resizeWindow(this.options.windowSize));
+    } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
+      var size = this.options.windowSize.split('x');
+      promisesList.push(this.resizeWindow(size[0], size[1]));
+    }
+    return Promise.all(promisesList).then(() => this.isRunning = true);
   }
 
   _beforeSuite() {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -167,7 +167,7 @@ class SeleniumWebdriver extends Helper {
 
   _before() {
     if (this.options.restart && !this.options.manualStart) return this._startBrowser();
-    if (!this.isRunning && !this.options.manualStart) return this._startBrowser()
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
   }
 
   _after() {
@@ -189,7 +189,7 @@ class SeleniumWebdriver extends Helper {
 
   _failed(test) {
     let err = test.err;
-    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false
+    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
     let promisesList = [];
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -189,7 +189,7 @@ class SeleniumWebdriver extends Helper {
 
   _failed(test) {
     let err = test.err;
-    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
+    if (err && err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
     let promisesList = [];
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -127,6 +127,8 @@ class SeleniumWebdriver extends Helper {
       .usingServer(this.options.seleniumAddress);
 
     if (this.options.proxy) this.browserBuilder.setProxy(this.options.proxy);
+
+    return Promise.resolve(this.browserBuilder);
   }
 
   static _checkRequirements() {
@@ -146,8 +148,6 @@ class SeleniumWebdriver extends Helper {
 
   _startBrowser() {
     this.browser = this.browserBuilder.build();
-    return this.browser.then(() => {
-      this.isRunning = true;
       let promisesList = [];
       if (this.options.windowSize == 'maximize') {
         promisesList.push(this.resizeWindow(this.options.windowSize));
@@ -155,8 +155,7 @@ class SeleniumWebdriver extends Helper {
         var size = this.options.windowSize.split('x');
         promisesList.push(this.resizeWindow(size[0], size[1]));
       }
-      return Promise.all(promisesList);
-    });
+      return Promise.all(promisesList).then(() => this.isRunning = true);
   }
 
   _beforeSuite() {
@@ -196,7 +195,7 @@ class SeleniumWebdriver extends Helper {
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {
       let fileName = clearString(test.title);
-      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
+      if (test.ctx && test.ctx.test && test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
       if (this.options.uniqueScreenshotNames) {
         fileName = `${fileName.substring(0, 10)}-${hashCode(fileName)}-${hashCode(test.file)}.failed.png`;
       } else {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -155,7 +155,7 @@ class SeleniumWebdriver extends Helper {
         var size = this.options.windowSize.split('x');
         promisesList.push(this.resizeWindow(size[0], size[1]));
       }
-      return Promise.all(promisesList)
+      return Promise.all(promisesList);
     });
   }
 
@@ -196,7 +196,7 @@ class SeleniumWebdriver extends Helper {
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {
       let fileName = clearString(test.title);
-      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`)
+      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
       if (this.options.uniqueScreenshotNames) {
         fileName = `${fileName.substring(0, 10)}-${hashCode(fileName)}-${hashCode(test.file)}.failed.png`;
       } else {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -146,7 +146,7 @@ class SeleniumWebdriver extends Helper {
 
   _startBrowser() {
     this.browser = this.browserBuilder.build();
-
+    this.isRunning = true;
     let promisesList = [];
     if (this.options.windowSize == 'maximize') {
       promisesList.push(this.resizeWindow(this.options.windowSize));
@@ -161,19 +161,18 @@ class SeleniumWebdriver extends Helper {
   _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {
       this.debugSection('Session', 'Starting singleton browser session');
-      this.isRunning = true;
       return this._startBrowser();
     }
   }
 
   _before() {
-    if (this.options.restart && !this.options.manualStart) {
-      return this._startBrowser();
-    }
+    if (this.options.restart && !this.options.manualStart) return this._startBrowser();
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser()
   }
 
   _after() {
     if (this.options.restart) return this.browser.quit();
+    if (!this.isRunning) return;
     if (this.options.keepBrowserState) return;
     if (this.options.keepCookies) return Promise.all([this.browser.executeScript('localStorage.clear();'), this.closeOtherTabs()]);
     // if browser should not be restarted
@@ -189,6 +188,8 @@ class SeleniumWebdriver extends Helper {
   }
 
   _failed(test) {
+    let err = test.err;
+    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false
     let promisesList = [];
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {

--- a/lib/helper/SeleniumWebdriver.js
+++ b/lib/helper/SeleniumWebdriver.js
@@ -146,16 +146,17 @@ class SeleniumWebdriver extends Helper {
 
   _startBrowser() {
     this.browser = this.browserBuilder.build();
-    this.isRunning = true;
-    let promisesList = [];
-    if (this.options.windowSize == 'maximize') {
-      promisesList.push(this.resizeWindow(this.options.windowSize));
-    } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
-      var size = this.options.windowSize.split('x');
-      promisesList.push(this.resizeWindow(size[0], size[1]));
-    }
-
-    return Promise.all(promisesList);
+    return this.browser.then(() => {
+      this.isRunning = true;
+      let promisesList = [];
+      if (this.options.windowSize == 'maximize') {
+        promisesList.push(this.resizeWindow(this.options.windowSize));
+      } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
+        var size = this.options.windowSize.split('x');
+        promisesList.push(this.resizeWindow(size[0], size[1]));
+      }
+      return Promise.all(promisesList)
+    });
   }
 
   _beforeSuite() {
@@ -171,8 +172,11 @@ class SeleniumWebdriver extends Helper {
   }
 
   _after() {
-    if (this.options.restart) return this.browser.quit();
     if (!this.isRunning) return;
+    if (this.options.restart) {
+      this.isRunning = false;
+      return this.browser.quit();
+    }
     if (this.options.keepBrowserState) return;
     if (this.options.keepCookies) return Promise.all([this.browser.executeScript('localStorage.clear();'), this.closeOtherTabs()]);
     // if browser should not be restarted
@@ -184,22 +188,28 @@ class SeleniumWebdriver extends Helper {
   }
 
   _finishTest() {
-    if (!this.options.restart) return this.browser.quit();
+    if (!this.options.restart && this.isRunning) return this.browser.quit();
   }
 
   _failed(test) {
-    let err = test.err;
-    if (err && err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
     let promisesList = [];
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {
-      let fileName = clearString(test.title) + '.failed.png';
+      let fileName = clearString(test.title);
+      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`)
       if (this.options.uniqueScreenshotNames) {
-        fileName = clearString(test.title.substring(0, 10)) + '-' + hashCode(test.title) + '-' + hashCode(test.file) + '.failed.png';
+        fileName = `${fileName.substring(0, 10)}-${hashCode(fileName)}-${hashCode(test.file)}.failed.png`;
+      } else {
+        fileName = fileName + '.failed.png';
       }
       promisesList.push(this.saveScreenshot(fileName, true));
     }
-    return Promise.all(promisesList);
+    return Promise.all(promisesList).catch((err) => {
+      if (err && err.type && err.type == "RuntimeError" && err.message && (err.message.indexOf("was terminated due to") > -1 || err.message.indexOf("no such window: target window already closed" > -1))) {
+        this.isRunning = false;
+        return;
+      }
+    });
   }
 
   _withinBegin(locator) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -285,39 +285,43 @@ class WebDriverIO extends Helper {
     } else {
       this.browser = webdriverio.remote(this.options).init();
     }
-    this.isRunning = true;
-    let promisesList = [];
-    if (this.options.timeouts) {
-      promisesList.push(this.defineTimeout(this.options.timeouts));
-    }
-    if (this.options.windowSize === 'maximize') {
-      promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
-        return this.browser.windowHandleSize({
-          width: res.value[0],
-          height: res.value[1]
-        });
-      }));
-    } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
-      let dimensions = this.options.windowSize.split('x');
-      promisesList.push(this.browser.windowHandleSize({
-        width: dimensions[0],
-        height: dimensions[1]
-      }));
-    }
-    return this.browser.then(() => Promise.all(promisesList));
+    return this.browser.then(() => {
+      this.isRunning = true;
+      let promisesList = [];
+      if (this.options.timeouts) {
+        promisesList.push(this.defineTimeout(this.options.timeouts));
+      }
+      if (this.options.windowSize === 'maximize') {
+        promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
+          return this.browser.windowHandleSize({
+            width: res.value[0],
+            height: res.value[1]
+          });
+        }));
+      } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
+        let dimensions = this.options.windowSize.split('x');
+        promisesList.push(this.browser.windowHandleSize({
+          width: dimensions[0],
+          height: dimensions[1]
+        }));
+      }
+      return Promise.all(promisesList);
+    });
   }
 
   _before() {
+    this.context = this.root;
     if (this.options.restart && !this.options.manualStart) return this._startBrowser();
     if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
-    this.failedTestName = null;
-    this.context = this.root;
     return this.browser;
   }
 
   _after() {
-    if (this.options.restart) return this.browser.end();
     if (!this.isRunning) return;
+    if (this.options.restart) {
+      this.isRunning = false;
+      return this.browser.end();
+    }
     if (this.options.keepBrowserState) return;
     if (this.options.keepCookies) {
       return Promise.all(
@@ -334,26 +338,31 @@ class WebDriverIO extends Helper {
   }
 
   _finishTest() {
-    if (!this.options.restart) return this.browser.end();
+    if (!this.options.restart && this.isRunning) return this.browser.end();
   }
 
   _failed(test) {
-    let err = test.err;
-    if (err && err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
-    if (this.options.disableScreenshots) return;
-    let fileName = clearString(test.title);
-    if (this.options.uniqueScreenshotNames) {
-      fileName =
-        fileName.substring(0, 10) + '-' + hashCode(test.title) + '-' +
-        hashCode(test.file) +
-        '.failed.png';
-    } else {
-      fileName = fileName + '.failed.png';
-    }
     let promisesList = [];
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
-    promisesList.push(this.saveScreenshot(fileName, this.options.fullPageScreenshots));
-    return Promise.all(promisesList);
+    if (!this.options.disableScreenshots) {
+      let fileName = clearString(test.title);
+      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`)
+      if (this.options.uniqueScreenshotNames) {
+        fileName =
+          fileName.substring(0, 10) + '-' + hashCode(fileName) + '-' +
+          hashCode(test.file) +
+          '.failed.png';
+      } else {
+        fileName = fileName + '.failed.png';
+      }
+      promisesList.push(this.saveScreenshot(fileName, this.options.fullPageScreenshots));
+    }
+    return Promise.all(promisesList).catch((err) => {
+      if (err && err.type && err.type == "RuntimeError" && err.message && (err.message.indexOf("was terminated due to") > -1 || err.message.indexOf("no such window: target window already closed" > -1))) {
+        this.isRunning = false;
+        return;
+      }
+    });
   }
 
   _withinBegin(locator) {
@@ -1084,7 +1093,7 @@ class WebDriverIO extends Helper {
    * ```
    */
   grabNumberOfVisibleElements(locator) {
-    return this.browser.elements(locator).then((res) => {
+    return this.browser.elements(withStrictLocator(locator)).then((res) => {
       if (!res.value || res.value.length === 0) {
         return 0;
       }

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -346,7 +346,7 @@ class WebDriverIO extends Helper {
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {
       let fileName = clearString(test.title);
-      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`)
+      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
       if (this.options.uniqueScreenshotNames) {
         fileName =
           fileName.substring(0, 10) + '-' + hashCode(fileName) + '-' +

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -309,7 +309,7 @@ class WebDriverIO extends Helper {
 
   _before() {
     if (this.options.restart && !this.options.manualStart) return this._startBrowser();
-    if (!this.isRunning && !this.options.manualStart) return this._startBrowser()
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
     this.failedTestName = null;
     this.context = this.root;
     return this.browser;
@@ -339,7 +339,7 @@ class WebDriverIO extends Helper {
 
   _failed(test) {
     let err = test.err;
-    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false
+    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
     if (this.options.disableScreenshots) return;
     let fileName = clearString(test.title);
     if (this.options.uniqueScreenshotNames) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -346,7 +346,7 @@ class WebDriverIO extends Helper {
     if (Object.keys(withinStore).length != 0) promisesList.push(this._withinEnd());
     if (!this.options.disableScreenshots) {
       let fileName = clearString(test.title);
-      if (test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
+      if (test.ctx && test.ctx.test && test.ctx.test.type == 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
       if (this.options.uniqueScreenshotNames) {
         fileName =
           fileName.substring(0, 10) + '-' + hashCode(fileName) + '-' +

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -339,7 +339,7 @@ class WebDriverIO extends Helper {
 
   _failed(test) {
     let err = test.err;
-    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
+    if (err && err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false;
     if (this.options.disableScreenshots) return;
     let fileName = clearString(test.title);
     if (this.options.uniqueScreenshotNames) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -275,7 +275,6 @@ class WebDriverIO extends Helper {
   _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {
       this.debugSection('Session', 'Starting singleton browser session');
-      this.isRunning = true;
       return this._startBrowser();
     }
   }
@@ -286,11 +285,11 @@ class WebDriverIO extends Helper {
     } else {
       this.browser = webdriverio.remote(this.options).init();
     }
+    this.isRunning = true;
     let promisesList = [];
     if (this.options.timeouts) {
       promisesList.push(this.defineTimeout(this.options.timeouts));
     }
-
     if (this.options.windowSize === 'maximize') {
       promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
         return this.browser.windowHandleSize({
@@ -309,7 +308,8 @@ class WebDriverIO extends Helper {
   }
 
   _before() {
-    if (this.options.restart && !this.options.manualStart) this._startBrowser();
+    if (this.options.restart && !this.options.manualStart) return this._startBrowser();
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser()
     this.failedTestName = null;
     this.context = this.root;
     return this.browser;
@@ -317,6 +317,7 @@ class WebDriverIO extends Helper {
 
   _after() {
     if (this.options.restart) return this.browser.end();
+    if (!this.isRunning) return;
     if (this.options.keepBrowserState) return;
     if (this.options.keepCookies) {
       return Promise.all(
@@ -337,6 +338,8 @@ class WebDriverIO extends Helper {
   }
 
   _failed(test) {
+    let err = test.err;
+    if (err.type && err.type == "RuntimeError" && err.message && err.message.indexOf("was terminated due to") > -1) this.isRunning = false
     if (this.options.disableScreenshots) return;
     let fileName = clearString(test.title);
     if (this.options.uniqueScreenshotNames) {

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -102,9 +102,10 @@ module.exports = function (suite) {
       if (opts.timeout) suite.timeout(opts.timeout);
 
       suite.file = file;
+      suite.fullTitle = () => `${suite.title}: ${suite.file}`;
       suites.unshift(suite);
-      suite.beforeEach('codeceptjs.before', scenario.setup);
-      afterEachHooks.push(['finialize codeceptjs', scenario.teardown]);
+      suite.beforeEach('codeceptjs.before', () => scenario.setup(suite));
+      afterEachHooks.push(['finialize codeceptjs', () => scenario.teardown(suite)]);
 
       suite.beforeAll('codeceptjs.beforeSuite', () => scenario.suiteSetup(suite));
       afterAllHooks.push(['codeceptjs.afterSuite', () => scenario.suiteTeardown(suite)]);

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -64,11 +64,11 @@ module.exports = function (suite) {
       test.timeout(0);
       test.inject = {};
 
+      suite.addTest(scenario.test(test));
       if (opts.retries) test.retries(opts.retries);
       if (opts.timeout) test.timeout(opts.timeout);
       test.opts = opts;
 
-      suite.addTest(scenario.test(test));
       return test;
     };
 

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -29,27 +29,11 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.suite.before, function (suite) {
-    try {
-      runAsyncHelpersHook('_beforeSuite', suite, true);
-    } catch (err) {
-      recorder.throw(err);
-    }
-    recorder.catch((err) => {
-      event.emit(event.test.failed, suite, err); // emit
-      throw err;
-    });
+    runAsyncHelpersHook('_beforeSuite', suite, true);
   });
 
   event.dispatcher.on(event.suite.after, function (suite) {
-    try {
-      runAsyncHelpersHook('_afterSuite', suite, true);
-    } catch (err) {
-      recorder.throw(err);
-    }
-    recorder.catch((err) => {
-      event.emit(event.test.failed, suite, err); // emit
-      throw err;
-    });
+    runAsyncHelpersHook('_afterSuite', suite, true);
   });
 
   event.dispatcher.on(event.test.started, function (test) {
@@ -58,15 +42,7 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.test.before, function () {
-    try {
-      runAsyncHelpersHook('_before');
-    } catch (err) {
-      recorder.throw(err);
-    }
-    recorder.catch((err) => {
-      event.emit(event.test.failed, suite, err); // emit
-      throw err;
-    });
+    runAsyncHelpersHook('_before');
   });
 
   event.dispatcher.on(event.test.failed, function (test) {

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -29,20 +29,26 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.suite.before, function (suite) {
+    try {
     runAsyncHelpersHook('_beforeSuite', suite, true);
-    recorder.catch((e) => {
-      recorder.stop();
-      process.exitCode = 1;
-      recorder.throw(e);
+    } catch (err) {
+      recorder.throw(err);
+    }
+    recorder.catch((err) => {
+      event.emit(event.test.failed, suite, err); // emit
+      throw err;
     });
   });
 
   event.dispatcher.on(event.suite.after, function (suite) {
-    runAsyncHelpersHook('_afterSuite', suite, true);
-    recorder.catch((e) => {
-      recorder.stop();
-      process.exitCode = 1;
-      recorder.throw(e);
+    try {
+      runAsyncHelpersHook('_afterSuite', suite, true);
+    } catch (err) {
+      recorder.throw(err);
+    }
+    recorder.catch((err) => {
+      event.emit(event.test.failed, suite, err); // emit
+      throw err;
     });
   });
 
@@ -52,11 +58,14 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.test.before, function () {
-    runAsyncHelpersHook('_before');
-    recorder.catch((e) => {
-      recorder.stop();
-      process.exitCode = 1;
-      recorder.throw(e);
+    try {
+      runAsyncHelpersHook('_before');
+    } catch (err) {
+      recorder.throw(err);
+    }
+    recorder.catch((err) => {
+      event.emit(event.test.failed, suite, err); // emit
+      throw err;
     });
   });
 

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -30,7 +30,7 @@ module.exports = function () {
 
   event.dispatcher.on(event.suite.before, function (suite) {
     try {
-    runAsyncHelpersHook('_beforeSuite', suite, true);
+      runAsyncHelpersHook('_beforeSuite', suite, true);
     } catch (err) {
       recorder.throw(err);
     }

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -30,10 +30,20 @@ module.exports = function () {
 
   event.dispatcher.on(event.suite.before, function (suite) {
     runAsyncHelpersHook('_beforeSuite', suite, true);
+    recorder.catch((e) => {
+      recorder.stop();
+      process.exitCode = 1;
+      recorder.throw(e);
+    });
   });
 
   event.dispatcher.on(event.suite.after, function (suite) {
     runAsyncHelpersHook('_afterSuite', suite, true);
+    recorder.catch((e) => {
+      recorder.stop();
+      process.exitCode = 1;
+      recorder.throw(e);
+    });
   });
 
   event.dispatcher.on(event.test.started, function (test) {
@@ -43,6 +53,11 @@ module.exports = function () {
 
   event.dispatcher.on(event.test.before, function () {
     runAsyncHelpersHook('_before');
+    recorder.catch((e) => {
+      recorder.stop();
+      process.exitCode = 1;
+      recorder.throw(e);
+    });
   });
 
   event.dispatcher.on(event.test.failed, function (test) {

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -26,6 +26,19 @@ var resumeTest = module.exports.resumeTest = function (res, done, error, returnS
   });
 };
 
+var injectHook = function(inject, suite) {
+  try {
+    inject();
+  } catch (err) {
+    recorder.throw(err);
+  }
+  recorder.catch((err) => {
+    event.emit(event.test.failed, suite, err);
+    throw err;
+  });
+  return recorder.promise();
+}
+
 /**
  * Wraps test function, injects support objects from container,
  * starts promise chain with recorder, performs before/after hooks
@@ -104,59 +117,31 @@ module.exports.injected = function (fn, suite, hookName) {
  * Starts promise chain, so helpers could enqueue their hooks
  */
 module.exports.setup = function (suite) {
-  try {
+  return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.test.before);
-  } catch (err) {
-    recorder.throw(err);
-  }
-  recorder.catch((err) => {
-    event.emit(event.test.failed, suite, err);
-    throw err;
-  });
-  return recorder.promise();
+  }, suite);
 };
 
 module.exports.teardown = function (suite) {
-  try {
+  return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.test.after);
-  } catch (err) {
-    recorder.throw(err);
-  }
-  recorder.catch((err) => {
-    event.emit(event.test.failed, suite, err);
-    throw err;
-  });
-  return recorder.promise();
+  }, suite);
 };
 
 module.exports.suiteSetup = function (suite) {
-  try {
+  return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.suite.before, suite);
-  } catch (err) {
-    recorder.throw(err);
-  }
-  recorder.catch((err) => {
-    event.emit(event.test.failed, suite, err);
-    throw err;
-  });
-  return recorder.promise();
+  }, suite);
 };
 
 module.exports.suiteTeardown = function (suite) {
-  try {
+  return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.suite.after, suite);
-  } catch (err) {
-    recorder.throw(err);
-  }
-  recorder.catch((err) => {
-    event.emit(event.test.failed, suite, err);
-    throw err;
-  });
-  return recorder.promise();
+  }, suite);
 };
 
 function getInjectedArguments(fn, test) {

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -80,7 +80,14 @@ module.exports.test = (test) => {
  * Injects arguments to function from controller
  */
 module.exports.injected = function (fn, suite, hookName) {
-  return function () {
+  return function (done) {
+    recorder.errHandler(function (err) {
+      recorder.session.start('teardown');
+      event.emit(event.test.failed, suite, err);
+      if (hookName === 'after') event.emit(event.test.after, suite);
+      if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
+      recorder.add(() => done(err));
+    });
     try {
       recorder.startUnlessRunning();
       this.test.body = fn.toString();
@@ -88,13 +95,8 @@ module.exports.injected = function (fn, suite, hookName) {
     } catch (err) {
       recorder.throw(err);
     }
-    recorder.catch((err) => {
-      event.emit(event.test.failed, suite, err); // emit
-      if (hookName === 'after') event.emit(event.test.after, suite);
-      if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
-      throw err;
-    });
-    return recorder.promise();
+    recorder.add(`finish ${hookName} hook`, () => done());
+    recorder.catch();
   };
 };
 

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -106,7 +106,7 @@ module.exports.setup = function (suite) {
     recorder.startUnlessRunning();
     event.emit(event.test.before);
   } catch (err) {
-    recorder.throw(err)
+    recorder.throw(err);
   }
   recorder.catch((err) => {
     event.emit(event.test.failed, suite, err);
@@ -120,7 +120,7 @@ module.exports.teardown = function (suite) {
     recorder.startUnlessRunning();
     event.emit(event.test.after);
   } catch (err) {
-    recorder.throw(err)
+    recorder.throw(err);
   }
   recorder.catch((err) => {
     event.emit(event.test.failed, suite, err);
@@ -134,7 +134,7 @@ module.exports.suiteSetup = function (suite) {
     recorder.startUnlessRunning();
     event.emit(event.suite.before, suite);
   } catch (err) {
-    recorder.throw(err)
+    recorder.throw(err);
   }
   recorder.catch((err) => {
     event.emit(event.test.failed, suite, err);
@@ -148,7 +148,7 @@ module.exports.suiteTeardown = function (suite) {
     recorder.startUnlessRunning();
     event.emit(event.suite.after, suite);
   } catch (err) {
-    recorder.throw(err)
+    recorder.throw(err);
   }
   recorder.catch((err) => {
     event.emit(event.test.failed, suite, err);

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -26,7 +26,7 @@ var resumeTest = module.exports.resumeTest = function (res, done, error, returnS
   });
 };
 
-var injectHook = function(inject, suite) {
+var injectHook = function (inject, suite) {
   try {
     inject();
   } catch (err) {
@@ -37,7 +37,7 @@ var injectHook = function(inject, suite) {
     throw err;
   });
   return recorder.promise();
-}
+};
 
 /**
  * Wraps test function, injects support objects from container,

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -101,24 +101,60 @@ module.exports.injected = function (fn, suite, hookName) {
 /**
  * Starts promise chain, so helpers could enqueue their hooks
  */
-module.exports.setup = function () {
-  recorder.startUnlessRunning();
-  event.emit(event.test.before);
+module.exports.setup = function (suite) {
+  try {
+    recorder.startUnlessRunning();
+    event.emit(event.test.before);
+  } catch (err) {
+    recorder.throw(err)
+  }
+  recorder.catch((err) => {
+    event.emit(event.test.failed, suite, err);
+    throw err;
+  });
+  return recorder.promise();
 };
 
-module.exports.teardown = function () {
-  recorder.startUnlessRunning();
-  event.emit(event.test.after);
+module.exports.teardown = function (suite) {
+  try {
+    recorder.startUnlessRunning();
+    event.emit(event.test.after);
+  } catch (err) {
+    recorder.throw(err)
+  }
+  recorder.catch((err) => {
+    event.emit(event.test.failed, suite, err);
+    throw err;
+  });
+  return recorder.promise();
 };
 
 module.exports.suiteSetup = function (suite) {
-  recorder.startUnlessRunning();
-  event.emit(event.suite.before, suite);
+  try {
+    recorder.startUnlessRunning();
+    event.emit(event.suite.before, suite);
+  } catch (err) {
+    recorder.throw(err)
+  }
+  recorder.catch((err) => {
+    event.emit(event.test.failed, suite, err);
+    throw err;
+  });
+  return recorder.promise();
 };
 
 module.exports.suiteTeardown = function (suite) {
-  recorder.startUnlessRunning();
-  event.emit(event.suite.after, suite);
+  try {
+    recorder.startUnlessRunning();
+    event.emit(event.suite.after, suite);
+  } catch (err) {
+    recorder.throw(err)
+  }
+  recorder.catch((err) => {
+    event.emit(event.test.failed, suite, err);
+    throw err;
+  });
+  return recorder.promise();
 };
 
 function getInjectedArguments(fn, test) {

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -74,6 +74,14 @@ describe('Nightmare', function () {
     });
   });
 
+  describe('scripts Inject', () => {
+    it('should reinject scripts after navigating to new page', () => {
+      return I.amOnPage('/')
+        .then(() => I.click("//div[@id='area1']/a"))
+        .then(() => I.waitForVisible("//input[@id='avatar']"));
+    });
+  });
+
   describe('see text : #see', () => {
     it('should fail when text is not on site', () => {
       return I.amOnPage('/')

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -14,7 +14,7 @@ require('co-mocha')(require('mocha'));
 let webApiTests = require('./webapi');
 
 describe('Nightmare', function () {
-  this.retries(4);
+  this.retries(1);
   this.timeout(35000);
 
   before(function() {
@@ -34,7 +34,7 @@ describe('Nightmare', function () {
 
   beforeEach(function() {
     webApiTests.init({ I, site_url});
-    return browser = I._before();
+    return I._before().then(() => browser = I.browser);
   });
 
   afterEach(() => {

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -14,7 +14,7 @@ require('co-mocha')(require('mocha'));
 let webApiTests = require('./webapi');
 
 describe('Nightmare', function () {
-  this.retries(1);
+  this.retries(4);
   this.timeout(35000);
 
   before(function() {

--- a/test/helper/Protractor_test.js
+++ b/test/helper/Protractor_test.js
@@ -31,8 +31,9 @@ describe('Protractor', function() {
   before(() => {
     global.codecept_dir = path.join(__dirname, '../data');
     I = new Protractor({url: site_url, browser: 'chrome'});
-    I._init();
-    I._beforeSuite();
+    return I._init().then(() => {
+      return I._beforeSuite();
+    });
   });
 
   after(() => {

--- a/test/helper/SeleniumWebdriver_test.js
+++ b/test/helper/SeleniumWebdriver_test.js
@@ -30,8 +30,11 @@ describe('SeleniumWebdriver', function () {
       restart: false
 
     });
-    I._init();
-    return I._beforeSuite().then(() => browser = I.browser);
+    return I._init().then(() => {
+      return I._beforeSuite().then(() => {
+        browser = I.browser;
+      });
+    });
   });
 
   after(function() {

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -287,6 +287,20 @@ describe('WebDriverIO', function () {
     });
   });
 
+  describe('#saveScreenshot', () => {
+    beforeEach(() => {
+      global.output_dir = path.join(global.codecept_dir, 'output');
+    });
+
+    it('should create a screenshot on fail  @ups', () => {
+      let sec = (new Date()).getUTCMilliseconds().toString();
+      let test = { title: 'sw should do smth '+sec };
+      return wd.amOnPage('/')
+        .then(() => wd._failed(test))
+        .then(() => assert.ok(fileExists(path.join(output_dir, `sw_should_do_smth_${sec}.failed.png`)), null, 'file does not exists'));
+    });
+  });
+
   describe('#waitForValue', () => {
     it('should wait for expected value for given locator', () => {
       return wd.amOnPage('/info')

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -263,6 +263,11 @@ describe('WebDriverIO', function () {
         .then(() => wd.grabNumberOfVisibleElements('//div[@id = "grab-multiple"]//a'))
         .then((num) => assert.equal(num, 3));
     });
+    it('should support locators like {xpath:"//div"}', () => {
+      return wd.amOnPage('/info')
+        .then(() => wd.grabNumberOfVisibleElements({xpath: '//div[@id = "grab-multiple"]//a'}))
+        .then((num) => assert.equal(num, 3));
+    });
   });
 
   describe('#waitInUrl, #waitUrlEquals', () => {


### PR DESCRIPTION
What is in this PR:
* Fix https://github.com/Codeception/CodeceptJS/issues/401
* Add more detailed error messages for Wait methods for Nightmare
* Fix adding screenshots to Mochawesome in Nightmare
* Fix unique screenshots names in Nightmare
* Fix Mochawesome context for failed screenshots. At this moment you have to put html report on the same folder, where you store screenshots
* Fix CodeceptJS work with hooks in helpers. Now we will finish codeceptJS correctly, if some errors appears in helpers hooks
* If we receive selenium grid error when use `restart:false`, then we will create a new session for next test
* Now CodeceptJS will create screenshots for failed hooks from Feature file
* Fix https://github.com/Codeception/CodeceptJS/issues/639
* Fix https://github.com/Codeception/CodeceptJS/issues/644