### PR TITLE
Restore original window size when taking full size screenshot

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1287,6 +1287,8 @@ class WebDriver extends Helper {
     }
 
     /* eslint-disable prefer-arrow-callback, comma-dangle, prefer-const */
+    const originalWindowSize = await this.browser.getWindowSize();
+
     let { width, height } = await this.browser.execute(function () {
       return {
         height: document.body.scrollHeight,
@@ -1299,7 +1301,8 @@ class WebDriver extends Helper {
 
     await this.browser.setWindowSize(width, height);
     this.debug(`Screenshot has been saved to ${outputFile}, size: ${width}x${height}`);
-    return this.browser.saveScreenshot(outputFile);
+    await this.browser.saveScreenshot(outputFile);
+    await this.browser.setWindowSize(originalWindowSize.width, originalWindowSize.height);
   }
 
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1301,8 +1301,9 @@ class WebDriver extends Helper {
 
     await this.browser.setWindowSize(width, height);
     this.debug(`Screenshot has been saved to ${outputFile}, size: ${width}x${height}`);
-    await this.browser.saveScreenshot(outputFile);
+    const buffer = await this.browser.saveScreenshot(outputFile);
     await this.browser.setWindowSize(originalWindowSize.width, originalWindowSize.height);
+    return buffer;
   }
 
 


### PR DESCRIPTION
`I.saveScreenshot(filename, fullPage)` with `fullPage = true` takes full page screenshot, but doesn't preserve or restore original windowsize. 
This PR will fix it.