### PR TITLE
Enable to use Step-by-step Report for WebDriver Plugin

### DIFF
--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -11,6 +11,7 @@ const { template, clearString, deleteDir } = require('../utils');
 
 const supportedHelpers = [
   'WebDriverIO',
+  'WebDriver',
   'Protractor',
   'Appium',
   'Nightmare',

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -173,7 +173,7 @@ module.exports = function (config) {
 
       slideHtml += template(templates.slides, {
         image: i,
-        caption: step.toString(),
+        caption: step.toString().replace(/\[\d{2}m/g, ''), // remove ANSI escape sequence
         isActive: stepNum ? '' : 'active',
         isError: step.status === 'failed' ? 'error' : '',
       });


### PR DESCRIPTION
Fix two problems: 

## Enable to use Step-by-step Report for WebDriver Plugin

That's simple :innocent: 

![image](https://user-images.githubusercontent.com/17092259/52157017-5a80ff80-26cf-11e9-9d75-90884fdec2f0.png)


## Remove ANSI escape character 

When using session, the console log is colored with ANSI escape character.

![image](https://user-images.githubusercontent.com/17092259/52156705-38867d80-26cd-11e9-8066-ba6893c20002.png)

However, it should not be displayed in the report.

before | after
--- | ---
![image](https://user-images.githubusercontent.com/17092259/52156701-2efd1580-26cd-11e9-9a57-621f245ead47.png) | ![image](https://user-images.githubusercontent.com/17092259/52156742-6f5c9380-26cd-11e9-8ba4-67f62f6576f5.png)



