### PR TITLE
add ability to require helpers from node_modules

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -105,11 +105,13 @@ function createHelpers(config) {
     try {
       if (config[helperName].require) {
         if (config[helperName].require.startsWith('.')) {
-          moduleName = path.resolve(global.codecept_dir, config[helperName].require) // custom helper
-        } else
-          moduleName = config[helperName].require // plugin helper
-      } else
-        moduleName = './helper/' + helperName; // built-in helper
+          moduleName = path.resolve(global.codecept_dir, config[helperName].require); // custom helper
+        } else {
+          moduleName = config[helperName].require; // plugin helper
+        }
+      } else {
+        moduleName = `./helper/${helperName}`; // built-in helper
+      }
       const HelperClass = require(moduleName);
       if (HelperClass._checkRequirements) {
         const requirements = HelperClass._checkRequirements();

--- a/lib/container.js
+++ b/lib/container.js
@@ -103,9 +103,13 @@ function createHelpers(config) {
   let helperModule;
   for (const helperName in config) {
     try {
-      const moduleName = config[helperName].require
-        ? path.resolve(global.codecept_dir, config[helperName].require) // custom helper
-        : `./helper/${helperName}`; // built-in helper
+      if (config[helperName].require) {
+        if (config[helperName].require.startsWith('.')) {
+          moduleName = path.resolve(global.codecept_dir, config[helperName].require) // custom helper
+        } else
+          moduleName = config[helperName].require // plugin helper
+      } else
+        moduleName = './helper/' + helperName; // built-in helper
       const HelperClass = require(moduleName);
       if (HelperClass._checkRequirements) {
         const requirements = HelperClass._checkRequirements();


### PR DESCRIPTION
We use private npm registry to share custom helpers between several projects.

These changes will give ability to require custom helpers from node_modules