### PR TITLE
Fixes users from merging on autoLogin plugin

### DIFF
--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -143,7 +143,7 @@ const defaultConfig = {
 */
 module.exports = function (config) {
   config = Object.assign(defaultConfig, config);
-  Object.keys(config.users).map(u => config.users[u] = Object.assign(defaultUser, config.users[u]));
+  Object.keys(config.users).map(u => config.users[u] = Object.assign({}, defaultUser, config.users[u]));
 
   if (config.saveToFile) {
     // loading from file


### PR DESCRIPTION
Prevents from using last user's methods in all cases. E.g. `admin` actually ends up using `inactiveUser`'s login.

```js
	plugins: {
		autoLogin: {
			enabled: true,
			saveToFile: false,
			inject: 'loginAs', // use `loginAs` instead of login
			users: {
				admin: {
					// methods
				},
				activeUser: {
					// methods
				},
				inactiveUser: {
					// methods
				},
			},
		},
	},
```