### PR TITLE
Make override option in `run-multiple` to respect the generated overridden config

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -34,7 +34,6 @@ module.exports = function (selectedRuns, options) {
   let codecept;
 
   const testRoot = getTestRoot(configFile);
-  config = getConfig(configFile);
 
   // copy opts to run
   Object.keys(options)
@@ -49,6 +48,11 @@ module.exports = function (selectedRuns, options) {
   } catch (e) {
     overrides = {};
   }
+
+  config = {
+    ...getConfig(configFile),
+    ...overrides,
+  };
 
   if (!config.multiple) {
     fail('Multiple runs not configured, add "multiple": { /../ } section to config');
@@ -128,10 +132,7 @@ function executeRun(runName, runConfig) {
   // override grep param and collect all params
   const params = ['run',
     '--child', `${runId++}.${runName}:${browserName}`,
-    '--override', JSON.stringify({
-      ...overriddenConfig,
-      ...overrides,
-    }),
+    '--override', JSON.stringify(overriddenConfig),
   ];
 
   Object.keys(childOpts).forEach((key) => {


### PR DESCRIPTION
`run-multiple` generates some overridden configs based on config file.

The current problem we have is that when we try to override one of the `run-multiple` generated config, it will simply pass down to the child runner and not respecting the `run-multiple` generated configs.

One of the symptoms is that when we override the `tests` config, it will make all runner running the same tests because the chunked config is being overridden.

This PR is to make `run-multiple`generate config based on the overridden version so that when we overrides the setting, it is still respecting the `run-multiple` generated configs.