### PR TITLE
added quotes for grep test groups

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -73,10 +73,11 @@ codeceptjs run --grep @slow
 
 Use regex for more flexible filtering:
 
-* `--grep (?=.*@smoke2)(?=.*@smoke3)` - run tests with @smoke2 and @smoke3 in name
-* `--grep @smoke2|@smoke3` - run tests with @smoke2 or @smoke3 in name
-* `--grep ((?=.*@smoke2)(?=.*@smoke3))|@smoke4` - run tests with (@smoke2 and @smoke3) or @smoke4 in name
-* `--grep (?=.*@smoke2)^(?!.*@smoke3)` - run tests with @smoke2 but without @smoke3 in name
+* `--grep '(?=.*@smoke2)(?=.*@smoke3)'` - run tests with @smoke2 and @smoke3 in name
+* `--grep '@smoke2|@smoke3'` - run tests with @smoke2 or @smoke3 in name
+* `--grep '((?=.*@smoke2)(?=.*@smoke3))|@smoke4'` - run tests with (@smoke2 and @smoke3) or @smoke4 in name
+* `--grep '(?=.*@smoke2)^(?!.*@smoke3)'` - run tests with @smoke2 but without @smoke3 in name
+* `--grep '(?=.*)^(?!.*@smoke4)'` - run all tests except @smoke4
 
 ## Debug
 


### PR DESCRIPTION
- avoid `bash: !.*@smoke4: event not found` errors