### PR TITLE
Add browser name to report file for multiple run

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -110,7 +110,7 @@ function runSuite(suite, suiteConf, browser) {
   // tweaking default output directories and for mochawesome
   overriddenConfig = replaceValue(overriddenConfig, 'output', path.join(config.output, outputDir));
   overriddenConfig = replaceValue(overriddenConfig, 'reportDir', path.join(config.output, outputDir));
-  overriddenConfig = replaceValue(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, ´${browser}_report.xml´));
+  overriddenConfig = replaceValue(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, browser + '_report.xml'));
 
   // override grep param and collect all params
   const params = ['run',

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -110,7 +110,7 @@ function runSuite(suite, suiteConf, browser) {
   // tweaking default output directories and for mochawesome
   overriddenConfig = replaceValue(overriddenConfig, 'output', path.join(config.output, outputDir));
   overriddenConfig = replaceValue(overriddenConfig, 'reportDir', path.join(config.output, outputDir));
-  overriddenConfig = replaceValue(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, 'report.xml'));
+  overriddenConfig = replaceValue(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, ´${browser}_report.xml´));
 
   // override grep param and collect all params
   const params = ['run',


### PR DESCRIPTION
The name of the report file for multiple runs is always report.xml. CI/CD Environments like Jenkins need unique names to recording test results