### PR TITLE
Fixed tags implementation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -76,14 +76,23 @@ Data(function*() {
 
 *HINT: If you don't use DataTable. add `toString()` method to each object added to data set, so the data could be pretty printed in a test name*
 
-## Groups
+## Tags
 
 Append `@tag` to your test name, so
-all tests with `@tag` could be executed with `--grep @tag` option.
 
 ```js
 Scenario('update user profile @slow')
 ```
+
+Alternativly, use `tag` method of Scenario to set additional tags:
+
+```js
+Scenario('update user profile', () => {
+  // test goes here
+}).tag('@slow').tag('important');
+```
+
+All tests with `@tag` could be executed with `--grep @tag` option.
 
 ```sh
 codeceptjs run --grep @slow
@@ -92,10 +101,12 @@ codeceptjs run --grep @slow
 Use regex for more flexible filtering:
 
 * `--grep '(?=.*@smoke2)(?=.*@smoke3)'` - run tests with @smoke2 and @smoke3 in name
-* `--grep '@smoke2|@smoke3'` - run tests with @smoke2 or @smoke3 in name
+* `--grep "\@smoke2|\@smoke3"` - run tests with @smoke2 or @smoke3 in name
 * `--grep '((?=.*@smoke2)(?=.*@smoke3))|@smoke4'` - run tests with (@smoke2 and @smoke3) or @smoke4 in name
 * `--grep '(?=.*@smoke2)^(?!.*@smoke3)'` - run tests with @smoke2 but without @smoke3 in name
 * `--grep '(?=.*)^(?!.*@smoke4)'` - run all tests except @smoke4
+
+
 
 ## Debug
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -167,69 +167,6 @@ exports.config = {
 
 **Note**: The `bootstrapAll` and `teardownAll` hooks are only called when using [Multiple Execution](http://codecept.io/advanced/#multiple-execution).
 
-## Plugins
-
-Plugins allow to use CodeceptJS internal API to extend functionality. Use internal event dispatcher, container, output, promise recorder, to create your own reporters, test listeners, etc.
-
-CodeceptJS includes [built-in plugins](https://codecept.io/plugins/) which extend basic functionality and can be turned on and off on purpose. Taking them as [examples](https://github.com/Codeception/CodeceptJS/tree/master/lib/plugin) you can develop your custom plugins.
-
-A plugin is a basic JS module returning a function. Plugins can have individual configs which are passed into this function:
-
-```js
-const defaultConfig = {
-  someDefaultOption: true
-}
-
-module.exports = function(config) {
-  config = Object.assign(defaultConfig, config);
-  // do stuff
-}
-```
-
-Plugin can register event listeners or hook into promise chain with recorder. See [API reference](https://github.com/Codeception/CodeceptJS/tree/master/lib/helper).
-
-To enable your custom plugin in config add it to `plugins` section. Specify path to node module using `require`.
-
-```js
-"plugins": {
-  "myPlugin": {
-    "require": "./path/to/my/module",
-    "enabled": true
-  }
-}
-```
-
-* `require` - specifies relative path to a plugin file. Path is relative to config file.
-* `enabled` - to enable this plugin.
-
-If a plugin is disabled (`enabled` is not set or false) this plugin can be enabled from command line:
-
-```
-./node_modules/.bin/codeceptjs run --plugin myPlugin
-```
-
-Several plugins can be enabled as well:
-
-```
-./node_modules/.bin/codeceptjs run --plugin myPlugin,allure
-```
-
-
-## Custom Hooks
-
-*(deprecated, use [plugins](#plugins))*
-
-Hooks are JavaScript files same as for bootstrap and teardown, which can be registered inside `hooks` section of config. Unlike `bootstrap` you can have multiple hooks registered:
-
-```json
-"hooks": [
-  "./server.js",
-  "./data_builder.js",
-  "./report_notification.js"
-]
-```
-
-Inside those JS files you can use CodeceptJS API (see below) to access its internals.
 
 ## API
 
@@ -302,6 +239,7 @@ Test events provide a test object with following fields:
 * `body` test function as a string
 * `opts` additional test options like retries, and others
 * `pending` true if test is scheduled for execution and false if a test has finished
+* `tags` array of tags for this test
 * `file` path to a file with a test.
 * `steps` array of executed steps (available only in `test.passed`, `test.failed`, `test.finished` event)
 
@@ -431,6 +369,93 @@ if (config.myKey == 'value') {
   // run hook
 }
 ```
+
+## Plugins
+
+Plugins allow to use CodeceptJS internal API to extend functionality. Use internal event dispatcher, container, output, promise recorder, to create your own reporters, test listeners, etc.
+
+CodeceptJS includes [built-in plugins](https://codecept.io/plugins/) which extend basic functionality and can be turned on and off on purpose. Taking them as [examples](https://github.com/Codeception/CodeceptJS/tree/master/lib/plugin) you can develop your custom plugins.
+
+A plugin is a basic JS module returning a function. Plugins can have individual configs which are passed into this function:
+
+```js
+const defaultConfig = {
+  someDefaultOption: true
+}
+
+module.exports = function(config) {
+  config = Object.assign(defaultConfig, config);
+  // do stuff
+}
+```
+
+Plugin can register event listeners or hook into promise chain with recorder. See [API reference](https://github.com/Codeception/CodeceptJS/tree/master/lib/helper).
+
+To enable your custom plugin in config add it to `plugins` section. Specify path to node module using `require`.
+
+```js
+"plugins": {
+  "myPlugin": {
+    "require": "./path/to/my/module",
+    "enabled": true
+  }
+}
+```
+
+* `require` - specifies relative path to a plugin file. Path is relative to config file.
+* `enabled` - to enable this plugin.
+
+If a plugin is disabled (`enabled` is not set or false) this plugin can be enabled from command line:
+
+```
+./node_modules/.bin/codeceptjs run --plugin myPlugin
+```
+
+Several plugins can be enabled as well:
+
+```
+./node_modules/.bin/codeceptjs run --plugin myPlugin,allure
+```
+
+### Example: Execute code for a specific group of tests
+
+If you need to execute some code before a group of tests, you can [mark these tests with a same tag](https://codecept.io/advanced/#tags). Then to listen for tests where this tag is included (see [test object api](#test-object)).
+
+Let's say we need to populate database for a group of tests.
+
+```js
+// populate database for slow tests
+const event = require('codeceptjs').event;
+
+module.exports = function() {
+
+  event.dispatcher.on(event.test.before, function (test) {
+
+    if (test.tags.indexOf('@populate') >= 0) {
+      recorder.add('populate database', async () => {
+        // populate database for this test
+      })
+    }
+  });
+}
+```
+
+## Custom Hooks
+
+*(deprecated, use [plugins](#plugins))*
+
+Hooks are JavaScript files same as for bootstrap and teardown, which can be registered inside `hooks` section of config. Unlike `bootstrap` you can have multiple hooks registered:
+
+```json
+"hooks": [
+  "./server.js",
+  "./data_builder.js",
+  "./report_notification.js"
+]
+```
+
+Inside those JS files you can use CodeceptJS API (see below) to access its internals.
+
 
 ## Custom Runner
 

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -105,10 +105,10 @@ declare class Locator implements ILocator {
 declare function actor(customSteps?: {}): CodeceptJS.{{I}};
 declare function Feature(title: string, opts?: {}): FeatureConfig;
 declare const Scenario: {
-	(title: string, callback: ICodeceptCallback): ScenarioConfig;
-	(title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;
-	only(title: string, callback: ICodeceptCallback): ScenarioConfig;
-	only(title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;
+  (title: string, callback: ICodeceptCallback): ScenarioConfig;
+  (title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;
+  only(title: string, callback: ICodeceptCallback): ScenarioConfig;
+  only(title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;
 }
 declare function xScenario(title: string, callback: ICodeceptCallback): ScenarioConfig;
 declare function xScenario(title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;

--- a/lib/interfaces/featureConfig.js
+++ b/lib/interfaces/featureConfig.js
@@ -40,6 +40,20 @@ class FeatureConfig {
     this.suite.config[helper] = obj;
     return this;
   }
+
+
+  /**
+   * Append a tag name to scenario title
+   * @param {*} tagName
+   */
+  tag(tagName) {
+    if (tagName[0] !== '@') {
+      tagName = `@${tagName}`;
+    }
+    this.suite.tags.push(tagName);
+    this.suite.title = `${this.suite.title.trim()} ${tagName}`;
+    return this;
+  }
 }
 
 module.exports = FeatureConfig;

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -15,7 +15,9 @@ module.exports = (text) => {
   const ast = parser.parse(text);
 
   const suite = new Suite(ast.feature.name, new Context());
-  suite.title = `${suite.title} ${ast.feature.tags.map(t => t.name).join(' ')}`.trim();
+  const tags = ast.feature.tags.map(t => t.name);
+  suite.title = `${suite.title} ${tags.join(' ')}`.trim();
+  suite.tags = tags || [];
   suite.comment = ast.feature.description;
   suite.feature = ast.feature;
   suite.timeout(0);
@@ -73,7 +75,10 @@ module.exports = (text) => {
               return step;
             });
           }
-          const test = new Test(`${child.name} ${JSON.stringify(current)}`, async () => runSteps(exampleSteps));
+          const tags = child.tags.map(t => t.name);
+          const title = `${child.name} ${JSON.stringify(current)} ${tags.join(' ')}`.trim();
+          const test = new Test(title, async () => runSteps(exampleSteps));
+          test.tags = suite.tags.concat(tags);
           test.timeout(0);
           test.async = true;
           suite.addTest(scenario.test(test));
@@ -81,9 +86,11 @@ module.exports = (text) => {
       }
       continue;
     }
-    const title = `${child.name} ${child.tags.map(t => t.name).join(' ')}`.trim();
+    const tags = child.tags.map(t => t.name);
+    const title = `${child.name} ${tags.join(' ')}`.trim();
     const test = new Test(title, async () => runSteps(child.steps));
     test.timeout(0);
+    test.tags = suite.tags.concat(tags);
     test.async = true;
     suite.addTest(scenario.test(test));
   }

--- a/lib/interfaces/scenarioConfig.js
+++ b/lib/interfaces/scenarioConfig.js
@@ -70,7 +70,18 @@ class ScenarioConfig {
       this.test.config = {};
     }
     this.test.config[helper] = obj;
-    return this.test;
+    return this;
+  }
+
+  /**
+   * Append a tag name to scenario title
+   * @param {*} tagName
+   */
+  tag(tagName) {
+    if (tagName[0] !== '@') tagName = `@${tagName}`;
+    this.test.tags.push(tagName);
+    this.test.title = `${this.test.title.trim()} ${tagName}`;
+    return this;
   }
 }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -34,7 +34,7 @@ module.exports = function (suite) {
   suite.on('pre-require', (context, file, mocha) => {
     const common = require('mocha/lib/interfaces/common')(suites, context);
 
-    const addScenario = function (title, opts, fn, data) {
+    const addScenario = function (title, opts = {}, fn, data) {
       const suite = suites[0];
 
       if (typeof opts === 'function' && !fn) {
@@ -51,6 +51,8 @@ module.exports = function (suite) {
           test.inject[key] = deps[key];
         });
       };
+
+      test.tags = (suite.tags || []).concat(title.match(/(\@\w+)/g)); // match tags from title
       test.file = file;
       test.async = true;
       test.timeout(0);
@@ -95,6 +97,7 @@ module.exports = function (suite) {
       if (opts.retries) suite.retries(opts.retries);
       if (opts.timeout) suite.timeout(opts.timeout);
 
+      suite.tags = title.match(/(\@\w+)/g) || []; // match tags from title
       suite.file = file;
       suite.fullTitle = () => `${suite.title}:`;
       suites.unshift(suite);

--- a/test/data/sandbox/features/examples.feature
+++ b/test/data/sandbox/features/examples.feature
@@ -3,6 +3,7 @@ Feature: Checkout examples process
   As a customer
   I want to be able to buy several products
 
+  @user
   Scenario Outline: order discount
     Given I have product with price <price>$ in my cart
     And discount for orders greater than $20 is 10 %

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -264,8 +264,7 @@ describe('Puppeteer', function () {
     it('should switch reference to iframe content', () => I.amOnPage('/iframe')
       .then(() => I.switchTo('[name="content"]'))
       .then(() => I.see('Information'))
-      .then(() => I.see('Lots of valuable data here'))
-    );
+      .then(() => I.see('Lots of valuable data here')));
 
     it('should return error if iframe selector is invalid', () => I.amOnPage('/iframe')
       .then(() => I.switchTo('#invalidIframeSelector'))

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -138,6 +138,26 @@ describe('BDD Gherkin', () => {
     });
   });
 
+  it('should run scenario outline by tag', (done) => {
+    exec(config_run_config('codecept.bdd.json') + ' --grep "@user" --steps', (err, stdout, stderr) => { //eslint-disable-line
+      stdout.should.not.include('0 passed');
+      stdout.should.include('I have product with price 10$');
+      assert(!err);
+      done();
+    });
+  });
+
+
+  it('should run scenario and scenario outline by tags', (done) => {
+    exec(config_run_config('codecept.bdd.json') + ' --grep "\@user|\@very" --steps', (err, stdout, stderr) => { //eslint-disable-line
+      stdout.should.not.include('0 passed');
+      stdout.should.include('I have product with price 10$');
+      stdout.should.include('I have product with $600 price in my cart');
+      stdout.should.include('6 passed');
+      assert(!err);
+      done();
+    });
+  });
 
   it('should show all available steps', (done) => {
     exec(`${runner} gherkin:steps --config ${codecept_dir}/codecept.bdd.json`, (err, stdout, stderr) => { //eslint-disable-line

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -18,6 +18,7 @@ const text = `
   As a customer
   I want to be able to buy several products
 
+  @super
   Scenario:
     Given I have product with 600 price
     And I have product with 1000 price
@@ -56,6 +57,17 @@ describe('BDD', () => {
     assert.equal(3, matchStep('I see ocean')());
     assert.equal(3, matchStep('I see world')());
   });
+
+  it('should contain tags', async () => {
+    let sum = 0;
+    Given(/I have product with (\d+) price/, param => sum += parseInt(param, 10));
+    When('I go to checkout process', () => sum += 10);
+    const suite = run(text);
+    suite.tests[0].fn(() => {});
+    assert.ok(suite.tests[0].tags);
+    assert.equal('@super', suite.tests[0].tags[0]);
+  });
+
 
   it('should load step definitions', async () => {
     let sum = 0;
@@ -188,8 +200,10 @@ describe('BDD', () => {
 
   it('should execute scenario outlines', () => {
     const text = `
+    @awesome @cool
     Feature: checkout process
 
+    @super
     Scenario Outline: order discount
       Given I have product with price <price>$ in my cart
       And discount is 10 %
@@ -217,6 +231,10 @@ describe('BDD', () => {
     const suite = run(text);
     const done = () => {};
     suite.tests.forEach(t => t.fn(done));
+    assert.ok(suite.tests[0].tags);
+    assert.equal('@awesome', suite.tests[0].tags[0]);
+    assert.equal('@cool', suite.tests[0].tags[1]);
+    assert.equal('@super', suite.tests[0].tags[2]);
     assert.equal(executed, 2);
     assert.equal(18, cart);
     assert.equal(18, sum);

--- a/test/unit/ui_test.js
+++ b/test/unit/ui_test.js
@@ -1,0 +1,114 @@
+const Mocha = require('mocha/lib/mocha');
+const makeUI = require('../../lib/ui');
+const assert = require('assert');
+const Suite = require('mocha/lib/suite');
+const should = require('chai').should();
+
+describe('ui', () => {
+  let suite;
+  let context;
+
+  beforeEach(() => {
+    context = {};
+    suite = new Suite('empty');
+    makeUI(suite);
+    suite.emit('pre-require', context, {}, new Mocha());
+  });
+
+  describe('basic constants', () => {
+    const constants = ['Before', 'Background', 'BeforeAll', 'After', 'AfterAll', 'Scenario', 'xScenario'];
+
+    constants.forEach((c) => {
+      it(`context should contain ${c}`, () => assert.ok(context[c]));
+    });
+  });
+
+  describe('Feature', () => {
+    let suiteConfig;
+
+    it('Feature should return featureConfig', () => {
+      suiteConfig = context.Feature('basic suite');
+      assert.ok(suiteConfig.suite);
+    });
+
+    it('should contain title', () => {
+      suiteConfig = context.Feature('basic suite');
+      assert.ok(suiteConfig.suite);
+      assert.equal(suiteConfig.suite.title, 'basic suite');
+      assert.equal(suiteConfig.suite.fullTitle(), 'basic suite:');
+    });
+
+    it('should contain tags', () => {
+      suiteConfig = context.Feature('basic suite');
+      assert.equal(0, suiteConfig.suite.tags.length);
+
+      suiteConfig = context.Feature('basic suite @very @important');
+      assert.ok(suiteConfig.suite);
+
+      suiteConfig.suite.tags.should.include('@very');
+      suiteConfig.suite.tags.should.include('@important');
+
+      suiteConfig.tag('@user');
+      suiteConfig.suite.tags.should.include('@user');
+
+      suiteConfig.suite.tags.should.not.include('@slow');
+      suiteConfig.tag('slow');
+      suiteConfig.suite.tags.should.include('@slow');
+    });
+
+    it('retries can be set', () => {
+      suiteConfig = context.Feature('basic suite');
+      suiteConfig.retry(3);
+      assert.equal(3, suiteConfig.suite.retries());
+    });
+
+    it('timeout can be set', () => {
+      suiteConfig = context.Feature('basic suite');
+      assert.equal(0, suiteConfig.suite.timeout());
+      suiteConfig.timeout(3);
+      assert.equal(3, suiteConfig.suite.timeout());
+    });
+
+    it('helpers can be configured', () => {
+      suiteConfig = context.Feature('basic suite');
+      assert(!suiteConfig.suite.config);
+      suiteConfig.config('WebDriverIO', { browser: 'chrome' });
+      assert.equal('chrome', suiteConfig.suite.config.WebDriverIO.browser);
+      suiteConfig.config({ browser: 'firefox' });
+      assert.equal('firefox', suiteConfig.suite.config[0].browser);
+      suiteConfig.config('WebDriverIO', () => {
+        return { browser: 'edge' };
+      });
+      assert.equal('edge', suiteConfig.suite.config.WebDriverIO.browser);
+    });
+  });
+
+  describe('Scenario', () => {
+    let scenarioConfig;
+
+    it('Scenario should return scenarioConfig', () => {
+      scenarioConfig = context.Scenario('basic scenario');
+      assert.ok(scenarioConfig.test);
+    });
+
+    it('should contain title', () => {
+      context.Feature('suite');
+      scenarioConfig = context.Scenario('scenario');
+      assert.equal(scenarioConfig.test.title, 'scenario');
+      assert.equal(scenarioConfig.test.fullTitle(), 'suite: scenario');
+    });
+
+    it('should contain tags', () => {
+      const suiteConfig = context.Feature('basic suite @cool');
+
+      scenarioConfig = context.Scenario('scenario @very @important');
+
+      scenarioConfig.test.tags.should.include('@cool');
+      scenarioConfig.test.tags.should.include('@very');
+      scenarioConfig.test.tags.should.include('@important');
+
+      scenarioConfig.tag('@user');
+      scenarioConfig.test.tags.should.include('@user');
+    });
+  });
+});


### PR DESCRIPTION
Changes:

* Groups officially renamed to tags for compatibility with BDD layer
* Test and suite objects to contain `tags` property which can be accessed from internal API
* Fixed adding tags for Scenario Outline in BDD
* Added `tag` method to ScenarioConfig and FeatureConfig:

```js
Scenario('update user profile', () => {
  // test goes here
}).tag('@slow');
```
* Added unit tests for ScenarioConfig, FeatureConfig, suite and test definitions