### PR TITLE
[AfterSuite|After] Allow AfterSuite and After test hooks to be defined after the first Scenario

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -39,22 +39,6 @@ module.exports = function (suite) {
         fn = opts;
         opts = {};
       }
-      /**
-       * load hooks from arrays to suite to prevent reordering
-       *
-       */
-      if (!afterAllHooksAreLoaded) {
-        afterAllHooks.forEach((hook) => {
-          suites[0].afterAll(hook[0], hook[1]);
-        });
-        afterAllHooksAreLoaded = true;
-      }
-      if (!afterEachHooksAreLoaded) {
-        afterEachHooks.forEach((hook) => {
-          suites[0].afterEach(hook[0], hook[1]);
-        });
-        afterEachHooksAreLoaded = true;
-      }
       if (suite.pending) {
         fn = null;
       }
@@ -124,7 +108,7 @@ module.exports = function (suite) {
     };
 
     context.AfterSuite = function (fn) {
-      suites[0].afterAll('AfterSuite', scenario.injected(fn, suites[0], 'afterSuite'));
+      afterAllHooks.unshift(['AfterSuite', scenario.injected(fn, suites[0], 'afterSuite')]);
     };
 
     context.Background = context.Before = function (fn) {
@@ -132,7 +116,7 @@ module.exports = function (suite) {
     };
 
     context.After = function (fn) {
-      suites[0].afterEach('After', scenario.injected(fn, suites[0], 'after'));
+      afterEachHooks.unshift(['After', scenario.injected(fn, suites[0], 'after')]);
     };
 
     /**
@@ -158,5 +142,24 @@ module.exports = function (suite) {
     };
 
     addDataContext(context);
+  });
+
+  suite.on('post-require', (context, file, mocha) => {
+    /**
+     * load hooks from arrays to suite to prevent reordering
+     */
+    if (!afterEachHooksAreLoaded && Array.isArray(afterEachHooks)) {
+      afterEachHooks.forEach((hook) => {
+        suites[0].afterEach(hook[0], hook[1]);
+      });
+      afterEachHooksAreLoaded = true;
+    }
+
+    if (!afterAllHooksAreLoaded && Array.isArray(afterAllHooks)) {
+      afterAllHooks.forEach((hook) => {
+        suites[0].afterAll(hook[0], hook[1]);
+      });
+      afterAllHooksAreLoaded = true;
+    }
   });
 };

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -124,7 +124,7 @@ module.exports = function (suite) {
     };
 
     context.AfterSuite = function (fn) {
-      afterAllHooks.unshift(['AfterSuite', scenario.injected(fn, suites[0], 'afterSuite')]);
+      suites[0].afterAll('AfterSuite', scenario.injected(fn, suites[0], 'afterSuite'));
     };
 
     context.Background = context.Before = function (fn) {
@@ -132,7 +132,7 @@ module.exports = function (suite) {
     };
 
     context.After = function (fn) {
-      afterEachHooks.unshift(['After', scenario.injected(fn, suites[0], 'after')]);
+      suites[0].afterEach('After', scenario.injected(fn, suites[0], 'after'));
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^8.9.3",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
-    "co-mocha": "^1.2. left-pad --save1",
+    "co-mocha": "^1.2",
     "documentation": "^4.0.0-beta1",
     "eslint": "^4.17.0",
     "eslint-config-airbnb-base": "^12.1.0",

--- a/test/data/helper.js
+++ b/test/data/helper.js
@@ -5,6 +5,26 @@ class MyHelper extends Helper {
     return 'hello world';
   }
 
+  _beforeSuite() {
+    console.log('Helper: I\'m simple BeforeSuite hook');
+  }
+
+  _before() {
+    console.log('Helper: I\'m simple Before hook');
+  }
+
+  _after() {
+    console.log('Helper: I\'m simple After hook');
+  }
+
+  _afterSuite() {
+    console.log('Helper: I\'m simple AfterSuite hook');
+  }
+
+  _failed() {
+    console.log('Helper: I\'m simple Failed hook');
+  }
+
   method2() {
     return 'hello another world';
   }
@@ -14,15 +34,15 @@ class MyHelper extends Helper {
   }
 
   stringWithHook(hookName) {
-    return `I'm generator ${hookName} hook`;
+    return `Test: I'm generator ${hookName} hook`;
   }
 
   asyncStringWithHook(hookName) {
-    return `I'm async/await ${hookName} hook`;
+    return `Test: I'm async/await ${hookName} hook`;
   }
 
   stringWithScenarioType(type) {
-    return `I'm ${type} test`;
+    return `Test: I'm ${type} test`;
   }
 }
 

--- a/test/data/sandbox/codecept.testhooks.different.order.json
+++ b/test/data/sandbox/codecept.testhooks.different.order.json
@@ -1,0 +1,14 @@
+{
+  "tests": "./*_test.testhooks.different.order.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "FakeDriver": {
+      "require": "../helper"
+    }
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/testhooks_test.testhooks.different.order.js
+++ b/test/data/sandbox/testhooks_test.testhooks.different.order.js
@@ -1,0 +1,25 @@
+Feature('Test hooks');
+
+BeforeSuite(async (I) => {
+  const text = await I.asyncStringWithHook('BeforeSuite');
+  console.log(text);
+});
+
+Before(async (I) => {
+  const text = await I.asyncStringWithHook('Before');
+  console.log(text);
+});
+
+Scenario('Simple test 1', () => {
+  console.log('Scenario: It\'s first test');
+});
+
+After(async (I) => {
+  const text = await I.asyncStringWithHook('After');
+  console.log(text);
+});
+
+AfterSuite(async (I) => {
+  const text = await I.asyncStringWithHook('AfterSuite');
+  console.log(text);
+});

--- a/test/data/sandbox/testhooks_test.testhooks.js
+++ b/test/data/sandbox/testhooks_test.testhooks.js
@@ -1,19 +1,19 @@
 Feature('Test hooks');
 
 BeforeSuite(() => {
-  console.log('I\'m simple BeforeSuite hook');
+  console.log('Test: I\'m simple BeforeSuite hook');
 });
 
 Before(() => {
-  console.log('I\'m simple Before hook');
+  console.log('Test: I\'m simple Before hook');
 });
 
 After(() => {
-  console.log('I\'m simple After hook');
+  console.log('Test: I\'m simple After hook');
 });
 
 AfterSuite(() => {
-  console.log('I\'m simple AfterSuite hook');
+  console.log('Test: I\'m simple AfterSuite hook');
 });
 
 BeforeSuite(function* (I) {
@@ -57,5 +57,5 @@ AfterSuite(async (I) => {
 });
 
 Scenario('Simple test 1', () => {
-  console.log('It\'s first test');
+  console.log('Scenario: It\'s first test');
 });

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -136,8 +136,8 @@ describe('CodeceptJS Runner', () => {
       expect(lines).to.include.members([
         'Test scenario types --',
         'It\'s usual test',
-        'I\'m generator test',
-        'I\'m async/await test',
+        'Test: I\'m generator test',
+        'Test: I\'m async/await test',
       ]);
       stdout.should.include('OK  | 3 passed');
       assert(!err);

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -85,7 +85,6 @@ describe('CodeceptJS Runner', () => {
   it('should run hooks from suites', (done) => {
     exec(codecept_run_config('codecept.testhooks.json'), (err, stdout) => {
       const lines = stdout.match(/\S.+/g);
-      console.log('lines', lines);
 
       expect(lines).to.include.members([
         'Helper: I\'m simple BeforeSuite hook',
@@ -114,7 +113,6 @@ describe('CodeceptJS Runner', () => {
   it('should run hooks from suites (in different order)', (done) => {
     exec(codecept_run_config('codecept.testhooks.different.order.json'), (err, stdout) => {
       const lines = stdout.match(/\S.+/g);
-      console.log('lines', lines);
 
       expect(lines).to.include.members([
         'Helper: I\'m simple BeforeSuite hook',

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -85,19 +85,46 @@ describe('CodeceptJS Runner', () => {
   it('should run hooks from suites', (done) => {
     exec(codecept_run_config('codecept.testhooks.json'), (err, stdout) => {
       const lines = stdout.match(/\S.+/g);
+      console.log('lines', lines);
+
       expect(lines).to.include.members([
-        'I\'m simple BeforeSuite hook',
-        'I\'m generator BeforeSuite hook',
-        'I\'m async/await BeforeSuite hook',
-        'I\'m simple Before hook',
-        'I\'m generator Before hook',
-        'I\'m async/await Before hook',
-        'I\'m generator After hook',
-        'I\'m simple After hook',
-        'I\'m async/await After hook',
-        'I\'m generator AfterSuite hook',
-        'I\'m simple AfterSuite hook',
-        'I\'m async/await AfterSuite hook',
+        'Helper: I\'m simple BeforeSuite hook',
+        'Test: I\'m simple BeforeSuite hook',
+        'Test: I\'m generator BeforeSuite hook',
+        'Test: I\'m async/await BeforeSuite hook',
+        'Helper: I\'m simple Before hook',
+        'Test: I\'m simple Before hook',
+        'Test: I\'m generator Before hook',
+        'Test: I\'m async/await Before hook',
+        'Test: I\'m generator After hook',
+        'Test: I\'m simple After hook',
+        'Test: I\'m async/await After hook',
+        'Helper: I\'m simple After hook',
+        'Test: I\'m generator AfterSuite hook',
+        'Test: I\'m simple AfterSuite hook',
+        'Test: I\'m async/await AfterSuite hook',
+        'Helper: I\'m simple AfterSuite hook',
+      ]);
+      stdout.should.include('OK  | 1 passed');
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should run hooks from suites (in different order)', (done) => {
+    exec(codecept_run_config('codecept.testhooks.different.order.json'), (err, stdout) => {
+      const lines = stdout.match(/\S.+/g);
+      console.log('lines', lines);
+
+      expect(lines).to.include.members([
+        'Helper: I\'m simple BeforeSuite hook',
+        'Test: I\'m async/await BeforeSuite hook',
+        'Helper: I\'m simple Before hook',
+        'Test: I\'m async/await Before hook',
+        'Test: I\'m async/await After hook',
+        'Helper: I\'m simple After hook',
+        'Test: I\'m async/await AfterSuite hook',
+        'Helper: I\'m simple AfterSuite hook',
       ]);
       stdout.should.include('OK  | 1 passed');
       assert(!err);


### PR DESCRIPTION
### Highlights

Allow `AfterSuite` and `After` test hooks to be defined after the first Scenario. This allows for a more flexible and natural placement of these two test hooks. Previously these two hooks needed to be placed before the first `Scenario`. Fixes #857

#### Example
```js
const assert = require('assert');

Feature('My new feature');

BeforeSuite((I) => {
  console.log('Before suite');
});

Before((I) => {
  console.log('Before each test');
});

Scenario('Test Case 1', (I) => {
    I.amOnPage('/');
});

Scenario('Test Case 2', (I) => {
  I.amOnPage('/');
});

After((I) => {
  console.log('After each test');
});

AfterSuite((I) => {
  console.log('Bfter suite');
});
```