### PR TITLE
Puppeteer fixes

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -63,6 +63,8 @@ class Puppeteer extends Helper {
       uniqueScreenshotNames: false,
       manualStart: false,
       restart: true,
+      keepCookies: false,
+      keepBrowserState: false,
       show: false,
       defaultPopupAction: 'accept',
     };
@@ -107,14 +109,30 @@ class Puppeteer extends Helper {
   }
 
   async _after() {
-    return this._stopBrowser();
+    if (!this.isRunning) return;
+    if (this.options.restart) {
+      this.isRunning = false;
+      return this._stopBrowser();
+    }
+
+    if (this.options.keepBrowserState) return;
+
+    if (!this.options.keepCookies) {
+      this.debugSection('Session', 'cleaning cookies and localStorage');
+      await this.browser.deleteCookie();
+    }
+    await this.browser.execute('localStorage.clear();').catch((err) => {
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
+    });
+    await this.closeOtherTabs();
+    return this.browser;
   }
 
   _afterSuite() {
   }
 
   _finishTest() {
-    if (!this.options.restart & this.isRunning) return this._stopBrowser();
+    if (!this.options.restart && this.isRunning) return this._stopBrowser();
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -61,6 +61,7 @@ class Puppeteer extends Helper {
       fullPageScreenshots: true,
       disableScreenshots: false,
       uniqueScreenshotNames: false,
+      manualStart: false,
       restart: true,
       show: false,
       defaultPopupAction: 'accept',
@@ -100,11 +101,20 @@ class Puppeteer extends Helper {
 
 
   async _before() {
-    return this._startBrowser();
+    if (this.options.restart && !this.options.manualStart) return this._startBrowser();
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
+    return this.browser;
   }
 
   async _after() {
     return this._stopBrowser();
+  }
+
+  _afterSuite() {
+  }
+
+  _finishTest() {
+    if (!this.options.restart & this.isRunning) return this._stopBrowser();
   }
 
   /**
@@ -238,6 +248,8 @@ class Puppeteer extends Helper {
       const dimensions = this.options.windowSize.split('x');
       await this.resizeWindow(parseInt(dimensions[0], 10), parseInt(dimensions[1], 10));
     }
+
+    this.isRunning = true;
   }
 
   async _stopBrowser() {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -250,6 +250,10 @@ class Puppeteer extends Helper {
     }
 
     this.isRunning = true;
+
+    if (this.options.userAgent) {
+      await this.page.setUserAgent(this.options.userAgent);
+    }
   }
 
   async _stopBrowser() {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -35,13 +35,18 @@ const consoleLogStore = new Console();
  *
  * This helper should be configured in codecept.json
  *
- * * `url` - base url of website to be tested
- * * `show` (optional, default: false) - show Google Chrome window for debug.
- * * `disableScreenshots` (optional, default: false)  - don't save screenshot on failure.
- * * `uniqueScreenshotNames` (optional, default: false)  - option to prevent screenshot override if you have scenarios with the same name in different suites.
+ * * `url`: base url of website to be tested
+ * * `show`: (optional, default: false) - show Google Chrome window for debug.
+ * * `restart`: (optional, default: true) - restart browser between tests.
+ * * `disableScreenshots`: (optional, default: false)  - don't save screenshot on failure.
+ * * `uniqueScreenshotNames`: (optional, default: false)  - option to prevent screenshot override if you have scenarios with the same name in different suites.
+ * * `keepBrowserState`: (optional, default: false) - keep browser state between tests when `restart` is set to false.
+ * * `keepCookies`: (optional, default: false) - keep cookies between tests when `restart` is set to false.
  * * `waitForAction`: (optional) how long to wait after click, doubleClick or PressKey actions in ms. Default: 100.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 1000.
  * * `windowSize`: (optional) default window size. Set a dimension like `640x480`.
+ * * `userAgent`: (optional) user-agent string.
+ * * `manualStart`: (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["Puppeteer"]._startBrowser()`.
  * * `chrome`: (optional) pass additional [Puppeteer run options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions). Example
  *
  * ```js


### PR DESCRIPTION
Fixed a bunch of issues with the Puppeteer helper.

- Exit gracefully after a test completes
- Add ability to set `user-agent` via config
- Add `keepCookies`,`keepBrowserState` and `restart` (feature parity between helpers)

Updated the documentation, but haven't added any tests for these. Wanted to fix the double-tab issue during startup, but see there's another PR already open for that from @reubenmiller.