### PR TITLE
Fix #1132 def generation for methods with only one param

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,7 @@ module.exports.toTypeDef = function (fn) {
   if (types.length === 1) {
     return combinedTypes.map(type => methodSignature(fn, paramNames, [type])).join('');
   }
-  
+
   for (let i = types.length - 2; i >= 0; i--) {
     combinedTypes = flatTail(combinedTypes, types[i]);
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -25,8 +25,8 @@ module.exports.toTypeDef = function (fn) {
 
   let combinedTypes = types[types.length - 1];
   if (!combinedTypes) return methodSignature(fn);
-  if (types.length === 1) return methodSignature(fn, paramNames, combinedTypes);
-
+  if (types.length === 1) 
+     return combinedTypes.map(type => methodSignature(fn, paramNames, [type])).join('');
 
   for (let i = types.length - 2; i >= 0; i--) {
     combinedTypes = flatTail(combinedTypes, types[i]);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -25,9 +25,10 @@ module.exports.toTypeDef = function (fn) {
 
   let combinedTypes = types[types.length - 1];
   if (!combinedTypes) return methodSignature(fn);
-  if (types.length === 1) 
-     return combinedTypes.map(type => methodSignature(fn, paramNames, [type])).join('');
-
+  if (types.length === 1) {
+    return combinedTypes.map(type => methodSignature(fn, paramNames, [type])).join('');
+  }
+  
   for (let i = types.length - 2; i >= 0; i--) {
     combinedTypes = flatTail(combinedTypes, types[i]);
   }


### PR DESCRIPTION
Methods with only one locator parameter should generate two methods in the interface definition.
