### PR TITLE
Appium test fixes

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -985,10 +985,10 @@ class Appium extends Webdriver {
    * Perform a certain touch action on the screen such as swipeDown, swipeUp, swipeLeft, swipeRight.
    *
    * ```js
-   * I.swipeDown('swipeDown'); // perform swipe down on the screen
-   * I.swipeDown('swipeUp'); // perform swipe up on the screen
-   * I.swipeDown('swipeLeft'); // perform swipe left on the screen
-   * I.swipeDown('swipeRight'); // perform swipe right on the screen
+   * I.performTouchAction('swipeDown'); // perform swipe down on the screen
+   * I.performTouchAction('swipeUp'); // perform swipe up on the screen
+   * I.performTouchAction('swipeLeft'); // perform swipe left on the screen
+   * I.performTouchAction('swipeRight'); // perform swipe right on the screen
    * ```
    *
    * @param action
@@ -1026,6 +1026,7 @@ class Appium extends Webdriver {
   }
 
   /**
+   *
    * Perform a swipe left on an element.
    *
    * ```js

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -893,7 +893,13 @@ class Appium extends Webdriver {
   }
 
   async _swipeOnPercentage(from, to) {
-    SCREEN_SIZE = SCREEN_SIZE || await this.browser.getWindowRect();
+    if (!SCREEN_SIZE) {
+      if (this.browser.isW3C) {
+        SCREEN_SIZE = await this.browser.getWindowRect();
+      } else {
+        SCREEN_SIZE = await this.browser.getWindowSize();
+      }
+    }
     const pressOptions = this._getDeviceScreenCoordinates(SCREEN_SIZE, from);
     const moveToScreenCoordinates = this._getDeviceScreenCoordinates(SCREEN_SIZE, to);
     await this.performSwipe(

--- a/test/helper/Appium_test.js
+++ b/test/helper/Appium_test.js
@@ -88,7 +88,7 @@ describe('Appium', function () {
       },
     );
 
-    it.only('should remove App and install it again', () => app.seeAppIsInstalled('io.selendroid.testapp')
+    it('should remove App and install it again', () => app.seeAppIsInstalled('io.selendroid.testapp')
       .then(() => app.removeApp('io.selendroid.testapp'))
       .then(() => app.seeAppIsNotInstalled('io.selendroid.testapp'))
       .then(() => app.installApp(apk_path))
@@ -220,7 +220,7 @@ describe('Appium', function () {
       assert.equal(val, '.WebViewActivity');
     });
 
-    it('should react on swipe action @second', function* () {
+    it('should react on swipe action', function* () {
       yield app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
       yield app.waitForText(
         'Gesture Type', 10,
@@ -345,7 +345,7 @@ describe('Appium', function () {
     });
 
     describe('#performTouchAction', () => {
-      it('should react on swipeUp action', function* () {
+      it('should react on swipeUp action @second', function* () {
         yield app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
         yield app.waitForText(
           'Gesture Type', 10,
@@ -359,7 +359,7 @@ describe('Appium', function () {
         expect(vy.split(' ')[1]).to.be.below(1006);
       });
 
-      it('should react on swipeDown action', function* () {
+      it('should react on swipeDown action @second', function* () {
         yield app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
         yield app.waitForText(
           'Gesture Type', 10,


### PR DESCRIPTION
@PeterNgTr I'd like to open up your PR #1564 once again, as it appeared that all Appium tests were disabled and they actually didn't run :sob: 

So let's try to enable them once again, and see if they pass. 

Also, I didn't understand what should we do with current swipe* actions? I mean you implemented swipe via `performTouchAction`, however, there is no transition plan for current actions and API is not compatible.

Should we deprecate current swipe*? 
How should they be replaced with newer API?