### PR TITLE
Support JSON objects as payload within REST

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -41,6 +41,14 @@ class REST extends Helper {
     }
   }
 
+  /**
+   * Set timeout for the request
+   *
+   * ```js
+   * I.setRequestTimeout(10000); // In milliseconds
+   * ```
+   *
+   */
   setRequestTimeout(newTimeout) {
     this.options.timeout = newTimeout;
   }
@@ -62,6 +70,18 @@ class REST extends Helper {
       throw new Error('Cannot send empty headers.');
     }
     headers = Object.assign(headers, customHeaders);
+  }
+
+  /**
+   * Reset headers for the request to default state
+   *
+   * ```js
+   * I.resetRequestHeaders();
+   * ```
+   *
+   */
+  resetRequestHeaders() {
+    headers = Object.assign({}, this.options.defaultHeaders);
   }
 
   _cleanRequestHeaders() {
@@ -101,6 +121,7 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPostRequest(url, payload = {}, headers = {}) {
+    payload = typeof payload === 'object' ? JSON.stringify(payload) : payload;
     request = unirest.post(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
@@ -117,6 +138,7 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPatchRequest(url, payload = {}, headers = {}) {
+    payload = typeof payload === 'object' ? JSON.stringify(payload) : payload;
     request = unirest.patch(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
@@ -133,6 +155,7 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPutRequest(url, payload = {}, headers = {}) {
+    payload = typeof payload === 'object' ? JSON.stringify(payload) : payload;
     request = unirest.put(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }


### PR DESCRIPTION
#### REST helper enhancements:
- [X] Added **_resetRequestHeaders_** function to set headers back to default at any given time
  - Use case: When several requests with different headers are sent within the same scenario, the **_resetHeaders: true_** within the config is not useful
- [X] Added support for JSON objects since payload (as a JSON) was automatically converted into "URL query" type of parameters:
`// if payload object was ---> payload = { "one": "The default", "two": false};`
`// when this was sent to a POST, the request object was converted it into:`
`// <uri>?one=The%20default&two=false` 
