### PR TITLE
Improve a11y selector support

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -192,6 +192,9 @@ Locator.clickable = {
     `.//label[contains(normalize-space(string(.)), ${literal})]`,
     `.//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][./@name = ${literal}]`,
     `.//button[./@name = ${literal}]`,
+    `.//*[@aria-label = ${literal}]`,
+    `.//*[@title = ${literal}]`,
+    `.//*[@aria-labelledby = //*[normalize-space(string(.)) = ${literal}]/@id ]`,
   ]),
 
   self: literal => `./self::*[contains(normalize-space(string(.)), ${literal}) or contains(normalize-space(@value), ${literal})]`,
@@ -205,6 +208,9 @@ Locator.field = {
   labelContains: literal => xpathLocator.combine([
     `.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@name = ${literal}) or ./@id = //label[contains(normalize-space(string(.)), ${literal})]/@for) or ./@placeholder = ${literal})]`,
     `.//label[contains(normalize-space(string(.)), ${literal})]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
+    `.//*[@aria-label = ${literal}]`,
+    `.//*[@title = ${literal}]`,
+    `.//*[@aria-labelledby = //*[normalize-space(string(.)) = ${literal}]/@id ]`,
   ]),
   byName: literal => `.//*[self::input | self::textarea | self::select][@name = ${literal}]`,
   byText: literal => xpathLocator.combine([

--- a/test/data/app/view/info.php
+++ b/test/data/app/view/info.php
@@ -9,7 +9,10 @@
 
 <p>Lots of valuable data here
 
-    <a href="/" id="back" aria-label="index"><img src="blank.gif" alt="Back"/></a>
+    <a href="/" id="back" aria-label="index via aria-label"><img src="blank.gif" alt="Back"/></a>
+    <a href="/" title="index via title"><img src="blank.gif" alt="Back"/></a>
+    <a href="/" aria-labelledby="label-span"><img src="blank.gif" alt="Back"/></a>
+    <span id="label-span">index via labelledby</span>
 </p>
 
 <div class="notice"><?php if (isset($notice)) echo $notice; ?></div>

--- a/test/helper/WebDriverIO_test.js
+++ b/test/helper/WebDriverIO_test.js
@@ -419,8 +419,18 @@ describe('WebDriverIO', function () {
       .then(() => wd.click('Submit', '//form'))
       .then(() => wd.waitInUrl('/form/complex')));
 
+    it('should click by aria-label', () => wd.amOnPage('/info')
+      .then(() => wd.click('index via aria-label'))
+      .then(() => wd.see('Welcome to test app!')));
+    it('should click by title', () => wd.amOnPage('/info')
+      .then(() => wd.click('index via title'))
+      .then(() => wd.see('Welcome to test app!')));
+    it('should click by aria-labelledby', () => wd.amOnPage('/info')
+      .then(() => wd.click('index via labelledby'))
+      .then(() => wd.see('Welcome to test app!')));
+
     it('should click by accessibility_id', () => wd.amOnPage('/info')
-      .then(() => wd.click('~index'))
+      .then(() => wd.click('~index via aria-label'))
       .then(() => wd.see('Welcome to test app!')));
   });
 


### PR DESCRIPTION
This is about improving a11y selection support in the Webdriver.io helper. Currently, only strings in aria-label are recognized. With this commit, the prefix "~" would also check for the title attribute (which is not only an a11y method to describe icons or abbreviations) and also aria-describedby and aria-labelledby. The aria-describedby and aria-labelledby methods are the same as the lookup of inputs by their labels text. 