### PR TITLE
Make actor type definition useful

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -64,7 +64,7 @@ declare class Locator implements ILocator {
 
 
 declare function actor(customSteps?: {
-	[action: string]: (this: CodeceptJS.I, ...args: any[]) => void
+  [action: string]: (this: CodeceptJS.I, ...args: any[]) => void
 }): CodeceptJS.{{I}};
 declare function actor(customSteps?: {}): CodeceptJS.{{I}};
 declare function Feature(title: string, opts?: {}): FeatureConfig;

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -62,6 +62,10 @@ declare class Locator implements ILocator {
   as(locator:string): Locator;
 }
 
+
+declare function actor(customSteps?: {
+	[action: string]: (this: CodeceptJS.I, ...args: any[]) => void
+}): CodeceptJS.{{I}};
 declare function actor(customSteps?: {}): CodeceptJS.{{I}};
 declare function Feature(title: string, opts?: {}): FeatureConfig;
 declare function Scenario(title: string, callback: ICodeceptCallback): ScenarioConfig;


### PR DESCRIPTION
By adding type annotation to `customSteps`, we get hint, that `this` is actually `CodeceptJS.I` and therefore we can do much more, while having some type checks.