### PR TITLE
Add nodeJs debugger support

### DIFF
--- a/bin/_codeceptjs
+++ b/bin/_codeceptjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+'use strict';
+
+var program = require('commander');
+var path = require('path');
+var Config = require('../lib/config');
+var Codecept = require('../lib/codecept');
+var print = require('../lib/output');
+var fileExists = require('../lib/utils').fileExists;
+var fs = require('fs');
+
+program.command('init [path]')
+  .description('Creates dummy config in current dir or [path]')
+  .action(require('../lib/command/init'));
+
+program.command('shell [path]')
+  .alias('sh')
+  .description('Interactive shell')
+  .option('--verbose', 'output internal logging information')
+  .option('--profile [value]', 'configuration profile to be used')
+  .action(require('../lib/command/interactive'));
+
+program.command('list [path]')
+  .alias('l')
+  .description('List all actions for I.')
+  .action(require('../lib/command/list'));
+
+program.command('def [path]')
+  .description('List all actions for I.')
+  .action(require('../lib/command/definitions'));
+
+program.command('generate:test [path]')
+  .alias('gt')
+  .description('Generates an empty test')
+  .action(require('../lib/command/generate').test);
+
+program.command('generate:pageobject [path]')
+  .alias('gpo')
+  .description('Generates an empty page object')
+  .action(require('../lib/command/generate').pageObject);
+
+program.command('generate:object [path]')
+  .alias('go')
+  .option('--type, -t [kind]', 'type of object to be created')
+  .description('Generates an empty support object (page/step/fragment)')
+  .action(require('../lib/command/generate').pageObject);
+
+program.command('generate:helper [path]')
+  .alias('gh')
+  .description('Generates a new helper')
+  .action(require('../lib/command/generate').helper);
+
+program.command('run [test]')
+  .description('Executes tests')
+
+  // codecept-only options
+  .option('--steps', 'show step-by-step execution')
+  .option('--debug', 'output additional information')
+  .option('--verbose', 'output internal logging information')
+  .option('-o, --override [value]', 'override current config options')
+  .option('--profile [value]', 'configuration profile to be used')
+  .option('-c, --config [file]', 'configuration file to be used')
+
+  // mocha options
+  .option('--colors', 'force enabling of colors')
+  .option('--no-colors', 'force disabling of colors')
+  .option('-G, --growl', 'enable growl notification support')
+  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
+  .option('-R, --reporter <name>', 'specify the reporter to use')
+  .option('-S, --sort', "sort test files")
+  .option('-b, --bail', "bail after first test failure")
+  .option('-d, --debug', "enable node's debugger, synonym for node --debug")
+  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-f, --fgrep <string>', 'only run tests containing <string>')
+  .option('-i, --invert', 'inverts --grep and --fgrep matches')
+  .option('--full-trace', 'display the full stack trace')
+  .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files')
+  .option('--debug-brk', "enable node's debugger breaking on the first line. Use it with node-inspector. See: http://codecept.io/advanced/#debug")
+  .option('--inspect', "enable node's debugger breaking on the first line. Use it with default NodeJs inspector. See: http://codecept.io/advanced/#debug")
+  .option('--inline-diffs', 'display actual/expected differences inline within each string')
+  .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
+  .option('--recursive', 'include sub directories')
+  .option('--trace', 'trace function calls')
+  .option('--child <string>', 'option for child processes')
+
+  .action(require('../lib/command/run'));
+
+program.command('run-multiple [suites...]')
+  .description('Executes tests multiple')
+  .option('-c, --config [file]', 'configuration file to be used')
+  .option('--all', 'run all suites')
+  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-f, --fgrep <string>', 'only run tests containing <string>')
+  .option('--steps', 'show step-by-step execution')
+  .option('--verbose', 'output internal logging information')
+  .option('--debug', 'output additional information')
+  .option('-o, --override [value]', 'override current config options')
+  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
+  .option('-R, --reporter <name>', 'specify the reporter to use')
+  .option('--recursive', 'include sub directories')
+
+  .action(require('../lib/command/run-multiple'));
+
+if (process.argv.length <= 2) {
+  console.log('CodeceptJS v' + Codecept.version());
+  program.outputHelp();
+}
+program.parse(process.argv);

--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -1,106 +1,31 @@
-#!/usr/bin/env node
 'use strict';
 
-var program = require('commander');
-var path = require('path');
-var Config = require('../lib/config');
-var Codecept = require('../lib/codecept');
-var print = require('../lib/output');
-var fileExists = require('../lib/utils').fileExists;
-var fs = require('fs');
+var spawn = require('child_process').spawn
+var args = [ __dirname + '/_codeceptjs' ];
 
-program.command('init [path]')
-  .description('Creates dummy config in current dir or [path]')
-  .action(require('../lib/command/init'));
+process.argv.slice(2).forEach(function(arg){
+  var flag = arg.split('=')[0];
 
-program.command('shell [path]')
-  .alias('sh')
-  .description('Interactive shell')
-  .option('--verbose', 'output internal logging information')
-  .option('--profile [value]', 'configuration profile to be used')
-  .action(require('../lib/command/interactive'));
-
-program.command('list [path]')
-  .alias('l')
-  .description('List all actions for I.')
-  .action(require('../lib/command/list'));
-
-program.command('def [path]')
-  .description('List all actions for I.')
-  .action(require('../lib/command/definitions'));
-
-program.command('generate:test [path]')
-  .alias('gt')
-  .description('Generates an empty test')
-  .action(require('../lib/command/generate').test);
-
-program.command('generate:pageobject [path]')
-  .alias('gpo')
-  .description('Generates an empty page object')
-  .action(require('../lib/command/generate').pageObject);
-
-program.command('generate:object [path]')
-  .alias('go')
-  .option('--type, -t [kind]', 'type of object to be created')
-  .description('Generates an empty support object (page/step/fragment)')
-  .action(require('../lib/command/generate').pageObject);
-
-program.command('generate:helper [path]')
-  .alias('gh')
-  .description('Generates a new helper')
-  .action(require('../lib/command/generate').helper);
-
-program.command('run [test]')
-  .description('Executes tests')
-
-  // codecept-only options
-  .option('--steps', 'show step-by-step execution')
-  .option('--debug', 'output additional information')
-  .option('--verbose', 'output internal logging information')
-  .option('-o, --override [value]', 'override current config options')
-  .option('--profile [value]', 'configuration profile to be used')
-  .option('-c, --config [file]', 'configuration file to be used')
-
-  // mocha options
-  .option('--colors', 'force enabling of colors')
-  .option('--no-colors', 'force disabling of colors')
-  .option('-G, --growl', 'enable growl notification support')
-  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
-  .option('-R, --reporter <name>', 'specify the reporter to use')
-  .option('-S, --sort', "sort test files")
-  .option('-b, --bail', "bail after first test failure")
-  .option('-d, --debug', "enable node's debugger, synonym for node --debug")
-  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
-  .option('-f, --fgrep <string>', 'only run tests containing <string>')
-  .option('-i, --invert', 'inverts --grep and --fgrep matches')
-  .option('--full-trace', 'display the full stack trace')
-  .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files')
-  .option('--debug-brk', "enable node's debugger breaking on the first line")
-  .option('--inline-diffs', 'display actual/expected differences inline within each string')
-  .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
-  .option('--recursive', 'include sub directories')
-  .option('--trace', 'trace function calls')
-  .option('--child <string>', 'option for child processes')
-
-  .action(require('../lib/command/run'));
-
-program.command('run-multiple [suites...]')
-  .description('Executes tests multiple')
-  .option('-c, --config [file]', 'configuration file to be used')
-  .option('--all', 'run all suites')
-  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
-  .option('-f, --fgrep <string>', 'only run tests containing <string>')
-  .option('--steps', 'show step-by-step execution')
-  .option('--verbose', 'output internal logging information')
-  .option('-o, --override [value]', 'override current config options')
-  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
-  .option('-R, --reporter <name>', 'specify the reporter to use')
-  .option('--recursive', 'include sub directories')
-
-  .action(require('../lib/command/run-multiple'));
-
-if (process.argv.length <= 2) {
-  console.log('CodeceptJS v' + Codecept.version());
-  program.outputHelp();
-}
-program.parse(process.argv);
+  switch (flag) {
+    case '--inspect':
+      args.unshift('--debug-brk');
+      args.unshift('--inspect');
+      break;
+    case '--debug-brk':
+      args.unshift('--debug-brk');
+      break;
+    default:
+      args.push(arg);
+      break;
+  }
+});
+var proc = spawn(process.argv[0], args, { stdio: [0,1,2] });
+proc.on('exit', function (code, signal) {
+  process.on('exit', function(){
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code);
+    }
+  });
+});

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -82,6 +82,18 @@ For advanced debugging use NodeJS debugger. In WebStorm IDE:
 node $NODE_DEBUG_OPTION ./node_modules/.bin/codeceptjs run
 ```
 
+Also you can use tools like default NodeJS inspector:
+```
+codeceptjs run --inspect
+```
+You will get link in console that you should open in chrome to get access to debugger. Set `debugger;` in your tests to set breakpoints.
+
+For [node-inspector](https://www.npmjs.com/package/node-inspector) use `--debug-brk` option:
+```
+codeceptjs run --debug-brk
+```
+After that run node-inspector and set breakpoints in any place you want.
+
 ## Multiple Execution
 
 CodeceptJS can execute multiple suites in parallel. This is useful if you want to execute same tests but on different browsers and with different configurations. Before using this feature you need to add `multiple` option to the config:

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -22,7 +22,6 @@ module.exports = function (test, options) {
   }
 
 
-
   if (!fileExists(outputDir = path.join(testRoot, config.output))) {
     output.print('creating output directory: ' + outputDir);
     mkdirp.sync(outputDir);

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -21,6 +21,8 @@ module.exports = function (test, options) {
     config = Config.append(JSON.parse(options.override));
   }
 
+
+
   if (!fileExists(outputDir = path.join(testRoot, config.output))) {
     output.print('creating output directory: ' + outputDir);
     mkdirp.sync(outputDir);


### PR DESCRIPTION
fix https://github.com/Codeception/CodeceptJS/issues/559 - "codeceptjs run --debug-brk" does nothing

Now there is two options --debug-brk and --inspect that passes to NodeJs and allow you to run NodeJs inspectors