### PR TITLE
Add return default width and height into _startBrowser

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -178,6 +178,8 @@ class Appium extends WebdriverIO {
       }
       if (this.options.windowSize === 'maximize' && !this.platform) {
         promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
+          this.options.defaultWidth = res.value[0];
+          this.options.defaultHeight = res.value[1];
           return this.browser.windowHandleSize({
             width: res.value[0],
             height: res.value[1]
@@ -185,9 +187,16 @@ class Appium extends WebdriverIO {
         }));
       } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && !this.platform) {
         let dimensions = this.options.windowSize.split('x');
+        this.options.defaultWidth = dimensions[0];
+        this.options.defaultHeight = dimensions[1];
         promisesList.push(this.browser.windowHandleSize({
           width: dimensions[0],
           height: dimensions[1]
+        }));
+      } else if (!this.options.windowSize && !this.platform) {
+        promisesList.push(this.browser.windowHandleSize().then((res) => {
+          this.options.defaultWidth = res.width;
+          this.options.defaultHeight = res.height;
         }));
       }
       return Promise.all(promisesList);

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -312,10 +312,10 @@ class WebDriverIO extends Helper {
           height: dimensions[1]
         }));
       } else if (!this.options.windowSize) {
-        return this.browser.windowHandleSize().then((res) => {
+        promisesList.push(this.browser.windowHandleSize().then((res) => {
           this.options.defaultWidth = res.width;
           this.options.defaultHeight = res.height;
-        });
+        }));
       }
       return Promise.all(promisesList);
     });

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -338,14 +338,21 @@ class WebDriverIO extends Helper {
     if (this.options.keepCookies) {
       return Promise.all(
         [this.browser.execute('localStorage.clear();').catch((err) => {
-          if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
-        }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)]);
+          if ((err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1) ||
+            (err.message.indexOf("timeout") > -1)) return
+          else throw err;
+        }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)])
+        .catch((err) => {
+          console.log(err)
+        });
     }
     if (this.options.desiredCapabilities.browserName) {
       this.debugSection('Session', 'cleaning cookies and localStorage');
       return Promise.all(
         [this.browser.deleteCookie(), this.browser.execute('localStorage.clear();').catch((err) => {
-          if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
+          if ((err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1) ||
+            (err.message.indexOf("timeout") > -1)) return
+          else throw err;
         }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)]);
     }
   }

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -341,10 +341,7 @@ class WebDriverIO extends Helper {
           if ((err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1) ||
             (err.message.indexOf("timeout") > -1)) return
           else throw err;
-        }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)])
-        .catch((err) => {
-          console.log(err)
-        });
+        }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)]);
     }
     if (this.options.desiredCapabilities.browserName) {
       this.debugSection('Session', 'cleaning cookies and localStorage');

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -296,6 +296,8 @@ class WebDriverIO extends Helper {
       }
       if (this.options.windowSize === 'maximize') {
         promisesList.push(this.browser.execute('return [screen.width, screen.height]').then((res) => {
+          this.options.defaultWidth = res.value[0];
+          this.options.defaultHeight = res.value[1];
           return this.browser.windowHandleSize({
             width: res.value[0],
             height: res.value[1]
@@ -303,10 +305,17 @@ class WebDriverIO extends Helper {
         }));
       } else if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
         let dimensions = this.options.windowSize.split('x');
+        this.options.defaultWidth = dimensions[0];
+        this.options.defaultHeight = dimensions[1];
         promisesList.push(this.browser.windowHandleSize({
           width: dimensions[0],
           height: dimensions[1]
         }));
+      } else if (!this.options.windowSize) {
+        return this.browser.windowHandleSize().then((res) => {
+          this.options.defaultWidth = res.width;
+          this.options.defaultHeight = res.height;
+        });
       }
       return Promise.all(promisesList);
     });
@@ -330,14 +339,14 @@ class WebDriverIO extends Helper {
       return Promise.all(
         [this.browser.execute('localStorage.clear();').catch((err) => {
           if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
-        }), this.closeOtherTabs()]);
+        }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)]);
     }
     if (this.options.desiredCapabilities.browserName) {
       this.debugSection('Session', 'cleaning cookies and localStorage');
       return Promise.all(
         [this.browser.deleteCookie(), this.browser.execute('localStorage.clear();').catch((err) => {
           if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
-        }), this.closeOtherTabs()]);
+        }), this.closeOtherTabs(), this.resizeWindow(this.options.defaultWidth, this.options.defaultHeight)]);
     }
   }
 


### PR DESCRIPTION
Previously, there were failures when trying to start a scenario with the original window size, before in the previous scenario the window size was reduced.

For example:
`
Before((I, ownerOfferPage) => {
    I.amOnPage(ownerOfferPage.url);
    ownerOfferPage.specialOfferPageShouldBeOpen();
});

Scenario('some scenario headline',
    function* (I, ownerOfferPage) {
        I.resizeWindow(1290, 780);
        yield* ownerOfferPage.viewContentBlocksAfterResize();
    });

Scenario('some scenario headline',
    function* (I, ownerOfferPage) {
        yield* ownerOfferPage.checkThatBillboardIsComeOnPage(); <--- failed here*
        yield* ownerOfferPage.checkThatRightBannerIsPresent();
        yield* ownerOfferPage.checkThatSuperFooterComeOnPage();
    });
`

* because in Before specialOfferPageShouldBeOpen() check default windows size.