### PR TITLE
Fixed storing all data in the test instance.

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -10,12 +10,12 @@ module.exports = function (context) {
           fn = opts;
           opts = {};
         }
+        opts.data = data.map(dataRow => dataRow.data);
         data.forEach((dataRow) => {
           const dataTitle = replaceTitle(title, dataRow);
           if (dataRow.skip) {
             context.xScenario(dataTitle);
           } else {
-            opts.data = dataRow;
             context.Scenario(dataTitle, opts, fn)
               .inject({ current: dataRow.data });
           }
@@ -27,12 +27,12 @@ module.exports = function (context) {
             fn = opts;
             opts = {};
           }
+          opts.data = data.map(dataRow => dataRow.data);
           data.forEach((dataRow) => {
             const dataTitle = replaceTitle(title, dataRow);
             if (dataRow.skip) {
               context.xScenario(dataTitle);
             } else {
-              opts.data = dataRow;
               context.Scenario.only(dataTitle, opts, fn)
                 .inject({ current: dataRow.data });
             }


### PR DESCRIPTION
Fixed storing all data in the test instance.
Previously, the instance had only the latest data, like:
```json
"opts": {
    "data": {
      "data": {
        "fieldValue": "admin"
      }
    }
  }
```
Now:
```json
{"fieldVelue":"admin"}
{
  "title": "При смешанном вводе не форматирует. Корректно форматирует при блюре @FBCARDS-654 | {\"fieldValue\":\"admin\"}",
  "body": "",
  "async": true,
  "sync": false,
  "timedOut": false,
  "pending": false,
  "type": "test",
  "tags": [
    "@FBCARDS-654"
  ],
  "file": "Properties/dontPrettifyOnInput.test.js",
  "inject": {
    "current": {
      "fieldVelue": "admin"
    }
  },
  "steps": [],
  "parent": "#<Suite>",
  "ctx": "#<Context>",
  "opts": {
    "data": [
      {
        "fieldValue": "davert"
      },
      {
        "fieldValue": "admin"
      },
      {
        "fieldValue": "admin"
      }
    ]
  }
}
```

Test:
```js
Data(function * () {
  yield { fieldValue: 'davert' }
  yield { fieldValue: 'admin' }
  yield { fieldValue: 'admin' }
}).only.Scenario()
```