### PR TITLE
Add grabBrowserUrl to WebDriverIO

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -902,6 +902,19 @@ class WebDriverIO extends Helper {
   }
 
   /**
+   * Get current URL from browser.
+   *
+   * ```js
+   * let url = yield I.grabBrowserUrl();
+   * console.log(`Current URL is [${url}]`);
+   * ```
+   */
+  async grabBrowserUrl() {
+    const res = await this.browser.url();
+    return res.value;
+  }
+
+  /**
    * {{> ../webapi/dontSeeInSource }}
    * Appium: support
    */


### PR DESCRIPTION
#### Enhancement to WebDriverIO helper:
- [X] Including **_grabBrowserUrl_** function to obtain current URL at any point during runtime
  - Useful for further parsing and/or validations