### PR TITLE
WebDriver: Fix cloud provider hostname rewrite

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -270,7 +270,7 @@ class WebDriver extends Helper {
     config = Object.assign(defaults, config);
 
 
-    config.hostname = config.host; // webdriverio spec
+    if (typeof config.host !== 'undefined') config.hostname = config.host; // webdriverio spec
     config.baseUrl = config.url || config.baseUrl;
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
       config.capabilities = config.desiredCapabilities;


### PR DESCRIPTION
`undefined` was assigned to `hostname` config options,
So cloud provider host detection was broken: 
object 
```
{"protocol":"https","hostname":"hub-cloud.browserstack.com","port":443}
```
was rewrited by incorrect object field:
```
{ ...,
  hostname: undefined,
  ...
}
```