### PR TITLE
WebDriver: Fix a failed _after Hook if not specified desiredCapabilities

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -383,7 +383,7 @@ class WebDriver extends Helper {
 
     if (this.options.keepBrowserState) return;
 
-    if (!this.options.keepCookies && this.options.capabilities.browserName) {
+    if (!this.options.keepCookies) {
       this.debugSection('Session', 'cleaning cookies and localStorage');
       await this.browser.deleteCookies();
     }


### PR DESCRIPTION
If not specified desiredCapabilities in config - tests failed in _after hook