### PR TITLE
Add documentation for --config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,12 @@ exports.config = {
 
 (Don't copy-paste this config, it's just demo)
 
+If you prefer to store your configuration files in a different location, or with a different name, you can do that with `--config` or `-c:
+
+```sh
+codeceptjs run --config=./path/to/my/config.json
+```
+
 ## Profile
 
 Using values from `process.profile` you can change the config dynamically.


### PR DESCRIPTION
I was looking for this option on the website and I could not find it. Then I went to Google and I still could not find it. Finally I started looking through Github's issue tracker and I finally found the information I needed in issue #636.

I believe this information is important to have on the configuration page, as it's quite literally in the name.