### PR TITLE
requests to API fix

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -170,7 +170,6 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPostRequest(url, payload = {}, headers = {}) {
-    payload = typeof payload !== 'object' ? JSON.parse(payload) : payload;
     request = unirest.post(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
@@ -187,7 +186,6 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPatchRequest(url, payload = {}, headers = {}) {
-    payload = typeof payload === 'object' ? JSON.stringify(payload) : payload;
     request = unirest.patch(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }
@@ -204,7 +202,6 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPutRequest(url, payload = {}, headers = {}) {
-    payload = typeof payload === 'object' ? JSON.stringify(payload) : payload;
     request = unirest.put(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -170,7 +170,7 @@ class REST extends Helper {
    * @param {object} headers
    */
   sendPostRequest(url, payload = {}, headers = {}) {
-    payload = typeof payload === 'object' ? JSON.stringify(payload) : payload;
+    payload = typeof payload !== 'object' ? JSON.parse(payload) : payload;
     request = unirest.post(this._url(url)).headers(headers).send(payload);
     return this._executeRequest(request);
   }

--- a/test/data/rest/db.json
+++ b/test/data/rest/db.json
@@ -1,1 +1,1 @@
-{"comments":[],"posts":[{"id":1,"title":"json-server","author":"davert"}]}
+{"posts":[{"id":1,"title":"json-server","author":"davert"}],"user":{"name":"davert"}}

--- a/test/data/rest/db.json
+++ b/test/data/rest/db.json
@@ -1,1 +1,1 @@
-{"posts":[{"id":1,"title":"json-server","author":"davert"}],"user":{"name":"davert"}}
+{"comments":[],"posts":[{"id":1,"title":"json-server","author":"davert"}]}

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -46,22 +46,30 @@ describe('REST', () => {
       response.body.name.should.eql('davert');
     }));
 
-    it('should send PATCH requests', () => I.sendPatchRequest('/user', { email: 'user@user.com' }).then((response) => {
-      const body = JSON.parse(Object.keys(response.body)[1]);
-      body.email.should.eql('user@user.com');
+    it('should send PATCH requests: payload format = json', () => I.sendPatchRequest('/user', { email: 'user@user.com' }).then((response) => {
+      response.body.email.should.eql('user@user.com');
+    }));
+    it('should send PATCH requests: payload format = form urlencoded', () => I.sendPatchRequest('/user', 'email=user@user.com').then((response) => {
+      response.body.email.should.eql('user@user.com');
     }));
 
-    it('should send POST requests', () => I.sendPostRequest('/user', { name: 'john' }).then((response) => {
-      const body = JSON.parse(Object.keys(response.body)[0]);
-      body.name.should.eql('john');
+    it('should send POST requests: payload format = json', () => I.sendPostRequest('/user', { name: 'john' }).then((response) => {
+      response.body.name.should.eql('john');
+    }));
+    it('should send POST requests: payload format = form urlencoded', () => I.sendPostRequest('/user', 'name=john').then((response) => {
+      response.body.name.should.eql('john');
     }));
 
-    it('should send PUT requests', () => I.sendPutRequest('/posts/1', { author: 'john' }).then((response) => {
-      const body = JSON.parse(Object.keys(response.body)[0]);
-      body.author.should.eql('john');
+    it('should send PUT requests: payload format = json', () => I.sendPutRequest('/posts/1', { author: 'john' }).then((response) => {
+      response.body.author.should.eql('john');
       return I.sendGetRequest('/posts/1').then((response) => {
-        const body = JSON.parse(Object.keys(response.body)[0]);
-        body.author.should.eql('john');
+        response.body.author.should.eql('john');
+      });
+    }));
+    it('should send PUT requests: payload format = form urlencoded', () => I.sendPutRequest('/posts/1', 'author=john').then((response) => {
+      response.body.author.should.eql('john');
+      return I.sendGetRequest('/posts/1').then((response) => {
+        response.body.author.should.eql('john');
       });
     }));
 


### PR DESCRIPTION
The latest changes from 1.1.2 are not working anymore for sendPostRequest .. if you are trying to send an object it's trying to convert it to string but the request itself is not successful. 

So with this change you can pass JSON object and also form urlencoded payload types.

example:
let payload = { username: "user1", password: "xxx" };
let payload2 = 'username=user1&password=xxx';

extra unit tests added + fixed old ones