### PR TITLE
Add timestamp to puppeteer console log messages

### DIFF
--- a/lib/helper/extras/Console.js
+++ b/lib/helper/extras/Console.js
@@ -1,3 +1,6 @@
+const withTimestamp = entry => Object.assign({
+  timestamp: Date.now(),
+}, entry);
 
 /**
  * Class to handle the interaction with the Console Class from Puppeteer
@@ -17,9 +20,9 @@ class Console {
 
   add(entry) {
     if (Array.isArray(entry)) {
-      this._logEntries = this._logEntries.concat(entry);
+      this._logEntries = this._logEntries.concat(entry.map(e => withTimestamp(e)));
     }
-    this._logEntries.push(entry);
+    this._logEntries.push(withTimestamp(entry));
   }
 }
 


### PR DESCRIPTION
Add unix timestamp to puppeteer console log message to be consistent with webdriverio