### PR TITLE
fix displaying undefined args in output

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -57,6 +57,8 @@ class Step {
         return arg.toString();
       } else if (typeof arg === "object") {
         return JSON.stringify(arg);
+      } else if (typeof arg === "undefined") {
+        return `${arg}`;
       } else if (arg.toString) {
         return arg.toString();
       }

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -29,6 +29,10 @@ describe('Step', () => {
 
     step.args = [{css: '.class'}];
     step.humanizeArgs().should.eql('{"css":".class"}');
+
+    let testUndefined;
+    step.args = [testUndefined, 'undefined'];
+    step.humanizeArgs().should.eql('undefined, "undefined');
   });
 
   it('should provide nice output', () => {


### PR DESCRIPTION
undefined args in test break it.

example:

Scenario.only('test', (I) => {
  let b;
  I.assertEqual(b, 'undefined');
});

expected:
```
@Test --
 test
 • I assert equal undefined, "undefined"
 ✖ FAILED in 7ms


-- FAILURES:

  1) @Test: test:
     undefined == 'undefined'
  
  Scenario Steps:
  
  - I.assertEqual(undefined, "undefined") at Test.Scenario (tests/test.js:12:5)
```

actual:
```
@Test --
 test
 ✖ FAILED in 1ms


-- FAILURES:

  1) @Test: test:
     Cannot read property 'toString' of undefined
```

This PR will fix the issue