### PR TITLE
Handle trailing comma at `utils.getParamNames`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cucumber-expressions": "^6.0.1",
     "escape-string-regexp": "^1.0.3",
     "figures": "^2.0.0",
-    "fn-args": "^3.0.0",
+    "fn-args": "^4.0.0",
     "gherkin": "^5.1.0",
     "glob": "^6.0.1",
     "inquirer": "^6.2.1",

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -11,6 +11,11 @@ describe('utils', () => {
     it('fn#1', () => utils.getParamNames((a, b) => {}).should.eql(['a', 'b']));
     it('fn#2', () => utils.getParamNames((I, userPage) => { }).should.eql(['I', 'userPage']));
     it('should handle single-param arrow functions with omitted parens', () => utils.getParamNames((I) => {}).should.eql(['I']));
+    it('should handle trailing comma', () => utils.getParamNames((
+      I,
+      trailing,
+      comma,
+    ) => {}).should.eql(['I', 'trailing', 'comma']));
   });
 
   describe('#methodsOfObject', () => {


### PR DESCRIPTION
This was a bug at `fn-args` library that got fixed with https://github.com/sindresorhus/fn-args/pull/10 . Before upgrading the `fn-args` library the test I added fails with:

```console
  1 failing

  1) utils
       #getParamNames
         should handle trailing comma:

      AssertionError: expected [ 'I', 'trailing', 'comma', '' ] to deeply equal [ 'I', 'trailing', 'comma' ]
      + expected - actual

       [
         "I"
         "trailing"
         "comma"
      -  ""
       ]
      
      at Context.it (test/unit/utils_test.js:18:21)
```

The upgrade fixes that issue:

```console
✓ should handle trailing comma
```