### PR TITLE
[Protractor] Fixing bug with I.seeAttributesOnElements and I.seeCssPropertiesOnElement

### DIFF
--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -10,7 +10,16 @@ const stringIncludes = require('../assert/include').includes;
 const { urlEquals, equals } = require('../assert/equal');
 const empty = require('../assert/empty').empty;
 const truth = require('../assert/truth').truth;
-const { xpathLocator, fileExists, clearString } = require('../utils');
+const {
+  xpathLocator,
+  fileExists,
+  clearString,
+  convertCssPropertiesToCamelCase,
+} = require('../utils');
+const {
+  isColorProperty,
+  convertColorToRGBA,
+} = require('../colorUtils');
 const ElementNotFound = require('./errors/ElementNotFound');
 const Locator = require('../locator');
 const path = require('path');
@@ -803,22 +812,28 @@ class Protractor extends Helper {
     const els = await this._locate(locator);
     assertElementExists(els, locator);
 
-    const attributeNames = Object.keys(cssProperties);
-    const expectedValues = attributeNames.map(name => cssProperties[name]);
+    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties);
+
+    const attributeNames = Object.keys(cssPropertiesCamelCase);
+    const expectedValues = attributeNames.map(name => cssPropertiesCamelCase[name]);
     const missingAttributes = [];
 
     for (const el of els) {
       const attributeValues = await Promise.all(attributeNames.map(attr => el.getCssValue(attr)));
 
-      // No need to convert colour properties as they are returned in rgba format
-      // see https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/1885
-      const missing = attributeValues.filter((actual, i) => actual !== expectedValues[i]);
+      const missing = attributeValues.filter((actual, i) => {
+        const prop = attributeNames[i];
+        let propValue = actual;
+        if (isColorProperty(prop) && propValue) {
+          propValue = convertColorToRGBA(propValue);
+        }
+        return propValue !== expectedValues[i];
+      });
       if (missing.length) {
-        missingAttributes.concat(missing);
+        missingAttributes.push(...missing);
       }
     }
-
-    return equals(`expected all elements (${locator}) have CSS Property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0);
+    return equals(`all elements (${locator}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0);
   }
 
   /**
@@ -834,14 +849,18 @@ class Protractor extends Helper {
 
     for (const el of els) {
       const attributeValues = await Promise.all(attributeNames.map(attr => el.getAttribute(attr)));
-
-      const missing = attributeValues.filter((actual, i) => actual !== expectedValues[i]);
+      const missing = attributeValues.filter((actual, i) => {
+        if (expectedValues[i] instanceof RegExp) {
+          return expectedValues[i].test(actual);
+        }
+        return actual !== expectedValues[i];
+      });
       if (missing.length) {
-        missingAttributes.concat(missing);
+        missingAttributes.push(...missing);
       }
     }
 
-    return equals(`expected all elements (${locator}) have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0);
+    return equals(`all elements (${locator}) to have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0);
   }
 
   /**

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -915,8 +915,9 @@ module.exports.tests = function () {
         await I.seeAttributesOnElements('//form', {
           method: 'get',
         });
+        throw Error('It should never get this far');
       } catch (e) {
-        e.message.should.include('expected all elements (//form) to have attributes {"method":"get"}');
+        e.message.should.include('all elements (//form) to have attributes {"method":"get"}');
       }
     });
 
@@ -935,6 +936,7 @@ module.exports.tests = function () {
           'qa-id': 'test',
           href: '/info',
         });
+        throw new Error('It should never get this far');
       } catch (e) {
         e.message.should.include('all elements (a) to have attributes {"qa-id":"test","href":"/info"}');
       }
@@ -956,6 +958,7 @@ module.exports.tests = function () {
         await I.seeCssPropertiesOnElements('h3', {
           'font-weight': 'non-bold',
         });
+        throw Error('It should never get this far');
       } catch (e) {
         e.message.should.include('expected all elements (h3) to have CSS property {"font-weight":"non-bold"}');
       }
@@ -981,6 +984,7 @@ module.exports.tests = function () {
           'margin-top': '0em',
           cursor: 'pointer',
         });
+        throw Error('It should never get this far');
       } catch (e) {
         e.message.should.include('expected all elements (a) to have CSS property {"margin-top":"0em","cursor":"pointer"}');
       }


### PR DESCRIPTION
#### Highlights

* `I.seeAttributesOnElements` and `I.seeCssPropertiesOnElements` were incorrectly passing when the attributes/properties did not match.