### PR TITLE
Add check to filter out inherited array properties inside getInjectedArguments

### DIFF
--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -233,15 +233,17 @@ const getInjectedArguments = (fn, test) => {
   const params = getParamNames(fn) || [];
   const objects = container.support();
   for (const key in params) {
-    const obj = params[key];
-    if (test && test.inject && test.inject[obj]) {
-      testArguments.push(test.inject[obj]);
-      continue;
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      const obj = params[key];
+      if (test && test.inject && test.inject[obj]) {
+        testArguments.push(test.inject[obj]);
+        continue;
+      }
+      if (!objects[obj]) {
+        throw new Error(`Object of type ${obj} is not defined in container`);
+      }
+      testArguments.push(container.support(obj));
     }
-    if (!objects[obj]) {
-      throw new Error(`Object of type ${obj} is not defined in container`);
-    }
-    testArguments.push(container.support(obj));
   }
   return testArguments;
 };


### PR DESCRIPTION
When `codeceptjs` breaks down the user written `Scenarios` it checks for Injected arguments inside each `Scenario`. When `Scenarios` are written to be `async` and contain a custom helper which returns promise this functionality breaks down and throws and error when testing 2 or more `Scenarios`. The `for...in` loop from `getInjectedArguments` adds additional properties which are part of the array prototype causing the error to be thrown.

This PR add a simple check within the `for...in` to ensure that current properties inside the loop is a valid property within the `params` array and not an inherited property

See Issue #1272 for more detailed information regarding the error.  

[`for...in` MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Array_iteration_and_for...in) for reference