### PR TITLE
Fix steps output for CLI for async/arrow functions

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -77,6 +77,13 @@ module.exports = {
   step(step) {
     if (outputLevel === 0) return;
     if (!step) return;
+    // Avoid to print non-gherkin steps, when gherkin is running for --steps mode
+    if (outputLevel === 1) {
+      if (!step.isMetaStep() && step.hasBDDAncestor()) {
+        return;
+      }
+    }
+
     let stepLine = step.toString();
     if (step.metaStep && outputLevel >= 2) {
       this.stepShift += 2;

--- a/lib/output.js
+++ b/lib/output.js
@@ -78,8 +78,7 @@ module.exports = {
     if (outputLevel === 0) return;
     if (!step) return;
     let stepLine = step.toString();
-    if (step.metaStep) {
-      if (outputLevel < 2) return;
+    if (step.metaStep && outputLevel >= 2) {
       this.stepShift += 2;
       stepLine = colors.green(truncate(stepLine, this.spaceShift));
     }

--- a/lib/step.js
+++ b/lib/step.js
@@ -100,6 +100,22 @@ class Step {
   isMetaStep() {
     return this.constructor.name === 'MetaStep';
   }
+
+  hasBDDAncestor() {
+    let hasBDD = false;
+    let processingStep;
+    processingStep = this;
+
+    while (processingStep.metaStep) {
+      if (processingStep.metaStep.actor.match(/^(Given|When|Then|And)/)) {
+        hasBDD = true;
+        break;
+      } else {
+        processingStep = processingStep.metaStep;
+      }
+    }
+    return hasBDD;
+  }
 }
 
 

--- a/test/data/sandbox/within_helper.js
+++ b/test/data/sandbox/within_helper.js
@@ -1,14 +1,15 @@
 
 const Helper = require('../../../lib/helper');
 const output = require('../../../lib/output');
+const Step = require('../../../lib/step');
 
-class Whithin extends Helper {
+class Within extends Helper {
   _withinBegin(testStr) {
-    output.step(`Hey! I am within Begin. I get ${testStr}`);
+    output.step(new Step(this.constructor.name, `Hey! I am within Begin. I get ${testStr}`));
   }
 
   _withinEnd() {
-    output.step('oh! I am within end(');
+    output.step(new Step(this.constructor.name, 'oh! I am within end('));
   }
 
   _failed() {
@@ -24,7 +25,7 @@ class Whithin extends Helper {
       setTimeout(() => {
         resolve('result');
       }, 100);
-    }).then(() => output.step('small Promise was finished'));
+    }).then(() => output.step(new Step(this.constructor.name, 'small Promise was finished')));
   }
 
   errorStep() {
@@ -32,4 +33,4 @@ class Whithin extends Helper {
   }
 }
 
-module.exports = Whithin;
+module.exports = Within;

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -21,7 +21,8 @@ describe('BDD Gherkin', () => {
       stdout.should.include('And I have product with $1000 price');
       stdout.should.include('Then I should see that total number of products is 2');
       stdout.should.include('And my order amount is $1600');
-      stdout.should.not.include('I add item 600');
+      stdout.should.not.include('I add item 600'); // 'Given' actor's non-gherkin step check
+      stdout.should.not.include('I see sum 1600'); // 'And' actor's non-gherkin step check
       assert(!err);
       done();
     });

--- a/test/runner/within_test.js
+++ b/test/runner/within_test.js
@@ -24,12 +24,12 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withoutGeneratorList.should.eql([
         'I small promise ',
-        'small Promise was finished',
-        'Hey! I am within Begin. I get blabla',
+        'I small  Promise was finished ',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I small promise ',
-        'small Promise was finished',
-        'oh! I am within end(',
+        'I small  Promise was finished ',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
       done();
     });
@@ -44,16 +44,16 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withGeneratorList.should.eql([
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
         'I small yield ',
         'I am small yield string',
-        'Hey! I am within Begin. I get blabla',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I small yield ',
         'I am small yield string',
         'I small promise ',
-        'small Promise was finished',
-        'oh! I am within end(',
+        'I small  Promise was finished ',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
 
       done();
@@ -69,16 +69,16 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withGeneratorListOtherOrder.should.eql([
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
         'I small yield ',
         'I am small yield string',
-        'Hey! I am within Begin. I get blabla',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
         'I small yield ',
         'I am small yield string',
-        'oh! I am within end(',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
 
       done();
@@ -94,16 +94,16 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withGeneratorList.should.eql([
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
         'I small yield ',
         'I am small yield string await',
-        'Hey! I am within Begin. I get blabla',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I small yield ',
         'I am small yield string await',
         'I small promise ',
-        'small Promise was finished',
-        'oh! I am within end(',
+        'I small  Promise was finished ',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
 
       done();
@@ -119,16 +119,16 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withGeneratorList.should.eql([
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
         'I small yield ',
         'I am small yield string await',
-        'Hey! I am within Begin. I get blabla',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
         'I small yield ',
         'I am small yield string await',
-        'oh! I am within end(',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
 
       done();
@@ -146,15 +146,15 @@ describe('CodeceptJS within', function () {
       withGeneratorListWithContinued.should.eql([
         'I small yield ',
         'I am small yield string',
-        'Hey! I am within Begin. I get blabla',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I small yield ',
         'I am small yield string',
         'I small promise ',
-        'small Promise was finished',
-        'oh! I am within end(',
+        'I small  Promise was finished ',
+        'I oh!  I am within end( ',
         'I small promise ',
-        'small Promise was finished',
+        'I small  Promise was finished ',
       ], 'check steps execution order');
       done();
     });
@@ -170,10 +170,10 @@ describe('CodeceptJS within', function () {
       errorInWithinList.should.eql([
         'I small yield ',
         'I am small yield string',
-        'Hey! I am within Begin. I get blabla',
+        'I  Hey!  I am within  Begin.  I get blabla ',
         'Within "blabla" ',
         'I error step ',
-        'oh! I am within end(',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
 
       done();
@@ -189,7 +189,7 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('FAILED');
       errorInTestList.should.eql([
         'I error step ',
-        'oh! I am within end(',
+        'I oh!  I am within end( ',
       ], 'check steps execution order');
 
       done();


### PR DESCRIPTION
Fix for #1321 
CLI output did not print steps for some types of async and arrow functions.
```
  non-async non-arrow braces
    Runner: runTest 
  ✔ OK in 3001ms

  non-async arrow non-braces
    Test: I 
  ✔ OK in 2136ms

  non-async arrow braces
    I am on page "/"
  ✔ OK in 1814ms

  async non-arrow braces
    Runner: runTest 
  ✔ OK in 1814ms

  async arrow non-braces
    I am on page "/"
  ✔ OK in 1852ms

  async arrow braces
    I am on page "/"
  ✔ OK in 1759ms
```


Also reworked `within` test, cause it used `step` class as logger for strings instead of creating Step.
It broke new logic, as `String` has not `Step`'s `hasBDDAncestor` method.

PS why we add spaces (` `) before literal strings in `Step.humanize()`?
```
    // insert a space before all caps
      .replace(/([A-Z])/g, ' $1')
```

PS, why spaces are added in the end of cli output? For example  `I blabla ` instead of `I blabla`