### PR TITLE
Enable Uploading To Hidden Input Element

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -710,7 +710,7 @@ class WebDriver extends Helper {
       }
     }
 
-    return el.setValue(file);
+    return el.addValue(file);
   }
 
   /**

--- a/test/data/app/view/form/file.php
+++ b/test/data/app/view/form/file.php
@@ -5,5 +5,9 @@
     <input type="file" id="avatar" name="avatar" />
     <input type="submit" value="Submit" />
 </form>
+<form action="/form/complex" method="POST" enctype="multipart/form-data">
+    <input type="file" id="hidden" name="hidden" style="display: none;" />
+    <input type="submit" value="Submit" />
+</form>
 </body>
 </html>

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -629,4 +629,13 @@ describe('WebDriver', function () {
       .then(() => wd.see('Information', 'h1'))
       .then(() => wd.dontSee('Iframe test', 'h1')));
   });
+
+  describe('#AttachFile', () => {
+    it('should attach to regular input element', () => wd.amOnPage('/form/file')
+      .then(() => wd.attachFile('Avatar', './app/avatar.jpg'))
+      .then(() => wd.seeInField('Avatar', 'avatar.jpg')));
+
+    it('should attach to invisible input element', () => wd.amOnPage('/form/file')
+      .then(() => wd.attachFile('hidden', '/app/avatar.jpg')));
+  });
 });


### PR DESCRIPTION
Original WebDriver helper's `attachFile()` method could'nt attach file to hidden input element, such as: 

```
<input type="file" id="upload" style="display: none;">
```

Given error was: 

```
     Error: element not interactable
  (Session info: headless chrome=70.0.3538.77)
  (Driver info: chromedriver=2.43.600233 (523efee95e3d68b8719b3a1c83051aa63aa6b10d),platform=Linux 4.17.9-041709-generic x86_64)
```

This patch will fixed that problem. 