### PR TITLE
Fix Puppeteer launch with browserWSEndpoint

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -404,10 +404,6 @@ class Puppeteer extends Helper {
         }
         throw err;
       }
-
-      // Clear any prior existing pages when connecting to remote websocket
-      await this.browser.newPage();
-      await this.closeOtherTabs();
     } else {
       this.browser = await puppeteer.launch(this.puppeteerOptions);
     }
@@ -425,6 +421,7 @@ class Puppeteer extends Helper {
       targetCreatedHandler.call(this, mainPage);
     }
     await this._setPage(mainPage);
+    await this.closeOtherTabs();
 
     if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0) {
       const dimensions = this.options.windowSize.split('x');


### PR DESCRIPTION
Puppeteer crashes with `WebSocket is not open: readyState 3 (CLOSED)` because we call `closeOtherTabs` before set a current page.

Example config
```
Puppeteer: {
            url: "http://localhost",
            chrome: {
                browserWSEndpoint: "ws://localhost:9990/devtools/browser/1bcc1a6c-faa7-42c2-a229-ac20ebac7b36",
                ignoreHTTPSErrors: true
            }
        },
```
