### PR TITLE
Fix incorrect description of waitUntilExists

### DIFF
--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -1385,7 +1385,7 @@ I.waitUntil(() => window.requests == 0, 5);
 
 ## waitUntilExists
 
-Waits for element not to be present on page (by default waits for 1sec).
+Waits for element be present on page (by default waits for 1sec).
 Element can be located by CSS or XPath.
 
 ```js


### PR DESCRIPTION
The description of `waitUntilExists` currently says (emphasis added) "Waits for element to **not be** present on page (by default waits for 1sec)." Prior to #934 this was (counterintuitively) true, but the method's behavior has now been changed to be consistent with its name.