### PR TITLE
Webdriver. Add possibility to define conditional checks interval for waitUntil

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1742,12 +1742,13 @@ class WebDriver extends Helper {
   /**
    * {{> ../webapi/waitUntil }}
    *
-   *
+   * @param interval (optional) time in seconds between condition checks.
    * * *Appium*: supported
    */
-  async waitUntil(fn, sec = null, timeoutMsg = null) {
+  async waitUntil(fn, sec = null, timeoutMsg = null, interval = null) {
     const aSec = sec || this.options.waitForTimeout;
-    return this.browser.waitUntil(fn, aSec * 1000, timeoutMsg);
+    const _interval = typeof interval === 'number' ? interval * 1000 : null;
+    return this.browser.waitUntil(fn, aSec * 1000, timeoutMsg, _interval);
   }
 
   /**

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1661,11 +1661,13 @@ class WebDriverIO extends Helper {
 
   /**
    * {{> ../webapi/waitUntil }}
-   * Appium: support
+   * @param interval (optional) time in seconds between condition checks.
+   * * *Appium*: supported
    */
-  async waitUntil(fn, sec = null, timeoutMsg = null) {
+  async waitUntil(fn, sec = null, timeoutMsg = null, interval = null) {
     const aSec = sec || this.options.waitForTimeout;
-    return this.browser.waitUntil(fn, aSec * 1000, timeoutMsg);
+    const _interval = typeof interval === 'number' ? interval * 1000 : null;
+    return this.browser.waitUntil(fn, aSec * 1000, timeoutMsg, _interval);
   }
 
   /**


### PR DESCRIPTION
Add 4th argument to `waitUntil` in `WebDriver` and `WebDriverIO`
It defines interval time between conditional checks.

https://webdriver.io/docs/api/browser/waitUntil.html
http://v4.webdriver.io/api/utility/waitUntil.html