### PR TITLE
Updated typescipt definitions.

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -21,14 +21,20 @@ interface ILocator {
   ios?: string;
 }
 
-declare const actor: () => CodeceptJS.{{I}};
-declare const Feature: (string: string) => void;
-declare const Scenario: (string: string, callback: ICodeceptCallback) => void;
-declare const Before: (callback: ICodeceptCallback) => void;
-declare const BeforeSuite: (callback: ICodeceptCallback) => void;
-declare const After: (callback: ICodeceptCallback) => void;
-declare const AfterSuite: (callback: ICodeceptCallback) => void;
-declare const within: (selector: string, callback: Function) => void;
+declare function actor(customSteps?: {}): CodeceptJS.{{I}};
+declare function Feature(string: string, opts?: {}): void;
+declare function Scenario(string: string, callback: ICodeceptCallback): void;
+declare function Scenario(string: string, opts: {}, callback: ICodeceptCallback): void;
+declare function xScenario(string: string, callback: ICodeceptCallback): void;
+declare function xScenario(string: string, opts: {}, callback: ICodeceptCallback): void;
+declare function Data(data: any): any;
+declare function xData(data: any): any;
+declare function Before(callback: ICodeceptCallback): void;
+declare function BeforeSuite(callback: ICodeceptCallback): void;
+declare function After(callback: ICodeceptCallback): void;
+declare function AfterSuite(callback: ICodeceptCallback): void;
+declare function within(selector: string, callback: Function): void;
+declare const codecept_helper: any;
 
 declare namespace CodeceptJS {
   export interface {{I}} {


### PR DESCRIPTION
Added Data, xData, xScenario definitions.
Added options for actor and Feature functions.

Rewrote declarations to "declare function ..." style to allow use of overloading for Scenario and xScenario. Now it allow use both with or without opts parameter.
Don't found variant to allow it with code style which has already been used. Therefore, rewrote all such declarations in single style.

Added declaration for codecept_helper, to remove errors in custom helpers. Maybe there are other ways to solve this, please, tell me if it's true. I'll remove it.
