### PR TITLE
WebDriverIO nested iframe support in the within block

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -249,7 +249,9 @@ within({frame: "#editor"}, () => {
 Nested IFrames can be set by passing array *(WebDriverIO & Nightmare only)*:
 
 ```js
-within({frame: [".content", "#editor"]);
+within({frame: [".content", "#editor"]}, () => {
+  I.see('Page');
+});
 ```
 
 ---

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -246,7 +246,7 @@ within({frame: "#editor"}, () => {
 });
 ```
 
-Nested IFrames can be set by passing array *(Nightmare only)*:
+Nested IFrames can be set by passing array *(WebDriverIO & Nightmare only)*:
 
 ```js
 within({frame: [".content", "#editor"]);

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -379,6 +379,12 @@ class WebDriverIO extends Helper {
     let frame = isFrameLocator(locator);
     let client = this.browser;
     if (frame) {
+      if (Array.isArray(frame)) {
+        withinStore.frame = frame.join('>');
+        return client
+          .frame(null)
+          .then(() => frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve()));
+      }
       withinStore.frame = frame;
       return this.switchTo(frame);
     }

--- a/test/acceptance/within_test.js
+++ b/test/acceptance/within_test.js
@@ -22,7 +22,7 @@ Scenario('within on iframe @WebDriverIO @Nightmare', (I) => {
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe @nightmare', (I) => {
+Scenario('within on nested iframe @WebDriverIO @nightmare', (I) => {
   I.amOnPage('/iframe');
   within({frame: ['[name=content]']}, () => {
     I.fillField('rus', 'Updated');
@@ -33,7 +33,7 @@ Scenario('within on nested iframe @nightmare', (I) => {
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe with a depth of 2 @WebDriverIO', (I) => {
+Scenario('within on nested iframe with a depth of 2 @WebDriverIO @nightmare', (I) => {
   I.amOnPage('/iframe_nested');
   within({frame: ['[name=wrapper]', '[name=content]']}, () => {
     I.fillField('rus', 'Updated');
@@ -44,7 +44,7 @@ Scenario('within on nested iframe with a depth of 2 @WebDriverIO', (I) => {
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe with a depth of 2 using ids @WebDriverIO', (I) => {
+Scenario('within on nested iframe with a depth of 2 using ids @WebDriverIO @nightmare', (I) => {
   I.amOnPage('/iframe_nested');
   within({frame: ['#wrapperId', '[name=content]']}, () => {
     I.fillField('rus', 'Updated');
@@ -55,7 +55,7 @@ Scenario('within on nested iframe with a depth of 2 using ids @WebDriverIO', (I)
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe with a depth of 2 using class @WebDriverIO', (I) => {
+Scenario('within on nested iframe with a depth of 2 using class @WebDriverIO @nightmare', (I) => {
   I.amOnPage('/iframe_nested');
   within({frame: ['.wrapperClass', '[name=content]']}, () => {
     I.fillField('rus', 'Updated');

--- a/test/acceptance/within_test.js
+++ b/test/acceptance/within_test.js
@@ -11,7 +11,7 @@ Scenario('within on form @WebDriverIO @protractor @nightmare', (I) => {
   I.dontSeeCheckboxIsChecked({css: "form[name=form1] input[name=first_test_radio]"});
 });
 
-Scenario('within on iframe @WebDriverIO @Nightmare', (I) => {
+Scenario('within on iframe @WebDriverIO', (I) => {
   I.amOnPage('/iframe');
   within({frame: 'iframe'}, () => {
     I.fillField('rus', 'Updated');
@@ -22,7 +22,27 @@ Scenario('within on iframe @WebDriverIO @Nightmare', (I) => {
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe @WebDriverIO @nightmare', (I) => {
+Scenario('within on iframe (without iframe navigation) @WebDriverIO @nightmare', (I) => {
+  I.amOnPage('/iframe');
+  within({frame: 'iframe'}, () => {
+    I.fillField('rus', 'Updated');
+    I.see('Sign in!');
+  });
+  I.see('Iframe test');
+  I.dontSee('Sign in!');
+});
+
+Scenario('within on nested iframe (without iframe navigation) (depth=2) @WebDriverIO @nightmare', (I) => {
+  I.amOnPage('/iframe_nested');
+  within({frame: ['[name=wrapper]', '[name=content]']}, () => {
+    I.fillField('rus', 'Updated');
+    I.see('Sign in!');
+  });
+  I.see('Nested Iframe test');
+  I.dontSee('Sign in!');
+});
+
+Scenario('within on nested iframe (depth=1) @WebDriverIO', (I) => {
   I.amOnPage('/iframe');
   within({frame: ['[name=content]']}, () => {
     I.fillField('rus', 'Updated');
@@ -33,7 +53,7 @@ Scenario('within on nested iframe @WebDriverIO @nightmare', (I) => {
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe with a depth of 2 @WebDriverIO @nightmare', (I) => {
+Scenario('within on nested iframe (depth=2) @WebDriverIO', (I) => {
   I.amOnPage('/iframe_nested');
   within({frame: ['[name=wrapper]', '[name=content]']}, () => {
     I.fillField('rus', 'Updated');
@@ -44,7 +64,7 @@ Scenario('within on nested iframe with a depth of 2 @WebDriverIO @nightmare', (I
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe with a depth of 2 using ids @WebDriverIO @nightmare', (I) => {
+Scenario('within on nested iframe (depth=2) and mixed id and xpath selector @WebDriverIO', (I) => {
   I.amOnPage('/iframe_nested');
   within({frame: ['#wrapperId', '[name=content]']}, () => {
     I.fillField('rus', 'Updated');
@@ -55,7 +75,7 @@ Scenario('within on nested iframe with a depth of 2 using ids @WebDriverIO @nigh
   I.dontSee('Email Address');
 });
 
-Scenario('within on nested iframe with a depth of 2 using class @WebDriverIO @nightmare', (I) => {
+Scenario('within on nested iframe (depth=2) and mixed class and xpath selector @WebDriverIO', (I) => {
   I.amOnPage('/iframe_nested');
   within({frame: ['.wrapperClass', '[name=content]']}, () => {
     I.fillField('rus', 'Updated');

--- a/test/acceptance/within_test.js
+++ b/test/acceptance/within_test.js
@@ -32,3 +32,36 @@ Scenario('within on nested iframe @nightmare', (I) => {
   I.see('Iframe test');
   I.dontSee('Email Address');
 });
+
+Scenario('within on nested iframe with a depth of 2 @WebDriverIO', (I) => {
+  I.amOnPage('/iframe_nested');
+  within({frame: ['[name=wrapper]', '[name=content]']}, () => {
+    I.fillField('rus', 'Updated');
+    I.click('Sign in!');
+    I.see('Email Address');
+  });
+  I.see('Nested Iframe test');
+  I.dontSee('Email Address');
+});
+
+Scenario('within on nested iframe with a depth of 2 using ids @WebDriverIO', (I) => {
+  I.amOnPage('/iframe_nested');
+  within({frame: ['#wrapperId', '[name=content]']}, () => {
+    I.fillField('rus', 'Updated');
+    I.click('Sign in!');
+    I.see('Email Address');
+  });
+  I.see('Nested Iframe test');
+  I.dontSee('Email Address');
+});
+
+Scenario('within on nested iframe with a depth of 2 using class @WebDriverIO', (I) => {
+  I.amOnPage('/iframe_nested');
+  within({frame: ['.wrapperClass', '[name=content]']}, () => {
+    I.fillField('rus', 'Updated');
+    I.click('Sign in!');
+    I.see('Email Address');
+  });
+  I.see('Nested Iframe test');
+  I.dontSee('Email Address');
+});

--- a/test/data/app/controllers.php
+++ b/test/data/app/controllers.php
@@ -154,6 +154,13 @@ class iframe {
     }
 }
 
+class iframe_nested {
+    public function GET()
+    {
+        include __DIR__.'/view/iframe_nested.php';
+    }
+}
+
 class facebookController {
     function GET($matches) {
         include __DIR__.'/view/facebook.php';

--- a/test/data/app/index.php
+++ b/test/data/app/index.php
@@ -38,6 +38,7 @@ $urls = array(
     '/external_url' => 'external_url',
     '/spinner' => 'spinner',
     '/iframe' => 'iframe',
+    '/iframe_nested' => 'iframe_nested',
     '/dynamic' => 'dynamic',
     '/timeout' => 'timeout',
 );

--- a/test/data/app/view/iframe_nested.php
+++ b/test/data/app/view/iframe_nested.php
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+
+<h1>Nested Iframe test</h1>
+
+<iframe id="wrapperId" name="wrapper" class="wrapperClass" src="iframe" style="width: 400px; height: 400px"/>
+
+</body>
+</html>

--- a/test/data/app/view/iframe_nested.php
+++ b/test/data/app/view/iframe_nested.php
@@ -7,7 +7,7 @@
 
 <h1>Nested Iframe test</h1>
 
-<iframe id="wrapperId" name="wrapper" class="wrapperClass" src="iframe" style="width: 400px; height: 400px"/>
+<iframe id="wrapperId" name="wrapper" class="wrapperClass" src="iframe" style="width: 600px; height: 600px"/>
 
 </body>
 </html>

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -25,7 +25,7 @@ describe('Nightmare', function () {
 
     I = new Nightmare({
       url: site_url,
-      windowSize: '500x400',
+      windowSize: '500x700',
       show: false
     });
     I._init();

--- a/test/helper/SeleniumWebdriver_test.js
+++ b/test/helper/SeleniumWebdriver_test.js
@@ -26,7 +26,7 @@ describe('SeleniumWebdriver', function () {
     I = new SeleniumWebdriver({
       url: site_url,
       browser: 'chrome',
-      windowSize: '500x400',
+      windowSize: '500x700',
       restart: false
 
     });

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -28,7 +28,7 @@ describe('WebDriverIO', function () {
     wd = new WebDriverIO({
       url: site_url,
       browser: 'chrome',
-      windowSize: '500x400',
+      windowSize: '500x700',
       smartWait: 10 // just to try
     });
   });

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -476,7 +476,7 @@ module.exports.tests = function() {
     it('should set initial window size', () => {
       return I.amOnPage('/form/resize')
         .then(() => I.click('Window Size'))
-        .then(() => I.see('Height 400', '#height'))
+        .then(() => I.see('Height 700', '#height'))
         .then(() => I.see('Width 500', '#width'));
     });
 
@@ -676,6 +676,23 @@ module.exports.tests = function() {
         .then(() => I.see('Toggle navigation', '.container fieldset'))
         .catch((err) => {
           if (!err) assert.fail('seen fieldset');
+        });
+    });
+
+    it('within should respect context in see when using nested frames', () => {
+      return I.amOnPage('/iframe_nested')
+        .then(() => I._withinBegin({frame: ['#wrapperId', '[name=content]']}))
+        .then(() => I.see('Kill & Destroy'))
+        .catch((err) => {
+          if (!err) assert.fail('seen "Kill & Destroy"');
+        })
+        .then(() => I.dontSee('Nested Iframe test'))
+        .catch((err) => {
+          if (!err) assert.fail('seen "Nested Iframe test"');
+        })
+        .then(() => I.dontSee('Iframe test'))
+        .catch((err) => {
+          if (!err) assert.fail('seen "Iframe test"');
         });
     });
   });


### PR DESCRIPTION
Adding support for setting nested iframes (i.e. as an array) to the WebDriverIO.

The application that I am testing makes heavy use of iframes, and overall WebDriverIO handles iframes better than Nightmare (though more on that later).

## Summary
* Within block now accepts nested frames when using the WebDriverIO Helper. Previously only the Nightmare Helper was supported.
* Changed the default window size for the Helper tests because the tab tests were failing because the clickable element was "off screen"
* Fixed acceptance test cases which were failing in the Nightmare Helper because Nightmare has problems if the any further navigation (i.e. clicking on a link) is done from within an iframe.

## Example
Here is the example Scenario taken out of the `./test/acceptance/within_test.js` which shows the usage.

```javascript
Scenario('within on nested iframe (depth=2) and mixed id and xpath selector @WebDriverIO', (I) => {
  I.amOnPage('/iframe_nested');
  within({frame: ['#wrapperId', '[name=content]']}, () => {
    I.fillField('rus', 'Updated');
    I.click('Sign in!');
    I.see('Email Address');
  });
  I.see('Nested Iframe test');
  I.dontSee('Email Address');
});
```

## Tests
The following tests were run after the changes and everything looks good.
* WebDriverIO acceptance tests: `node ./bin/codecept.js run -c ./test/acceptance/codecept.WebDriverIO.json --grep WebDriverIO`
* Nightmare acceptance: `node ./bin/codecept.js run -c ./test/acceptance/codecept.Nightmare.json --grep nightmare`
* Core tests: `npm tests`
* WebDriverIO tests: `mocha test/helper/WebDriverIO_test.js`
* Nightmare tests: `mocha test/helper/SeleniumWebdriver_test.js`


## Extra notes about iframes and Nightmare

The following works with WebDriverIO, but not with Nightmare. Nightware will say that it can not find the text `Email Address`, and it will print out the text of all elements from the iframe page before the I.click('Sign in!') was executed.

```javascript
Scenario('within on iframe @WebDriverIO', (I) => {
  I.amOnPage('/iframe');
  within({frame: 'iframe'}, () => {
    I.fillField('rus', 'Updated');
    I.click('Sign in!');
    I.see('Email Address');
  });
  I.see('Iframe test');
  I.dontSee('Email Address');
});
```
I will chalk this up to a limitation with Nightmare and not due to my code changes since these tests were already failing when I made my fork.

P.S. This is my first pull request, so just let me know if I need to change something to get it into the 'standard' pull request format.