### PR TITLE
placeholder for ~ locator only test case write once run on both Appium and WebDriverIO

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1870,6 +1870,27 @@ class WebDriverIO extends Helper {
       ));
     });
   }
+
+  /**
+   * placeholder for ~ locator only test case write once run on both Appium and WebDriverIO
+   */
+  runOnIOS(caps, fn) {
+    return;
+  }
+
+  /**
+   * placeholder for ~ locator only test case write once run on both Appium and WebDriverIO
+   */
+  runOnAndroid(caps, fn) {
+    return;
+  }
+
+  /**
+   * placeholder for ~ locator only test case write once run on both Appium and WebDriverIO
+   */
+  runInWeb(fn) {
+    return fn();
+  }
 }
 
 function proceedSee(assertType, text, context, strict = false) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1875,14 +1875,12 @@ class WebDriverIO extends Helper {
    * placeholder for ~ locator only test case write once run on both Appium and WebDriverIO
    */
   runOnIOS(caps, fn) {
-    return;
   }
 
   /**
    * placeholder for ~ locator only test case write once run on both Appium and WebDriverIO
    */
   runOnAndroid(caps, fn) {
-    return;
   }
 
   /**


### PR DESCRIPTION
Test case with locator ~ now can write once run on Android, iOS and Web with #728 , but if write I.runOnIOS() I.runOnAndroid() or I.runInWeb() in test case, then we also need a [reactweb_helper.js](https://github.com/flyskywhy/noder-react-native/blob/bdbaf35e5ab05b7de9d8c6ccb370a21827eb1424/e2e/helpers/reactweb_helper.js) required in [codecept.conf.js](https://github.com/flyskywhy/noder-react-native/blob/bdbaf35e5ab05b7de9d8c6ccb370a21827eb1424/codecept.conf.js) , if this PR is accepted and publish a new version, then the reactweb_helper.js is not needed.