### PR TITLE
Enable config override when running parallel tests

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -14,7 +14,7 @@ const clearString = require('../utils').clearString;
 const runner = path.join(__dirname, '/../../bin/codecept');
 let config;
 const childOpts = {};
-const copyOptions = ['steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'debug'];
+const copyOptions = ['override', 'steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'debug'];
 
 // codeceptjs run:multiple smoke:chrome regression:firefox - will launch smoke run in chrome and regression in firefox
 // codeceptjs run:multiple smoke:chrome regression - will launch smoke run in chrome and regression in firefox and chrome


### PR DESCRIPTION
Just found that the `--override` CLI flag was ignored when running tests in parallel. This fixes it.

Also, using the `--colors` with run-multiple exit with `error: unknown option `--colors'`