### PR TITLE
AutoLogin plugin and some important fixes for 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* [**autoLogin**](https://codecept.io/plugins#autoLogin) plugin added. Allows to log in once and reuse browser session. When session expires - automatically logs in again. Can persist session between runs by saving cookies to file.
+
 ## 2.0.2
 
 * [Puppeteer] Improved handling of connection with remote browser using Puppeteer by @martomo

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -26,7 +26,9 @@ class RoboFile extends \Robo\Tasks
         $this->stopOnFail();
         $this->_copy('CHANGELOG.md', 'docs/changelog.md');
         $this->_copy('docker/README.md', 'docs/docker.md');
-        $this->_exec('npm install');
+        $this->taskExec('npm install')
+            ->dir('website')
+            ->run();
         $this
             ->taskExec('USE_SSH=true GIT_USER=davertmik npm run publish-gh-pages')
             ->dir('website')

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -18,6 +18,7 @@ class RoboFile extends \Robo\Tasks
 
     function publishSite()
     {
+        $this->stopOnFail();
         $this->taskGitStack()
             ->checkout('docusaurus')
             ->merge('master')
@@ -25,6 +26,7 @@ class RoboFile extends \Robo\Tasks
         $this->stopOnFail();
         $this->_copy('CHANGELOG.md', 'docs/changelog.md');
         $this->_copy('docker/README.md', 'docs/docker.md');
+        $this->_exec('npm install');
         $this
             ->taskExec('USE_SSH=true GIT_USER=davertmik npm run publish-gh-pages')
             ->dir('website')
@@ -33,6 +35,7 @@ class RoboFile extends \Robo\Tasks
         $this->taskGitStack()
             ->checkout('master')
             ->run();
+        $this->_exec('rm -rf website');
     }
 
     function testServer()

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -336,9 +336,3 @@ Function passed into session can use `I`, page objects, and any objects declared
 This function can also be declared as async (but doesn't work as generator).
 
 Also, you can use `within` inside a session but you can't call session from inside `within`.
-
----
-
-### done()
-
-CodeceptJS through helpers provides user friendly API to interact with a webpage. In this section we described using WebDriver helper which allows to control browser through Selenium WebDriver.

--- a/docs/data.md
+++ b/docs/data.md
@@ -83,6 +83,8 @@ This can also be used to emulate Ajax requests:
 I.sendPostRequest('/update-status', {}, { http_x_requested_with: 'xmlhttprequest' });
 ```
 
+> See complete reference on [REST](http://codecept.io/helpers/REST) helper
+
 ## Data Generation with Factories
 
 This concept is extended by [ApiDataFactory](http://codecept.io/helpers/ApiDataFactory/) helper.
@@ -90,7 +92,8 @@ It builds data according to defined rules and uses API to store them and automat
 This way setting data for a test is as simple as writing:
 
 ```js
-let post = yield I.have('post');
+// inside async function
+let post = await I.have('post');
 I.haveMultiple('comment', 5, { postId: post.id});
 ```
 
@@ -131,7 +134,7 @@ Next is to configure helper to match factories with API:
    },
    factories: {
      user: {
-        uri: "/users"
+        uri: "/users",
         factory: "./factories/user"
      }
    }
@@ -145,7 +148,9 @@ At the end of a test ApiDataFactory will clean up created record for you. This i
 ids from crated records and running `DELETE /api/users/{id}` requests at the end of a test.
 This rules can be customized in helper configuration.
 
-### API Requests Using Browser Session
+> See complete reference on [ApiDataFactory](http://codecept.io/helpers/ApiDataFactory) helper
+
+## API Requests Using Browser Session
 
 Both REST and ApiDataFactory helpers allow override requests before sending.
 This feature can be used to fetch current browser cookies and set them to REST API client.
@@ -165,8 +170,8 @@ Let's see how to configure ApiDataFactory alongside with WebDriver to share cook
     },
     factories: {
       user: {
-          uri: "/users"
-          factory: "./factories/user"
+          uri: "/users",
+          factory: "./factories/user",
       }
     },
     onRequest: async (request) => {
@@ -176,7 +181,8 @@ Let's see how to configure ApiDataFactory alongside with WebDriver to share cook
   }
   WebDriver: {
     url: 'https://local.app/',
-    browser: 'chrome'
+    browser: 'chrome',
+  }
 ```
 
 In this case we are accessing WebDriver helper. However, you can replace WebDriver with any helper you use.

--- a/docs/helpers/ApiDataFactory.md
+++ b/docs/helpers/ApiDataFactory.md
@@ -128,15 +128,11 @@ This behavior can be configured with following options:
 -   `create`: override create options. Expected format: `{ method: uri }`. Example: `{ "post": "/users/create" }`
 -   `delete`: override delete options. Expected format: `{ method: uri }`. Example: `{ "post": "/users/delete/{id}" }`
 
-Create and delete requests can also be overridden with a function:
+Requests can also be overridden with a function which returns [axois request config][4].
 
 ```js
-create: (data) => {
-   return { method: 'post', url: '/posts', data }
-},
-delete: (id) => {
-   return { method: 'delete', url: '/posts', data: { id } }
-}
+create: (data) => ({ method: 'post', url: '/posts', data }),
+delete: (id) => ({ method: 'delete', url: '/posts', data: { id } })
 ```
 
 Requests can be updated on the fly by using `onRequest` function. For instance, you can pass in current session from a cookie.
@@ -248,3 +244,5 @@ I.haveMultiple('post', 3, { author: 'davert' });
 [2]: https://www.npmjs.com/package/faker
 
 [3]: http://codecept.io/helpers/REST/
+
+[4]: https://github.com/axios/axios#request-config

--- a/docs/helpers/ApiDataFactory.md
+++ b/docs/helpers/ApiDataFactory.md
@@ -216,7 +216,8 @@ Generates a new record using factory and saves API request to store it.
 // create a user
 I.have('user');
 // create user with defined email
-I.have('user', { email: 'user@user.com'});
+// and receive it when inside async function
+const user = await I.have('user', { email: 'user@user.com'});
 ```
 
 #### Parameters
@@ -230,10 +231,10 @@ Generates bunch of records and saves multiple API requests to store them.
 
 ```js
 // create 3 posts
-I.have('post', 3);
+I.haveMultiple('post', 3);
 
 // create 3 posts by one author
-I.have('post', 3, { author: 'davert' });
+I.haveMultiple('post', 3, { author: 'davert' });
 ```
 
 #### Parameters

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -86,6 +86,127 @@ Possible config options:
 
 -   `config`  
 
+## 
+
+Logs user in for the first test and reuses session for next tests.
+Works by saving cookies into memory or file.
+If a session expires automatically logs in again.
+
+> For better development experience cookies can be saved into file, so a session can be reused while writing tests.
+
+#### Usage
+
+1.  Enable this plugin and configure as described below
+2.  Define user session names (example: `user`, `editor`, `admin`, etc).
+3.  Define how users are logged in and how to check that user is logged in
+4.  Use `loginAs` object inside your tests to log in:
+
+```js
+// inside a test file
+// use loginAs to inject auto-login function
+Before(loginAs => {
+   loginAs('user'); // login using user session
+});
+
+// Alternatively log in for one scenario
+Scenario('log me in', (I, loginAs) => {
+   loginAs('admin');
+   I.see('I am logged in');
+});
+```
+
+#### Configuration
+
+-   `saveToFile` (default: false) - save cookies to file. Allows to reuse session between execution.
+-   `inject` (default: `loginAs`) - name of the login function to use
+-   `users` - an array containing different session names and functions to:
+    -   `login` - sign in into the system
+    -   `check` - check that user is logged in
+    -   `fetch` - to get current cookies (by default `I.grabCookie()`)
+    -   `load` - to set cookies (by default `I.setCookie(cookie)`)
+
+#### Example: Simple login
+
+```js
+autoLogin: {
+  enabled: true,
+  saveToFile: true,
+  inject: 'loginAs',
+  users: {
+    admin: {
+      // loginAsAdmin function is defined in `steps_file.js`
+      login: (I) => I.loginAsAdmin(),
+      // if we see `Admin` on page, we assume we are logged in
+      check: (I) => I.see('Admin'),
+      // we take all cookies from a browser
+      fetch: I => I.grabCookie(),
+      // we set all available cookies to restore session
+      restore: (I, cookie) => I.setCookie(cookie)
+    }
+  }
+}
+```
+
+#### Example: Multiple users
+
+```js
+autoLogin: {
+  enabled: true,
+  saveToFile: true,
+  inject: 'loginAs',
+  users: {
+    user: {
+      login: (I) => {
+         I.amOnPage('/login');
+         I.fillField('email', 'user@site.com');
+         I.fillField('password', '123456');
+         I.click('Login');
+      }
+      check: (I) => I.see('User', '.navbar'),
+    },
+    admin: {
+      login: (I) => {
+         I.amOnPage('/login');
+         I.fillField('email', 'admin@site.com');
+         I.fillField('password', '123456');
+         I.click('Login');
+      }
+      check: (I) => I.see('Admin', '.navbar'),
+    },
+  }
+}
+```
+
+#### Example: Keep cookies between tests
+
+If you decide to keep cookies between tests you don't need to save/retrieve cookies between tests.
+But you need to login once work until session expires.
+For this case, disable `fetch` and `restore` methods.
+
+```js
+helpers: {
+   WebDriver: {
+     // config goes here
+     keepCookies: true; // keep cookies for all tests
+   }
+},
+plugins: {
+   autoLogin: {
+    admin: {
+      login: (I) => {
+         I.amOnPage('/login');
+         I.fillField('email', 'admin@site.com');
+         I.fillField('password', '123456');
+         I.click('Login');
+      }
+      check: (I) => I.see('Admin', '.navbar'),
+      fetch: () => {}, // empty function
+      restore: () => {}, // empty funciton
+    }
+  }
+}
+```
+
 ## retryFailedStep
 
 Retries each failed step in a test.

--- a/lib/helper/ApiDataFactory.js
+++ b/lib/helper/ApiDataFactory.js
@@ -258,7 +258,8 @@ class ApiDataFactory extends Helper {
    * // create a user
    * I.have('user');
    * // create user with defined email
-   * I.have('user', { email: 'user@user.com'});
+   * // and receive it when inside async function
+   * const user = await I.have('user', { email: 'user@user.com'});
    * ```
    *
    * @param {*} factory factory to use
@@ -275,10 +276,10 @@ class ApiDataFactory extends Helper {
    *
    * ```js
    * // create 3 posts
-   * I.have('post', 3);
+   * I.haveMultiple('post', 3);
    *
    * // create 3 posts by one author
-   * I.have('post', 3, { author: 'davert' });
+   * I.haveMultiple('post', 3, { author: 'davert' });
    * ```
    *
    * @param {*} factory

--- a/lib/helper/ApiDataFactory.js
+++ b/lib/helper/ApiDataFactory.js
@@ -127,15 +127,11 @@ const REST = require('./REST');
  * * `create`: override create options. Expected format: `{ method: uri }`. Example: `{ "post": "/users/create" }`
  * * `delete`: override delete options. Expected format: `{ method: uri }`. Example: `{ "post": "/users/delete/{id}" }`
  *
- * Create and delete requests can also be overridden with a function:
+ * Requests can also be overridden with a function which returns [axois request config](https://github.com/axios/axios#request-config).
  *
  * ```js
- * create: (data) => {
- *    return { method: 'post', url: '/posts', data }
- * },
- * delete: (id) => {
- *    return { method: 'delete', url: '/posts', data: { id } }
- * }
+ * create: (data) => ({ method: 'post', url: '/posts', data }),
+ * delete: (id) => ({ method: 'delete', url: '/posts', data: { id } })
  *
  * ```
  *
@@ -242,6 +238,7 @@ class ApiDataFactory extends Helper {
     // clean up all created items
     for (const factoryName in this.created) {
       const createdItems = this.created[factoryName];
+      if (!createdItems.length) continue;
       this.debug(`Deleting ${createdItems.length} ${factoryName}(s)`);
       for (const id in createdItems) {
         promises.push(this._requestDelete(factoryName, createdItems[id]));
@@ -335,14 +332,19 @@ Current file error: ${err.message}`);
    * @param {*} data
    */
   _requestCreate(factory, data) {
-    const method = Object.keys(this.factories[factory].create)[0];
-    const url = this.factories[factory].create[method];
-    const request = {
-      baseURL: this.config.endpoint,
-      method,
-      url,
-      data,
-    };
+    let request = createRequestFromFunction(this.factories[factory].create, data);
+
+    if (!request) {
+      const method = Object.keys(this.factories[factory].create)[0];
+      const url = this.factories[factory].create[method];
+      request = {
+        method,
+        url,
+        data,
+      };
+    }
+
+    request.baseURL = this.config.endpoint;
 
     return this.restHelper._executeRequest(request).then((resp) => {
       const id = this._fetchId(resp.data, factory);
@@ -361,15 +363,21 @@ Current file error: ${err.message}`);
    * @param {*} id
    */
   _requestDelete(factory, id) {
-    const method = Object.keys(this.factories[factory].delete)[0];
-    const url = this.factories[factory].delete[method].replace('{id}', id);
-    const request = {
-      baseURL: this.config.endpoint,
-      method,
-      url,
-    };
+    if (!this.factories[factory].delete) return;
+    let request = createRequestFromFunction(this.factories[factory].delete, id);
 
-    return this.restHelper._executeRequest(request).then(() => {
+    if (!request) {
+      const method = Object.keys(this.factories[factory].delete)[0];
+      const url = this.factories[factory].delete[method].replace('{id}', id);
+      request = {
+        method,
+        url,
+      };
+    }
+
+    request.baseURL = this.config.endpoint;
+
+    return this.restHelper._executeRequest(request).then((response) => {
       const idx = this.created[factory].indexOf(id);
       this.debugSection('Deleted Id', `Id: ${id}`);
       this.created[factory].splice(idx, 1);
@@ -378,3 +386,8 @@ Current file error: ${err.message}`);
 }
 
 module.exports = ApiDataFactory;
+
+function createRequestFromFunction(param, data) {
+  if (typeof param !== 'function') return;
+  return param(data);
+}

--- a/lib/helper/ApiDataFactory.js
+++ b/lib/helper/ApiDataFactory.js
@@ -292,6 +292,9 @@ class ApiDataFactory extends Helper {
   }
 
   _createItem(model, data) {
+    if (!this.factories[model]) {
+      throw new Error(`Factory ${model} is not defined in config`);
+    }
     let modulePath = this.factories[model].factory;
     try {
       try {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -475,6 +475,7 @@ class WebDriver extends Helper {
    * @param locator element located by CSS|XPath|strict locator.
    */
   async _locate(locator, smartWait = false) {
+    if (require('../store').debugMode) smartWait = false;
     if (!this.options.smartWait || !smartWait) {
       const els = await this.$$(withStrictLocator(locator));
       return els;

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -62,6 +62,7 @@ function parseInput(cmd) {
   }
   store.debugMode = true;
   try {
+    const locate = global.locate; // enable locate in this context
     const I = container.support('I');
     eval(`I.${cmd}`); // eslint-disable-line no-eval
   } catch (err) {

--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -12,12 +12,12 @@ const defaultUser = {
     I.amOnPage('/'); // open a page
     I.setCookie(cookies);
   },
-}
+};
 
 const defaultConfig = {
   saveToFile: false,
-  inject: 'login'
-}
+  inject: 'login',
+};
 
 /**
  * Logs user in for the first test and reuses session for next tests.
@@ -142,7 +142,7 @@ const defaultConfig = {
  *
 */
 module.exports = function (config) {
-  config = Object.assign(defaultConfig, config)
+  config = Object.assign(defaultConfig, config);
   Object.keys(config.users).map(u => config.users[u] = Object.assign(defaultUser, config.users[u]));
 
   if (config.saveToFile) {
@@ -160,7 +160,7 @@ module.exports = function (config) {
     }
   }
 
-  let loginFunction = async (name) => {
+  const loginFunction = async (name) => {
     const userSession = config.users[name];
     const I = container.support('I');
     const cookies = store[`${name}_session`];
@@ -175,7 +175,7 @@ module.exports = function (config) {
       }
       store[`${name}_session`] = cookies;
       store.debugMode = false;
-    }
+    };
 
     if (!cookies) return loginAndSave();
 
@@ -190,7 +190,7 @@ module.exports = function (config) {
       return loginAndSave().then(() => {
         recorder.add(() => recorder.session.restore('auto login'));
         recorder.catch(err => debug('continue'));
-      }).catch(err => {
+      }).catch((err) => {
         recorder.session.restore('auto login');
         recorder.session.restore('check login');
         recorder.throw(err);
@@ -202,11 +202,10 @@ module.exports = function (config) {
     });
 
     return recorder.promise();
-  }
+  };
 
   // adding this to DI container
   const support = {};
   support[config.inject] = loginFunction;
   container.append({ support });
-
 };

--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -1,0 +1,212 @@
+const fs = require('fs');
+const path = require('path');
+const { fileExists } = require('../utils');
+const container = require('../container');
+const store = require('../store');
+const recorder = require('../recorder');
+const debug = require('../output').debug;
+
+const defaultUser = {
+  fetch: I => I.grabCookie(),
+  restore: (I, cookies) => {
+    I.amOnPage('/'); // open a page
+    I.setCookie(cookies);
+  },
+}
+
+const defaultConfig = {
+  saveToFile: false,
+  inject: 'login'
+}
+
+/**
+ * Logs user in for the first test and reuses session for next tests.
+ * Works by saving cookies into memory or file.
+ * If a session expires automatically logs in again.
+ *
+ * > For better development experience cookies can be saved into file, so a session can be reused while writing tests.
+ *
+ * #### Usage
+ *
+ * 1. Enable this plugin and configure as described below
+ * 2. Define user session names (example: `user`, `editor`, `admin`, etc).
+ * 3. Define how users are logged in and how to check that user is logged in
+ * 4. Use `loginAs` object inside your tests to log in:
+ *
+ * ```js
+ * // inside a test file
+ * // use loginAs to inject auto-login function
+ * Before(loginAs => {
+ *    loginAs('user'); // login using user session
+ * });
+ *
+ * // Alternatively log in for one scenario
+ * Scenario('log me in', (I, loginAs) => {
+ *    loginAs('admin');
+ *    I.see('I am logged in');
+ * });
+ * ```
+ *
+ * #### Configuration
+ *
+ * * `saveToFile` (default: false) - save cookies to file. Allows to reuse session between execution.
+ * * `inject` (default: `loginAs`) - name of the login function to use
+ * * `users` - an array containing different session names and functions to:
+ *    * `login` - sign in into the system
+ *     * `check` - check that user is logged in
+ *     * `fetch` - to get current cookies (by default `I.grabCookie()`)
+ *     * `load` - to set cookies (by default `I.setCookie(cookie)`)
+ *
+ *
+ * #### Example: Simple login
+ *
+ * ```js
+ * autoLogin: {
+ *   enabled: true,
+ *   saveToFile: true,
+ *   inject: 'loginAs',
+ *   users: {
+ *     admin: {
+ *       // loginAsAdmin function is defined in `steps_file.js`
+ *       login: (I) => I.loginAsAdmin(),
+ *       // if we see `Admin` on page, we assume we are logged in
+ *       check: (I) => I.see('Admin'),
+ *       // we take all cookies from a browser
+ *       fetch: I => I.grabCookie(),
+ *       // we set all available cookies to restore session
+ *       restore: (I, cookie) => I.setCookie(cookie)
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * #### Example: Multiple users
+ *
+ * ```js
+ * autoLogin: {
+ *   enabled: true,
+ *   saveToFile: true,
+ *   inject: 'loginAs',
+ *   users: {
+ *     user: {
+ *       login: (I) => {
+ *          I.amOnPage('/login');
+ *          I.fillField('email', 'user@site.com');
+ *          I.fillField('password', '123456');
+ *          I.click('Login');
+ *       }
+ *       check: (I) => I.see('User', '.navbar'),
+ *     },
+ *     admin: {
+  *       login: (I) => {
+  *          I.amOnPage('/login');
+  *          I.fillField('email', 'admin@site.com');
+  *          I.fillField('password', '123456');
+  *          I.click('Login');
+  *       }
+  *       check: (I) => I.see('Admin', '.navbar'),
+  *     },
+ *   }
+ * }
+ * ```
+ *
+ * #### Example: Keep cookies between tests
+ *
+ * If you decide to keep cookies between tests you don't need to save/retrieve cookies between tests.
+ * But you need to login once work until session expires.
+ * For this case, disable `fetch` and `restore` methods.
+ *
+ * ```js
+ * helpers: {
+ *    WebDriver: {
+ *      // config goes here
+ *      keepCookies: true; // keep cookies for all tests
+ *    }
+ * },
+ * plugins: {
+ *    autoLogin: {
+ *     admin: {
+ *       login: (I) => {
+ *          I.amOnPage('/login');
+ *          I.fillField('email', 'admin@site.com');
+ *          I.fillField('password', '123456');
+ *          I.click('Login');
+ *       }
+ *       check: (I) => I.see('Admin', '.navbar'),
+ *       fetch: () => {}, // empty function
+ *       restore: () => {}, // empty funciton
+ *     }
+ *   }
+ * }
+ * ```
+ *
+*/
+module.exports = function (config) {
+  config = Object.assign(defaultConfig, config)
+  Object.keys(config.users).map(u => config.users[u] = Object.assign(defaultUser, config.users[u]));
+
+  if (config.saveToFile) {
+    // loading from file
+    for (const name in config.users) {
+      const fileName = path.join(global.output_dir, `${name}_session.json`);
+      if (!fileExists(fileName)) continue;
+      const data = fs.readFileSync(fileName).toString();
+      try {
+        store[`${name}_session`] = JSON.parse(data);
+      } catch (err) {
+        throw new Error(`Could not load session from ${fileName}\n${err}`);
+      }
+      debug(`Loaded user session for ${name}`);
+    }
+  }
+
+  let loginFunction = async (name) => {
+    const userSession = config.users[name];
+    const I = container.support('I');
+    const cookies = store[`${name}_session`];
+
+    const loginAndSave = async () => {
+      userSession.login(I);
+      store.debugMode = true;
+      const cookies = await userSession.fetch(I);
+      if (config.saveToFile) {
+        debug(`Saved user session into file for ${name}`);
+        fs.writeFileSync(path.join(global.output_dir, `${name}_session.json`), JSON.stringify(cookies));
+      }
+      store[`${name}_session`] = cookies;
+      store.debugMode = false;
+    }
+
+    if (!cookies) return loginAndSave();
+
+    store.debugMode = true;
+
+    recorder.session.start('check login');
+    userSession.restore(I, cookies);
+    userSession.check(I);
+    recorder.session.catch(() => {
+      debug(`Failed auto login for ${name}, logging in again`);
+      recorder.session.start('auto login');
+      return loginAndSave().then(() => {
+        recorder.add(() => recorder.session.restore('auto login'));
+        recorder.catch(err => debug('continue'));
+      }).catch(err => {
+        recorder.session.restore('auto login');
+        recorder.session.restore('check login');
+        recorder.throw(err);
+      });
+    });
+    recorder.add(() => {
+      store.debugMode = false;
+      recorder.session.restore('check login');
+    });
+
+    return recorder.promise();
+  }
+
+  // adding this to DI container
+  const support = {};
+  support[config.inject] = loginFunction;
+  container.append({ support });
+
+};

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -1,5 +1,4 @@
 const event = require('../event');
-const store = require('../store');
 const recorder = require('../recorder');
 
 const defaultConfig = {
@@ -43,8 +42,10 @@ module.exports = (config) => {
   const customWhen = config.when;
 
   const when = (err) => {
+    const store = require('../store');
     if (store.debugMode) return false;
     if (customWhen) return customWhen(err);
+    return true;
   };
   config.when = when;
 

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -40,10 +40,11 @@ const defaultConfig = {
  */
 module.exports = (config) => {
   config = Object.assign(defaultConfig, config);
+  let customWhen = config.when;
 
   const when = (err) => {
     if (store.debugMode) return false;
-    if (config.when) return config.when(err);
+    if (customWhen) return customWhen(err);
   };
   config.when = when;
 

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -40,7 +40,7 @@ const defaultConfig = {
  */
 module.exports = (config) => {
   config = Object.assign(defaultConfig, config);
-  let customWhen = config.when;
+  const customWhen = config.when;
 
   const when = (err) => {
     if (store.debugMode) return false;

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -102,6 +102,8 @@ module.exports.injected = function (fn, suite, hookName) {
       recorder.add(() => done(err));
     });
 
+    if (!fn) throw new Error('fn is not defined');
+
     if (isAsyncFunction(fn)) {
       event.emit(event.hook.started, suite);
       recorder.startUnlessRunning();

--- a/lib/store.js
+++ b/lib/store.js
@@ -3,4 +3,4 @@ const store = {
   debugMode: false,
 };
 
-module.exports = store;
+module.exports = () => store;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,6 +40,7 @@ const isGenerator = module.exports.isGenerator = function (fn) {
 };
 
 const isAsyncFunction = module.exports.isAsyncFunction = function (fn) {
+  if (!fn) return false;
   return fn[Symbol.toStringTag] === 'AsyncFunction';
 };
 

--- a/test/data/rest/db.json
+++ b/test/data/rest/db.json
@@ -1,1 +1,10 @@
-{"posts":[{"id":1,"title":"json-server","author":"davert"}],"user":{"name":"davert"}}
+{
+  "comments": [],
+  "posts": [
+    {
+      "id": 1,
+      "title": "json-server",
+      "author": "davert"
+    }
+  ]
+}

--- a/test/rest/ApiDataFactory_test.js
+++ b/test/rest/ApiDataFactory_test.js
@@ -97,6 +97,24 @@ describe('ApiDataFactory', function () {
       post.author.should.eql('Vasya');
     });
 
+    it('can use functions to set factories', async () => {
+      const I = new ApiDataFactory({
+        endpoint: api_url,
+        factories: {
+          post: {
+            factory: path.join(__dirname, '/../data/rest/posts_factory.js'),
+            create: (data) => ({ url: '/posts', method: 'post', data: { author: 'Yorik', title: 'xxx', body: 'yyy' } }),
+            delete: (id) => ({ url: '/posts/' + id, method: 'delete' })
+          },
+        },
+      });
+      const post = await I.have('post');
+      post.author.should.eql('Yorik');
+      await I._after();
+      resp = await I.restHelper.sendGetRequest('/posts');
+      resp.data.length.should.eql(1);
+    });
+
     it('should cleanup created data', async () => {
       await I.have('post', { author: 'Tapac' });
       let resp = await I.restHelper.sendGetRequest('/posts/2');

--- a/test/rest/ApiDataFactory_test.js
+++ b/test/rest/ApiDataFactory_test.js
@@ -103,8 +103,8 @@ describe('ApiDataFactory', function () {
         factories: {
           post: {
             factory: path.join(__dirname, '/../data/rest/posts_factory.js'),
-            create: (data) => ({ url: '/posts', method: 'post', data: { author: 'Yorik', title: 'xxx', body: 'yyy' } }),
-            delete: (id) => ({ url: '/posts/' + id, method: 'delete' })
+            create: data => ({ url: '/posts', method: 'post', data: { author: 'Yorik', title: 'xxx', body: 'yyy' } }),
+            delete: id => ({ url: `/posts/${id}`, method: 'delete' }),
           },
         },
       });


### PR DESCRIPTION
* [**autoLogin plugin**](https://codecept.io/plugins#autoLogin) added. Allows to log in once and reuse browser session. When session expires - automatically logs in again. Can persist session between runs by saving cookies to file.
* Fixed `Maximum stack trace` issue in `retryFailedStep` plugin.
* Added `locate()` function into the interactive shell.
* [WebDriver] Disabled smartWait for interactive shell.
