### PR TITLE
WebDriver (WDIO 5): Change isElementDisplayed to isDisplayed API call.

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -991,12 +991,9 @@ class WebDriver extends Helper {
    * * *Appium*: supported
    */
   async seeElement(locator) {
-    const res = await this._locate(locator, true);
-    if (!res || res.length === 0) {
-      return truth(`elements of ${locator}`, 'to be seen').assert(false);
-    }
-
-    const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
+    const res = await this._locate(withStrictLocator(locator), true);
+    assertElementExists(res);
+    const selected = await forEachAsync(res, async el => el.isDisplayed());
     return truth(`elements of ${locator}`, 'to be seen').assert(selected);
   }
 
@@ -1007,11 +1004,11 @@ class WebDriver extends Helper {
    * * *Appium*: supported
    */
   async dontSeeElement(locator) {
-    const res = await this._locate(locator, false);
+    const res = await this._locate(withStrictLocator(locator), true);
     if (!res || res.length === 0) {
       return truth(`elements of ${locator}`, 'to be seen').negate(false);
     }
-    const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
+    const selected = await forEachAsync(res, async el => el.isDisplayed());
     return truth(`elements of ${locator}`, 'to be seen').negate(selected);
   }
 
@@ -1189,7 +1186,7 @@ class WebDriver extends Helper {
   async grabNumberOfVisibleElements(locator) {
     const res = await this._locate(locator);
 
-    let selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
+    let selected = await forEachAsync(res, async el => el.isDisplayed());
     if (!Array.isArray(selected)) selected = [selected];
     selected = selected.filter(val => val === true);
     return selected.length;
@@ -1725,7 +1722,7 @@ class WebDriver extends Helper {
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return false;
-      const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
+      const selected = await forEachAsync(res, async el => el.isDisplayed());
       if (Array.isArray(selected)) {
         return selected.filter(val => val === true).length > 0;
       }
@@ -1741,7 +1738,7 @@ class WebDriver extends Helper {
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return false;
-      let selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
+      let selected = await forEachAsync(res, async el => el.isDisplayed());
 
       if (!Array.isArray(selected)) selected = [selected];
       return selected.length === num;
@@ -1759,7 +1756,7 @@ class WebDriver extends Helper {
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return true;
-      const selected = await forEachAsync(res, async el => this.browser.isElementDisplayed(getElementId(el)));
+      const selected = await forEachAsync(res, async el => el.isDisplayed());
       return !selected.length;
     }, aSec * 1000, `element (${new Locator(locator)}) still visible after ${aSec} sec`);
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1004,7 +1004,7 @@ class WebDriver extends Helper {
    * * *Appium*: supported
    */
   async dontSeeElement(locator) {
-    const res = await this._locate(withStrictLocator(locator), true);
+    const res = await this._locate(withStrictLocator(locator), false);
     if (!res || res.length === 0) {
       return truth(`elements of ${locator}`, 'to be seen').negate(false);
     }


### PR DESCRIPTION
WebDriver helper's method `seeElement`.

`browser.isElementDisplayed(elemId)` will be  deprecated.
Changed to `elem.isDisplayed()`

https://webdriver.io/docs/api/element/isDisplayed.html

#1518
This PR fix WDIO call, but there are WDIO error, due to not implemented driver's API:
https://github.com/webdriverio/webdriverio/pull/3601