### PR TITLE
fix actor path replacement in page object template

### DIFF
--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -103,7 +103,7 @@ module.exports.pageObject = function (genPath, opts) {
       }
       actor = `require('${actorPath}')`;
     }
-    if (!safeFileWrite(pageObjectFile, pageObjectTemplate.replace('{{actor}}', actor))) return;
+    if (!safeFileWrite(pageObjectFile, pageObjectTemplate.replace('actor', actor))) return;
     const name = lcfirst(result.name) + ucfirst(kind);
     config.include[name] = result.filename;
 


### PR DESCRIPTION
Had a problem with extending actor object with my methods due to incorrect actor require in page object files:
Was: const I = actor();
Now: const I = require('../actor_path.js')();