### PR TITLE
Adds clickLink method to Puppeteer helper

### DIFF
--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -314,6 +314,19 @@ I.click({css: 'nav a.login'});
 -   `locator`  clickable link or button located by text, or any element located by CSS|XPath|strict locator
 -   `context`  (optional) element to search in CSS|XPath|Strict locator
 
+## clickLink
+
+Performs a click and waits for navigation before moving on.
+
+```js
+I.click('Logout', '#nav');
+```
+
+**Parameters**
+
+-   `locator`  clickable link or button located by text, or any element located by CSS|XPath|strict locator
+-   `context`  (optional) element to search in CSS|XPath|Strict locator
+
 ## closeCurrentTab
 
 Close current tab and switches to previous.

--- a/docs/webapi/clickLink.mustache
+++ b/docs/webapi/clickLink.mustache
@@ -1,0 +1,7 @@
+Performs a click on a link and waits for navigation before moving on.
+
+```js
+I.click('Logout', '#nav');
+```
+@param locator clickable link or button located by text, or any element located by CSS|XPath|strict locator
+@param context (optional) element to search in CSS|XPath|Strict locator

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -813,6 +813,13 @@ class Puppeteer extends Helper {
   }
 
   /**
+   * Performs a click and waits for navigation before moving on.
+   */
+  async clickLink(locator, context = null) {
+    return proceedClick.call(this, locator, context, { waitForNavigation: true });
+  }
+
+  /**
    * {{> ../webapi/doubleClick }}
    */
   async doubleClick(locator, context = null) {
@@ -1801,7 +1808,12 @@ async function proceedClick(locator, context = null, options = {}) {
     assertElementExists(els, locator, 'Clickable element');
   }
   await els[0].click(options);
-  return this.waitForNavigation() && this._waitForAction();
+  const promises = [];
+  if (options.waitForNavigation) {
+    promises.push(this.waitForNavigation());
+  }
+  promises.push(this._waitForAction());
+  return await Promise.all(promises);
 }
 
 async function findClickable(matcher, locator) {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -813,7 +813,7 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * Performs a click and waits for navigation before moving on.
+   * {{> ../webapi/clickLink }}
    */
   async clickLink(locator, context = null) {
     return proceedClick.call(this, locator, context, { waitForNavigation: true });

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1813,7 +1813,7 @@ async function proceedClick(locator, context = null, options = {}) {
     promises.push(this.waitForNavigation());
   }
   promises.push(this._waitForAction());
-  return await Promise.all(promises);
+  return Promise.all(promises);
 }
 
 async function findClickable(matcher, locator) {


### PR DESCRIPTION
Fixes the `click()` method so by default it doesn't trigger a `waitForNavigation()` and instead adds a new `clickLink()` method to trigger a `waitForNavigation()` when clicking an element that should trigger a navigation.