### PR TITLE
Proper hash handling for Puppeteer URL

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -259,8 +259,7 @@ class Puppeteer extends Helper {
    * Gets page URL including hash.
    */
   async _getPageUrl() {
-    const hash = await this.executeScript(() => window.location.hash);
-    return this.page.url() + hash; // page.url() ignores hash.
+    return this.executeScript(() => window.location.href);
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -256,6 +256,14 @@ class Puppeteer extends Helper {
   }
 
   /**
+   * Gets page URL including hash.
+   */
+  async _getPageUrl() {
+    const hash = await this.executeScript(() => window.location.hash);
+    return this.page.url() + hash; // page.url() ignores hash.
+  }
+
+  /**
    * Grab the text within the popup. If no popup is visible then it will return null
    *
    * ```js
@@ -892,32 +900,28 @@ class Puppeteer extends Helper {
    * {{> ../webapi/seeInCurrentUrl }}
    */
   async seeInCurrentUrl(url) {
-    const currentUrl = this.page.url();
-    stringIncludes('url').assert(url, currentUrl);
+    stringIncludes('url').assert(url, await this._getPageUrl());
   }
 
   /**
    * {{> ../webapi/dontSeeInCurrentUrl }}
    */
   async dontSeeInCurrentUrl(url) {
-    const currentUrl = await this.page.url();
-    stringIncludes('url').negate(url, currentUrl);
+    stringIncludes('url').negate(url, await this._getPageUrl());
   }
 
   /**
    * {{> ../webapi/seeCurrentUrlEquals }}
    */
   async seeCurrentUrlEquals(url) {
-    const currentUrl = await this.page.url();
-    urlEquals(this.options.url).assert(url, currentUrl);
+    urlEquals(this.options.url).assert(url, await this._getPageUrl());
   }
 
   /**
    * {{> ../webapi/dontSeeCurrentUrlEquals }}
    */
   async dontSeeCurrentUrlEquals(url) {
-    const currentUrl = await this.page.url();
-    urlEquals(this.options.url).negate(url, currentUrl);
+    urlEquals(this.options.url).negate(url, await this._getPageUrl());
   }
 
   /**
@@ -970,7 +974,7 @@ class Puppeteer extends Helper {
    * {{> ../webapi/grabCurrentUrl }}
    */
   async grabCurrentUrl() {
-    return this.page.url();
+    return this._getPageUrl();
   }
 
   /**
@@ -1460,7 +1464,7 @@ class Puppeteer extends Helper {
       const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
       return currUrl.indexOf(urlPart) > -1;
     }, { timeout: waitTimeout }, urlPart).catch(async (e) => {
-      const currUrl = this.page.url(); // Required because the waitForFunction can't return data.
+      const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
       if (/waiting failed: timeout/i.test(e.message)) {
         throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`);
       } else {
@@ -1484,7 +1488,7 @@ class Puppeteer extends Helper {
       const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
       return currUrl.indexOf(urlPart) > -1;
     }, { timeout: waitTimeout }, urlPart).catch(async (e) => {
-      const currUrl = this.page.url(); // Required because the waitForFunction can't return data.
+      const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
       if (/waiting failed: timeout/i.test(e.message)) {
         throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`);
       } else {


### PR DESCRIPTION
Puppeteer's `page.url()` ignores hash. This is an attempt to fix it in order to maintain consistency with other helpers.