### PR TITLE
[Nightmare] Prevent I.amOnpage navigation if the browser is already at the given url

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -12,6 +12,7 @@ const Locator = require('../locator');
 const co = require('co');
 const path = require('path');
 const ElementNotFound = require('./errors/ElementNotFound');
+const urlResolve = require('url').resolve;
 
 const specialKeys = {
   Backspace: '\u0008',
@@ -346,7 +347,12 @@ class Nightmare extends Helper {
    */
   async amOnPage(url, headers = null) {
     if (url.indexOf('http') !== 0) {
-      url = this.options.url + url;
+      url = urlResolve(this.options.url, url);
+    }
+    const currentUrl = await this.browser.url();
+    if (url === currentUrl) {
+      // navigating to the same url will cause an error in nightmare, so don't do it
+      return;
     }
     return this.browser.goto(url, headers).then((res) => {
       this.debugSection('URL', res.url);

--- a/test/helper/Nightmare_test.js
+++ b/test/helper/Nightmare_test.js
@@ -59,6 +59,9 @@ describe('Nightmare', function () {
       const url = yield browser.url();
       return url.should.eql(`${siteUrl}/`);
     });
+
+    it('should open same page twice without error', () => I.amOnPage('/')
+      .then(() => I.amOnPage('/')));
   });
 
   webApiTests.tests();


### PR DESCRIPTION
#### Highlights
**[Nightmare]**
* Check if browser is already at given url in `I.amOnPage`. If so then don't navigate to it as it will cause an error in nightmare. Fixes #713 
* Using nodejs url.resolve rather than straight string concatenation so it is inline with the webdriverio behaviour.
