### PR TITLE
fix multiple.parallel.chunks

### DIFF
--- a/lib/command/run-multiple/chunk.js
+++ b/lib/command/run-multiple/chunk.js
@@ -62,7 +62,7 @@ const createChunks = (config, pattern) => {
   let chunks = [];
   if (typeof config.chunks === 'function') {
     chunks = config.chunks.call(this, files);
-  } else if (typeof config.chunks === 'number') {
+  } else if (typeof config.chunks === 'number' || typeof config.chunks === 'string' ) {
     chunks = splitFiles(files, Math.ceil(files.length / config.chunks));
   } else {
     throw new Error('chunks is neither a finite number or a valid function');

--- a/lib/command/run-multiple/chunk.js
+++ b/lib/command/run-multiple/chunk.js
@@ -62,7 +62,7 @@ const createChunks = (config, pattern) => {
   let chunks = [];
   if (typeof config.chunks === 'function') {
     chunks = config.chunks.call(this, files);
-  } else if (typeof config.chunks === 'number' || typeof config.chunks === 'string' ) {
+  } else if (typeof config.chunks === 'number' || typeof config.chunks === 'string') {
     chunks = splitFiles(files, Math.ceil(files.length / config.chunks));
   } else {
     throw new Error('chunks is neither a finite number or a valid function');


### PR DESCRIPTION
if multiple.parallel.chunks param in codecept.conf.js set as environment variable, codeceptjs throw "chunks is neither a finite number or a valid function".

example:

```
    multiple: {
        parallel: {
            chunks: process.env.CHUNKS || 20,
            ...
        }
```