### PR TITLE
Tests can run in parallel and accept '--override' flags

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -15,6 +15,7 @@ const runner = path.join(__dirname, '/../../bin/codecept');
 let config;
 const childOpts = {};
 const copyOptions = ['override', 'steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'debug', 'plugins'];
+let overrides = {};
 
 // codeceptjs run:multiple smoke:chrome regression:firefox - will launch smoke run in chrome and regression in firefox
 // codeceptjs run:multiple smoke:chrome regression - will launch smoke run in chrome and regression in firefox and chrome
@@ -41,6 +42,13 @@ module.exports = function (selectedRuns, options) {
     .forEach((key) => {
       childOpts[key] = options[key];
     });
+
+  try {
+    overrides = JSON.parse(childOpts.override);
+    delete childOpts.override;
+  } catch (e) {
+    overrides = {};
+  }
 
   if (!config.multiple) {
     fail('Multiple runs not configured, add "multiple": { /../ } section to config');
@@ -120,7 +128,10 @@ function executeRun(runName, runConfig) {
   // override grep param and collect all params
   const params = ['run',
     '--child', `${runId++}.${runName}:${browserName}`,
-    '--override', JSON.stringify(overriddenConfig),
+    '--override', JSON.stringify({
+      ...overriddenConfig,
+      ...overrides,
+    }),
   ];
 
   Object.keys(childOpts).forEach((key) => {

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -122,22 +122,4 @@ describe('CodeceptJS Multiple Runner', function () {
       done();
     });
   });
-
-  it('should merge overrides provided on launch', (done) => {
-    // const override = JSON.stringify({ "helpers": {
-    //   "FakeDriver": {
-    //     "require": "../fake_driver",
-    //     "browser": "foobar",
-    //     "windowSize": "maximize"
-    //   }
-    // }});
-    const override = '{"multiple": {"chunks": {"chunks": 3 }}}';
-    const codecept_override_run = `${codecept_run} --override '${override}' `;
-    return exec(`${codecept_override_run}chunks`, (err, stdout, stderr) => {
-      stdout.should.include('CodeceptJS'); // feature
-      assert(!err);
-      done();
-    });
-  });
 });
-

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -122,5 +122,22 @@ describe('CodeceptJS Multiple Runner', function () {
       done();
     });
   });
+
+  it('should merge overrides provided on launch', (done) => {
+    // const override = JSON.stringify({ "helpers": {
+    //   "FakeDriver": {
+    //     "require": "../fake_driver",
+    //     "browser": "foobar",
+    //     "windowSize": "maximize"
+    //   }
+    // }});
+    const override = '{"multiple": {"chunks": {"chunks": 3 }}}';
+    const codecept_override_run = `${codecept_run} --override '${override}' `;
+    return exec(`${codecept_override_run}chunks`, (err, stdout, stderr) => {
+      stdout.should.include('CodeceptJS'); // feature
+      assert(!err);
+      done();
+    });
+  });
 });
 


### PR DESCRIPTION
This PR is in relation to [the issue raised by my team earlier this week](https://github.com/Codeception/CodeceptJS/issues/1291). Please read the issue for an explanation of the problem we found.

We have made changes to `run-multiple.js` so that the CodeceptJS internal`--overrides` and user `--overrides` are both adhered to. 

There are some config fields which cannot be overridden: browser config, browser name and run name. We decided not to change the existing CodeceptJS code which made this the case.

However, we were unable to unit test our changes as the output for the calls in `run_multiple_test.js` only output the fields listed above which cannot be changed.

We are now using this patch on our project. We have manually tested that the tests are run in parallel correctly and are no longer run on every thread.

How would the CodeceptJS team approach unit testing this change? We explored a few options but were unable to unit test this correctly.