### PR TITLE
grabNumberOfVisibleElements to return also 0 visible elements

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1012,7 +1012,6 @@ class WebDriverIO extends Helper {
    */
   async grabNumberOfVisibleElements(locator) {
     const res = await this._locate(locator);
-    assertElementExists(res, locator);
 
     let selected = await forEachAsync(res.value, async el => this.browser.elementIdDisplayed(el.ELEMENT));
     if (!Array.isArray(selected)) selected = [selected];


### PR DESCRIPTION
Assertion removed from grabNumberOfVisibleElements method to accept also zero visible elements.
- this method should return also value if no elements are displayed on the page
- issue was discussed also on slack channel

