### PR TITLE
Allow providing arbitrary objects in config includes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ After running `codeceptjs init` it should be saved in test root.
 Here is an overview of available options with their defaults:
 
 * **tests**: `"./*_test.js"` - pattern to locate tests
-* **include**: `{}` - actors and pageobjects to be registered in DI container and i  ncluded in tests.
+* **include**: `{}` - actors and page objects to be registered in DI container and included in tests. Accepts objects and module `require ` paths
 * **timeout**: `10000` - default tests timeout
 * **output**: `"./output"` - where to store failure screenshots, etc
 * **helpers**: `{}` - list of enabled helpers
@@ -48,6 +48,10 @@ exports.config = {
 
   // don't build monolithic configs
   mocha: require('./mocha.conf.js') || {},
+  includes: {
+    loginPage: './src/pages/login_page',
+    dashboardPage: new DashboardPage()
+  }
 
   // here goes config as it was in codecept.json
   // ....

--- a/lib/container.js
+++ b/lib/container.js
@@ -135,15 +135,7 @@ function createHelpers(config) {
 function createSupportObjects(config) {
   let objects = {};
   for (let name in config) {
-    let module = config[name];
-    if (module.charAt(0) === '.') {
-      module = path.join(global.codecept_dir, module);
-    }
-    try {
-      objects[name] = require(module);
-    } catch (err) {
-      throw new Error(`Could not include object ${name} from module '${module}'\n${err.message}`);
-    }
+    objects[name] = getSupportObject(config, name);
     try {
       if (typeof objects[name] === 'function') {
         objects[name] = objects[name]();
@@ -163,6 +155,26 @@ function createSupportObjects(config) {
   }
 
   return objects;
+}
+
+function getSupportObject(config, name) {
+  let module = config[name];
+  if (typeof module === 'string') {
+    return loadSupportObject(module, name);
+  } else {
+    return module;
+  }
+}
+
+function loadSupportObject(modulePath, supportObjectName) {
+  if (modulePath.charAt(0) === '.') {
+    modulePath = path.join(global.codecept_dir, modulePath);
+  }
+  try {
+    return require(modulePath);
+  } catch (err) {
+    throw new Error(`Could not include object ${supportObjectName} from module '${modulePath}'\n${err.message}`);
+  }
 }
 
 function loadTranslation(translation) {

--- a/test/data/dummy_page.js
+++ b/test/data/dummy_page.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+
+  openDummyPage: () => {
+    return 'dummy page opened';
+  }
+
+};

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -112,6 +112,16 @@ describe('Container', () => {
       container.support('I').should.have.keys('_init', 'doSomething');
       assert(global.I_initialized);
     });
+
+    it('should load DI includes defined as require paths', () => {
+      container.create({
+        include: {
+          dummyPage: './data/dummy_page'
+        }
+      });
+      assert.ok(container.support('dummyPage'))
+      container.support('dummyPage').should.have.keys('openDummyPage');
+    });
   });
 
   describe('#append', () => {

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -113,10 +113,24 @@ describe('Container', () => {
       assert(global.I_initialized);
     });
 
-    it('should load DI includes defined as require paths', () => {
+    it('should load DI includes provided as require paths', () => {
       container.create({
         include: {
           dummyPage: './data/dummy_page'
+        }
+      });
+      assert.ok(container.support('dummyPage'))
+      container.support('dummyPage').should.have.keys('openDummyPage');
+    });
+
+    it('should load DI includes provided as objects', () => {
+      container.create({
+        include: {
+          dummyPage: {
+            openDummyPage: () => {
+              return 'dummy page opened';
+            }
+          }
         }
       });
       assert.ok(container.support('dummyPage'))


### PR DESCRIPTION
Currently `config.includes` expects a map with `require` paths as values. This change allows providing object instances as well, e.g.:

```
exports.config = {
  includes: {
    loginPageObject: './load/me/from/here',
    homePageObject: new HomePageObject()
  }
}
```