### PR TITLE
Enable ScenarioContext functions for data driven tests

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -103,26 +103,57 @@ function applyFunctionToAllScenarios(scenarios, funct, ...args) {
 
 function dataScenarioConfig(scenarios) {
   return {
+    /**
+     * Declares that test throws error.
+     * Can pass an Error object or regex matching expected message.
+     *
+     * @param {*} err
+     */
     throws(err) {
       applyFunctionToAllScenarios(scenarios, 'throws', err);
       return this;
     },
+
+    /**
+     * Declares that test should fail.
+     * If test passes - throws an error.
+     * Can pass an Error object or regex matching expected message.
+     *
+     * @param {*} err
+     */
     fails() {
       applyFunctionToAllScenarios(scenarios, 'fails');
       return this;
     },
+    /**
+     * Retry this test for x times
+     *
+     * @param {*} retries
+     */
     retry(retries) {
       applyFunctionToAllScenarios(scenarios, 'retry', retries);
       return this;
     },
+    /**
+     * Set timeout for this test
+     * @param {*} timeout
+     */
     timeout() {
       applyFunctionToAllScenarios(scenarios, 'timeout');
       return this;
     },
+    /**
+     * Configures a helper.
+     * Helper name can be omitted and values will be applied to first helper.
+     */
     config(helper, obj) {
       applyFunctionToAllScenarios(scenarios, 'config', helper, obj);
       return this;
     },
+    /**
+     * Append a tag name to scenario title
+     * @param {*} tagName
+     */
     tag(tagName) {
       applyFunctionToAllScenarios(scenarios, 'tag', tagName);
       return this;

--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -1,5 +1,6 @@
 const isGenerator = require('../utils').isGenerator;
 const DataTable = require('./table');
+const DataScenarioConfig = require('./dataScenarioConfig');
 
 module.exports = function (context) {
   context.Data = function (dataTable) {
@@ -15,13 +16,13 @@ module.exports = function (context) {
         data.forEach((dataRow) => {
           const dataTitle = replaceTitle(title, dataRow);
           if (dataRow.skip) {
-            scenarios.push(context.xScenario(dataTitle));
+            context.xScenario(dataTitle);
           } else {
             scenarios.push(context.Scenario(dataTitle, opts, fn)
               .inject({ current: dataRow.data }));
           }
         });
-        return dataScenarioConfig(scenarios);
+        return new DataScenarioConfig(scenarios);
       },
       only: {
         Scenario(title, opts, fn) {
@@ -36,12 +37,11 @@ module.exports = function (context) {
             if (dataRow.skip) {
               scenarios.push(context.xScenario(dataTitle));
             } else {
-
               scenarios.push(context.Scenario.only(dataTitle, opts, fn)
                 .inject({ current: dataRow.data }));
             }
           });
-          return dataScenarioConfig(scenarios);
+          return new DataScenarioConfig(scenarios);
         },
       },
     };
@@ -96,68 +96,4 @@ function detectDataType(dataTable) {
   }
 
   throw new Error('Invalid data type. Data accepts either: DataTable || generator || Array || function');
-}
-
-function applyFunctionToAllScenarios(scenarios, funct, ...args) {
-  scenarios.forEach(scenario => scenario[funct](...args));
-}
-
-function dataScenarioConfig(scenarios) {
-  return {
-    /**
-     * Declares that test throws error.
-     * Can pass an Error object or regex matching expected message.
-     *
-     * @param {*} err
-     */
-    throws(err) {
-      applyFunctionToAllScenarios(scenarios, 'throws', err);
-      return this;
-    },
-
-    /**
-     * Declares that test should fail.
-     * If test passes - throws an error.
-     * Can pass an Error object or regex matching expected message.
-     *
-     * @param {*} err
-     */
-    fails() {
-      applyFunctionToAllScenarios(scenarios, 'fails');
-      return this;
-    },
-    /**
-     * Retry this test for x times
-     *
-     * @param {*} retries
-     */
-    retry(retries) {
-      applyFunctionToAllScenarios(scenarios, 'retry', retries);
-      return this;
-    },
-    /**
-     * Set timeout for this test
-     * @param {*} timeout
-     */
-    timeout() {
-      applyFunctionToAllScenarios(scenarios, 'timeout');
-      return this;
-    },
-    /**
-     * Configures a helper.
-     * Helper name can be omitted and values will be applied to first helper.
-     */
-    config(helper, obj) {
-      applyFunctionToAllScenarios(scenarios, 'config', helper, obj);
-      return this;
-    },
-    /**
-     * Append a tag name to scenario title
-     * @param {*} tagName
-     */
-    tag(tagName) {
-      applyFunctionToAllScenarios(scenarios, 'tag', tagName);
-      return this;
-    },
-  };
 }

--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -35,7 +35,7 @@ module.exports = function (context) {
           data.forEach((dataRow) => {
             const dataTitle = replaceTitle(title, dataRow);
             if (dataRow.skip) {
-              scenarios.push(context.xScenario(dataTitle));
+              context.xScenario(dataTitle);
             } else {
               scenarios.push(context.Scenario.only(dataTitle, opts, fn)
                 .inject({ current: dataRow.data }));

--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -97,11 +97,11 @@ function detectDataType(dataTable) {
   throw new Error('Invalid data type. Data accepts either: DataTable || generator || Array || function');
 }
 
-function dataScenarioConfig(scenarios) {
-  function applyFunctionToAllScenarios(scenarios, funct, ...args) {
-    scenarios.forEach(scenario => scenario[funct](...args));
-  }
+function applyFunctionToAllScenarios(scenarios, funct, ...args) {
+  scenarios.forEach(scenario => scenario[funct](...args));
+}
 
+function dataScenarioConfig(scenarios) {
   return {
     throws(err) {
       applyFunctionToAllScenarios(scenarios, 'throws', err);

--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -6,6 +6,7 @@ module.exports = function (context) {
     const data = detectDataType(dataTable);
     return {
       Scenario(title, opts, fn) {
+        const scenarios = [];
         if (typeof opts === 'function' && !fn) {
           fn = opts;
           opts = {};
@@ -13,16 +14,18 @@ module.exports = function (context) {
         data.forEach((dataRow) => {
           const dataTitle = replaceTitle(title, dataRow);
           if (dataRow.skip) {
-            context.xScenario(dataTitle);
+            scenarios.push(context.xScenario(dataTitle));
           } else {
             opts.data = dataRow;
-            context.Scenario(dataTitle, opts, fn)
-              .inject({ current: dataRow.data });
+            scenarios.push(context.Scenario(dataTitle, opts, fn)
+              .inject({ current: dataRow.data }));
           }
         });
+        return dataScenarioConfig(scenarios);
       },
       only: {
         Scenario(title, opts, fn) {
+          const scenarios = [];
           if (typeof opts === 'function' && !fn) {
             fn = opts;
             opts = {};
@@ -30,13 +33,14 @@ module.exports = function (context) {
           data.forEach((dataRow) => {
             const dataTitle = replaceTitle(title, dataRow);
             if (dataRow.skip) {
-              context.xScenario(dataTitle);
+              scenarios.push(context.xScenario(dataTitle));
             } else {
               opts.data = dataRow;
-              context.Scenario.only(dataTitle, opts, fn)
-                .inject({ current: dataRow.data });
+              scenarios.push(context.Scenario.only(dataTitle, opts, fn)
+                .inject({ current: dataRow.data }));
             }
           });
+          return dataScenarioConfig(scenarios);
         },
       },
     };
@@ -91,4 +95,37 @@ function detectDataType(dataTable) {
   }
 
   throw new Error('Invalid data type. Data accepts either: DataTable || generator || Array || function');
+}
+
+function dataScenarioConfig(scenarios) {
+  function applyFunctionToAllScenarios(scenarios, funct, ...args) {
+    scenarios.forEach(scenario => scenario[funct](...args));
+  }
+
+  return {
+    throws(err) {
+      applyFunctionToAllScenarios(scenarios, 'throws', err);
+      return this;
+    },
+    fails() {
+      applyFunctionToAllScenarios(scenarios, 'fails');
+      return this;
+    },
+    retry(retries) {
+      applyFunctionToAllScenarios(scenarios, 'retry', retries);
+      return this;
+    },
+    timeout() {
+      applyFunctionToAllScenarios(scenarios, 'timeout');
+      return this;
+    },
+    config(helper, obj) {
+      applyFunctionToAllScenarios(scenarios, 'config', helper, obj);
+      return this;
+    },
+    tag(tagName) {
+      applyFunctionToAllScenarios(scenarios, 'tag', tagName);
+      return this;
+    },
+  };
 }

--- a/lib/data/dataScenarioConfig.js
+++ b/lib/data/dataScenarioConfig.js
@@ -24,6 +24,7 @@ class DataScenarioConfig {
     this.scenarios.forEach(scenario => scenario.fails());
     return this;
   }
+
   /**
      * Retry this test for x times
      *
@@ -33,6 +34,7 @@ class DataScenarioConfig {
     this.scenarios.forEach(scenario => scenario.retry(retries));
     return this;
   }
+
   /**
      * Set timeout for this test
      * @param {*} timeout
@@ -41,6 +43,7 @@ class DataScenarioConfig {
     this.scenarios.forEach(scenario => scenario.timeout(timeout));
     return this;
   }
+
   /**
      * Configures a helper.
      * Helper name can be omitted and values will be applied to first helper.
@@ -49,6 +52,7 @@ class DataScenarioConfig {
     this.scenarios.forEach(scenario => scenario.config(helper, obj));
     return this;
   }
+
   /**
      * Append a tag name to scenario title
      * @param {*} tagName

--- a/lib/data/dataScenarioConfig.js
+++ b/lib/data/dataScenarioConfig.js
@@ -1,0 +1,62 @@
+class DataScenarioConfig {
+  constructor(scenarios) {
+    this.scenarios = scenarios;
+  }
+
+  /**
+     * Declares that test throws error.
+     * Can pass an Error object or regex matching expected message.
+     *
+     * @param {*} err
+     */
+  throws(err) {
+    this.scenarios.forEach(scenario => scenario.throws(err));
+    return this;
+  }
+
+  /**
+     * Declares that test should fail.
+     * If test passes - throws an error.
+     * Can pass an Error object or regex matching expected message.
+     *
+     */
+  fails() {
+    this.scenarios.forEach(scenario => scenario.fails());
+    return this;
+  }
+  /**
+     * Retry this test for x times
+     *
+     * @param {*} retries
+     */
+  retry(retries) {
+    this.scenarios.forEach(scenario => scenario.retry(retries));
+    return this;
+  }
+  /**
+     * Set timeout for this test
+     * @param {*} timeout
+     */
+  timeout(timeout) {
+    this.scenarios.forEach(scenario => scenario.timeout(timeout));
+    return this;
+  }
+  /**
+     * Configures a helper.
+     * Helper name can be omitted and values will be applied to first helper.
+     */
+  config(helper, obj) {
+    this.scenarios.forEach(scenario => scenario.config(helper, obj));
+    return this;
+  }
+  /**
+     * Append a tag name to scenario title
+     * @param {*} tagName
+     */
+  tag(tagName) {
+    this.scenarios.forEach(scenario => scenario.tag(tagName));
+    return this;
+  }
+}
+
+module.exports = DataScenarioConfig;

--- a/test/unit/data/ui_test.js
+++ b/test/unit/data/ui_test.js
@@ -1,0 +1,82 @@
+const Mocha = require('mocha/lib/mocha');
+const makeUI = require('../../../lib/ui');
+const addData = require('../../../lib/data/context');
+const DataTable = require('../../../lib/data/table');
+const Suite = require('mocha/lib/suite');
+const should = require('chai').should();
+
+describe('ui', () => {
+  let suite;
+  let context;
+  let dataTable;
+
+  beforeEach(() => {
+    context = {};
+    suite = new Suite('empty');
+    makeUI(suite);
+    suite.emit('pre-require', context, {}, new Mocha());
+    addData(context);
+
+    dataTable = new DataTable(['login', 'password']);
+    dataTable.add(['jon', 'snow']);
+    dataTable.xadd(['tyrion', 'lannister']);
+    dataTable.add(['jaime', 'lannister']);
+  });
+
+  describe('Data', () => {
+    it('can add a tag to all scenarios', () => {
+      dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
+
+      dataScenarioConfig.tag('@user');
+
+      dataScenarioConfig.scenarios.forEach((scenario) => {
+        scenario.test.tags.should.include('@user');
+      });
+    });
+
+    it('can add a timout to all scenarios', () => {
+      dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
+
+      dataScenarioConfig.timeout(3);
+
+      dataScenarioConfig.scenarios.forEach(scenario => should.equal(3, scenario.test._timeout));
+    });
+
+    it('can add retries to all scenarios', () => {
+      dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
+
+      dataScenarioConfig.retry(3);
+
+      dataScenarioConfig.scenarios.forEach(scenario => should.equal(3, scenario.test._retries));
+    });
+
+    it('can expect failure for all scenarios', () => {
+      dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
+
+      dataScenarioConfig.fails();
+
+      dataScenarioConfig.scenarios.forEach(scenario => should.exist(scenario.test.throws));
+    });
+
+    it('can expect a specific error for all scenarios', () => {
+      const err = new Error();
+
+      dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
+
+      dataScenarioConfig.throws(err);
+
+      dataScenarioConfig.scenarios.forEach(scenario => should.equal(err, scenario.test.throws));
+    });
+
+    it('can configure a helper for all scenarios', () => {
+      const helperName = 'myHelper';
+      const helper = {};
+
+      dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
+
+      dataScenarioConfig.config(helperName, helper);
+
+      dataScenarioConfig.scenarios.forEach(scenario => should.equal(helper, scenario.test.config[helperName]));
+    });
+  });
+});


### PR DESCRIPTION
Currently the `ScenarioContext` functions `throws()`,` fails()`, `retry()`, `timeout()`, `config()` and `tag()` are not supported when running data driven scenarios with `Data()`. The pull request would make them available for data driven scenarios and apply them to all scenarios within the data table.