### PR TITLE
Fixes allure report not generating steps after #1307

### DIFF
--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -92,12 +92,12 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (!step.metaStep && currentStep) {
+    if (step.metaStep) {
       startMetaStep(step.metaStep);
-      if (currentStep !== step) {
-        reporter.startStep(step.toString());
-        currentStep = step;
-      }
+    }
+    if (currentStep !== step) {
+      reporter.startStep(step.toString());
+      currentStep = step;
     }
   });
 


### PR DESCRIPTION
Hi!

This fixes Allure report generation.
After #1307 `steps` stopped generating in Allure XML.

@PeterNgTr maybe you can also verify that your reports are generated correctly after this fix?

If all is ok then we need to generate a reference Allure report to run the tests against it in the future. 