### PR TITLE
Fixed ss name too long when using complex capabilities in run-multiple

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -121,7 +121,7 @@ function executeRun(runName, runConfig) {
   if (browserConfig.outputName) {
     outputDir += typeof browserConfig.outputName === 'function' ? browserConfig.outputName() : browserConfig.outputName;
   } else {
-    outputDir += JSON.stringify(browserConfig).replace(/[^\d\w]+/g, '_');
+    outputDir += JSON.stringify(browserName).replace(/[^\d\w]+/g, '_');
   }
   outputDir += `_${runId}`;
 


### PR DESCRIPTION
Fixed https://github.com/Codeception/CodeceptJS/issues/1636

Error: ENAMETOOLONG: name too long, open '/path/to/project/output/smoke__browser_firefox_desiredCapabilities_moz_firefoxOptions_args_purgecaches_window_size_375x667_prefs_general_useragent_override_Mozilla_5_0_iPhone_CPU_iPhone_OS_11_0_like_Mac_OS_X_AppleWebKit_604_1_38_KHTML_like_Gecko_Version_11_0_Mobile_15A372_Safari_604_1_log_level_trace_acceptInsecureCerts_true_selenoidOptions_enableVNC_true_enableLog_true_logName_session_log_log_sessionTimeout_10m__2/record_Add_virtual_selectio_1556886655/index.html