### PR TITLE
fix timeouts definition for W3C compatible drivers for WebDriverIO

### DIFF
--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -494,19 +494,24 @@ class WebDriverIO extends Helper {
    * ```
    */
   async defineTimeout(timeouts) {
-    if (timeouts.implicit) {
-      await this.browser.timeouts('implicit', timeouts.implicit);
-    }
-    if (timeouts['page load']) {
-      await this.browser.timeouts('page load', timeouts['page load']);
-    }
-    // both pageLoad and page load are accepted
-    // see http://webdriver.io/api/protocol/timeouts.html
-    if (timeouts.pageLoad) {
-      await this.browser.timeouts('page load', timeouts.pageLoad);
-    }
-    if (timeouts.script) {
-      await this.browser.timeouts('script', timeouts.script);
+    try {
+      // try to set W3C compatible timeouts
+      await this.browser.timeouts(timeouts);
+    } catch (error) {
+      if (timeouts.implicit) {
+        await this.browser.timeouts('implicit', timeouts.implicit);
+      }
+      if (timeouts['page load']) {
+        await this.browser.timeouts('page load', timeouts['page load']);
+      }
+      // both pageLoad and page load are accepted
+      // see http://webdriver.io/api/protocol/timeouts.html
+      if (timeouts.pageLoad) {
+        await this.browser.timeouts('page load', timeouts.pageLoad);
+      }
+      if (timeouts.script) {
+        await this.browser.timeouts('script', timeouts.script);
+      }
     }
     return this.browser; // return the last response
   }


### PR DESCRIPTION
Modern browsers starts to drop out old webdriver syntax.
For example Safari 12 and FF 63 does not support old syntax for timeout setting.

We should use new w3c compatible syntax in such cases
http://webdriver.io/api/protocol/timeouts.html
