### PR TITLE
properly propagate errors in asyncWrapper around async functions

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -168,6 +168,7 @@ function createSupportObjects(config) {
     return function () {
       return f.apply(this, arguments).catch((e) => {
         recorder.saveFirstAsyncError(e);
+        throw e;
       });
     };
   };


### PR DESCRIPTION
I don't really see, why this wrapper would be needed. It silently catches any
errors thrown by async functions. Even if a rejected promise is being
returned. This is very different from just returning a promise. In case
it's rejected, the error will bubble up and fail any test.

This fixes #1109 for me.