### PR TITLE
add injectDependencies method

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -60,6 +60,11 @@ module.exports = function (suite) {
       }
       const test = new Test(title, fn);
       test.fullTitle = () => `${suite.title}: ${title}`;
+      test.injectDependencies = (deps) => {
+        Object.keys(deps).forEach((key) => {
+          test.inject[key] = deps[key];
+        });
+      }
       test.file = file;
       test.async = true;
       test.timeout(0);


### PR DESCRIPTION
As mentioned in https://github.com/Codeception/CodeceptJS/pull/820#issuecomment-352279338
Now test object has injectDependencies method that allow to inject custom deps to test:

usage:
```
require('./common').forEach((t) => t.injectDependencies());
```