### PR TITLE
SyntaxError: Unexpected token ) on codeceptjs init

### DIFF
--- a/lib/mocha_factory.js
+++ b/lib/mocha_factory.js
@@ -38,7 +38,7 @@ class MochaFactory {
     if (reporterOptions['codeceptjs-cli-reporter'] && attributes) {
       Object.defineProperty(
         reporterOptions, 'codeceptjs/lib/reporter/cli',
-        attributes,
+        attributes
       );
       delete reporterOptions['codeceptjs-cli-reporter'];
     }


### PR DESCRIPTION
Invoking `codeceptjs init` resulted in the following exception due to an extraneous, trailing comma in the argument list on npm installed version 1.1.5.

```
./node_modules/codeceptjs/lib/mocha_factory.js:42
      );
      ^

SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (./node_modules/codeceptjs/lib/container.js:4:22)
```