### PR TITLE
fix: xpath detection fails when it starts with `./`

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -248,7 +248,7 @@ function isAccessibility(locator) {
 }
 
 function isXPath(locator) {
-  return locator.substr(0, 2) === '//' || locator.substr(0, 3) === './/';
+  return locator.substr(0, 2) === '//' || locator.substr(0, 2) === './';
 }
 
 function removePrefix(xpath) {


### PR DESCRIPTION
Context: when using `Locator.clickable.self`, the xpath generated starts with `./self::...`, but the locator was not considered as `xpath` (fallbacking to `css`) so it failed to select the element.