### PR TITLE
Fix bootstrapAll and teardownAll launch with path as argument

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -31,6 +31,7 @@ module.exports = function (selectedRuns, options) {
   let codecept;
 
   const testRoot = getTestRoot(configFile);
+  global.codecept_dir = testRoot;
 
   // copy opts to run
   Object.keys(options)


### PR DESCRIPTION
Fix for #1346;

global variable with path was not defined for `run-multiple`, so `bootstrapAll` and `teardownAll` were run with error

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:28:11)
    at Object.join (path.js:1236:7)
    at module.exports (CodeceptJS/lib/hooks.js:8:31)
    at Command.module.exports (CodeceptJS/lib/command/run-multiple.js:67:3)

```