### PR TITLE
[Nightmare|Bugfix] Init browser with about:blank so browser does not hang if scenario fails before I.amOnPage() is called

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -231,6 +231,7 @@ class Nightmare extends Helper {
       this.browser = this.Nightmare(this.options);
       await this.browser;
     }
+    await this.browser.goto('about:blank'); // Load a blank page so .saveScreenshot (/evaluate) will work
     this.isRunning = true;
     this.browser.on('dom-ready', () => this._injectClientScripts());
     this.browser.on('did-start-loading', () => this._injectClientScripts());


### PR DESCRIPTION
#### Highlights

* Initialise Nightmare (in _startBrowser) on a blank page
* Fixes following issues, #786 & #898 

#### Root Cause

If a scenario fails before `I.amOnPage` is called, then the subsequent call to the _failed hook in the Nightmare helper, tries to take a screenshot of the browser. Before a screenshot is taken the height and width of the browser is retrieved using `browser.evaulate`, however if Nightmare has not had `.goto` called on it, then `.evaulate` will timeout.
