### PR TITLE
fixed no screenshots on passed cases allure

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -270,7 +270,7 @@ Possible config options:
 
 -   `config`  
 
-## stepByStepReport
+## screenshotsForAllureReport
 
 ![step-by-step-report][2]
 
@@ -299,13 +299,10 @@ Possible config options:
 -   `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
 -   `fullPageScreenshots`: should full page screenshots be used. Default: false.
 -   `output`: a directory where reports should be stored. Default: `output`.
--   `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
 
 ##### Allure Reports
 
-If Allure plugin is enabled this plugin attaches each saved screenshot to allure report when stepByStepAllure is set to true.
-
--   `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
+-   `screenshotsForAllureReport`: If Allure plugin is enabled this plugin attaches each saved screenshot to allure report. Default: false.
 
 ### Parameters
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -299,10 +299,13 @@ Possible config options:
 -   `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
 -   `fullPageScreenshots`: should full page screenshots be used. Default: false.
 -   `output`: a directory where reports should be stored. Default: `output`.
+-   `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
 
 ##### Allure Reports
 
-If Allure plugin is enabled this plugin attaches each saved screenshot to allure report.
+If Allure plugin is enabled this plugin attaches each saved screenshot to allure report when stepByStepAllure is set to true.
+
+-   `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
 
 ### Parameters
 

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -206,9 +206,9 @@ module.exports = function (genPath, options) {
 
 function addAllMethodsInObject(supportObj, actions, methods, translations) {
   for (const action of methodsOfObject(supportObj)) {
-    let fn = supportObj[action];
+    const fn = supportObj[action];
     if (!fn.name) {
-      Object.defineProperty(fn, "name", {value: action});
+      Object.defineProperty(fn, 'name', { value: action });
     }
     const actionAlias = translations ? translations.actionAliasFor(action) : action;
     if (!actions[actionAlias]) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -87,7 +87,7 @@ function getParams(fn) {
     });
     return params;
   } catch (err) {
-    console.log('Error in ' + newFn.toString());
+    console.log(`Error in ${newFn.toString()}`);
     console.error(err);
   }
 }

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -23,6 +23,7 @@ const defaultConfig = {
   ignoreSteps: [],
   fullPageScreenshots: false,
   output: global.output_dir,
+  stepByStepAllure: false,
 };
 
 const templates = {};
@@ -58,11 +59,12 @@ const templates = {};
  * * `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
  * * `fullPageScreenshots`: should full page screenshots be used. Default: false.
  * * `output`: a directory where reports should be stored. Default: `output`.
+ * * `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
  *
  * ##### Allure Reports
  *
- * If Allure plugin is enabled this plugin attaches each saved screenshot to allure report.
- *
+ * If Allure plugin is enabled this plugin attaches each saved screenshot to allure report when stepByStepAllure is set to true.
+ * * `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
  *
  * @param {*} config
  */
@@ -148,6 +150,12 @@ module.exports = function (config) {
       error = err;
     }
     savedStep = step;
+
+    const allureReporter = Container.plugins('allure');
+    if (allureReporter && (config.stepByStepAllure === true)) {
+      output.plugin('stepByStepReport', 'Adding screenshot to Allure');
+      allureReporter.addAttachment('Screenshot', fs.readFileSync(path.join(dir, fileName)), 'image/png');
+    }
   }
 
   function persist(test, err) {

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -68,7 +68,6 @@ const templates = {};
  * @param {*} config
  */
 
-screenshotsForAllureReport;
 module.exports = function (config) {
   const helpers = Container.helpers();
   let helper;

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -148,12 +148,6 @@ module.exports = function (config) {
       error = err;
     }
     savedStep = step;
-
-    const allureReporter = Container.plugins('allure');
-    if (allureReporter) {
-      output.plugin('stepByStepReport', 'Adding screenshot to Allure');
-      allureReporter.addAttachment('Screenshot', fs.readFileSync(path.join(dir, fileName)), 'image/png');
-    }
   }
 
   function persist(test, err) {

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -11,6 +11,7 @@ const { template, clearString, deleteDir } = require('../utils');
 
 const supportedHelpers = [
   'WebDriverIO',
+  'WebDriver',
   'Protractor',
   'Appium',
   'Nightmare',
@@ -23,7 +24,7 @@ const defaultConfig = {
   ignoreSteps: [],
   fullPageScreenshots: false,
   output: global.output_dir,
-  stepByStepAllure: false,
+  screenshotsForAllureReport: false,
 };
 
 const templates = {};
@@ -59,15 +60,15 @@ const templates = {};
  * * `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
  * * `fullPageScreenshots`: should full page screenshots be used. Default: false.
  * * `output`: a directory where reports should be stored. Default: `output`.
- * * `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
  *
  * ##### Allure Reports
  *
- * If Allure plugin is enabled this plugin attaches each saved screenshot to allure report when stepByStepAllure is set to true.
- * * `stepByStepAllure`: attaches each saved screenshot to allure report. Default: false
+ * * `screenshotsForAllureReport`: If Allure plugin is enabled this plugin attaches each saved screenshot to allure report. Default: false.
  *
  * @param {*} config
  */
+
+screenshotsForAllureReport;
 module.exports = function (config) {
   const helpers = Container.helpers();
   let helper;
@@ -101,12 +102,11 @@ module.exports = function (config) {
     savedStep = null;
   });
 
+  event.dispatcher.on(event.step.failed, persistStep);
+
   event.dispatcher.on(event.step.after, (step) => {
     recorder.add('screenshot of failed test', async () => persistStep(step), true);
   });
-
-  event.dispatcher.on(event.step.failed, persistStep);
-
 
   event.dispatcher.on(event.test.passed, (test) => {
     if (!config.deleteSuccessful) return persist(test);
@@ -152,9 +152,9 @@ module.exports = function (config) {
     savedStep = step;
 
     const allureReporter = Container.plugins('allure');
-    if (allureReporter && (config.stepByStepAllure === true)) {
+    if (allureReporter && config.screenshotsForAllureReport) {
       output.plugin('stepByStepReport', 'Adding screenshot to Allure');
-      allureReporter.addAttachment('Screenshot', fs.readFileSync(path.join(dir, fileName)), 'image/png');
+      allureReporter.addAttachment(`Screenshot of step ${step}`, fs.readFileSync(path.join(dir, fileName)), 'image/png');
     }
   }
 
@@ -174,7 +174,7 @@ module.exports = function (config) {
 
       slideHtml += template(templates.slides, {
         image: i,
-        caption: step.toString(),
+        caption: step.toString().replace(/\[\d{2}m/g, ''), // remove ANSI escape sequence
         isActive: stepNum ? '' : 'active',
         isError: step.status === 'failed' ? 'error' : '',
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ const isGenerator = module.exports.isGenerator = function (fn) {
 };
 
 const isFunction = module.exports.isFunction = function (fn) {
-  return typeof fn === 'function'
+  return typeof fn === 'function';
 };
 
 const isAsyncFunction = module.exports.isAsyncFunction = function (fn) {


### PR DESCRIPTION
By this reported https://github.com/Codeception/CodeceptJS/issues/1494 I found out that:

- The screenshot to attach to allure for failed test cases is already handled in `screenshotOnFail.js`
```
        const allureReporter = Container.plugins('allure');
        if (allureReporter) {
          allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
        }
```

so, we don't need to handle it again in `stepByStepReport.js`
```
    const allureReporter = Container.plugins('allure');
    if (allureReporter && (step.status !== 'success')) {
      output.plugin('stepByStepReport', 'Adding screenshot to Allure');
      allureReporter.addAttachment('Screenshot', fs.readFileSync(path.join(dir, fileName)), 'image/png');
    }
```

this will lead to 
- duplicate screenshots on allure reports.
- screenshot will be added to passed cases on allure reports.