### PR TITLE
[Multiple-Run] Adding new bootstrapAll and teardownAll hooks

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -179,4 +179,9 @@ Output is printed for all running processes. Each line is tagged with a suite an
 [basic:firefox] -- FAILURES:
 ```
 
+### Hooks
+
+Hooks are available when using the `run-multiple` command to perform actions before the test suites start and after the test suites have finished. See [Hooks](http://codecept.io/hooks/#bootstrap-teardown) for an example.
+
+
 ## done()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,9 @@ Here is an overview of available options with their defaults:
 * **mocha**: `{}` - mocha options, [reporters](http://codecept.io/reports/) can be configured here
 * **multiple**: `{}` - multiple options, see [Multiple Execution](http://codecept.io/advanced/#multiple-execution)
 * **bootstrap**: `"./bootstrap.js"` - an option to run code _before_ tests are run. See [Hooks](http://codecept.io/hooks/#bootstrap-teardown)).
-* **teardown**: - an option to run code _after_ tests are run. See [Hooks](http://codecept.io/hooks/#bootstrap-teardown).
+* **bootstrapAll**: `"./bootstrap.js"` - an option to run code _before_ all test suites are run when using the run-multiple mode. See [Hooks](http://codecept.io/hooks/#bootstrap-teardown)).
+* **teardown**: - an option to run code _after_  all test suites are run when using the run-multiple mode. See [Hooks](http://codecept.io/hooks/#bootstrap-teardown).
+* **teardownAll**: - an option to run code _after_ tests are run. See [Hooks](http://codecept.io/hooks/#bootstrap-teardown).
 * **noGlobals**: `false` - disable registering global variables like `Actor`, `Helper`, `pause`, `within`, `DataTable`
 * **hooks**: - include custom listeners to plug into execution workflow. See [Custom Hooks](http://codecept.io/hooks/#custom-hooks)
 * **translation**: - [locale](http://codecept.io/translation/) to be used to print s  teps output, as well as used in source code.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -7,6 +7,8 @@ CodeceptJS provides API to run custom code before and after the test and inject 
 In case you need to execute arbitrary code before or after the tests,
 you can use `bootstrap` and `teardown` config. Use it to start and stop webserver, Selenium, etc.
 
+When using the [Multiple Execution](http://codecept.io/advanced/#multiple-execution) mode , there are two additional hooks available; `bootstrapAll` and `teardownAll`. These hooks are only called once each; before all of the test suites are run (`bootstrapAll`) and after all of the test suites have finished (`teardownAll`).
+
 There are different ways to define bootstrap and teardown functions:
 
 * JS file executed as is (synchronously).
@@ -106,6 +108,64 @@ exports.config = {
 }
 
 ```
+
+### Example: BootstrapAll & TeardownAll Inside Config
+
+Using JavaScript-style config `codecept.conf.js`, bootstrapAll and teardownAll functions can be placed inside of it:
+
+
+```js
+const fs = require('fs');
+const tempFolder = process.cwd() + '/tmpFolder';
+
+exports.config = {
+  tests: "./*_test.js",
+  helpers: {},
+
+  multiple: {
+    suite1: {
+      grep: '@suite1',
+      browsers: [ 'chrome', 'firefox' ],
+    },
+    suite2: {
+      grep: '@suite2',
+      browsers: [ 'chrome' ],
+    },
+  },
+
+  // adding bootstrapAll/teardownAll
+  bootstrapAll: function(done) {
+    fs.mkdir(tempFolder, (err) => {
+      console.log('Create a temp folder before all test suites start', err);
+      done();
+    });
+  },
+
+  bootstrap: function(done) {
+    console.log('Do some pretty suite setup stuff');
+    done(); // Don't forget to call done()
+  },
+
+  teardown: function(done) {
+    console.log('Cool, one of the test suites have finished');
+    done();
+  },
+
+  teardownAll: function(done) {
+    console.log('All suites are now done so we should clean up the temp folder');
+
+    fs.rmdir(tempFolder, (err) => {
+      console.log('Ok, now I am done', err);
+      done();
+    });
+  },
+
+  // ...
+  // other config options
+}
+```
+
+**Note**: The `bootstrapAll` and `teardownAll` hooks are only called when using [Multiple Execution](http://codecept.io/advanced/#multiple-execution).
 
 ## Custom Hooks
 

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -87,7 +87,6 @@ module.exports = function (suites, options) {
     // throw error if no configuration
     if (suiteConf.browsers.length === 0) throw new Error(`Browser ${browser} not found in multiple suite "${suiteName}" config`);
 
-    totalSubprocessCount += suiteConf.browsers.length;
     const suiteForks = runSuite(suiteName, suiteConf);
     if (Array.isArray(suiteForks)) {
       forksToExecute.push(...suiteForks);

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -61,6 +61,7 @@ module.exports = function (suites, options) {
     processesDone = resolve;
   });
 
+  const forksToExecute = [];
   // iterate options
   suites.forEach((suite) => {
     // get suites
@@ -87,8 +88,17 @@ module.exports = function (suites, options) {
     if (suiteConf.browsers.length === 0) throw new Error(`Browser ${browser} not found in multiple suite "${suiteName}" config`);
 
     totalSubprocessCount += suiteConf.browsers.length;
-    runSuite(suiteName, suiteConf);
+    const suiteForks = runSuite(suiteName, suiteConf);
+    if (Array.isArray(suiteForks)) {
+      forksToExecute.push(...suiteForks);
+    } else {
+      forksToExecute.push(suiteForks);
+    }
   });
+
+  // Execute all forks
+  totalSubprocessCount = forksToExecute.length;
+  forksToExecute.forEach(currentForkFunc => currentForkFunc.call(this));
 
   return childProcessesPromise.then(() => {
     // fire hook
@@ -100,17 +110,15 @@ module.exports = function (suites, options) {
 function runSuite(suite, suiteConf, browser) {
   if (!browser) {
     // run configurations
-    suiteConf.browsers.forEach((b) => {
+    return suiteConf.browsers.map((b) => {
       const browserConf = Object.assign({}, suiteConf);
       if (typeof b === 'object') {
         browserConf.browser = b;
-        runSuite(suite, browserConf, b.browser);
-      } else {
-        browserConf.browser = { browser: b };
-        runSuite(suite, browserConf, b);
+        return runSuite(suite, browserConf, b.browser);
       }
+      browserConf.browser = { browser: b };
+      return runSuite(suite, browserConf, b);
     });
-    return;
   }
 
   // clone config
@@ -152,19 +160,25 @@ function runSuite(suite, suiteConf, browser) {
     params.push(suiteConf.grep);
   }
 
-  fork(runner, params, { stdio: [0, 1, 2, 'ipc'] })
-    .on('exit', (code) => {
-      if (code !== 0) {
-        process.exitCode = 1;
-      }
+  const onProcessEnd = (errorCode) => {
+    if (errorCode !== 0) {
+      process.exitCode = errorCode;
+    }
+    subprocessCount += 1;
+    if (subprocessCount === totalSubprocessCount) {
+      processesDone();
+    }
+    return errorCode;
+  };
 
-      subprocessCount += 1;
-      if (subprocessCount === totalSubprocessCount) {
-        processesDone();
-      }
-      return process.exitCode;
+  // Return function of fork for later execution
+  return () => fork(runner, params, { stdio: [0, 1, 2, 'ipc'] })
+    .on('exit', (code) => {
+      return onProcessEnd(code);
     })
-    .on('error', err => process.exitCode = 1);
+    .on('error', (err) => {
+      return onProcessEnd(1);
+    });
 }
 
 

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -7,6 +7,8 @@ const Config = require('../config');
 const fork = require('child_process').fork;
 const output = require('../output');
 const path = require('path');
+const runHook = require('../hooks');
+const event = require('../event');
 
 const runner = path.join(__dirname, '/../../bin/codecept');
 let config;
@@ -19,6 +21,9 @@ const copyOptions = ['steps', 'reporter', 'verbose', 'config', 'reporter-options
 // codeceptjs run:multiple smoke regression'
 
 let suiteId = 1;
+let subprocessCount = 0;
+let totalSubprocessCount = 0;
+let processesDone;
 
 module.exports = function (suites, options) {
   // registering options globally to use in config
@@ -49,6 +54,13 @@ module.exports = function (suites, options) {
     fail('No suites provided. Use --all option to run all configured suites');
   }
 
+  const done = () => event.emit(event.multiple.before, null);
+  runHook(config.bootstrapAll, done, 'multiple.bootstrap');
+
+  const childProcessesPromise = new Promise((resolve, reject) => {
+    processesDone = resolve;
+  });
+
   // iterate options
   suites.forEach((suite) => {
     // get suites
@@ -71,11 +83,17 @@ module.exports = function (suites, options) {
         return b === browser;
       });
     }
-
     // throw error if no configuration
     if (suiteConf.browsers.length === 0) throw new Error(`Browser ${browser} not found in multiple suite "${suiteName}" config`);
 
+    totalSubprocessCount += suiteConf.browsers.length;
     runSuite(suiteName, suiteConf);
+  });
+
+  return childProcessesPromise.then(() => {
+    // fire hook
+    const done = () => event.emit(event.multiple.after, null);
+    runHook(config.teardownAll, done, 'multiple.teardown');
   });
 };
 
@@ -136,10 +154,14 @@ function runSuite(suite, suiteConf, browser) {
 
   fork(runner, params, { stdio: [0, 1, 2, 'ipc'] })
     .on('exit', (code) => {
-      if (code === 0) {
-        return null;
+      if (code !== 0) {
+        process.exitCode = 1;
       }
-      process.exitCode = 1;
+
+      subprocessCount += 1;
+      if (subprocessCount === totalSubprocessCount) {
+        processesDone();
+      }
       return process.exitCode;
     })
     .on('error', err => process.exitCode = 1);

--- a/lib/event.js
+++ b/lib/event.js
@@ -32,6 +32,10 @@ module.exports = {
     after: 'global.after',
     result: 'global.result',
   },
+  multiple: {
+    before: 'multiple.before',
+    after: 'multiple.after',
+  },
 
   emit(event, param) {
     let msg = `Emitted | ${event}`;


### PR DESCRIPTION
#### Highlights

* New `bootstrapAll` and `teardownAll` hooks which are used when running the `run-multiple` command. The `bootstrapAll` hook is trigger before any test suites have started, and `teardownAll` is triggered once all of the suites have finished. The two hooks also have event equivalents; `multiple.before` and `multiple.after`. #957, #678 

#### Background

Previously only `bootstrap` and `teardown` hooks were available. When using the `run-multiple` command, the `bootstrap` and `teardown` hooks trigger every time a suite starts and finishes. This makes them ill suited to perform general setup and cleanup tasks when using the [Multiple Execution](https://codecept.io/advanced/#multiple-execution) command.