### PR TITLE
Fixing the issue #790

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -103,7 +103,7 @@ class REST extends Helper {
    * @param object headers
    */
   sendPostRequest(url, payload = {}, headers = {}) {
-    request = unirest.post(this._url(url)).send(payload).headers(headers);
+    request = unirest.post(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
 
@@ -119,7 +119,7 @@ class REST extends Helper {
    * @param object headers
    */
   sendPatchRequest(url, payload = {}, headers = {}) {
-    request = unirest.patch(this._url(url)).send(payload).headers(headers);
+    request = unirest.patch(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
 
@@ -135,7 +135,7 @@ class REST extends Helper {
    * @param object headers
    */
   sendPutRequest(url, payload = {}, headers = {}) {
-    request = unirest.put(this._url(url)).send(payload).headers(headers);
+    request = unirest.put(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
 


### PR DESCRIPTION
Using haveRequestHeaders before sendPostRequest give us an empty header type.