### PR TITLE
Fix syntax of the generate commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,19 +118,19 @@ codeceptjs shell
 Create new test
 
 ```sh
-codeceptjs generate test
+codeceptjs generate:test
 ```
 
 Create new pageobject
 
 ```sh
-codeceptjs generate pageobject
+codeceptjs generate:pageobject
 ```
 
 Create new helper
 
 ```sh
-codeceptjs generate helper
+codeceptjs generate:helper
 ```
 
 ## TypeScript Definitions


### PR DESCRIPTION
A colon is required between `generate` and the type of object to create