### PR TITLE
[Helpers] Adding grabCurrentUrl to Puppeteer, Protractor and Nightmare

### DIFF
--- a/docs/webapi/grabBrowserUrl.mustache
+++ b/docs/webapi/grabBrowserUrl.mustache
@@ -1,0 +1,7 @@
+Get current URL from browser.
+Resumes test execution, so should be used inside an async function.
+
+```js
+let url = await I.grabBrowserUrl();
+console.log(`Current URL is [${url}]`);
+```

--- a/docs/webapi/grabCurrentUrl.mustache
+++ b/docs/webapi/grabCurrentUrl.mustache
@@ -2,6 +2,6 @@ Get current URL from browser.
 Resumes test execution, so should be used inside an async function.
 
 ```js
-let url = await I.grabBrowserUrl();
+let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -379,6 +379,13 @@ class Nightmare extends Helper {
   }
 
   /**
+   * {{> ../webapi/grabBrowserUrl }}
+   */
+  async grabBrowserUrl() {
+    return this.browser.url();
+  }
+
+  /**
    * {{> ../webapi/seeInCurrentUrl }}
    */
   async seeInCurrentUrl(url) {

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -379,9 +379,9 @@ class Nightmare extends Helper {
   }
 
   /**
-   * {{> ../webapi/grabBrowserUrl }}
+   * {{> ../webapi/grabCurrentUrl }}
    */
-  async grabBrowserUrl() {
+  async grabCurrentUrl() {
     return this.browser.url();
   }
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -391,9 +391,9 @@ class Protractor extends Helper {
   }
 
   /**
-   * {{> ../webapi/grabBrowserUrl }}
+   * {{> ../webapi/grabCurrentUrl }}
    */
-  async grabBrowserUrl() {
+  async grabCurrentUrl() {
     return this.browser.getCurrentUrl();
   }
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -391,6 +391,13 @@ class Protractor extends Helper {
   }
 
   /**
+   * {{> ../webapi/grabBrowserUrl }}
+   */
+  async grabBrowserUrl() {
+    return this.browser.getCurrentUrl();
+  }
+
+  /**
    * {{> ../webapi/selectOption }}
    */
   async selectOption(select, option) {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -939,9 +939,9 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * {{> ../webapi/grabBrowserUrl }}
+   * {{> ../webapi/grabCurrentUrl }}
    */
-  async grabBrowserUrl() {
+  async grabCurrentUrl() {
     return this.page.url();
   }
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -939,6 +939,13 @@ class Puppeteer extends Helper {
   }
 
   /**
+   * {{> ../webapi/grabBrowserUrl }}
+   */
+  async grabBrowserUrl() {
+    return this.page.url();
+  }
+
+  /**
    * {{> ../webapi/seeInSource }}
    */
   async seeInSource(text) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -893,9 +893,15 @@ class WebDriverIO extends Helper {
   }
 
   /**
-   * {{> ../webapi/grabBrowserUrl }}
+   * {{> ../webapi/grabCurrentUrl }}
    */
+  async grabCurrentUrl() {
+    const res = await this.browser.url();
+    return res.value;
+  }
+
   async grabBrowserUrl() {
+    console.log('grabBrowserUrl deprecated. Use grabCurrentUrl instead');
     const res = await this.browser.url();
     return res.value;
   }

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -893,12 +893,7 @@ class WebDriverIO extends Helper {
   }
 
   /**
-   * Get current URL from browser.
-   *
-   * ```js
-   * let url = yield I.grabBrowserUrl();
-   * console.log(`Current URL is [${url}]`);
-   * ```
+   * {{> ../webapi/grabBrowserUrl }}
    */
   async grabBrowserUrl() {
     const res = await this.browser.url();

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -23,7 +23,7 @@ module.exports.tests = function () {
     if (fileExists(dataFile)) require('fs').unlinkSync(dataFile);
   });
 
-  describe('current url : #seeInCurrentUrl, #seeCurrentUrlEquals, ...', () => {
+  describe('current url : #seeInCurrentUrl, #seeCurrentUrlEquals, #grabBrowserUrl, ...', () => {
     it('should check for url fragment', function* () {
       yield I.amOnPage('/form/checkbox');
       yield I.seeInCurrentUrl('/form');
@@ -40,6 +40,12 @@ module.exports.tests = function () {
       yield I.amOnPage('/info');
       yield I.seeCurrentUrlEquals(`${siteUrl}/info`);
       return I.dontSeeCurrentUrlEquals(`${siteUrl}/form`);
+    });
+
+    it('should grab browser url', function* () {
+      yield I.amOnPage('/info');
+      const url = yield I.grabBrowserUrl();
+      return assert.equal(url, `${siteUrl}/info`);
     });
   });
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -23,7 +23,7 @@ module.exports.tests = function () {
     if (fileExists(dataFile)) require('fs').unlinkSync(dataFile);
   });
 
-  describe('current url : #seeInCurrentUrl, #seeCurrentUrlEquals, #grabBrowserUrl, ...', () => {
+  describe('current url : #seeInCurrentUrl, #seeCurrentUrlEquals, #grabCurrentUrl, ...', () => {
     it('should check for url fragment', function* () {
       yield I.amOnPage('/form/checkbox');
       yield I.seeInCurrentUrl('/form');
@@ -44,7 +44,7 @@ module.exports.tests = function () {
 
     it('should grab browser url', function* () {
       yield I.amOnPage('/info');
-      const url = yield I.grabBrowserUrl();
+      const url = yield I.grabCurrentUrl();
       return assert.equal(url, `${siteUrl}/info`);
     });
   });


### PR DESCRIPTION
#### Highlights

* Adding support for `I.grabCurrentUrl` to all helpers. #952 
* Deprecated `I.grabBrowserUrl` in favour of `I.grabCurrentUrl` in WebDriverIO Helper
