### PR TITLE
Added WebDriver to autoDelay plugin supported helpers list

### DIFF
--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -5,6 +5,7 @@ const event = require('../event');
 const log = require('../output').log;
 
 const supportedHelpers = [
+  'WebDriver',
   'WebDriverIO',
   'Protractor',
   'Appium',


### PR DESCRIPTION
WebDriverIO is deprecated and should be removed from the list when the deprecation notices are removed. For now, both should be supported.