### PR TITLE
[Data Driven Tests] Accept plain arrays (regression fix)

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -46,6 +46,11 @@ module.exports = function (context) {
   };
 };
 
+function isTableDataRow(row) {
+  const has = Object.prototype.hasOwnProperty;
+  return has.call(row, 'data') && has.call(row, 'skip');
+}
+
 function detectDataType(dataTable) {
   if (dataTable instanceof DataTable) {
     return dataTable.rows;
@@ -64,7 +69,15 @@ function detectDataType(dataTable) {
     return dataTable();
   }
   if (Array.isArray(dataTable)) {
-    return dataTable;
+    return dataTable.map((item) => {
+      if (isTableDataRow(item)) {
+        return item;
+      }
+      return {
+        data: item,
+        skip: false,
+      };
+    });
   }
 
   throw new Error('Invalid data type. Data accepts either: DataTable || generator || Array || function');

--- a/test/data/sandbox/ddt_test.ddt.js
+++ b/test/data/sandbox/ddt_test.ddt.js
@@ -22,3 +22,7 @@ Data(function* () {
 }).Scenario('Should log accounts3', (I, current) => {
   console.log(`Got changed login ${current[0]}`);
 });
+
+Data(['1', '2', '3']).Scenario('Should log array of strings', (I, current) => {
+  console.log(`Got array item ${current}`);
+});


### PR DESCRIPTION
### Highlights

* Support plain arrays again in the Data Driven Tests. (Fixes #920)

### Background

Plain arrays worked in v1.0.1 but broke some time later.

The docs (advanced.md) already mention that `Data sets can also be defined with array, generator, or a function.`. So no need to update them.

Here is the example which now works again.

```js
Feature('ehm');

// Case 1: Allow plain arrays
Data(['1', '2', '3']).Scenario('data table test array', (I, current) => {
    I.amOnPage('/');
    console.log(current);
});
```