### PR TITLE
[WebDriverIO] Use inbuilt dragAndDrop function

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1348,13 +1348,10 @@ class WebDriverIO extends Helper {
       return this.browser.touchUp(location.value.x, location.value.y);
     }
 
-    let res = await this.moveCursorTo(withStrictLocator.call(this, srcElement));
-    if (res.state !== 'success') throw new Error(`Unable to move cursor to (${srcElement})`);
-    res = await this.browser.buttonDown();
-    if (res.state !== 'success') throw new Error(`Failed to press button down on (${srcElement})`);
-    res = await this.moveCursorTo(withStrictLocator.call(this, destElement));
-    if (res.state !== 'success') throw new Error(`Unable to move cursor to (${destElement})`);
-    return this.browser.buttonUp();
+    return client.dragAndDrop(
+      withStrictLocator.call(this, srcElement),
+      withStrictLocator.call(this, destElement),
+    );
   }
 
 

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -646,4 +646,18 @@ describe('WebDriverIO', function () {
         assert.equal(matchingLogs.length, 2);
       }));
   });
+
+  describe('#dragAndDrop', () => {
+    it('Drag item from source to target (no iframe) @dragNdrop', () => wd.amOnPage('http://jqueryui.com/resources/demos/droppable/default.html')
+      .then(() => wd.seeElementInDOM('#draggable'))
+      .then(() => wd.dragAndDrop('#draggable', '#droppable'))
+      .then(() => wd.see('Dropped')));
+
+    it('Drag and drop from within an iframe', () => wd.amOnPage('http://jqueryui.com/droppable')
+      .then(() => wd.resizeWindow(700, 700))
+      .then(() => wd.switchTo('//iframe[@class="demo-frame"]'))
+      .then(() => wd.seeElementInDOM('#draggable'))
+      .then(() => wd.dragAndDrop('#draggable', '#droppable'))
+      .then(() => wd.see('Dropped')));
+  });
 });


### PR DESCRIPTION
#### Highlights
* [WebDriverIO] Utilise the inbuilt WebDriverIO dragAndDrop function instead of doing mouse moves and clicks manually. Fixes #822

#### Notes
* This still does not work with Firefox