### PR TITLE
Add --config option to the codeceptjs def command

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -25,6 +25,7 @@ program.command('list [path]')
 
 program.command('def [path]')
   .description('List all actions for I.')
+  .option('-c, --config [file]', 'configuration file to be used')
   .action(require('../lib/command/definitions'));
 
 program.command('generate:test [path]')

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -131,6 +131,7 @@ TypeScript Definitions allows IDEs to provide autocompletion when writing tests.
 
 ```sh
 codeceptjs def
+codeceptjs def --config path/to/codecept.json
 ```
 
 Produces `steps.d.ts` file, which referenced in the very beginning of a test file.

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -29,9 +29,10 @@ declare module "codeceptjs" {
 }
 `;
 
-module.exports = function (genPath) {
-  const testsPath = getTestRoot(genPath);
-  const config = getConfig(testsPath);
+module.exports = function (genPath, options) {
+  const configFile = options.config || genPath;
+  const testsPath = getTestRoot(configFile);
+  const config = getConfig(configFile);
   if (!config) return;
 
   const codecept = new Codecept(config, {});

--- a/test/runner/list_test.js
+++ b/test/runner/list_test.js
@@ -30,4 +30,19 @@ describe('list/def commands', () => {
       done();
     });
   });
+
+  it('def should create definition file given a config file', (done) => {
+    try {
+      require('fs').unlinkSync(`${codecept_dir}/steps.d.ts`);
+    } catch (e) {
+      // continue regardless of error
+    }
+    exec(`${runner} def --config ${codecept_dir}/codecept.ddt.json`, (err, stdout, stderr) => {
+      stdout.should.include('Definitions were generated in steps.d.ts');
+      stdout.should.include('<reference path="./steps.d.ts" />');
+      require('fs').existsSync(`${codecept_dir}/steps.d.ts`).should.be.ok;
+      assert(!err);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
#### Highlights

* Add support for custom codeceptjs configuration files when using the `codeceptjs def` command. Usage `codeceptjs def --config /path/to/config.json`. #879