### PR TITLE
Puppeteer helper, proceedClick should return _waitForAction

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1484,7 +1484,7 @@ async function proceedClick(locator, context = null, options = {}) {
     assertElementExists(els, locator, 'Clickable element');
   }
   await els[0].click(options);
-  await this._waitForAction();
+  return this._waitForAction();
 }
 
 async function findClickable(matcher, locator) {


### PR DESCRIPTION
Since [click](https://github.com/Codeception/CodeceptJS/blob/master/lib/helper/Puppeteer.js#L625-L641) return the value from `proceedClick`.
I think `proceedClick` should return waitForAction just like other actions.