### PR TITLE
[Bugfix #932] Clear value attribute instead of innerhtml for TEXTAREA elements

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -749,12 +749,10 @@ class Puppeteer extends Helper {
     // await el.focus();
     const tag = await el.getProperty('tagName').then(el => el.jsonValue());
     const editable = await el.getProperty('contenteditable').then(el => el.jsonValue());
-
-    if (tag === 'TEXTAREA' || editable) {
-      await this._evaluateHandeInContext(el => el.innerHTML = '', el);
-    }
-    if (tag === 'INPUT') {
+    if (tag === 'INPUT' || tag === 'TEXTAREA') {
       await this._evaluateHandeInContext(el => el.value = '', el);
+    } else if (editable) {
+      await this._evaluateHandeInContext(el => el.innerHTML = '', el);
     }
     await el.type(value, { delay: 10 });
     return this._waitForAction();

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -64,7 +64,7 @@ module.exports = function (suite) {
         Object.keys(deps).forEach((key) => {
           test.inject[key] = deps[key];
         });
-      }
+      };
       test.file = file;
       test.async = true;
       test.timeout(0);

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -319,6 +319,14 @@ module.exports.tests = function () {
       return assert.equal(formContents('description'), 'Nothing special');
     });
 
+    it('should fill textarea by overwritting the existing value', function* () {
+      yield I.amOnPage('/form/textarea');
+      yield I.fillField('Description', 'Nothing special');
+      yield I.fillField('Description', 'Some other text');
+      yield I.click('Submit');
+      return assert.equal(formContents('description'), 'Some other text');
+    });
+
     it('should append field value', function* () {
       yield I.amOnPage('/form/field');
       yield I.appendField('Name', '_AND_NEW');


### PR DESCRIPTION
### Highlights
* Fixing #932. The TEXTAREA item wasn't being cleared because the innerhtml attribute was being cleared instead of the value attribute.
* Lint fix

### References
* [text area value vs innerhtml](https://stackoverflow.com/questions/5314186/javascript-get-textarea-input-via-value-or-innerhtml)