### PR TITLE
waitForInvisible - implement treatNonPresentAsInvisible option (#943)

### DIFF
--- a/docs/webapi/waitForInvisible.mustache
+++ b/docs/webapi/waitForInvisible.mustache
@@ -7,3 +7,4 @@ I.waitForInvisible('#popup');
 
 @param locator element located by CSS|XPath|strict locator
 @param sec time seconds to wait, 1 by default
+@param treatNonPresentAsInvisible when true, succeeds when the element is either hidden or not present. otherwise, succeeds only if the element is hidden.

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -42,6 +42,7 @@ let withinStatus = false;
  * * `waitForAction`: (optional) how long to wait after click, doubleClick or PressKey actions in ms. Default: 500.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 1000.
  * * `windowSize`: (optional) default window size. Set a dimension like `640x480`.
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present
  *
  * + options from [Nightmare configuration](https://github.com/segmentio/nightmare#api)
  *
@@ -63,6 +64,7 @@ class Nightmare extends Helper {
       keepCookies: false,
       js_errors: null,
       enableHAR: false,
+      treatNonPresentAsInvisible: false,
     };
 
     this.isRunning = false;
@@ -854,17 +856,18 @@ class Nightmare extends Helper {
   /**
    * {{> ../webapi/waitForVisible }}
    */
-  waitForInvisible(locator, sec) {
+  waitForInvisible(locator, sec, treatNonPresentAsInvisible = null) {
     this.browser.options.waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const allowNonPresent = (treatNonPresentAsInvisible === null) ? this.options.treatNonPresentAsInvisible : treatNonPresentAsInvisible;
     locator = new Locator(locator, 'css');
 
-    return this.browser.wait((by, locator) => {
+    return this.browser.wait((by, locator, allowNonPresent) => {
       const el = window.codeceptjs.findElement(by, locator);
-      if (!el) return false;
+      if (!el) return allowNonPresent;
       return el.offsetParent === null;
-    }, locator.type, locator.value).catch((err) => {
+    }, locator.type, locator.value, allowNonPresent).catch((err) => {
       if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
-        throw new Error(`element (${JSON.stringify(locator)}) still visible after ${sec} sec`);
+        throw new Error(`element (${JSON.stringify(locator)}) not invisible after ${sec} sec`);
       } else throw err;
     });
   }

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -42,7 +42,7 @@ let withinStatus = false;
  * * `waitForAction`: (optional) how long to wait after click, doubleClick or PressKey actions in ms. Default: 500.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 1000.
  * * `windowSize`: (optional) default window size. Set a dimension like `640x480`.
- * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present.
  *
  * + options from [Nightmare configuration](https://github.com/segmentio/nightmare#api)
  *

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -947,15 +947,15 @@ class Protractor extends Helper {
     const aSec = sec || this.options.waitForTimeout;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
     const invisibleTest = EC.invisibilityOf(el);
-    
+
     const test = allowNonPresent ? invisibleTest : EC.and(invisibleTest, EC.presenceOf(el));
 
-    try{
+    try {
       await this.browser.wait(test, aSec * 1000);
     } catch (err) {
       throw err.name === 'TimeoutError'
-          ? new Error(`element (${JSON.stringify(locator)}) not invisible after ${aSec} sec`)
-          : err;
+        ? new Error(`element (${JSON.stringify(locator)}) not invisible after ${aSec} sec`)
+        : err;
     }
   }
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -42,7 +42,7 @@ let withinStore = {};
  * * `scriptsTimeout`: (optional) timeout in milliseconds for each script run on the browser, 10000 by default.
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
  * * `manualStart` (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriverIO"]._startBrowser()`
- * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present.
  * * `capabilities`: {} - list of [Desired Capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
  * * `proxy`: set proxy settings
  *
@@ -954,7 +954,7 @@ class Protractor extends Helper {
       await this.browser.wait(test, aSec * 1000);
     } catch (err) {
       throw err.name === 'TimeoutError'
-          ? new Error(`element (${JSON.stringify(locator)}) not invisible after ${sec} sec`)
+          ? new Error(`element (${JSON.stringify(locator)}) not invisible after ${aSec} sec`)
           : err;
     }
   }

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -42,6 +42,7 @@ let withinStore = {};
  * * `scriptsTimeout`: (optional) timeout in milliseconds for each script run on the browser, 10000 by default.
  * * `windowSize`: (optional) default window size. Set to `maximize` or a dimension in the format `640x480`.
  * * `manualStart` (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriverIO"]._startBrowser()`
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present
  * * `capabilities`: {} - list of [Desired Capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities)
  * * `proxy`: set proxy settings
  *
@@ -116,6 +117,7 @@ class Protractor extends Helper {
       waitForTimeout: 1000, // ms
       windowSize: null,
       driver: 'hosted',
+      treatNonPresentAsInvisible: false,
       capabilities: {},
       angular: true,
     };
@@ -940,10 +942,21 @@ class Protractor extends Helper {
   /**
    * {{> ../webapi/waitForInvisible }}
    */
-  async waitForInvisible(locator, sec = null) {
+  async waitForInvisible(locator, sec = null, treatNonPresentAsInvisible = null) {
+    const allowNonPresent = (treatNonPresentAsInvisible === null) ? this.options.treatNonPresentAsInvisible : treatNonPresentAsInvisible;
     const aSec = sec || this.options.waitForTimeout;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
-    return this.browser.wait(EC.invisibilityOf(el), aSec * 1000);
+    const invisibleTest = EC.invisibilityOf(el);
+    
+    const test = allowNonPresent ? invisibleTest : EC.and(invisibleTest, EC.presenceOf(el));
+
+    try{
+      await this.browser.wait(test, aSec * 1000);
+    } catch (err) {
+      throw err.name === 'TimeoutError'
+          ? new Error(`element (${JSON.stringify(locator)}) not invisible after ${sec} sec`)
+          : err;
+    }
   }
 
   async waitForStalenessOf(locator, sec = null) {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1288,16 +1288,9 @@ class Puppeteer extends Helper {
     const matcher = await this.context;
     const context = await this._getContext();
 
-    let selector;
-    let selectionFunction;
-    
-    if (locator.isCSS()) {
-      selector = locator.simplify();
-      selectionFunction = queryAll;
-    } else {
-      selector = locator.value;
-      selectionFunction = $XPath;
-    }
+    const isCSS = locator.isCSS();
+    const selector = isCSS ? locator.simplify() : locator.value;
+    const selectionFunction = isCSS ? queryAll : $XPath;
 
     const visibleFn = function (selector, selectionFunctionStr, allowNonPresent) {
       const selectionFunction = new Function('node', 'selector', `return (${selectionFunctionStr})(node, selector);`);

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1309,7 +1309,7 @@ class Puppeteer extends Helper {
  
     return waiter.catch((err) => {
       throw (err && err.message && err.message.indexOf('timeout') !== -1)
-         ? new Error(`element (${locator.toString()}) not invisible after ${waitTimeout / 1000} sec`)
+         ? new Error(`element (${locator.toString()}) not invisible after ${waitTimeout / 1000} sec\n${err.message}`)
          : err;
     });
   }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1293,17 +1293,17 @@ class Puppeteer extends Helper {
     const selectionFunction = isCSS ? queryAll : $XPath;
 
     const visibleFn = function (selector, selectionFunctionStr, allowNonPresent) {
-      const selectionFunction = new Function('node', 'selector', `return (${selectionFunctionStr})(node, selector);`);
+      const selectionFunction = new Function('node', 'selector', `return (${selectionFunctionStr})(node, selector);`); // eslint-disable-line no-new-func
       const selected = selectionFunction(null, selector);
       if (selected.length === 0) return allowNonPresent;
       return selected.filter(el => el.offsetParent === null).length > 0;
     };
     const waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, selector, selectionFunction.toString(), allowNonPresent);
- 
+
     return waiter.catch((err) => {
       throw (err && err.message && err.message.indexOf('timeout') !== -1)
-         ? new Error(`element (${locator.toString()}) not invisible after ${waitTimeout / 1000} sec\n${err.message}`)
-         : err;
+        ? new Error(`element (${locator.toString()}) not invisible after ${waitTimeout / 1000} sec\n${err.message}`)
+        : err;
     });
   }
 
@@ -1796,7 +1796,7 @@ function assertElementExists(res, locator, prefix, suffix) {
 
 function queryAll(node, selector) {
   const found = (node || document).querySelectorAll(selector);
-  
+
   return Array.from(found);
 }
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -48,6 +48,7 @@ const consoleLogStore = new Console();
  * * `windowSize`: (optional) default window size. Set a dimension like `640x480`.
  * * `userAgent`: (optional) user-agent string.
  * * `manualStart`: (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["Puppeteer"]._startBrowser()`.
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present.
  * * `chrome`: (optional) pass additional [Puppeteer run options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions). Example
  *
  * ```js
@@ -74,6 +75,7 @@ class Puppeteer extends Helper {
       keepBrowserState: false,
       show: false,
       defaultPopupAction: 'accept',
+      treatNonPresentAsInvisible: false,
     };
 
     this.isRunning = false;
@@ -1279,23 +1281,36 @@ class Puppeteer extends Helper {
   /**
    * {{> ../webapi/waitForInvisible }}
    */
-  async waitForInvisible(locator, sec) {
+  async waitForInvisible(locator, sec, treatNonPresentAsInvisible = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const allowNonPresent = (treatNonPresentAsInvisible === null) ? this.options.treatNonPresentAsInvisible : treatNonPresentAsInvisible;
     locator = new Locator(locator, 'css');
     const matcher = await this.context;
-    let waiter;
     const context = await this._getContext();
+
+    let selector;
+    let selectionFunction;
+    
     if (locator.isCSS()) {
-      waiter = context.waitForSelector(locator.simplify(), { timeout: waitTimeout, hidden: true });
+      selector = locator.simplify();
+      selectionFunction = queryAll;
     } else {
-      const visibleFn = function (locator, $XPath) {
-        eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).filter(el => el.offsetParent === null).length > 0;
-      };
-      waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, $XPath.toString());
+      selector = locator.value;
+      selectionFunction = $XPath;
     }
+
+    const visibleFn = function (selector, selectionFunctionStr, allowNonPresent) {
+      const selectionFunction = new Function('node', 'selector', `return (${selectionFunctionStr})(node, selector);`);
+      const selected = selectionFunction(null, selector);
+      if (selected.length === 0) return allowNonPresent;
+      return selected.filter(el => el.offsetParent === null).length > 0;
+    };
+    const waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, selector, selectionFunction.toString(), allowNonPresent);
+ 
     return waiter.catch((err) => {
-      throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${err.message}`);
+      throw (err && err.message && err.message.indexOf('timeout') !== -1)
+         ? new Error(`element (${locator.toString()}) not invisible after ${waitTimeout / 1000} sec`)
+         : err;
     });
   }
 
@@ -1784,6 +1799,12 @@ function assertElementExists(res, locator, prefix, suffix) {
   if (!res || res.length === 0) {
     throw new ElementNotFound(locator, prefix, suffix);
   }
+}
+
+function queryAll(node, selector) {
+  const found = (node || document).querySelectorAll(selector);
+  
+  return Array.from(found);
 }
 
 function $XPath(element, selector) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -41,6 +41,7 @@ let withinStore = {};
  * capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities).
  * * `manualStart`: (optional, default: false) - do not start browser before a test, start it manually inside a helper
  * with `this.helpers["WebDriverIO"]._startBrowser()`.
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present
  * * `timeouts`: [WebDriverIO timeouts](http://webdriver.io/guide/testrunner/timeouts.html) defined as hash.
  *
  * Example:
@@ -216,6 +217,7 @@ class WebDriverIO extends Helper {
       keepCookies: false,
       keepBrowserState: false,
       deprecationWarnings: false,
+      treatNonPresentAsInvisible: false,
       timeouts: {
         script: 1000, // ms
       },
@@ -1571,17 +1573,19 @@ class WebDriverIO extends Helper {
    * {{> ../webapi/waitForInvisible }}
    * Appium: support
    */
-  async waitForInvisible(locator, sec = null) {
+  async waitForInvisible(locator, sec = null, treatNonPresentAsInvisible = null) {
     const aSec = sec || this.options.waitForTimeout;
+    const aAllowNonPresent = (treatNonPresentAsInvisible === null) ? this.options.treatNonPresentAsInvisible : treatNonPresentAsInvisible;
+    
     return this.browser.waitUntil(async () => {
       const res = await this.browser.elements(withStrictLocator.call(this, locator));
-      if (!res.value || res.value.length === 0) return false;
+      if (!res.value || res.value.length === 0) return aAllowNonPresent;
       const selected = await forEachAsync(res.value, async el => this.browser.elementIdDisplayed(el.ELEMENT));
       if (Array.isArray(selected)) {
         return selected.filter(val => val === false).length > 0;
       }
       return !selected;
-    }, aSec * 1000, `element (${locator}) still visible after ${aSec} sec`);
+    }, aSec * 1000, `element (${locator}) not invisible after ${aSec} sec`);
   }
 
   /**

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1576,7 +1576,7 @@ class WebDriverIO extends Helper {
   async waitForInvisible(locator, sec = null, treatNonPresentAsInvisible = null) {
     const aSec = sec || this.options.waitForTimeout;
     const aAllowNonPresent = (treatNonPresentAsInvisible === null) ? this.options.treatNonPresentAsInvisible : treatNonPresentAsInvisible;
-    
+
     return this.browser.waitUntil(async () => {
       const res = await this.browser.elements(withStrictLocator.call(this, locator));
       if (!res.value || res.value.length === 0) return aAllowNonPresent;

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -41,7 +41,7 @@ let withinStore = {};
  * capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities).
  * * `manualStart`: (optional, default: false) - do not start browser before a test, start it manually inside a helper
  * with `this.helpers["WebDriverIO"]._startBrowser()`.
- * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present
+ * * `treatNonPresentAsInvisible`: (optional, default: false) - when true, waitForInvisible will succeed when no elements matching the selector are present.
  * * `timeouts`: [WebDriverIO timeouts](http://webdriver.io/guide/testrunner/timeouts.html) defined as hash.
  *
  * Example:

--- a/test/data/app/view/form/wait_invisible.php
+++ b/test/data/app/view/form/wait_invisible.php
@@ -15,6 +15,12 @@
 
 
 </script>
-
+<div id="step_2">Step Two Button</div>
+<script>
+  setTimeout(function () {
+      var step2 = document.getElementById('step_2');
+      step2.parentElement.removeChild(step2);
+  }, 1000);
+</script>
 </body>
 </html>

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -640,8 +640,8 @@ module.exports.tests = function () {
       .then(() => I.seeElement('#step_2'))
       .then(() => I.waitForInvisible('#step_2', 2))
       .then(
-          () => { throw new Error('waitForInvisible should not succeed here'); },
-          e => assert.equal(e.message, 'element (#step_2) not invisible after 2 sec')
+          () => Promise.reject(new Error('waitForInvisible should not succeed here')),
+          e => assert(/^element \(.+\) not invisible after 2 sec$/.test(e.message), `incorrect failure message: ${e.message}`)
        )
        .then(() => I.dontSeeElement('#step_2')));
   });

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -3,7 +3,6 @@ require('co-mocha')(require('mocha'));
 let I;
 let data;
 let siteUrl;
-let defaultOptions;
 
 const assert = require('assert');
 const path = require('path');
@@ -14,8 +13,6 @@ const fileExists = require('../../lib/utils').fileExists;
 
 module.exports.init = function (testData) {
   data = testData;
-  // store initial options
-  if (!defaultOptions) defaultOptions = testData.I.options;
 };
 
 module.exports.tests = function () {
@@ -23,7 +20,6 @@ module.exports.tests = function () {
 
   beforeEach(() => {
     I = data.I;
-    I.options = JSON.parse(JSON.stringify(defaultOptions));
     siteUrl = data.siteUrl;
     if (fileExists(dataFile)) require('fs').unlinkSync(dataFile);
   });
@@ -609,9 +605,11 @@ module.exports.tests = function () {
   });
 
   describe('#waitForInvisible', () => {
-    beforeEach(() => {
-        assert.equal(I.options.treatNonPresentAsInvisible, false);
-    });
+    // ensure that treatNonPresentAsInvisible is false in the default options
+    beforeEach(() => assert.equal(I.options.treatNonPresentAsInvisible, false));
+    
+    // restore setting to false if it was changed during a test
+    afterEach(() => { I.options.treatNonPresentAsInvisible = false; });
       
     it('should wait for element to be invisible', () => I.amOnPage('/form/wait_invisible')
       .then(() => I.see('Step One Button'))

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -632,33 +632,29 @@ module.exports.tests = function () {
       .then(() => I.waitForInvisible(step2Css))
       .then(() => I.dontSeeElement(step2Css)));
 
-    it('should allow specifying treatNonPresentAsInvisible as a function parameter', () => I.amOnPage('/form/wait_invisible')
-      .then(() => I.seeElement(step2Css))
-      .then(() => I.waitForInvisible(step2Css, null, true))
-      .then(() => I.dontSeeElement(step2Css)));
+    function allowNonPresentFunctionParameter(selector, description) {
+      it(`should allow specifying treatNonPresentAsInvisible as a function parameter - ${description} version`, () => I.amOnPage('/form/wait_invisible')
+        .then(() => I.seeElement(selector))
+        .then(() => I.waitForInvisible(selector, null, true))
+        .then(() => I.dontSeeElement(selector)));
+    }
 
-    it('should allow specifying treatNonPresentAsInvisible as a function parameter - XPath version', () => I.amOnPage('/form/wait_invisible')
-      .then(() => I.seeElement(step2XPath))
-      .then(() => I.waitForInvisible(step2XPath, null, true))
-      .then(() => I.dontSeeElement(step2XPath)));
+    allowNonPresentFunctionParameter(step2Css, 'CSS');
+    allowNonPresentFunctionParameter(step2XPath, 'XPath');
 
-    it('should not treat non-present elements as invisible by default', () => I.amOnPage('/form/wait_invisible')
-      .then(() => I.seeElement(step2Css))
-      .then(() => I.waitForInvisible(step2Css, 2))
-      .then(
-        () => Promise.reject(new Error('waitForInvisible should not succeed here')),
-        e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`),
-      )
-      .then(() => I.dontSeeElement(step2Css)));
+    function waitForInvisibleDefaultBehavior(selector, description) {
+      it(`should not treat non-present elements as invisible by default - ${description} version`, () => I.amOnPage('/form/wait_invisible')
+        .then(() => I.seeElement(selector))
+        .then(() => I.waitForInvisible(selector, 2))
+        .then(
+          () => Promise.reject(new Error('waitForInvisible should not succeed here')),
+          e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`),
+        )
+        .then(() => I.dontSeeElement(selector)));
+    }
 
-    it('should not treat non-present elements as invisible by default - XPath version', () => I.amOnPage('/form/wait_invisible')
-      .then(() => I.seeElement(step2XPath))
-      .then(() => I.waitForInvisible(step2XPath, 2))
-      .then(
-        () => Promise.reject(new Error('waitForInvisible should not succeed here')),
-        e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`),
-      )
-      .then(() => I.dontSeeElement(step2XPath)));
+    waitForInvisibleDefaultBehavior(step2Css, 'CSS');
+    waitForInvisibleDefaultBehavior(step2XPath, 'XPath');
   });
 
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -649,7 +649,7 @@ module.exports.tests = function () {
       .then(() => I.waitForInvisible(step2Css, 2))
       .then(
           () => Promise.reject(new Error('waitForInvisible should not succeed here')),
-          e => assert(/^element \(.+\) not invisible after 2 sec$/.test(e.message), `incorrect failure message: ${e.message}`)
+          e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`)
        )
        .then(() => I.dontSeeElement(step2Css)));
 
@@ -658,7 +658,7 @@ module.exports.tests = function () {
       .then(() => I.waitForInvisible(step2XPath, 2))
       .then(
           () => Promise.reject(new Error('waitForInvisible should not succeed here')),
-          e => assert(/^element \(.+\) not invisible after 2 sec$/.test(e.message), `incorrect failure message: ${e.message}`)
+          e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`)
        )
        .then(() => I.dontSeeElement(step2XPath)));
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -625,26 +625,44 @@ module.exports.tests = function () {
       .then(() => I.dontSeeElement('//div[@id="step_1"]'))
       .then(() => I.seeElementInDOM('//div[@id="step_1"]')));
 
+    const step2Css = '#step_2';
+    const step2XPath = '//div[@id = "step_2"]';
+      
     it('should allow specifying treatNonPresentAsInvisible as a config option', () => I.amOnPage('/form/wait_invisible')
       .then(() => { I.options.treatNonPresentAsInvisible = true })
-      .then(() => I.seeElement('#step_2'))
-      .then(() => I.waitForInvisible('#step_2'))
-      .then(() => I.dontSeeElement('#step_2')));
+      .then(() => I.seeElement(step2Css))
+      .then(() => I.waitForInvisible(step2Css))
+      .then(() => I.dontSeeElement(step2Css)));
 
     it('should allow specifying treatNonPresentAsInvisible as a function parameter', () => I.amOnPage('/form/wait_invisible')
-      .then(() => I.seeElement('#step_2'))
-      .then(() => I.waitForInvisible('#step_2', null, true))
-      .then(() => I.dontSeeElement('#step_2')));
+      .then(() => I.seeElement(step2Css))
+      .then(() => I.waitForInvisible(step2Css, null, true))
+      .then(() => I.dontSeeElement(step2Css)));
       
+    it('should allow specifying treatNonPresentAsInvisible as a function parameter - XPath version', () => I.amOnPage('/form/wait_invisible')
+      .then(() => I.seeElement(step2XPath))
+      .then(() => I.waitForInvisible(step2XPath, null, true))
+      .then(() => I.dontSeeElement(step2XPath)));
+
     it('should not treat non-present elements as invisible by default', () => I.amOnPage('/form/wait_invisible')
-      .then(() => I.seeElement('#step_2'))
-      .then(() => I.waitForInvisible('#step_2', 2))
+      .then(() => I.seeElement(step2Css))
+      .then(() => I.waitForInvisible(step2Css, 2))
       .then(
           () => Promise.reject(new Error('waitForInvisible should not succeed here')),
           e => assert(/^element \(.+\) not invisible after 2 sec$/.test(e.message), `incorrect failure message: ${e.message}`)
        )
-       .then(() => I.dontSeeElement('#step_2')));
-  });
+       .then(() => I.dontSeeElement(step2Css)));
+
+    it('should not treat non-present elements as invisible by default - XPath version', () => I.amOnPage('/form/wait_invisible')
+      .then(() => I.seeElement(step2XPath))
+      .then(() => I.waitForInvisible(step2XPath, 2))
+      .then(
+          () => Promise.reject(new Error('waitForInvisible should not succeed here')),
+          e => assert(/^element \(.+\) not invisible after 2 sec$/.test(e.message), `incorrect failure message: ${e.message}`)
+       )
+       .then(() => I.dontSeeElement(step2XPath)));
+
+   });
 
 
   describe('within tests', () => {

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -607,10 +607,10 @@ module.exports.tests = function () {
   describe('#waitForInvisible', () => {
     // ensure that treatNonPresentAsInvisible is false in the default options
     beforeEach(() => assert.equal(I.options.treatNonPresentAsInvisible, false));
-    
+
     // restore setting to false if it was changed during a test
     afterEach(() => { I.options.treatNonPresentAsInvisible = false; });
-      
+
     it('should wait for element to be invisible', () => I.amOnPage('/form/wait_invisible')
       .then(() => I.see('Step One Button'))
       .then(() => I.seeElement('#step_1'))
@@ -625,9 +625,9 @@ module.exports.tests = function () {
 
     const step2Css = '#step_2';
     const step2XPath = '//div[@id = "step_2"]';
-      
+
     it('should allow specifying treatNonPresentAsInvisible as a config option', () => I.amOnPage('/form/wait_invisible')
-      .then(() => { I.options.treatNonPresentAsInvisible = true })
+      .then(() => { I.options.treatNonPresentAsInvisible = true; })
       .then(() => I.seeElement(step2Css))
       .then(() => I.waitForInvisible(step2Css))
       .then(() => I.dontSeeElement(step2Css)));
@@ -636,7 +636,7 @@ module.exports.tests = function () {
       .then(() => I.seeElement(step2Css))
       .then(() => I.waitForInvisible(step2Css, null, true))
       .then(() => I.dontSeeElement(step2Css)));
-      
+
     it('should allow specifying treatNonPresentAsInvisible as a function parameter - XPath version', () => I.amOnPage('/form/wait_invisible')
       .then(() => I.seeElement(step2XPath))
       .then(() => I.waitForInvisible(step2XPath, null, true))
@@ -646,21 +646,20 @@ module.exports.tests = function () {
       .then(() => I.seeElement(step2Css))
       .then(() => I.waitForInvisible(step2Css, 2))
       .then(
-          () => Promise.reject(new Error('waitForInvisible should not succeed here')),
-          e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`)
-       )
-       .then(() => I.dontSeeElement(step2Css)));
+        () => Promise.reject(new Error('waitForInvisible should not succeed here')),
+        e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`),
+      )
+      .then(() => I.dontSeeElement(step2Css)));
 
     it('should not treat non-present elements as invisible by default - XPath version', () => I.amOnPage('/form/wait_invisible')
       .then(() => I.seeElement(step2XPath))
       .then(() => I.waitForInvisible(step2XPath, 2))
       .then(
-          () => Promise.reject(new Error('waitForInvisible should not succeed here')),
-          e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`)
-       )
-       .then(() => I.dontSeeElement(step2XPath)));
-
-   });
+        () => Promise.reject(new Error('waitForInvisible should not succeed here')),
+        e => assert(/^element \(.+\) not invisible after 2 sec/.test(e.message), `incorrect failure message: ${e.message}`),
+      )
+      .then(() => I.dontSeeElement(step2XPath)));
+  });
 
 
   describe('within tests', () => {


### PR DESCRIPTION
In #943, I observed that `waitForInvisible`, rather than simply waiting for there to be no visible elements matching the selector, actually waits until there is _at least one_ invisible element matching the selector (at least in most implementations this is true; see below).

I posited that this was somewhat unintuitive from a testing perspective because when a test is waiting for an element to disappear, the test shouldn't care about whether the element is actually hidden or removed from the DOM.

I also indicated that the failure message "element (...) still visible after ... sec" was misleading, because it could say the element was "still visible" even in situations where the element didn't exist at all.

@reubenmiller said that the current behavior _is_ desirable as the default behavior, but suggested that I add a new option that would make `waitForInvisible` agnostic w.r.t. elements' presence or non-presence in the DOM, so that is what I have done in this pull request. I have also changed the failure messages to be consistent across all helpers, as "element (...) not invisible after ... sec".

One important note about these changes:

I noticed some inconsistency in `waitForInvisible`'s behavior across the different helpers in their implementation prior to my changes:

- In the Protractor helper, its behavior was to succeed either if the element was non-present or hidden, because that's what `EC.invisibilityOf(el)` does.
- In the Puppeteer helper, its behavior was to succeed either if the element was non-present or hidden, **but only when using a CSS selector**, because that's what `EC.invisibilityOf(el)` does. When using an XPath selector, its behavior was to wait for at least one hidden element, just like in the Nightmare and WebdriverIO helpers.

I have modified all helpers to be consistent and added unit tests to verify this, but this would imply a breaking change for anyone relying on the previously inconsistent behavior in the Protractor and Puppeteer helpers.