### PR TITLE
[Puppeteer] Fixing function calls when clearing the cookies and localstorage

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -130,9 +130,9 @@ class Puppeteer extends Helper {
 
     if (!this.options.keepCookies) {
       this.debugSection('Session', 'cleaning cookies and localStorage');
-      await this.browser.deleteCookie();
+      await this.clearCookie();
     }
-    await this.browser.execute('localStorage.clear();').catch((err) => {
+    await this.executeScript('localStorage.clear();').catch((err) => {
       if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
     });
     await this.closeOtherTabs();


### PR DESCRIPTION
#### Highlights

Fixing bug where a non-existant functions were being called when trying to clear the cookies and localstorage. Introduced with the Puppeteer restart = false browser logic. #954 