### PR TITLE
docs(FileSystemHelper): add a reminder for users to activate the helper

### DIFF
--- a/docs/helpers/FileSystem.md
+++ b/docs/helpers/FileSystem.md
@@ -10,6 +10,18 @@ I.seeInThisFile('FileSystem');
 I.dontSeeInThisFile("WebDriverIO");
 ```
 
+Include the helper in your configuration file helpers section:
+
+```js
+{
+  ...
+  "helpers": {
+    ...
+    "FileSystem": {}
+  },
+
+```
+
 ## amInPath
 
 Enters a directory In local filesystem.


### PR DESCRIPTION
This pull adds a reminder in the documentation to avoid people having the trouble of FileSystem Helper functions not being available just because they forgot to add the Helper in the configuration file. For instance:`I.writeToFile is not a function`

It happened to me so I guess it will happen to others. 

Signed-off-by: javigomez <javier@typeform.com>