### PR TITLE
Fix Maximum call stack size exceeded via Object reference in retryFailedStep plugin

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -48,7 +48,6 @@ module.exports = (config) => {
     if (passedWhen) return passedWhen(err);
     return true;
   };
-  
   config.when = when;
 
   event.dispatcher.on(event.test.before, (test) => {

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -41,10 +41,14 @@ const defaultConfig = {
 module.exports = (config) => {
   config = Object.assign(defaultConfig, config);
 
+  const passedWhen = config.when;
+
   const when = (err) => {
     if (store.debugMode) return false;
-    if (config.when) return config.when(err);
+    if (passedWhen) return passedWhen(err);
+    return true;
   };
+  
   config.when = when;
 
   event.dispatcher.on(event.test.before, (test) => {


### PR DESCRIPTION
Currently when using the plugin you will see `Maximum call stack size exceeded` error due to infinite object reference, rather than a function. Instead we take a copy of passed in `when` and use the static copy, additionally if no `when` is specified in, we should be retrying all of the failed steps.