### PR TITLE
Fix the way to use puppeteer console message

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -222,7 +222,7 @@ class Puppeteer extends Helper {
         this.withinLocator = null;
         page.on('load', frame => this.context = page.$('body'));
         page.on('console', (msg) => {
-          this.debugSection(msg.type, Array.isArray(msg.args) ? msg.args.join(' ') : msg.args);
+          this.debugSection(msg.type(), msg.args().join(' '));
           consoleLogStore.add(msg);
         });
       });


### PR DESCRIPTION
Hi, I saw issue #889 and #891 try to fix it.
But the solution is incorrect.

Base on the puppeteer [API](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-consolemessage) and [code](https://github.com/GoogleChrome/puppeteer/blob/cb684ebbc4de271c7f2187f4e52c0b3a83cc0122/lib/Page.js#L1032-L1064).
This object only have get method. And return value of `args()` is Non-nullable.
So I fix the code to align the API.

I have tested on my test case (encounter issue #889 before), and it works fine now.

