### PR TITLE
Fixing I.click so it accepts an explicit xpath selector. Fixes #989

### DIFF
--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -1130,7 +1130,7 @@ async function proceedIsChecked(assertType, option) {
 async function findClickable(matcher, locator) {
   locator = new Locator(locator);
   if (!locator.isFuzzy()) {
-    const els = await this._locate(locator.value, true);
+    const els = await this._locate(locator, true);
     assertElementExists(els, locator.value);
     return els[0];
   }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1670,7 +1670,7 @@ async function proceedClick(locator, context = null, options = {}) {
 
 async function findClickable(matcher, locator) {
   locator = new Locator(locator);
-  if (!locator.isFuzzy()) return findElements.call(this, matcher, locator.simplify());
+  if (!locator.isFuzzy()) return findElements.call(this, matcher, locator);
 
   let els;
   const literal = xpathLocator.literal(locator.value);

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -157,6 +157,14 @@ module.exports.tests = function () {
       // yield I.wait(3);
       return I.seeCurrentUrlEquals('/');
     });
+
+    it('should click link with xpath locator', function* () {
+      yield I.amOnPage('/form/example7');
+      yield I.click({
+        xpath: '(//*[@title = "Chocolate Bar"])[1]',
+      });
+      return I.seeCurrentUrlEquals('/');
+    });
   });
 
   describe('#doubleClick', () => {


### PR DESCRIPTION
### Highlights

* Fixed bug with `I.click` when using an object selector with the xpath property. It only affected the **Puppeteer** and **Protractor** helpers. Fixes #989
* Added tests for all browser helpers to check for this condition

#### Example which now works
```js
Scenario('I click using custom xpath selector', (I) => {
  I.amOnPage('/');
  I.click({
    xpath: '(//*[@class])[1]',
  });
});
```