### PR TITLE
Fix typo. Improve order of prompts.

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -90,14 +90,8 @@ module.exports = function (initPath) {
     {
       name: 'steps',
       type: 'confirm',
-      message: 'Would you like to extend I object with custom steps?',
+      message: 'Would you like to extend the "I" object with custom steps?',
       default: true,
-    },
-    {
-      name: 'translation',
-      type: 'list',
-      message: 'Do you want to choose localization for tests?',
-      choices: translations,
     },
     {
       name: 'steps_file',
@@ -107,6 +101,12 @@ module.exports = function (initPath) {
       when(answers) {
         return answers.steps;
       },
+    },
+    {
+      name: 'translation',
+      type: 'list',
+      message: 'Do you want to choose localization for tests?',
+      choices: translations,
     },
   ]).then((result) => {
     const config = defaultConfig;


### PR DESCRIPTION
I think grouping the questions by topic makes sense - or why do I get asked about custom steps, then about translations and then about custom steps again? Any specific reason?