### PR TITLE
WDIO v5 - Updated some deprecated methods

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2057,7 +2057,8 @@ async function proceedSeeField(assertType, field, value) {
 
   const proceedMultiple = async (fields) => {
     const fieldResults = toArray(await forEachAsync(fields, async (el) => {
-      return el.getValue();
+      const elementId = getElementId(el);
+      return this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value');
     }));
 
     if (typeof value === 'boolean') {
@@ -2076,7 +2077,7 @@ async function proceedSeeField(assertType, field, value) {
   const filterSelectedByValue = async (elements, value) => {
     return filterAsync(elements, async (el) => {
       const elementId = getElementId(el);
-      const currentValue = await this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value');
+      const currentValue = this.browser.isW3C ? await el.getValue() : await this.browser.getElementAttribute(elementId, 'value');
       const isSelected = await this.browser.isElementSelected(elementId);
       return currentValue === value && isSelected;
     });

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -795,7 +795,7 @@ class WebDriver extends Helper {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
 
-    return forEachAsync(res, async el => this.browser.getElementAttribute(getElementId(el), 'value'));
+    return forEachAsync(res, async el => el.getValue());
   }
 
   /**
@@ -814,7 +814,7 @@ class WebDriver extends Helper {
   async grabAttributeFrom(locator, attr) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    return forEachAsync(res, async el => this.browser.getElementAttribute(getElementId(el), attr));
+    return forEachAsync(res, async el => el.getAttribute(attr));
   }
 
   /**
@@ -1116,7 +1116,7 @@ class WebDriver extends Helper {
     const elemAmount = res.length;
 
     let attrs = await forEachAsync(res, async (el) => {
-      return forEachAsync(Object.keys(attributes), async attr => this.browser.getElementAttribute(getElementId(el), attr));
+      return forEachAsync(Object.keys(attributes), async attr => el.getAttribute(attr));
     });
 
     const values = Object.keys(attributes).map(key => attributes[key]);
@@ -1628,7 +1628,7 @@ class WebDriver extends Helper {
       async () => {
         const res = await findFields.call(this, field);
         if (!res || res.length === 0) return false;
-        const selected = await forEachAsync(res, async el => this.browser.getElementAttribute(getElementId(el), 'value'));
+        const selected = await forEachAsync(res, async el => el.getValue());
         if (Array.isArray(selected)) {
           return selected.filter(part => part.indexOf(value) >= 0).length > 0;
         }
@@ -2057,7 +2057,7 @@ async function proceedSeeField(assertType, field, value) {
 
   const proceedMultiple = async (fields) => {
     const fieldResults = toArray(await forEachAsync(fields, async (el) => {
-      return this.browser.getElementAttribute(getElementId(el), 'value');
+      return el.getValue();
     }));
 
     if (typeof value === 'boolean') {
@@ -2076,13 +2076,13 @@ async function proceedSeeField(assertType, field, value) {
   const filterSelectedByValue = async (elements, value) => {
     return filterAsync(elements, async (el) => {
       const elementId = getElementId(el);
-      const currentValue = await this.browser.getElementAttribute(elementId, 'value');
+      const currentValue = await el.getValue();
       const isSelected = await this.browser.isElementSelected(elementId);
       return currentValue === value && isSelected;
     });
   };
 
-  const tag = await this.browser.getElementTagName(elemId);
+  const tag = await elem.getTagName();
   if (tag === 'select') {
     const subOptions = await this.browser.findElementsFromElement(elemId, 'css', 'option');
 
@@ -2097,7 +2097,7 @@ async function proceedSeeField(assertType, field, value) {
   }
 
   if (tag === 'input') {
-    const fieldType = await this.browser.getElementAttribute(elemId, 'type');
+    const fieldType = await elem.getAttribute('type');
 
     if (fieldType === 'checkbox' || fieldType === 'radio') {
       if (typeof value === 'boolean') {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2076,7 +2076,7 @@ async function proceedSeeField(assertType, field, value) {
   const filterSelectedByValue = async (elements, value) => {
     return filterAsync(elements, async (el) => {
       const elementId = getElementId(el);
-      const currentValue = await el.getValue();
+      const currentValue = await this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value');
       const isSelected = await this.browser.isElementSelected(elementId);
       return currentValue === value && isSelected;
     });


### PR DESCRIPTION
This PR updated some deprecated method names when running against wdio v5 with firefox for instance and will fix the issue in https://github.com/Codeception/CodeceptJS/issues/1524

- https://webdriver.io/docs/api/element/getTagName.html
- https://webdriver.io/docs/api/element/getAttribute.html
- https://webdriver.io/docs/api/element/getValue.html