### PR TITLE
change margin for code examples to look closer to its description

### DIFF
--- a/css/extra.css
+++ b/css/extra.css
@@ -367,7 +367,7 @@ body .bs-sidebar {
 }
 
 .reference p {
-  margin-bottom: 1em;
+  margin: 1em 0 0.5em;
   line-height: 1.5em;
 }
 


### PR DESCRIPTION
Change text margin, so code examples are closer to their description.

Before, it's looked as code example relates to text after them. It's a little bit confusing: 
![image](https://user-images.githubusercontent.com/11647141/47436709-b1fa0000-d7af-11e8-8c06-f91b1db4f545.png)
