### PR TITLE
Async await support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- 6
 - 8
+- 9
 sudo: required
 dist: trusty
 env:

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -168,25 +168,49 @@ To see all possible assertions see the helper's reference.
 Sometimes you need to retrieve a data from a page to use it in next steps of a scenario.
 Imagine, application generates a password and you want to ensure that user can login using this password.
 
-```js
-I.fillField('email', 'miles@davis.com')
-I.click('Generate Password');
-let password = yield I.grabTextFrom('#password');
-I.click('Login');
-I.fillField('email', 'miles@davis.com');
-I.fillField('password', password);
-I.click('Log in!');
-```
-
-`grabTextFrom` action is used here to retrieve text from an element. All actions starting with `grab` prefix are expected to return data. In order to synchronize this step with a scenario you should pause test execution with `yield` keyword of ES6. To make it work your test should be written inside a generator function (notice `*` in its definition):
-
-```js
-Scenario('use page title', function*(I) {
-  // ...
-  var password = yield I.grabTextFrom('#password');
-  I.fillField('password', password);
-});
-```
+There are two ways to do this:
+1. Generators
+    ```js
+    I.fillField('email', 'miles@davis.com')
+    I.click('Generate Password');
+    const password = yield I.grabTextFrom('#password');
+    I.click('Login');
+    I.fillField('email', 'miles@davis.com');
+    I.fillField('password', password);
+    I.click('Log in!');
+    ```
+    
+    `grabTextFrom` action is used here to retrieve text from an element. All actions starting with `grab` prefix are expected to return data. In order to synchronize this step with a scenario you should pause test execution with `yield` keyword of ES6. To make it work your test should be written inside a generator function (notice `*` in its definition):
+    
+    ```js
+    Scenario('use page title', function*(I) {
+      // ...
+      const password = yield I.grabTextFrom('#password');
+      I.fillField('password', password);
+    });
+    ```
+    
+ 2. Async/Await
+     ```js
+     I.fillField('email', 'miles@davis.com')
+     I.click('Generate Password');
+     const password = await I.grabTextFrom('#password');
+     I.click('Login');
+     I.fillField('email', 'miles@davis.com');
+     I.fillField('password', password);
+     I.click('Log in!');
+     ```
+     
+     `grabTextFrom` action is used here to retrieve text from an element. All actions starting with `grab` prefix are expected to return data. In order to synchronize this step with a scenario you should pause test execution with `await` keyword of ES6. To make it work your test should be written inside a async function (notice `async` in its definition). To use `async/await` you have to use node v8.9.1 or higher:
+     
+     ```js
+     Scenario('use page title', async (I) => {
+       // ...
+       const password = await I.grabTextFrom('#password');
+       I.fillField('password', password);
+     });
+     ```
+     
 
 ## Waiting
 

--- a/docs/pageobjects.md
+++ b/docs/pageobjects.md
@@ -67,6 +67,49 @@ Scenario('login', (I, loginPage) => {
 });
 ```
 
+Also you can use `async/await` inside PageObject:
+```js
+'use strict';
+let I;
+
+module.exports = {
+
+  _init() {
+    I = actor();
+  },
+
+  // setting locators
+  container: "//div[@class = 'numbers']",
+  mainItem: {
+    number: ".//div[contains(@class, 'numbers__main-number')]",
+    title: ".//div[contains(@class, 'numbers__main-title-block')]"
+  },
+
+  // introducing methods
+  openMainArticle() => {
+    I.waitForVisible(this.container)
+    let title;
+    within(this.container, async () => {
+      title = await I.grabTextFrom(this.mainItem.number);
+      let subtitle = await I.grabTextFrom(this.mainItem.title);
+      title = title + " " + subtitle.charAt(0).toLowerCase() + subtitle.slice(1);
+      I.click(this.mainItem.title)
+    })
+    return title;
+  }
+}
+```
+
+and use them in your tests:
+
+```js
+Scenario('login2', async (I, loginPage, basePage) => {
+  let title = mainPage.openMainArticle()
+  basePage.pageShouldBeOpened(title)
+});
+```
+
+
 Also you can use generators inside a PageObject:
 
 ```js
@@ -105,7 +148,7 @@ module.exports = {
 and use them in your tests:
 
 ```js
-Scenario('login2', (I, loginPage, basePage) => {
+Scenario('login2', function* (I, loginPage, basePage) {
   let title = yield* mainPage.openMainArticle()
   basePage.pageShouldBeOpened(title)
 });

--- a/lib/container.js
+++ b/lib/container.js
@@ -137,15 +137,7 @@ function createHelpers(config) {
 function createSupportObjects(config) {
   let objects = {};
   for (let name in config) {
-    let module = config[name];
-    if (module.charAt(0) === '.') {
-      module = path.join(global.codecept_dir, module);
-    }
-    try {
-      objects[name] = require(module);
-    } catch (err) {
-      throw new Error(`Could not include object ${name} from module '${module}'\n${err.message}`);
-    }
+    objects[name] = getSupportObject(config, name);
     try {
       if (typeof objects[name] === 'function') {
         objects[name] = objects[name]();
@@ -184,6 +176,26 @@ function createSupportObjects(config) {
   });
 
   return objects;
+}
+
+function getSupportObject(config, name) {
+  let module = config[name];
+  if (typeof module === 'string') {
+    return loadSupportObject(module, name);
+  } else {
+    return module;
+  }
+}
+
+function loadSupportObject(modulePath, supportObjectName) {
+  if (modulePath.charAt(0) === '.') {
+    modulePath = path.join(global.codecept_dir, modulePath);
+  }
+  try {
+    return require(modulePath);
+  } catch (err) {
+    throw new Error(`Could not include object ${supportObjectName} from module '${modulePath}'\n${err.message}`);
+  }
 }
 
 function loadTranslation(translation) {

--- a/lib/container.js
+++ b/lib/container.js
@@ -3,6 +3,7 @@ let path = require('path');
 let fileExists = require('./utils').fileExists;
 let Translation = require('./translation');
 let MochaFactory = require('./mocha_factory');
+let recorder = require('./recorder');
 
 let container = {
   helpers: {},
@@ -122,7 +123,8 @@ function createHelpers(config) {
       }
       helpers[helperName] = new HelperClass(config[helperName]);
     } catch (err) {
-      throw new Error(`Could not load helper ${helperName} from module '${module}':\n${err.message}\n${JSON.stringify(err)}`);
+      throw new Error(
+        `Could not load helper ${helperName} from module '${module}':\n${err.message}\n${JSON.stringify(err)}`);
     }
   }
 
@@ -135,7 +137,15 @@ function createHelpers(config) {
 function createSupportObjects(config) {
   let objects = {};
   for (let name in config) {
-    objects[name] = getSupportObject(config, name);
+    let module = config[name];
+    if (module.charAt(0) === '.') {
+      module = path.join(global.codecept_dir, module);
+    }
+    try {
+      objects[name] = require(module);
+    } catch (err) {
+      throw new Error(`Could not include object ${name} from module '${module}'\n${err.message}`);
+    }
     try {
       if (typeof objects[name] === 'function') {
         objects[name] = objects[name]();
@@ -154,27 +164,26 @@ function createSupportObjects(config) {
     }
   }
 
+  const asyncWrapper = function(f) {
+    return function() {
+      return f.apply(this, arguments).catch(e => {
+        recorder.saveFirstAsyncError(e);
+      });
+
+    }
+  }
+
+  Object.keys(objects).forEach((object) => {
+    const currentObject = objects[object]
+    Object.keys(currentObject).forEach((method) => {
+      const currentMethod = currentObject[method];
+      if (currentMethod[Symbol.toStringTag] === 'AsyncFunction') {
+        objects[object][method] = asyncWrapper(currentMethod)
+      }
+    })
+  })
+
   return objects;
-}
-
-function getSupportObject(config, name) {
-  let module = config[name];
-  if (typeof module === 'string') {
-    return loadSupportObject(module, name);
-  } else {
-    return module;
-  }
-}
-
-function loadSupportObject(modulePath, supportObjectName) {
-  if (modulePath.charAt(0) === '.') {
-    modulePath = path.join(global.codecept_dir, modulePath);
-  }
-  try {
-    return require(modulePath);
-  } catch (err) {
-    throw new Error(`Could not include object ${supportObjectName} from module '${modulePath}'\n${err.message}`);
-  }
 }
 
 function loadTranslation(translation) {

--- a/lib/container.js
+++ b/lib/container.js
@@ -164,24 +164,24 @@ function createSupportObjects(config) {
     }
   }
 
-  const asyncWrapper = function(f) {
-    return function() {
+  const asyncWrapper = function (f) {
+    return function () {
       return f.apply(this, arguments).catch(e => {
         recorder.saveFirstAsyncError(e);
       });
 
-    }
-  }
+    };
+  };
 
   Object.keys(objects).forEach((object) => {
-    const currentObject = objects[object]
+    const currentObject = objects[object];
     Object.keys(currentObject).forEach((method) => {
       const currentMethod = currentObject[method];
       if (currentMethod[Symbol.toStringTag] === 'AsyncFunction') {
-        objects[object][method] = asyncWrapper(currentMethod)
+        objects[object][method] = asyncWrapper(currentMethod);
       }
-    })
-  })
+    });
+  });
 
   return objects;
 }

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -6,7 +6,7 @@ let errFn;
 let next;
 let queueId = 0;
 let sessionId = null;
-
+let asyncErr = null;
 let log = require('./output').log;
 let tasks = [];
 
@@ -58,6 +58,7 @@ module.exports = {
     if (promise && running) this.catch();
     queueId++;
     sessionId = null;
+    asyncErr = null;
     log(currentQueue() + `Starting recording promises`);
     promise = Promise.resolve();
     oldPromises = [];
@@ -152,6 +153,16 @@ module.exports = {
     return this.add('throw error ' + err, function () {
       throw err;
     });
+  },
+
+  saveFirstAsyncError(err) {
+    if (asyncErr == null) {
+      asyncErr = err
+    }
+  },
+
+  getAsyncErr() {
+    return asyncErr;
   },
 
   /**

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -24,6 +24,7 @@ module.exports = {
    */
   start() {
     running = true;
+    asyncErr = null;
     errFn = null;
     this.reset();
   },
@@ -156,13 +157,17 @@ module.exports = {
   },
 
   saveFirstAsyncError(err) {
-    if (asyncErr == null) {
+    if (asyncErr === null) {
       asyncErr = err;
     }
   },
 
   getAsyncErr() {
     return asyncErr;
+  },
+
+  cleanAsyncErr() {
+    asyncErr = null;
   },
 
   /**

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -157,7 +157,7 @@ module.exports = {
 
   saveFirstAsyncError(err) {
     if (asyncErr == null) {
-      asyncErr = err
+      asyncErr = err;
     }
   },
 

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -6,8 +6,8 @@ let getParamNames = require('./utils').getParamNames;
 let isGenerator = require('./utils').isGenerator;
 
 
-var resumeTest = module.exports.resumeTest = function(res, done, error, returnStatement) {
-  recorder.add('create new promises queue for generator', function(data) {
+var resumeTest = module.exports.resumeTest = function (res, done, error, returnStatement) {
+  recorder.add('create new promises queue for generator', function (data) {
     recorder.session.start('generator'); // creating a new promise chain
     try {
       let resume = res.next(data);
@@ -26,7 +26,7 @@ var resumeTest = module.exports.resumeTest = function(res, done, error, returnSt
   });
 };
 
-var injectHook = function(inject, suite) {
+var injectHook = function (inject, suite) {
   try {
     inject();
   } catch (err) {
@@ -52,8 +52,8 @@ module.exports.test = (test) => {
 
   test.steps = [];
 
-  test.fn = function(done) {
-    recorder.errHandler(function(err) {
+  test.fn = function (done) {
+    recorder.errHandler(function (err) {
       recorder.session.start('teardown');
       event.emit(event.test.failed, test, err);
       recorder.add(() => done(err));
@@ -71,12 +71,12 @@ module.exports.test = (test) => {
         recorder.add('finish test', () => done());
         recorder.catch();
       }).catch(e => {
-        console.log('scenario', e)
-        recorder.saveFirstAsyncError(e)
+        console.log('scenario', e);
+        recorder.saveFirstAsyncError(e);
         recorder.session.start('teardown');
         event.emit(event.test.failed, test, recorder.getAsyncErr());
         recorder.add(() => done(recorder.getAsyncErr()));
-      })
+      });
     } else {
       try {
         event.emit(event.test.started, test);
@@ -112,9 +112,9 @@ module.exports.test = (test) => {
 /**
  * Injects arguments to function from controller
  */
-module.exports.injected = function(fn, suite, hookName) {
-  return function(done) {
-    recorder.errHandler(function(err) {
+module.exports.injected = function (fn, suite, hookName) {
+  return function (done) {
+    recorder.errHandler(function (err) {
       recorder.session.start('teardown');
       event.emit(event.test.failed, suite, err);
       if (hookName === 'after') event.emit(event.test.after, suite);
@@ -131,7 +131,7 @@ module.exports.injected = function(fn, suite, hookName) {
         recorder.add(`finish ${hookName} hook`, () => done());
         recorder.catch();
       }).catch(e => {
-        recorder.saveFirstAsyncError(e)
+        recorder.saveFirstAsyncError(e);
         recorder.session.start('teardown');
         event.emit(event.test.failed, suite, recorder.getAsyncErr());
         if (hookName === 'after') event.emit(event.test.after, suite);
@@ -173,28 +173,28 @@ module.exports.injected = function(fn, suite, hookName) {
 /**
  * Starts promise chain, so helpers could enqueue their hooks
  */
-module.exports.setup = function(suite) {
+module.exports.setup = function (suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.test.before);
   }, suite);
 };
 
-module.exports.teardown = function(suite) {
+module.exports.teardown = function (suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.test.after);
   }, suite);
 };
 
-module.exports.suiteSetup = function(suite) {
+module.exports.suiteSetup = function (suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.suite.before, suite);
   }, suite);
 };
 
-module.exports.suiteTeardown = function(suite) {
+module.exports.suiteTeardown = function (suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.suite.after, suite);

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -59,11 +59,6 @@ module.exports.test = (test) => {
       recorder.add(() => done(err));
     });
 
-    process.on('unhandledRejection', (reason, p) => {
-      console.log('Unhandled Rejection at: Promise', p, 'reason:', reason.stack);
-      // application specific logging, throwing an error, or other logic here
-    });
-
     if (testFn[Symbol.toStringTag] === 'AsyncFunction') {
       event.emit(event.test.started, test);
       testFn.apply(test, getInjectedArguments(testFn, test)).then((res) => {
@@ -71,7 +66,6 @@ module.exports.test = (test) => {
         recorder.add('finish test', () => done());
         recorder.catch();
       }).catch(e => {
-        console.log('scenario', e);
         recorder.saveFirstAsyncError(e);
         recorder.session.start('teardown');
         event.emit(event.test.failed, test, recorder.getAsyncErr());

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -55,6 +55,7 @@ module.exports.test = (test) => {
   test.fn = function (done) {
     recorder.errHandler(function (err) {
       recorder.session.start('teardown');
+      recorder.cleanAsyncErr();
       event.emit(event.test.failed, test, err);
       recorder.add(() => done(err));
     });
@@ -66,10 +67,11 @@ module.exports.test = (test) => {
         recorder.add('finish test', () => done());
         recorder.catch();
       }).catch(e => {
-        recorder.saveFirstAsyncError(e);
+        const err = (recorder.getAsyncErr() === null) ? e : recorder.getAsyncErr()
         recorder.session.start('teardown');
-        event.emit(event.test.failed, test, recorder.getAsyncErr());
-        recorder.add(() => done(recorder.getAsyncErr()));
+        recorder.cleanAsyncErr();
+        event.emit(event.test.failed, test, err);
+        recorder.add(() => done(err));
       });
     } else {
       try {
@@ -110,6 +112,7 @@ module.exports.injected = function (fn, suite, hookName) {
   return function (done) {
     recorder.errHandler(function (err) {
       recorder.session.start('teardown');
+      recorder.cleanAsyncErr();
       event.emit(event.test.failed, suite, err);
       if (hookName === 'after') event.emit(event.test.after, suite);
       if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
@@ -125,12 +128,13 @@ module.exports.injected = function (fn, suite, hookName) {
         recorder.add(`finish ${hookName} hook`, () => done());
         recorder.catch();
       }).catch(e => {
-        recorder.saveFirstAsyncError(e);
+        const err = (recorder.getAsyncErr() === null) ? e : recorder.getAsyncErr()
         recorder.session.start('teardown');
-        event.emit(event.test.failed, suite, recorder.getAsyncErr());
+        recorder.cleanAsyncErr();
+        event.emit(event.test.failed, suite, err);
         if (hookName === 'after') event.emit(event.test.after, suite);
         if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
-        recorder.add(() => done(recorder.getAsyncErr()));
+        recorder.add(() => done(err));
       });
     } else {
       try {

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -6,8 +6,8 @@ let getParamNames = require('./utils').getParamNames;
 let isGenerator = require('./utils').isGenerator;
 
 
-var resumeTest = module.exports.resumeTest = function (res, done, error, returnStatement) {
-  recorder.add('create new promises queue for generator', function (data) {
+var resumeTest = module.exports.resumeTest = function(res, done, error, returnStatement) {
+  recorder.add('create new promises queue for generator', function(data) {
     recorder.session.start('generator'); // creating a new promise chain
     try {
       let resume = res.next(data);
@@ -26,7 +26,7 @@ var resumeTest = module.exports.resumeTest = function (res, done, error, returnS
   });
 };
 
-var injectHook = function (inject, suite) {
+var injectHook = function(inject, suite) {
   try {
     inject();
   } catch (err) {
@@ -52,37 +52,57 @@ module.exports.test = (test) => {
 
   test.steps = [];
 
-  test.fn = function (done) {
-    recorder.errHandler(function (err) {
+  test.fn = function(done) {
+    recorder.errHandler(function(err) {
       recorder.session.start('teardown');
       event.emit(event.test.failed, test, err);
       recorder.add(() => done(err));
     });
 
-    try {
+    process.on('unhandledRejection', (reason, p) => {
+      console.log('Unhandled Rejection at: Promise', p, 'reason:', reason.stack);
+      // application specific logging, throwing an error, or other logic here
+    });
+
+    if (testFn[Symbol.toStringTag] === 'AsyncFunction') {
       event.emit(event.test.started, test);
-      let res = testFn.apply(test, getInjectedArguments(testFn, test));
-      if (isGenerator(testFn)) {
-        try {
-          res.next(); // running test
-        } catch (err) {
-          event.emit(event.test.failed, test, err);
-          done(err);
-          return test;
-        }
-        recorder.catch(); // catching possible errors in promises
-        resumeTest(res, () => {
-          recorder.add('fire test.passed', () => event.emit(event.test.passed, test));
-          recorder.add('finish generator with no error', () => done()); // finish him
-        });
-      }
-    } catch (err) {
-      recorder.throw(err);
-    } finally {
-      if (!isGenerator(testFn)) {
+      testFn.apply(test, getInjectedArguments(testFn, test)).then((res) => {
         recorder.add('fire test.passed', () => event.emit(event.test.passed, test));
         recorder.add('finish test', () => done());
         recorder.catch();
+      }).catch(e => {
+        console.log('scenario', e)
+        recorder.saveFirstAsyncError(e)
+        recorder.session.start('teardown');
+        event.emit(event.test.failed, test, recorder.getAsyncErr());
+        recorder.add(() => done(recorder.getAsyncErr()));
+      })
+    } else {
+      try {
+        event.emit(event.test.started, test);
+        let res = testFn.apply(test, getInjectedArguments(testFn, test));
+        if (isGenerator(testFn)) {
+          try {
+            res.next(); // running test
+          } catch (err) {
+            event.emit(event.test.failed, test, err);
+            done(err);
+            return test;
+          }
+          recorder.catch(); // catching possible errors in promises
+          resumeTest(res, () => {
+            recorder.add('fire test.passed', () => event.emit(event.test.passed, test));
+            recorder.add('finish generator with no error', () => done()); // finish him
+          });
+        }
+      } catch (err) {
+        recorder.throw(err);
+      } finally {
+        if (!isGenerator(testFn)) {
+          recorder.add('fire test.passed', () => event.emit(event.test.passed, test));
+          recorder.add('finish test', () => done());
+          recorder.catch();
+        }
       }
     }
   };
@@ -92,40 +112,59 @@ module.exports.test = (test) => {
 /**
  * Injects arguments to function from controller
  */
-module.exports.injected = function (fn, suite, hookName) {
-  return function (done) {
-    recorder.errHandler(function (err) {
+module.exports.injected = function(fn, suite, hookName) {
+  return function(done) {
+    recorder.errHandler(function(err) {
       recorder.session.start('teardown');
       event.emit(event.test.failed, suite, err);
       if (hookName === 'after') event.emit(event.test.after, suite);
       if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
       recorder.add(() => done(err));
     });
-    try {
+
+    if (fn[Symbol.toStringTag] === 'AsyncFunction') {
       event.emit(event.hook.started, suite);
       recorder.startUnlessRunning();
       this.test.body = fn.toString();
-      let res = fn.apply(this, getInjectedArguments(fn));
-      if (isGenerator(fn)) {
-        try {
-          res.next(); // running test
-        } catch (err) {
-          event.emit(event.test.failed, event.test, err);
-          done(err);
-        }
-        recorder.catch(); // catching possible errors in promises
-        resumeTest(res, () => {
-          recorder.add('fire hook.passed', () => event.emit(event.hook.passed, suite));
-          recorder.add(`finish ${hookName} hook`, () => done());
-        });
-      }
-    } catch (err) {
-      recorder.throw(err);
-    } finally {
-      if (!isGenerator(fn)) {
+      fn.apply(this, getInjectedArguments(fn)).then(() => {
         recorder.add('fire hook.passed', () => event.emit(event.hook.passed, suite));
         recorder.add(`finish ${hookName} hook`, () => done());
         recorder.catch();
+      }).catch(e => {
+        recorder.saveFirstAsyncError(e)
+        recorder.session.start('teardown');
+        event.emit(event.test.failed, suite, recorder.getAsyncErr());
+        if (hookName === 'after') event.emit(event.test.after, suite);
+        if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
+        recorder.add(() => done(recorder.getAsyncErr()));
+      });
+    } else {
+      try {
+        event.emit(event.hook.started, suite);
+        recorder.startUnlessRunning();
+        this.test.body = fn.toString();
+        let res = fn.apply(this, getInjectedArguments(fn));
+        if (isGenerator(fn)) {
+          try {
+            res.next(); // running test
+          } catch (err) {
+            event.emit(event.test.failed, event.test, err);
+            done(err);
+          }
+          recorder.catch(); // catching possible errors in promises
+          resumeTest(res, () => {
+            recorder.add('fire hook.passed', () => event.emit(event.hook.passed, suite));
+            recorder.add(`finish ${hookName} hook`, () => done());
+          });
+        }
+      } catch (err) {
+        recorder.throw(err);
+      } finally {
+        if (!isGenerator(fn)) {
+          recorder.add('fire hook.passed', () => event.emit(event.hook.passed, suite));
+          recorder.add(`finish ${hookName} hook`, () => done());
+          recorder.catch();
+        }
       }
     }
   };
@@ -134,28 +173,28 @@ module.exports.injected = function (fn, suite, hookName) {
 /**
  * Starts promise chain, so helpers could enqueue their hooks
  */
-module.exports.setup = function (suite) {
+module.exports.setup = function(suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.test.before);
   }, suite);
 };
 
-module.exports.teardown = function (suite) {
+module.exports.teardown = function(suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.test.after);
   }, suite);
 };
 
-module.exports.suiteSetup = function (suite) {
+module.exports.suiteSetup = function(suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.suite.before, suite);
   }, suite);
 };
 
-module.exports.suiteTeardown = function (suite) {
+module.exports.suiteTeardown = function(suite) {
   return injectHook(() => {
     recorder.startUnlessRunning();
     event.emit(event.suite.after, suite);

--- a/test/data/helper.js
+++ b/test/data/helper.js
@@ -19,6 +19,14 @@ class MyHelper extends Helper {
     return `I'm generator ${hookName} hook`;
   }
 
+  asyncStringWithHook(hookName) {
+    return `I'm async/await ${hookName} hook`;
+  }
+
+  stringWithScenarioType(type) {
+    return `I'm ${type} test`;
+  }
+
 }
 
 module.exports = MyHelper;

--- a/test/data/sandbox/codecept.testscenario.json
+++ b/test/data/sandbox/codecept.testscenario.json
@@ -1,0 +1,14 @@
+{
+  "tests": "./*_test.testscenario.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "FakeDriver": {
+      "require": "../helper"
+    }
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/testhooks_test.testhooks.js
+++ b/test/data/sandbox/testhooks_test.testhooks.js
@@ -36,6 +36,26 @@ AfterSuite(function* (I) {
   console.log(text);
 });
 
+BeforeSuite(async (I) => {
+  let text = await I.asyncStringWithHook('BeforeSuite');
+  console.log(text);
+});
+
+Before(async (I) => {
+  let text = await I.asyncStringWithHook('Before');
+  console.log(text);
+});
+
+After(async (I) => {
+  let text = await I.asyncStringWithHook('After');
+  console.log(text);
+});
+
+AfterSuite(async (I) => {
+  let text = await I.asyncStringWithHook('AfterSuite');
+  console.log(text);
+});
+
 Scenario('Simple test 1', () => {
   console.log(`It's first test`);
 });

--- a/test/data/sandbox/testscenario_test.testscenario.js
+++ b/test/data/sandbox/testscenario_test.testscenario.js
@@ -1,0 +1,15 @@
+Feature('Test scenario types');
+
+Scenario('Simple test', () => {
+  console.log(`It's usual test`);
+});
+
+Scenario('Simple generator test', function* (I) {
+  const text = yield I.stringWithScenarioType('generator')
+  console.log(text);
+});
+
+Scenario('Simple async/await test', async (I) => {
+  const text = await I.stringWithScenarioType('async/await')
+  console.log(text);
+});

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -87,19 +87,38 @@ describe('CodeceptJS Runner', () => {
   });
 
   it('should run hooks from suites', (done) => {
-    exec(codecept_run_config('codecept.testhooks.json'), (err, stdout, stderr) => {
+    exec(codecept_run_config('codecept.testhooks.json'), (err, stdout) => {
       let lines = stdout.match(/\S.+/g);
       expect(lines).to.include.members([
         `I'm simple BeforeSuite hook`,
         `I'm generator BeforeSuite hook`,
+        `I'm async/await BeforeSuite hook`,
         `I'm simple Before hook`,
         `I'm generator Before hook`,
+        `I'm async/await Before hook`,
         `I'm generator After hook`,
         `I'm simple After hook`,
+        `I'm async/await After hook`,
         `I'm generator AfterSuite hook`,
         `I'm simple AfterSuite hook`,
+        `I'm async/await AfterSuite hook`,
       ]);
       stdout.should.include('OK  | 1 passed');
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should run different types of scenario', (done) => {
+    exec(codecept_run_config('codecept.testscenario.json'), (err, stdout) => {
+      let lines = stdout.match(/\S.+/g);
+      expect(lines).to.include.members([
+        `Test scenario types --`,
+        `It's usual test`,
+        `I'm generator test`,
+        `I'm async/await test`
+      ]);
+      stdout.should.include('OK  | 3 passed');
       assert(!err);
       done();
     });

--- a/test/unit/scenario_test.js
+++ b/test/unit/scenario_test.js
@@ -23,7 +23,7 @@ describe('Scenario', () => {
 
   it('should work with generator func', () => {
     let counter = 0;
-    test.fn = function*() {
+    test.fn = function* () {
       yield counter++;
       yield counter++;
       yield counter++;
@@ -31,8 +31,26 @@ describe('Scenario', () => {
     };
     scenario.setup();
     scenario.test(test).fn(() => null);
+    recorder.add('validation', () => assert.equal(counter, 3))
+    return recorder.promise();
+  });
+
+  it('should work with async func', () => {
+    let counter = 0;
+    let error;
+    test.fn = () => {
+      recorder.add('test', async function() {
+        await counter++;
+        await counter++;
+        await counter++;
+        counter++;
+      })
+    }
+
+    scenario.setup();
+    scenario.test(test).fn(() => null);
+    recorder.add('validation', () => assert.equal(counter, 4))
     return recorder.promise()
-      .then(() => assert.equal(counter, 3));
   });
 
   describe('events', () => {


### PR DESCRIPTION
Goals:

- [x] Support async/await in Feature hooks
- [x] Support async/await in Scenarios
- [x] Add tests for async/await
- [x] Update documentation


User benefits, when using async await:

if you want to use `grab` methods in pageObject, you have to create generator function in pageObject and then call this function with specific `yield*` in scenario

e.g.:

```
// pageObject:

goToTestPage: function* () {
  const url = yield I.grabTextFrom('mylocator');
  I.amOnPage(url);
}

// in Test:
Scenario('test', function* (myPageObject) {
  yield* myPageObject.goToTestPage()
});
```
because of this `yield`'s tests will look ugly. And also you have to remember is your function in pageObject a generator or not.

With async/await you should pass await only in case, when you want to get returned value.

e.g.:

```
// pageObject:

async goToTestPage() {
  const url = await I.grabTextFrom('mylocator');
  I.amOnPage(url);
}

// in Test:
Scenario('test', (myPageObject) => {
  myPageObject.goToTestPage()
});

// or example with return:
// pageObject:

async goToTestPage() {
  const url = await I.grabTextFrom('mylocator');
  I.amOnPage(url);
  return(url)
}

// in Test:
Scenario('test', async (myPageObject) => {
  const test = await myPageObject.goToTestPage();
  console.log(test)
});
```