### PR TITLE
Enable test runner for nested test directories

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -21,14 +21,20 @@ interface ILocator {
   ios?: string;
 }
 
-declare const actor: () => CodeceptJS.{{I}};
-declare const Feature: (string: string) => void;
-declare const Scenario: (string: string, callback: ICodeceptCallback) => void;
-declare const Before: (callback: ICodeceptCallback) => void;
-declare const BeforeSuite: (callback: ICodeceptCallback) => void;
-declare const After: (callback: ICodeceptCallback) => void;
-declare const AfterSuite: (callback: ICodeceptCallback) => void;
-declare const within: (selector: string, callback: Function) => void;
+declare function actor(customSteps?: {}): CodeceptJS.{{I}};
+declare function Feature(string: string, opts?: {}): void;
+declare function Scenario(string: string, callback: ICodeceptCallback): void;
+declare function Scenario(string: string, opts: {}, callback: ICodeceptCallback): void;
+declare function xScenario(string: string, callback: ICodeceptCallback): void;
+declare function xScenario(string: string, opts: {}, callback: ICodeceptCallback): void;
+declare function Data(data: any): any;
+declare function xData(data: any): any;
+declare function Before(callback: ICodeceptCallback): void;
+declare function BeforeSuite(callback: ICodeceptCallback): void;
+declare function After(callback: ICodeceptCallback): void;
+declare function AfterSuite(callback: ICodeceptCallback): void;
+declare function within(selector: string, callback: Function): void;
+declare const codecept_helper: any;
 
 declare namespace CodeceptJS {
   export interface {{I}} {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "json-server": "./node_modules/json-server/bin/index.js test/data/rest/db.json -p 8010 --watch -m test/data/rest/headers.js",
     "lint": "eslint bin/ examples/ lib/ test/ translations/",
     "lint-fix": "eslint bin/ examples/ lib/ test/ translations/ --fix",
-    "test": "npm run lint && mocha test/unit && mocha test/runner"
+    "test": "npm run lint && mocha test/unit --recursive && mocha test/runner --recursive"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/test/unit/assert/equal_test.js
+++ b/test/unit/assert/equal_test.js
@@ -23,13 +23,13 @@ describe('equal assertion', () => {
     equal.params.expected = 'hello';
     equal.params.actual = 'hi';
     const err = equal.getFailedAssertion();
-    err.inspect().should.equal("expected contents of webpage 'hello' to equal 'hi'");
+    err.inspect().should.equal('expected contents of webpage "hello" to equal "hi"');
   });
 
   it('should provide nice negate error message', () => {
     equal.params.expected = 'hello';
     equal.params.actual = 'hello';
     const err = equal.getFailedNegation();
-    err.inspect().should.equal("expected contents of webpage 'hello' not to equal 'hello'");
+    err.inspect().should.equal('expected contents of webpage "hello" not to equal "hello"');
   });
 });


### PR DESCRIPTION
"npm test" did not use tests in nested directories, for example "test/unit/assert"
see https://mochajs.org/#the-test-directory

Fixed test according to linter rules.