### PR TITLE
Fixed typo in pressKey function description

### DIFF
--- a/docs/webapi/pressKey.mustache
+++ b/docs/webapi/pressKey.mustache
@@ -1,5 +1,5 @@
 Presses a key on a focused element.
-Speical keys like 'Enter', 'Control', [etc](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value)
+Special keys like 'Enter', 'Control', [etc](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value)
 will be replaced with corresponding unicode.
 If modifier key is used (Control, Command, Alt, Shift) in array, it will be released afterwards.
 


### PR DESCRIPTION
Fixed the typo in the source file rather than in the generated markdown file (as per suggestion in PR #916).