### PR TITLE
fix locator's simplify call, fix toXPath function

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -1353,7 +1353,7 @@ function parseLocator(locator) {
   if (locator.type === 'css' && !this.isWeb) throw new Error('Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id');
   if (locator.type === 'name' && !this.isWeb) throw new Error("Can't locate element by name in Native context. Use either ID, class name or accessibility id");
   if (locator.type === 'id' && !this.isWeb && this.platform === 'android') return `//*[@resource-id='${locator.value}']`;
-  return locator.stringify();
+  return locator.simplify();
 }
 
 // in the end of a file

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -97,7 +97,7 @@ class Locator {
 
   toXPath() {
     if (this.isXPath()) return this.value;
-    if (this.isCSS) return cssToXPath(this.value);
+    if (this.isCSS()) return cssToXPath(this.value);
     throw new Error('Can\'t be converted to XPath');
   }
 


### PR DESCRIPTION
Fix error `TypeError: locator.stringify is not a function` for iOS app testing

https://stackoverflow.com/questions/54992632/codeceptjs-locator-stringify-is-not-a-function-error-while-running-codecept-with/

I think it will not fully fix error.
fuzzy selectors are not processed for iOS app testing