### PR TITLE
Removed comma after last argument

### DIFF
--- a/lib/mocha_factory.js
+++ b/lib/mocha_factory.js
@@ -38,7 +38,7 @@ class MochaFactory {
     if (reporterOptions['codeceptjs-cli-reporter'] && attributes) {
       Object.defineProperty(
         reporterOptions, 'codeceptjs/lib/reporter/cli',
-        attributes,
+        attributes
       );
       delete reporterOptions['codeceptjs-cli-reporter'];
     }


### PR DESCRIPTION
`npx codeceptjs init` crashes because of unnecessary comma in `./codeceptjs/lib/mocha_factory.js:42`

Stack trace:

    SyntaxError: Unexpected token )
      at createScript (vm.js:56:10)
      at Object.runInThisContext (vm.js:97:10)
      at Module._compile (module.js:549:28)
      at Object.Module._extensions..js (module.js:586:10)
      at Module.load (module.js:494:32)
      at tryModuleLoad (module.js:453:12)
      at Function.Module._load (module.js:445:3)
      at Module.require (module.js:504:17)
      at require (internal/module.js:20:19)
      at Object.<anonymous> 
      (/Users/miron/workspace/project/node_modules/codeceptjs/lib/container.js:4:22)

Node version `6.13.0`

Removing the last comma fixes this issue.