### PR TITLE
fix-1069: fix WebDriverIO browser opening after tests with option restart=false

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -357,7 +357,7 @@ class WebDriverIO extends Helper {
   }
 
   _finishTest() {
-    if (!this.options.restart) return this._startBrowser();
+    if (!this.options.restart && this.isRunning) return this._stopBrowser();
   }
 
   _session() {


### PR DESCRIPTION
Fix typo (I think), made in [1049](https://github.com/Codeception/CodeceptJS/pull/1049/files#diff-c873b3f20f4ccf0b26a50fbebbf074d6R359) pull request.

Now WebDriverIO does not start driver/browser session after test completion.
#1069 