### PR TITLE
Resolve several issues with WebDriver helper.

### DIFF
--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -1537,7 +1537,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [9]: http://jster.net/category/windows-modals-popups
 
-[10]: http://webdriver.io/guide/testrunner/timeouts.html
+[10]: https://webdriver.io/docs/timeouts.html
 
 [11]: https://vuejs.org/v2/api/#Vue-nextTick
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -314,7 +314,7 @@ class WebDriver extends Helper {
     try {
       requireg('webdriverio');
     } catch (e) {
-      return ['webdriverio@^5.1.0'];
+      return ['webdriverio@^5.2.0'];
     }
   }
 
@@ -527,7 +527,7 @@ class WebDriver extends Helper {
   }
 
   /**
-   * Set [WebDriver timeouts](http://webdriver.io/guide/testrunner/timeouts.html) in realtime.
+   * Set [WebDriver timeouts](https://webdriver.io/docs/timeouts.html) in realtime.
    * Appium: support only web testing.
    * Timeouts are expected to be passed as object:
    *
@@ -538,27 +538,8 @@ class WebDriver extends Helper {
    *
    * @param timeouts WebDriver timeouts object.
    */
-  async defineTimeout(timeouts) {
-    try {
-      // try to set W3C compatible timeouts
-      await this.browser.setTimeout(timeouts);
-    } catch (error) {
-      if (timeouts.implicit) {
-        await this.browser.setTimeout('implicit', timeouts.implicit);
-      }
-      if (timeouts['page load']) {
-        await this.browser.setTimeout('page load', timeouts['page load']);
-      }
-      // both pageLoad and page load are accepted
-      // see http://webdriver.io/api/protocol/timeouts.html
-      if (timeouts.pageLoad) {
-        await this.browser.setTimeout('page load', timeouts.pageLoad);
-      }
-      if (timeouts.script) {
-        await this.browser.setTimeout('script', timeouts.script);
-      }
-    }
-    return this.browser; // return the last response
+  defineTimeout(timeouts) {
+    return this.browser.setTimeout(timeouts);
   }
 
   /**
@@ -1385,7 +1366,7 @@ class WebDriver extends Helper {
       return;
     }
     if (this.browser.isW3C) {
-      return this.browser.setWindowRect(0, 0, parseInt(width, 10), parseInt(height, 10));
+      return this.browser.setWindowRect(null, null, parseInt(width, 10), parseInt(height, 10));
     }
     return this.browser.setWindowSize(parseInt(width, 10), parseInt(height, 10));
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -388,7 +388,7 @@ class WebDriver extends Helper {
 
     if (this.options.keepBrowserState) return;
 
-    if (!this.options.keepCookies && this.options.desiredCapabilities.browserName) {
+    if (!this.options.keepCookies && this.options.capabilities.browserName) {
       this.debugSection('Session', 'cleaning cookies and localStorage');
       await this.browser.deleteCookies();
     }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -565,7 +565,7 @@ class WebDriver extends Helper {
       assertElementExists(res, locator, 'Clickable element');
     }
     const elem = usingFirstElement(res);
-    return this.browser[clickMethod](elem.ELEMENT);
+    return this.browser[clickMethod](getElementId(elem));
   }
 
   /**
@@ -599,8 +599,9 @@ class WebDriver extends Helper {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator, 'Clickable element');
     const elem = usingFirstElement(res);
-    if (this.browser.isMobile) return this.browser.touchClick(elem.ELEMENT);
-    await this.browser.moveTo(elem.ELEMENT);
+    const elementId = getElementId(elem);
+    if (this.browser.isMobile) return this.browser.touchClick(elementId);
+    await this.browser.moveTo(elementId);
     this.browser.buttonDown('right');
   }
 
@@ -635,7 +636,7 @@ class WebDriver extends Helper {
     const res = await findFields.call(this, field);
     assertElementExists(res, field, 'Field');
     const elem = usingFirstElement(res);
-    return elem.clearValue(elem.ELEMENT);
+    return elem.clearValue(getElementId(elem));
   }
 
 
@@ -652,18 +653,19 @@ class WebDriver extends Helper {
     }
 
     // select options by visible text
-    let els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(elem.ELEMENT, 'xpath', Locator.select.byVisibleText(xpathLocator.literal(opt))));
+    let els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byVisibleText(xpathLocator.literal(opt))));
 
     const clickOptionFn = async (el) => {
       if (el[0]) el = el[0];
-      if (el && el.ELEMENT) return this.browser.elementClick(el.ELEMENT);
+      const elementId = getElementId(el);
+      if (elementId) return this.browser.elementClick(elementId);
     };
 
     if (Array.isArray(els) && els.length) {
       return forEachAsync(els, clickOptionFn);
     }
     // select options by value
-    els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(elem.ELEMENT, 'xpath', Locator.select.byValue(xpathLocator.literal(opt))));
+    els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byValue(xpathLocator.literal(opt))));
     if (els.length === 0) {
       throw new ElementNotFound(select, `Option "${option}" in`, 'was not found neither by a visible text nor by a value');
     }
@@ -711,10 +713,11 @@ class WebDriver extends Helper {
 
     assertElementExists(res, field, 'Checkable');
     const elem = usingFirstElement(res);
+    const elementId = getElementId(elem);
 
-    const isSelected = await this.browser.isElementSelected(elem.ELEMENT);
+    const isSelected = await this.browser.isElementSelected(elementId);
     if (isSelected.value) return Promise.resolve(true);
-    return this.browser[clickMethod](elem.ELEMENT);
+    return this.browser[clickMethod](elementId);
   }
 
   /**
@@ -729,10 +732,11 @@ class WebDriver extends Helper {
 
     assertElementExists(res, field, 'Checkable');
     const elem = usingFirstElement(res);
+    const elementId = getElementId(elem);
 
-    const isSelected = await this.browser.isElementSelected(elem.ELEMENT);
+    const isSelected = await this.browser.isElementSelected(elementId);
     if (!isSelected.value) return Promise.resolve(true);
-    return this.browser[clickMethod](elem.ELEMENT);
+    return this.browser[clickMethod](elementId);
   }
 
   /**
@@ -744,9 +748,9 @@ class WebDriver extends Helper {
     assertElementExists(res, locator);
     let val;
     if (res.length > 1) {
-      val = await forEachAsync(res, async el => this.browser.getElementText(el.ELEMENT));
+      val = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
     } else {
-      val = await this.browser.getElementText(res[0].ELEMENT);
+      val = await this.browser.getElementText(getElementId(res[0]));
     }
     this.debugSection('Grab', val);
     return val;
@@ -770,7 +774,7 @@ class WebDriver extends Helper {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
 
-    return forEachAsync(res, async el => this.browser.getElementAttribute(el.ELEMENT, 'value'));
+    return forEachAsync(res, async el => this.browser.getElementAttribute(getElementId(el), 'value'));
   }
 
   /**
@@ -779,7 +783,7 @@ class WebDriver extends Helper {
   async grabCssPropertyFrom(locator, cssProperty) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    return forEachAsync(res, async el => this.browser.getElementCSSValue(el.ELEMENT, cssProperty));
+    return forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
   }
 
   /**
@@ -789,7 +793,7 @@ class WebDriver extends Helper {
   async grabAttributeFrom(locator, attr) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    return forEachAsync(res, async el => this.browser.getElementAttribute(el.ELEMENT, attr));
+    return forEachAsync(res, async el => this.browser.getElementAttribute(getElementId(el), attr));
   }
 
   /**
@@ -906,7 +910,7 @@ class WebDriver extends Helper {
       return truth(`elements of ${locator}`, 'to be seen').assert(false);
     }
 
-    const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(el.ELEMENT));
+    const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
     return truth(`elements of ${locator}`, 'to be seen').assert(selected);
   }
 
@@ -919,7 +923,7 @@ class WebDriver extends Helper {
     if (!res || res.length === 0) {
       return truth(`elements of ${locator}`, 'to be seen').negate(false);
     }
-    const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(el.ELEMENT));
+    const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
     return truth(`elements of ${locator}`, 'to be seen').negate(selected);
   }
 
@@ -1027,7 +1031,7 @@ class WebDriver extends Helper {
 
     let props = await forEachAsync(res, async (el) => {
       return forEachAsync(Object.keys(cssProperties), async (prop) => {
-        const propValue = await this.browser.getElementCSSValue(el.ELEMENT, prop);
+        const propValue = await this.browser.getElementCSSValue(getElementId(el), prop);
         if (isColorProperty(prop) && propValue && propValue.value) {
           return convertColorToRGBA(propValue.value);
         }
@@ -1061,7 +1065,7 @@ class WebDriver extends Helper {
     const elemAmount = res.length;
 
     let attrs = await forEachAsync(res, async (el) => {
-      return forEachAsync(Object.keys(attributes), async attr => this.browser.getElementAttribute(el.ELEMENT, attr));
+      return forEachAsync(Object.keys(attributes), async attr => this.browser.getElementAttribute(getElementId(el), attr));
     });
 
     const values = Object.keys(attributes).map(key => attributes[key]);
@@ -1085,7 +1089,7 @@ class WebDriver extends Helper {
   async grabNumberOfVisibleElements(locator) {
     const res = await this._locate(locator);
 
-    let selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(el.ELEMENT));
+    let selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
     if (!Array.isArray(selected)) selected = [selected];
     selected = selected.filter(val => val === true);
     return selected.length;
@@ -1174,8 +1178,9 @@ class WebDriver extends Helper {
       const res = await this._locate(withStrictLocator(locator), true);
       assertElementExists(res);
       const elem = usingFirstElement(res);
-      if (this.browser.isMobile) return this.browser.touchScroll(elem.ELEMENT, offsetX, offsetY);
-      const location = await this.browser.getElementLocation(elem.ELEMENT);
+      const elementId = getElementId(elem);
+      if (this.browser.isMobile) return this.browser.touchScroll(elementId, offsetX, offsetY);
+      const location = await this.browser.getElementLocation(elementId);
       assertElementExists(location, 'Failed to receive', 'location');
       /* eslint-disable prefer-arrow-callback */
       return this.browser.execute(function (x, y) { return window.scrollTo(x, y); }, location.x + offsetX, location.y + offsetY);
@@ -1427,7 +1432,7 @@ class WebDriver extends Helper {
       if (!res || res.length === 0) {
         return false;
       }
-      const selected = await forEachAsync(res, async el => this.browser.getElementEnabled(el.ELEMENT));
+      const selected = await forEachAsync(res, async el => this.browser.getElementEnabled(getElementId(el)));
       if (Array.isArray(selected)) {
         return selected.filter(val => val === true).length > 0;
       }
@@ -1510,7 +1515,7 @@ class WebDriver extends Helper {
       async () => {
         const res = await this.$$(withStrictLocator.call(this, _context));
         if (!res || res.length === 0) return false;
-        const selected = await forEachAsync(res, async el => this.browser.getElementText(el.ELEMENT));
+        const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
         if (Array.isArray(selected)) {
           return selected.filter(part => part.indexOf(text) >= 0).length > 0;
         }
@@ -1530,7 +1535,7 @@ class WebDriver extends Helper {
       async () => {
         const res = await findFields.call(this, field);
         if (!res || res.length === 0) return false;
-        const selected = await forEachAsync(res, async el => this.browser.getElementAttribute(el.ELEMENT, 'value'));
+        const selected = await forEachAsync(res, async el => this.browser.getElementAttribute(getElementId(el), 'value'));
         if (Array.isArray(selected)) {
           return selected.filter(part => part.indexOf(value) >= 0).length > 0;
         }
@@ -1549,7 +1554,7 @@ class WebDriver extends Helper {
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return false;
-      const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(el.ELEMENT));
+      const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
       if (Array.isArray(selected)) {
         return selected.filter(val => val === true).length > 0;
       }
@@ -1565,7 +1570,7 @@ class WebDriver extends Helper {
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return false;
-      let selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(el.ELEMENT));
+      let selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
 
       if (!Array.isArray(selected)) selected = [selected];
       return selected.length === num;
@@ -1581,7 +1586,7 @@ class WebDriver extends Helper {
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return true;
-      const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(el.ELEMENT));
+      const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
       return !selected.length;
     }, aSec * 1000, `element (${new Locator(locator)}) still visible after ${aSec} sec`);
   }
@@ -1835,7 +1840,7 @@ async function proceedSee(assertType, text, context, strict = false) {
   const res = await this._locate(withStrictLocator(context), smartWaitEnabled);
   assertElementExists(res, context);
 
-  const selected = await forEachAsync(res, async el => this.browser.getElementText(el.ELEMENT));
+  const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
 
   if (strict) {
     if (Array.isArray(selected)) {
@@ -1941,10 +1946,11 @@ async function proceedSeeField(assertType, field, value) {
   const res = await findFields.call(this, field);
   assertElementExists(res, field, 'Field');
   const elem = usingFirstElement(res);
+  const elemId = getElementId(elem);
 
   const proceedMultiple = async (fields) => {
     const fieldResults = toArray(await forEachAsync(fields, async (el) => {
-      return this.browser.getElementAttribute(el.ELEMENT, 'value');
+      return this.browser.getElementAttribute(getElementId(el), 'value');
     }));
 
     if (typeof value === 'boolean') {
@@ -1956,21 +1962,22 @@ async function proceedSeeField(assertType, field, value) {
     }
   };
 
-  const proceedSingle = el => this.browser.getElementAttribute(el.ELEMENT, 'value').then(res => stringIncludes(`fields by ${field}`)[assertType](value, res));
+  const proceedSingle = el => this.browser.getElementAttribute(getElementId(el), 'value').then(res => stringIncludes(`fields by ${field}`)[assertType](value, res));
 
-  const filterBySelected = async elements => filterAsync(elements, async el => this.browser.isElementSelected(el.ELEMENT));
+  const filterBySelected = async elements => filterAsync(elements, async el => this.browser.isElementSelected(getElementId(el)));
 
   const filterSelectedByValue = async (elements, value) => {
     return filterAsync(elements, async (el) => {
-      const currentValue = await this.browser.getElementAttribute(el.ELEMENT, 'value');
-      const isSelected = await this.browser.isElementSelected(el.ELEMENT);
+      const elementId = getElementId(el);
+      const currentValue = await this.browser.getElementAttribute(elementId, 'value');
+      const isSelected = await this.browser.isElementSelected(elementId);
       return currentValue === value && isSelected;
     });
   };
 
-  const tag = await this.browser.getElementTagName(elem.ELEMENT);
+  const tag = await this.browser.getElementTagName(elemId);
   if (tag === 'select') {
-    const subOptions = await this.browser.findElementsFromElement(elem.ELEMENT, 'css', 'option');
+    const subOptions = await this.browser.findElementsFromElement(elemId, 'css', 'option');
 
     if (value === '') {
       // Don't filter by value
@@ -1983,7 +1990,7 @@ async function proceedSeeField(assertType, field, value) {
   }
 
   if (tag === 'input') {
-    const fieldType = await this.browser.getElementAttribute(elem.ELEMENT, 'type');
+    const fieldType = await this.browser.getElementAttribute(elemId, 'type');
 
     if (fieldType === 'checkbox' || fieldType === 'radio') {
       if (typeof value === 'boolean') {
@@ -2011,7 +2018,7 @@ async function proceedSeeCheckbox(assertType, field) {
   const res = await findFields.call(this, field);
   assertElementExists(res, field, 'Field');
 
-  const selected = await forEachAsync(res, async el => this.browser.isElementSelected(el.ELEMENT));
+  const selected = await forEachAsync(res, async el => this.browser.isElementSelected(getElementId(el)));
   return truth(`checkable field "${field}"`, 'to be checked')[assertType](selected);
 }
 
@@ -2051,6 +2058,20 @@ function usingFirstElement(els) {
   return els[0];
 }
 
+function getElementId(el) {
+  // W3C WebDriver web element identifier
+  // https://w3c.github.io/webdriver/#dfn-web-element-identifier
+  if (el['element-6066-11e4-a52e-4f735466cecf']) {
+    return el['element-6066-11e4-a52e-4f735466cecf'];
+  }
+  // (deprecated) JsonWireProtocol identifier
+  // https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object
+  if (el.ELEMENT) {
+    return el.ELEMENT;
+  }
+  return null;
+}
+
 function prepareLocateFn(context) {
   if (!context) return this._locate.bind(this);
   let el;
@@ -2059,7 +2080,7 @@ function prepareLocateFn(context) {
     if (el) return this.browser.findElementsFromElement(el, l.type, l.value);
     return this._locate(context, true).then((res) => {
       assertElementExists(res, context, 'Context element');
-      return this.browser.findElementsFromElement(el = res[0].ELEMENT, l.type, l.value);
+      return this.browser.findElementsFromElement(el = getElementId(res[0]), l.type, l.value);
     });
   };
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "sinon-chai": "^2.14.0",
     "typescript": "^2.9.2",
     "unirest": "^0.5.1",
-    "webdriverio": "^5.1.0",
+    "webdriverio": "^5.2.0",
     "xmldom": "^0.1.27",
     "xpath": "0.0.27"
   },


### PR DESCRIPTION
* Update webdriverio package to version 5.2.0.
  * Allowing to define timeouts accordingly for Firefox/Safari (fixes #1393)
  * Set window size without specifying position at 0x0 coordinates, which are incorrectly evaluated as boolean by Safaridriver.
* Properly clear cookies when no `desiredCapabilites` defined. (fixes #1407)
* Check both W3C WebDriver web element identifier (`element-6066-11e4-a52e-4f735466cecf`) and JsonWireProtocol identifier (`ELEMENT`) when retrieving element id.
