### PR TITLE
Add support to use WSEndpoint on Puppeteer

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -59,7 +59,8 @@ const consoleLogStore = new Console();
  *
  * ```js
  * "chrome": {
- *   "executablePath" : "/path/to/Chrome"
+ *   "executablePath" : "/path/to/Chrome",
+ *   "browserWSEndpoint": "ws://localhost:3000"
  * }
  * ```
  *
@@ -376,7 +377,7 @@ class Puppeteer extends Helper {
   }
 
   async _startBrowser() {
-    this.browser = await puppeteer.launch(this.puppeteerOptions);
+    this.browser = this.puppeteerOptions.browserWSEndpoint ? await puppeteer.connect(this.puppeteerOptions) : await puppeteer.launch(this.puppeteerOptions);
     this.browser.on('targetcreated', target => target.page().then(page => targetCreatedHandler.call(this, page)));
     this.browser.on('targetchanged', (target) => {
       this.debugSection('Url', target.url());


### PR DESCRIPTION
Hello,
With this PR will be possible to use remote chrome instances like https://www.browserless.io/ or docker containers like https://github.com/joelgriffith/browserless.

I saw that currently the project is not mocking Puppeteer and we don't have tests to `_startBrowser`, so I don't know how test it. Should I mock Puppeteer?