### PR TITLE
Add payload parameter to DELETE method on REST helper

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -210,10 +210,11 @@ class REST extends Helper {
    * @param {*} url
    * @param {object} headers
    */
-  async sendDeleteRequest(url, headers = {}) {
+  async sendDeleteRequest(url, payload = {}, headers = {}) {
     const request = {
       baseURL: this._url(url),
       method: 'DELETE',
+      data: payload,
       headers,
     };
 

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -76,6 +76,14 @@ describe('REST', () => {
       response.data.should.be.empty;
     })));
 
+    it('should send DELETE requests: payload format = form urlencoded', () => I.sendDeleteRequest('/posts/1', 'author=john').then(() => I.sendGetRequest('/posts').then((response) => {
+      response.data.should.be.empty;
+    })));
+
+    it('should send DELETE requests: payload format = json', () => I.sendDeleteRequest('/posts/1', { author: 'john' }).then(() => I.sendGetRequest('/posts').then((response) => {
+      response.data.should.be.empty;
+    })));
+
     it('should update request with onRequest', async () => {
       I.config.onRequest = request => request.data = { name: 'Vasya' };
       return I.sendPostRequest('/user', { name: 'john' }).then((response) => {


### PR DESCRIPTION
I was trying to execute a DELETE method with a payload then I realized it just accepts headers.
Didn't investigate much about it and hopefully I'm not violating anything.

Found this one:
https://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request

TL;DR
```If a DELETE request includes an entity body, the body is ignored [...]```

