### PR TITLE
fixed the case when there are more than one matched element

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
     "no-cond-assign": 0,
     "import/no-unresolved": 0,
     "no-await-in-loop": 0,
-    "arrow-body-style": 0
+    "arrow-body-style": 0,
+    "no-loop-func": 0
   }
 }

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -374,6 +374,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
+An array as a result will be returned if there are more than one matched element.
 Resumes test execution, so **should be used inside async with `await`** operator.
 
 ```js

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -520,6 +520,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
+An array as a result will be returned if there are more than one matched element.
 Resumes test execution, so **should be used inside async with `await`** operator.
 
 ```js

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -581,6 +581,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
+An array as a result will be returned if there are more than one matched element.
 Resumes test execution, so **should be used inside async with `await`** operator.
 
 ```js

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -623,6 +623,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
+An array as a result will be returned if there are more than one matched element.
 Resumes test execution, so **should be used inside async with `await`** operator.
 
 ```js

--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -631,6 +631,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
+An array as a result will be returned if there are more than one matched element.
 Resumes test execution, so **should be used inside async with `await`** operator.
 
 ```js

--- a/docs/webapi/grabAttributeFrom.mustache
+++ b/docs/webapi/grabAttributeFrom.mustache
@@ -1,4 +1,5 @@
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
+An array as a result will be returned if there are more than one matched element.
 Resumes test execution, so **should be used inside async with `await`** operator.
 
 ```js

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -792,9 +792,16 @@ class Nightmare extends Helper {
    */
   async grabAttributeFrom(locator, attr) {
     locator = new Locator(locator, 'css');
-    const el = await this.browser.findElement(locator.toStrict());
-    assertElementExists(el, locator);
-    return this.browser.evaluate((el, attr) => window.codeceptjs.fetchElement(el).getAttribute(attr), el, attr);
+    const els = await this.browser.findElements(locator.toStrict());
+    const array = [];
+
+    for (let index = 0; index < els.length; index++) {
+      const el = els[index];
+      assertElementExists(el, locator);
+      array.push(await this.browser.evaluate((el, attr) => window.codeceptjs.fetchElement(el).getAttribute(attr), el, attr));
+    }
+
+    return array.length === 1 ? array[0] : array;
   }
 
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -728,9 +728,14 @@ class Protractor extends Helper {
   async grabAttributeFrom(locator, attr) {
     const els = await this._locate(locator);
     assertElementExists(els);
-    return els[0].getAttribute(attr);
-  }
+    const array = [];
 
+    for (let index = 0; index < els.length; index++) {
+      const el = els[index];
+      array.push(await el.getAttribute(attr));
+    }
+    return array.length === 1 ? array[0] : array;
+  }
   /**
    * {{> ../webapi/seeInTitle }}
    */

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1363,8 +1363,14 @@ class Puppeteer extends Helper {
   async grabAttributeFrom(locator, attr) {
     const els = await this._locate(locator);
     assertElementExists(els, locator);
-    return this._evaluateHandeInContext((el, attr) => el[attr] || el.getAttribute(attr), els[0], attr)
-      .then(t => t.jsonValue());
+    const array = [];
+
+    for (let index = 0; index < els.length; index++) {
+      const a = await this._evaluateHandeInContext((el, attr) => el[attr] || el.getAttribute(attr), els[index], attr);
+      array.push(await a.jsonValue());
+    }
+
+    return array.length === 1 ? array[0] : array;
   }
 
   /**


### PR DESCRIPTION
Fixed this case:

> I have noticed one thing about grabAttributeFrom method: there are 6 elements on a page and I expected grabAttributeFrom to return me an array. Here is my code
I.amOnPage('https://www.mcmakler.de/lp/de/immobilienbewertung'); const src = await I.grabAttributeFrom('.footer-branded div img', 'src'); console.log(src);

but it actually returns the value from the first element and that’s it. The page I am testing is public, so you can see that there are actually 6 elements found using this selector.