### PR TITLE
Skip test in allure-report

### DIFF
--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -65,6 +65,14 @@ module.exports = (config) => {
     reporter.startSuite(suite.fullTitle());
   });
 
+  event.dispatcher.on(event.suite.before, (suite) => {
+    for (const test of suite.tests) {
+      if (test.pending) {
+        reporter.pendingCase(test.title);
+      }
+    }
+  });
+
   event.dispatcher.on(event.hook.started, (hook) => {
     isHookSteps = true;
   });


### PR DESCRIPTION
Good decision will be then when will be added event `test.skipped`.
But this decision faster and lighter.