### PR TITLE
docs: fix bootstrap description for custom runner documentation

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -467,7 +467,10 @@ codecept.initGlobals(__dirname);
 Container.create(config, opts);
 
 // initialize listeners
-codecept.bootstrap();
+codecept.runHooks();
+
+// run bootstrap function from config
+codecept.runBootstrap();
 
 // load tests
 codecept.loadTests('*_test.js');

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -206,9 +206,9 @@ module.exports = function (genPath, options) {
 
 function addAllMethodsInObject(supportObj, actions, methods, translations) {
   for (const action of methodsOfObject(supportObj)) {
-    let fn = supportObj[action];
+    const fn = supportObj[action];
     if (!fn.name) {
-      Object.defineProperty(fn, "name", {value: action});
+      Object.defineProperty(fn, 'name', { value: action });
     }
     const actionAlias = translations ? translations.actionAliasFor(action) : action;
     if (!actions[actionAlias]) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -87,7 +87,7 @@ function getParams(fn) {
     });
     return params;
   } catch (err) {
-    console.log('Error in ' + newFn.toString());
+    console.log(`Error in ${newFn.toString()}`);
     console.error(err);
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ const isGenerator = module.exports.isGenerator = function (fn) {
 };
 
 const isFunction = module.exports.isFunction = function (fn) {
-  return typeof fn === 'function'
+  return typeof fn === 'function';
 };
 
 const isAsyncFunction = module.exports.isAsyncFunction = function (fn) {


### PR DESCRIPTION
Fixed doc to avoid https://codecept.discourse.group/t/boostrap-is-not-a-function-error/64
After #1270 

Also fix a few lines to linter requirements.

@DavertMik, maybe we should add linter run on commit before test run?
And add ~"run linter" line in CONTRIBUTING doc ?