### PR TITLE
[Helpers] Changes to I.waitForInvisible behaviour and test cases for I.waitForDetached

### DIFF
--- a/docs/webapi/dontSeeElement.mustache
+++ b/docs/webapi/dontSeeElement.mustache
@@ -1,3 +1,3 @@
-Opposite to `seeElement`. Checks that element is not visible
+Opposite to `seeElement`. Checks that element is not visible (or in DOM)
 
 @param locator located by CSS|XPath|Strict locator

--- a/docs/webapi/waitForInvisible.mustache
+++ b/docs/webapi/waitForInvisible.mustache
@@ -1,4 +1,4 @@
-Waits for an element to become invisible on a page (by default waits for 1sec).
+Waits for an element to be removed or become invisible on a page (by default waits for 1sec).
 Element can be located by CSS or XPath.
 
 ```

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -907,7 +907,7 @@ class Nightmare extends Helper {
 
     return this.browser.wait((by, locator) => window.codeceptjs.findElement(by, locator) === null, locator.type, locator.value).catch((err) => {
       if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
-        throw new Error(`element (${JSON.stringify(locator)}) still present on page after ${sec} sec`);
+        throw new Error(`element (${JSON.stringify(locator)}) still on page after ${sec} sec`);
       } else throw err;
     });
   }

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -867,7 +867,7 @@ class Nightmare extends Helper {
 
     return this.browser.wait((by, locator) => {
       const el = window.codeceptjs.findElement(by, locator);
-      if (!el) return false;
+      if (!el) return true;
       return !(el.offsetWidth > 0 && el.offsetHeight > 0);
     }, locator.type, locator.value).catch((err) => {
       if (err.message && err.message.indexOf('.wait() timed out after') > -1) {

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -919,7 +919,11 @@ class Protractor extends Helper {
   async waitForDetached(locator, sec = null) {
     const aSec = sec || this.options.waitForTimeout;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
-    return this.browser.wait(EC.not(EC.presenceOf(el)), aSec * 1000);
+    return this.browser.wait(EC.not(EC.presenceOf(el)), aSec * 1000).catch((err) => {
+      if (err.message && err.message.indexOf('Wait timed out after') > -1) {
+        throw new Error(`element (${JSON.stringify(locator)}) still on page after ${sec} sec`);
+      } else throw err;
+    });
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1400,7 +1400,8 @@ class Puppeteer extends Helper {
     } else {
       const visibleFn = function (locator, $XPath) {
         eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).filter(el => el.offsetParent === null).length > 0;
+        const matches = $XPath(null, locator);
+        return matches.length === 0 || matches.filter(el => el.offsetParent === null).length > 0;
       };
       waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, $XPath.toString());
     }

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1575,7 +1575,7 @@ class WebDriverIO extends Helper {
     const aSec = sec || this.options.waitForTimeout;
     return this.browser.waitUntil(async () => {
       const res = await this.browser.elements(withStrictLocator.call(this, locator));
-      if (!res.value || res.value.length === 0) return false;
+      if (!res.value || res.value.length === 0) return true;
       const selected = await forEachAsync(res.value, async el => this.browser.elementIdDisplayed(el.ELEMENT));
       if (Array.isArray(selected)) {
         return selected.filter(val => val === false).length > 0;

--- a/test/data/app/view/form/wait_detached.php
+++ b/test/data/app/view/form/wait_detached.php
@@ -1,0 +1,22 @@
+<html>
+<head>
+    <style>
+        .invisible_button { display: none; }
+    </style>
+</head>
+
+<body>
+
+<div id="step_1">Step One Button</div>
+<div id="step_2">Step Two Button</div>
+<script>
+  setTimeout(function () {
+    document.getElementById('step_1').style.display = 'none'; // Hide button
+    var step2 = document.getElementById('step_2'); // Remove button
+    step2.parentElement.removeChild(step2);
+  }, 1000);
+
+</script>
+
+</body>
+</html>

--- a/test/data/app/view/form/wait_invisible.php
+++ b/test/data/app/view/form/wait_invisible.php
@@ -8,11 +8,13 @@
 <body>
 
 <div id="step_1">Step One Button</div>
+<div id="step_2">Step Two Button</div>
 <script>
   setTimeout(function () {
     document.getElementById('step_1').style.display = 'none';
+    var step2 = document.getElementById('step_2');
+    step2.parentElement.removeChild(step2);
   }, 1000);
-
 
 </script>
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -621,8 +621,55 @@ module.exports.tests = function () {
       .then(() => I.waitForInvisible('//div[@id="step_1"]'))
       .then(() => I.dontSeeElement('//div[@id="step_1"]'))
       .then(() => I.seeElementInDOM('//div[@id="step_1"]')));
+
+    it('should wait for element to be removed', () => I.amOnPage('/form/wait_invisible')
+      .then(() => I.see('Step Two Button'))
+      .then(() => I.seeElement('#step_2'))
+      .then(() => I.waitForInvisible('#step_2', 2))
+      .then(() => I.dontSeeElement('#step_2')));
+
+    it('should wait for element to be removed by XPath', () => I.amOnPage('/form/wait_invisible')
+      .then(() => I.see('Step Two Button'))
+      .then(() => I.seeElement('//div[@id="step_2"]'))
+      .then(() => I.waitForInvisible('//div[@id="step_2"]', 2))
+      .then(() => I.dontSeeElement('//div[@id="step_2"]')));
   });
 
+  describe('#waitForDetached', () => {
+    it('should throw an error if the element still exists in DOM', () => I.amOnPage('/form/wait_detached')
+      .then(() => I.see('Step One Button'))
+      .then(() => I.seeElement('#step_1'))
+      .then(() => I.waitForDetached('#step_1', 2))
+      .then(() => {
+        throw Error('Should not get this far');
+      })
+      .catch((err) => {
+        err.message.should.include('still on page after');
+      }));
+
+    it('should throw an error if the element still exists in DOM by XPath', () => I.amOnPage('/form/wait_detached')
+      .then(() => I.see('Step One Button'))
+      .then(() => I.seeElement('#step_1'))
+      .then(() => I.waitForDetached('#step_1', 2))
+      .then(() => {
+        throw Error('Should not get this far');
+      })
+      .catch((err) => {
+        err.message.should.include('still on page after');
+      }));
+
+    it('should wait for element to be removed from DOM', () => I.amOnPage('/form/wait_detached')
+      .then(() => I.see('Step Two Button'))
+      .then(() => I.seeElement('#step_2'))
+      .then(() => I.waitForDetached('#step_2', 2))
+      .then(() => I.dontSeeElementInDOM('#step_2')));
+
+    it('should wait for element to be removed from DOM by XPath', () => I.amOnPage('/form/wait_detached')
+      .then(() => I.seeElement('//div[@id="step_2"]'))
+      .then(() => I.waitForDetached('//div[@id="step_2"]'))
+      .then(() => I.dontSeeElement('//div[@id="step_2"]'))
+      .then(() => I.dontSeeElementInDOM('//div[@id="step_2"]')));
+  });
 
   describe('within tests', () => {
     afterEach(() => I._withinEnd());


### PR DESCRIPTION
#### Highlights
* Changed behaviour of the `I.waitForInvisible` so that it treats a nonexistent DOM element the same as an invisible DOM element. The behaviour is now the same across all of the Browser Helpers. #943 
* Added test cases for `I.waitForDetached` and changed the error messages so that are the same across the Helpers.

#### Miscellaneous/Credits
* Thanks to @JLRishe who originally created a similar PR #950 and originally pointed out this problem. Unfortunately I gave some misguided information which lead him on a wild goose chase and caused confusion from the main Contributors (my apologies). @JLRishe Please do not let this discourage you from future PRs :)