### PR TITLE
fixed the scrollTo does not work when running in mobile testing

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1299,7 +1299,7 @@ class WebDriver extends Helper {
       assertElementExists(res);
       const elem = usingFirstElement(res);
       const elementId = getElementId(elem);
-      if (this.browser.isMobile) return this.browser.touchScroll(elementId, offsetX, offsetY);
+      if (this.browser.isMobile) return this.browser.touchScroll(offsetX, offsetY, elementId);
       const location = await elem.getLocation();
       assertElementExists(location, 'Failed to receive', 'location');
       /* eslint-disable prefer-arrow-callback */


### PR DESCRIPTION
Fixed this issue
```
Lokyy   [Today at 2:43 PM]
Hello All , For Mobile Testing,  when I use,  I.scrollTo('some-locator'); is giving me the following error -  `Error: Malformed type for "xoffset" parameter of command touchScroll
 Expected: number
 Actual: string`
```