### PR TITLE
Add option `output` to stepByStepReport plugin

### DIFF
--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -85,10 +85,10 @@ module.exports = function (config) {
   let slides = {};
   let error;
   let savedStep = null;
-  let reportDir = config.output ? path.resolve(global.codecept_dir, config.output) : defaultConfig.output;
   const uuid = Math.floor(new Date().getTime() / 1000);
   const recordedTests = {};
   const pad = '0000';
+  const reportDir = config.output ? path.resolve(global.codecept_dir, config.output) : defaultConfig.output;
 
   event.dispatcher.on(event.test.before, (test) => {
     dir = path.join(reportDir, `record_${clearString(test.title).substring(0, 20)}_${uuid}`);

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -22,6 +22,7 @@ const defaultConfig = {
   animateSlides: true,
   ignoreSteps: [],
   fullPageScreenshots: false,
+  output: global.output_dir,
 };
 
 const templates = {};
@@ -56,6 +57,7 @@ const templates = {};
  * * `animateSlides`: should animation for slides to be used. Default: true.
  * * `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
  * * `fullPageScreenshots`: should full page screenshots be used. Default: false.
+ * * `output`: a directory where reports should be stored. Default: `output`.
  *
  * ##### Allure Reports
  *
@@ -83,12 +85,13 @@ module.exports = function (config) {
   let slides = {};
   let error;
   let savedStep = null;
+  let reportDir = config.output ? path.resolve(global.codecept_dir, config.output) : defaultConfig.output;
   const uuid = Math.floor(new Date().getTime() / 1000);
   const recordedTests = {};
   const pad = '0000';
 
   event.dispatcher.on(event.test.before, (test) => {
-    dir = path.join(global.output_dir, `record_${clearString(test.title).substring(0, 20)}_${uuid}`);
+    dir = path.join(reportDir, `record_${clearString(test.title).substring(0, 20)}_${uuid}`);
     mkdirp.sync(dir);
     stepNum = 0;
     error = null;
@@ -127,9 +130,9 @@ module.exports = function (config) {
       records: links,
     });
 
-    fs.writeFileSync(path.join(global.output_dir, 'records.html'), indexHTML);
+    fs.writeFileSync(path.join(reportDir, 'records.html'), indexHTML);
 
-    output.print(`${figures.circleFilled} Step-by-step preview: ${colors.white.bold(`file://${global.output_dir}/records.html`)}`);
+    output.print(`${figures.circleFilled} Step-by-step preview: ${colors.white.bold(`file://${reportDir}/records.html`)}`);
   });
 
   async function persistStep(step) {
@@ -139,7 +142,7 @@ module.exports = function (config) {
     try {
       stepNum++;
       slides[fileName] = step;
-      await helper.saveScreenshot(path.relative(global.output_dir, path.join(dir, fileName)), config.fullPageScreenshots);
+      await helper.saveScreenshot(path.relative(reportDir, path.join(dir, fileName)), config.fullPageScreenshots);
     } catch (err) {
       output.plugin(`Can't save step screenshot: ${err}`);
       error = err;
@@ -185,7 +188,7 @@ module.exports = function (config) {
 
     const index = path.join(dir, 'index.html');
     fs.writeFileSync(index, html);
-    recordedTests[`${test.parent.title}: ${test.title}`] = path.relative(global.output_dir, index);
+    recordedTests[`${test.parent.title}: ${test.title}`] = path.relative(reportDir, index);
   }
 
   function isStepIgnored(step) {


### PR DESCRIPTION
add option `output` to stepByStepReport plugin for customize output-directory.
Example:

```
  "plugins": {
    "stepByStepReport": {
      "enabled": true,
      "output": "./output/report"
    }
 }
```