### PR TITLE
Fix typo in `include:` configuration, add actor include.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,8 @@ exports.config = {
 
   // don't build monolithic configs
   mocha: require('./mocha.conf.js') || {},
-  includes: {
+  include: {
+    I: './src/steps_file.js',
     loginPage: './src/pages/login_page',
     dashboardPage: new DashboardPage()
   }


### PR DESCRIPTION
The configuration example said `includes:` with an additional `s` instead of `include:`.
I also added the actor import.