### PR TITLE
Fixing invalid output directory path for run-multiple

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -2,6 +2,7 @@ const getConfig = require('./utils').getConfig;
 const getTestRoot = require('./utils').getTestRoot;
 const fail = require('./utils').fail;
 const deepMerge = require('./utils').deepMerge;
+const clearString = require('./utils').clearString;
 const Codecept = require('../codecept');
 const Config = require('../config');
 const fork = require('child_process').fork;
@@ -104,6 +105,8 @@ function executeRun(runName, runConfig) {
     outputDir += JSON.stringify(browserConfig).replace(/[^\d\w]+/g, '_');
   }
   outputDir += `_${runId}`;
+
+  outputDir = clearString(outputDir);
 
   // tweaking default output directories and for mochawesome
   overriddenConfig = replaceValue(overriddenConfig, 'output', path.join(config.output, outputDir));

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -2,7 +2,6 @@ const getConfig = require('./utils').getConfig;
 const getTestRoot = require('./utils').getTestRoot;
 const fail = require('./utils').fail;
 const deepMerge = require('./utils').deepMerge;
-const clearString = require('./utils').clearString;
 const Codecept = require('../codecept');
 const Config = require('../config');
 const fork = require('child_process').fork;
@@ -11,6 +10,7 @@ const path = require('path');
 const runHook = require('../hooks');
 const event = require('../event');
 const collection = require('./run-multiple/collection');
+const clearString = require('../utils').clearString;
 
 const runner = path.join(__dirname, '/../../bin/codecept');
 let config;


### PR DESCRIPTION
This should address related issues #1084 and #1111 for which root cause was invalid output directory path on Windows due to colon character being present (i.e. `parallel:...`).  This was causing `mkdirp` module to infinitely recurse, leading to max call stack size error.

Proposed solution uses pre-existing `clearString()` function in `lib/utils.js` to replace invalid characters in string.