### PR TITLE
Move Allure screenshot attachment

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -80,6 +80,10 @@ module.exports = function (config) {
 
       try {
         await helper.saveScreenshot(fileName, options.fullPageScreenshots);
+        const allureReporter = Container.plugins('allure');
+        if (allureReporter) {
+          allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
+        }
       } catch (err) {
         if (err &&
             err.type &&
@@ -89,11 +93,6 @@ module.exports = function (config) {
         ) {
           helper.isRunning = false;
         }
-      }
-
-      const allureReporter = Container.plugins('allure');
-      if (allureReporter) {
-        allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
       }
     }, true);
   });


### PR DESCRIPTION
Moving to Allure screenshot attaching inside the screenshot try/catch block

If there is an exception saving a screenshot it should not try and add a file that does not exist to the Allure report. 