### PR TITLE
change library for get params

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const getParams = require('js-function-reflector');
-const getFunctionArguments = require('get-function-arguments');
+const getFunctionArguments = require('fn-args');
 
 function isObject(item) {
   return item && typeof item === 'object' && !Array.isArray(item);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.14.1",
     "escape-string-regexp": "^1.0.3",
-    "get-function-arguments": "^1.0.0",
+    "fn-args": "^3.0.0",
     "glob": "^6.0.1",
     "inquirer": "^0.11.0",
     "js-function-reflector": "^1.3.1",

--- a/test/data/sandbox/testscenario_test.testscenario.js
+++ b/test/data/sandbox/testscenario_test.testscenario.js
@@ -14,7 +14,8 @@ Scenario('Simple async/await test', async (I) => {
   console.log(text);
 });
 
-Scenario('Should understand async without brackets', async (I) => {
+// eslint-disable-next-line arrow-parens
+Scenario('Should understand async without brackets', async I => {
   const text = await I.stringWithScenarioType('asyncbrackets');
   console.log(text);
 });

--- a/test/data/sandbox/testscenario_test.testscenario.js
+++ b/test/data/sandbox/testscenario_test.testscenario.js
@@ -13,3 +13,8 @@ Scenario('Simple async/await test', async (I) => {
   const text = await I.stringWithScenarioType('async/await');
   console.log(text);
 });
+
+Scenario('Should understand async without brackets', async (I) => {
+  const text = await I.stringWithScenarioType('asyncbrackets');
+  console.log(text);
+});

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -113,8 +113,9 @@ describe('CodeceptJS Runner', () => {
         'It\'s usual test',
         'I\'m generator test',
         'I\'m async/await test',
+        'I\'m asyncbrackets test',
       ]);
-      stdout.should.include('OK  | 3 passed');
+      stdout.should.include('OK  | 4 passed');
       assert(!err);
       done();
     });


### PR DESCRIPTION
Current library doesn't support syntax like this:

```
Scenario('test', async I => {
 ...
});

It returns error `Error: Object of type async I is not defined in container`
```

With updated library this will be fixed