### PR TITLE
Changed type definition of PageObjects to get auto completion

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -178,7 +178,7 @@ module.exports = function (genPath, options) {
   const callbackParams = [];
   for (const name in supports) {
     if (name === 'I') continue;
-    callbackParams.push(`${name}:any`);
+    callbackParams.push(`${name}:CodeceptJS.${name}`);
     const pageObject = supports[name];
     const pageMethods = addAllMethodsInObject(pageObject, {}, []);
     let pageObjectExport = pageObjectTemplate.replace('{{methods}}', pageMethods.join(''));


### PR DESCRIPTION
In order to get auto completion in test files for page objects the type of the page object must not be any in type definitions.