### PR TITLE
Webdriver: grabHTMLFrom returns array of innerHTML from the set of matched elements

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -777,10 +777,9 @@ class WebDriver extends Helper {
    * * *Appium*: supported only for web testing
    */
   async grabHTMLFrom(locator) {
-    const res = await this._locate(locator, true);
-    assertElementExists(res, locator);
-    const elem = usingFirstElement(res);
-    const html = await elem.getHTML();
+    const elems = await this._locate(locator, true);
+    assertElementExists(elems, locator);
+    const html = Promise.all(elems.map(async elem => elem.getHTML(false)));
     this.debugSection('Grab', html);
     return html;
   }

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -167,13 +167,13 @@ describe('WebDriver', function () {
       .then(() => wd.grabSource())
       .then(source => assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')));
 
-    it('should grab the source for element', () => wd.amOnPage('/')
+    it('should grab the innerHTML for an element', () => wd.amOnPage('/')
       .then(() => wd.grabHTMLFrom('#area1'))
-      .then(source => assert.equal(
+      .then(source => assert.deepEqual(
         source,
-        `<div id="area1" qa-id="test">
+        [`
     <a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>
-</div>`,
+`],
       )));
   });
 


### PR DESCRIPTION
Before 2.0, grabHTMLFrom returned an array of strings with innerHTML of the set of matched elements. After 2.0, it returns the outerHTML of the first element. That it returns the outerHTML is a bug as documentation says that it returns innerHTML and other helpers also return innerHTML. 

That it returns an array instead of just the first element is similar to the usage of getHTML of webdriverio, where you have a $(selector).getHTML(false) to return innerHTML for a set of matches. And it is very useful when you need to test multiple elements (e.g. "ul > li"). And if you only need the first result, you can simply use destruction (like "const [html] = await I.grabHTMLFrom(...);" ). Last but not least, an upgrade to 2.0 would not break the grabHTMLFrom function. 