### PR TITLE
Correctly extract default extension

### DIFF
--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -26,7 +26,7 @@ module.exports.test = function (genPath) {
   output.print('Creating a new test...');
   output.print('----------------------');
 
-  const defaultExt = config.tests.match(/\*(.*?)$/[1])[0] || '_test.js';
+  const defaultExt = config.tests.match(/([^\*/]*?)$/[1])[0] || '_test.js';
 
   inquirer.prompt([
     {


### PR DESCRIPTION
By using this regexp it will correctly match extensions from `config.test`, that fallow format like `./**/*_test.js`, or `./**/*.test.js`. 
Example on [regexer.com](regexr.com/3vo4k)

Also, forcing `_helper.js` extension in JS world is weird, therefor option to make it `.helper.js` would be nice.