### PR TITLE
Fixed running tests with different data and with only

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -31,7 +31,7 @@ module.exports = function (context) {
               context.xScenario(`${title} | ${dataRow.data}`);
             } else {
               opts.data = dataRow;
-              context.Scenario.only(`${title} | ${dataRow.data}`, opts, fn)
+              context.Scenario(`${title} | ${dataRow.data}`, opts, fn)
                 .inject({ current: dataRow.data });
             }
           });

--- a/test/data/sandbox/codecept.sddt.json
+++ b/test/data/sandbox/codecept.sddt.json
@@ -1,0 +1,11 @@
+{
+  "tests": "./*_test.sddt.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/ddt_test.sddt.js
+++ b/test/data/sandbox/ddt_test.sddt.js
@@ -1,0 +1,5 @@
+Feature('SDDT');
+
+Data(['1', '2', '3']).only.Scenario('Should log array of strings', (I, current) => {
+  console.log(`Got array item ${current}`);
+});

--- a/test/runner/interface_test.js
+++ b/test/runner/interface_test.js
@@ -71,6 +71,22 @@ describe('CodeceptJS Interface', () => {
     });
   });
 
+  it('should run all different data for tests with only', (done) => {
+    exec(config_run_config('codecept.sddt.json'), (err, stdout, stderr) => {
+      const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '');
+      output.should.include(`Got array item 1
+  ✔ Should log array of strings | 1`);
+
+      output.should.include(`Got array item 2
+  ✔ Should log array of strings | 2`);
+
+      output.should.include(`Got array item 3
+  ✔ Should log array of strings | 3`);
+      assert(!err);
+      done();
+    });
+  });
+
   it('should execute expected promise chain', (done) => {
     exec(`${codecept_run} --verbose`, (err, stdout, stderr) => {
       const lines = stdout.match(/\S.+/g);


### PR DESCRIPTION
When running tests with different data and "only" - the test was performed only with the latest data.

Example:
```js
Data([
  `Automation name ${uuid4()}`, 
  `Название страницы на русском ${uuid4()}`
]).only.Scenario('Test name', async (I, pagesFactory, current) => {
  let spec = await I.havePageSpec({name: current})

  let pages = await pagesFactory.createPages([spec])
  I.seeValue('name', pages[0].page, { name: current })
})
```

Log:
```bash
Pages/API/Private/Pages/Create --
  ✔ Test name | Название страницы на русском cd5211ad-8f61-4131-94a2-71762d96ded1 in 271ms

  OK  | 1 passed   // 907ms
```