### PR TITLE
Fix url protocol detection for non-http urls

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -401,7 +401,7 @@ class Nightmare extends Helper {
    * ```
    */
   async amOnPage(url, headers = null) {
-    if (url.indexOf('http') !== 0) {
+    if (!(/^\w+\:\/\//.test(url))) {
       url = urlResolve(this.options.url, url);
     }
     const currentUrl = await this.browser.url();

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -427,7 +427,7 @@ class Protractor extends Helper {
    * {{> ../webapi/amOnPage }}
    */
   async amOnPage(url) {
-    if (url.indexOf('http') !== 0) {
+    if (!(/^\w+\:\/\//.test(url))) {
       url = this.options.url + url;
     }
     const res = await this.browser.get(url);

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -494,7 +494,7 @@ class Puppeteer extends Helper {
    * {{> ../webapi/amOnPage }}
    */
   async amOnPage(url) {
-    if (url.indexOf('http') !== 0) {
+    if (!(/^\w+\:\/\//.test(url))) {
       url = this.options.url + url;
     }
     await this.page.goto(url, { waitUntil: this.options.waitForNavigation });

--- a/test/data/sandbox/page_slider.html
+++ b/test/data/sandbox/page_slider.html
@@ -1,0 +1,35 @@
+<!-- Example based oncode from https://www.w3schools.com/howto/howto_js_rangeslider.asp -->
+
+<div id="slidecontainer">
+  <input
+    type="range"
+    min="1"
+    max="100"
+    value="50"
+    class="slider"
+    id="mySlider"
+  />
+</div>
+<div><span>Value:</span> <span id="demo"></span></div>
+
+<script>
+  var slider = document.getElementById("mySlider");
+  var output = document.getElementById("demo");
+  output.innerHTML = slider.value;
+
+  slider.oninput = function() {
+    output.innerHTML = this.value;
+  };
+</script>
+
+<style>
+  #slidecontainer {
+    width: 100%;
+  }
+  .slider {
+    width: 100%;
+    height: 25px;
+    background: #d3d3d3;
+    outline: none;
+  }
+</style>

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -550,7 +550,7 @@ describe('Puppeteer', function () {
 
   describe('#dragSlider', () => {
     it('should drag scrubber to given position', async () => {
-      await I.amOnPage('https://www.w3schools.com/howto/howto_js_rangeslider.asp');
+      await I.amOnPage(`file://${path.resolve(__dirname, '../data/sandbox/page_slider.html')}`);
       await I.seeElementInDOM('#slidecontainer input');
       const before = await I.grabValueFrom('#slidecontainer input');
       await I.dragSlider('#slidecontainer input', 20);


### PR DESCRIPTION
1. Fixed url protocol detection for non-http urls.
Now `file://path/to/file`, `ftp://...` and similar is correct fo Puppeteer, Nightmare and Protractor helpers.
Before `https` and `https` have worked only.

2. Fixed test for page slider in `Puppeteer_test.js`
It could not load w3c site and test fails last 2 days.
Now this test use local sandbox html.