### PR TITLE
fix absolute path support

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -154,7 +154,9 @@ class Codecept {
     const mocha = container.mocha();
     mocha.files = this.testFiles;
     if (test) {
-      test = fsPath.join(global.codecept_dir, test);
+      if (!fsPath.isAbsolute(test)) {
+        test = fsPath.join(global.codecept_dir, test);
+      }
       mocha.files = mocha.files.filter(t => fsPath.basename(t, '.js') === test || t === test);
     }
     event.emit(event.all.before, this);


### PR DESCRIPTION
I found an issue with running a single test by absolute path, which doesn't allow to run or debug tests in WebStorm IDE