### PR TITLE
fixed 1561 properly

### DIFF
--- a/lib/assert/equal.js
+++ b/lib/assert/equal.js
@@ -6,6 +6,9 @@ const output = require('../output');
 class EqualityAssertion extends Assertion {
   constructor(params) {
     const comparator = function (a, b) {
+      if (b.length === 0) {
+        b = '';
+      }
       return a === b;
     };
     super(comparator, params);

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2069,9 +2069,6 @@ async function forEachAsync(array, callback, option = {}) {
       throw err;
     }
   }
-  if (values.length === 0) {
-    return '';
-  }
   return values;
 }
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2069,6 +2069,9 @@ async function forEachAsync(array, callback, option = {}) {
       throw err;
     }
   }
+  if (values.length === 0) {
+    return '';
+  }
   return values;
 }
 

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -206,6 +206,7 @@ describe('WebDriver', function () {
       }));
 
     it('should check text is not equal to empty string of element text', () => wd.amOnPage('https://codecept.discourse.group/')
+      .then(() => wd.seeTextEquals('', '[id="site-logo"]'))
       .then(() => wd.seeTextEquals('This is not empty', '[id="site-logo"]'))
       .catch((e) => {
         e.should.be.instanceOf(Error);


### PR DESCRIPTION
well the previous patch for `seeTextEquals` is not proper. This aims to make a proper fix.

I found the root cause, the problem is when `codeceptjs` try to get the text from the locator, it returns an `array`

```
const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
```
In this case, the locator has no text it returns an `empty array`. However the the text you want to compare is a `string`. And the `equals` method is 

```
const comparator = function (a, b) {
      return a === b;
    };
```

and by this, it returns `false`, even though both are empty but one is `string`, one is `array`. 