### PR TITLE
Remove some extra back-ticks in documentation

### DIFF
--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -516,7 +516,7 @@ Reload the page
 Reload the current page.
 
 ```js
-`I.refreshPage();
+I.refreshPage();
 ```
 
 ## resizeWindow

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -769,7 +769,7 @@ Reloads page
 Reload the current page.
 
 ```js
-`I.refreshPage();
+I.refreshPage();
 ```
 
 ## resetModule

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -744,7 +744,7 @@ I.pressKey(['Control','a']);
 Reload the current page.
 
 ```js
-`I.refreshPage();
+I.refreshPage();
 ```
 
 ## resizeWindow

--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -863,7 +863,7 @@ I.pressKey('Control');
 Reload the current page.
 
 ```js
-`I.refreshPage();
+I.refreshPage();
 ```
 
 ## resizeWindow


### PR DESCRIPTION
I noticed what I assume are some extra back-ticks in the documentation.