### PR TITLE
[Fix] Prevent against missing config parameters

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -25,7 +25,7 @@ class Codecept {
    * @param {*} opts
    */
   constructor(config, opts) {
-    this.config = config;
+    this.config = Config.create(config);
     this.opts = opts;
     this.testFiles = new Array();
   }


### PR DESCRIPTION
Prevent against missing config parameters when running codecept manually.  Fix #720