### PR TITLE
Fix errors on using interactive shell with Allure plugin

### DIFF
--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -23,8 +23,13 @@ module.exports = function (path, options) {
 
     output.print('String interactive shell for current suite...');
     recorder.start();
-    event.emit(event.suite.before, {});
-    event.emit(event.test.before);
+    event.emit(event.suite.before, {
+      fullTitle: () => 'Interactive Shell',
+      tests: [],
+    });
+    event.emit(event.test.before, {
+      title: '',
+    });
     require('../pause')();
     recorder.add(() => event.emit(event.test.after));
     recorder.add(() => event.emit(event.suite.after, {}));


### PR DESCRIPTION
fix https://github.com/Codeception/CodeceptJS/issues/1414

With Allure plugin, `codeceptjs shell` failed with those errors:

```
TypeError: suite.fullTitle is not a function
```

```
TypeError: suite.tests is not iterable
```

```
TypeError: Cannot read property 'title' of undefined
```

These are occured by lack of parameters on `event.emit()`.

```
event.emit(event.suite.before, {}); // should have fullTitle() and tests
event.emit(event.test.before); // should have title
```

This PR fixes those errors.