### PR TITLE
fixed WebDriver findFields() method: added label priority

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2216,7 +2216,7 @@ async function findFields(locator) {
   if (!locator.isFuzzy()) return this._locate(locator.simplify(), true);
 
   const literal = xpathLocator.literal(locator.value);
-  let els = await this._locate(Locator.field.labelEquals(literal));
+  let els = await this._locate(Locator.field.labelContains(literal));
   if (els.length) return els;
 
   els = await this._locate(Locator.field.byText(literal));

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2216,7 +2216,10 @@ async function findFields(locator) {
   if (!locator.isFuzzy()) return this._locate(locator.simplify(), true);
 
   const literal = xpathLocator.literal(locator.value);
-  let els = await this._locate(Locator.field.byText(literal));
+  let els = await this._locate(Locator.field.labelEquals(literal));
+  if (els.length) return els;
+
+  els = await this._locate(Locator.field.byText(literal));
   if (els.length) return els;
 
   els = await this._locate(Locator.field.byName(literal));


### PR DESCRIPTION
This PR fixes bug when you're try to fill field on page has field already filled with value included text from label of field you want to fill. Bug is appeared when second field placed under first field.

Example:
I.fillField('coolField', 'value includes label name for awesomeField')
I.fillField('awesomeField', 'new value') <-- this method will fill `coolField` instead of `awesomeField` cause Locator.field.byText() find first matches text, not label