### PR TITLE
Update ts Locator definitions

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -29,14 +29,16 @@ declare class ScenarioConfig {
 }
 
 interface ILocator {
+  id?: string;
   xpath?: string;
   css?: string;
   name?: string;
-  value?: string;
   frame?: string;
   android?: string;
   ios?: string;
 }
+
+type LocatorOrString = string | ILocator | Locator;
 
 declare class Helper {
   /** Abstract method to provide required config options */
@@ -78,28 +80,22 @@ declare class Helper {
   debugSection(section: string, msg: string): void
 }
 
-declare class Locator implements ILocator {
-  xpath?: string;
-  css?: string;
-  name?: string;
-  value?: string;
-  frame?: string;
-  android?: string;
-  ios?: string;
+declare class Locator {
+  constructor(locator: LocatorOrString, defaultType?: string);
 
-  or(locator:string): Locator;
-  find(locator:string): Locator;
-  withChild(locator:string): Locator;
-  find(locator:string): Locator;
-  at(position:number): Locator;
+  or(locator: LocatorOrString): Locator;
+  find(locator: LocatorOrString): Locator;
+  withChild(locator: LocatorOrString): Locator;
+  withDescendant(locator: LocatorOrString): Locator;
+  at(position: number): Locator;
   first(): Locator;
   last(): Locator;
-  inside(locator:string): Locator;
-  before(locator:string): Locator;
-  after(locator:string): Locator;
-  withText(locator:string): Locator;
-  withAttr(locator:object): Locator;
-  as(locator:string): Locator;
+  inside(locator: LocatorOrString): Locator;
+  before(locator: LocatorOrString): Locator;
+  after(locator: LocatorOrString): Locator;
+  withText(text: string): Locator;
+  withAttr(attrs: object): Locator;
+  as(output: string): Locator;
 }
 
 
@@ -123,14 +119,10 @@ declare function BeforeSuite(callback: ICodeceptCallback): void;
 declare function After(callback: ICodeceptCallback): void;
 declare function AfterSuite(callback: ICodeceptCallback): void;
 
-declare function locate(selector: string): Locator;
-declare function locate(selector: ILocator): Locator;
-declare function within(selector: string, callback: Function): Promise<any>;
-declare function within(selector: ILocator, callback: Function): Promise<any>;
-declare function session(selector: string, callback: Function): Promise<any>;
-declare function session(selector: ILocator, callback: Function): Promise<any>;
-declare function session(selector: string, config: any, callback: Function): Promise<any>;
-declare function session(selector: ILocator, config: any, callback: Function): Promise<any>;
+declare function locate(selector: LocatorOrString): Locator;
+declare function within(selector: LocatorOrString, callback: Function): Promise<any>;
+declare function session(selector: LocatorOrString, callback: Function): Promise<any>;
+declare function session(selector: LocatorOrString, config: any, callback: Function): Promise<any>;
 declare function pause(): void;
 
 declare const codeceptjs: any;

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -121,8 +121,8 @@ declare function AfterSuite(callback: ICodeceptCallback): void;
 
 declare function locate(selector: LocatorOrString): Locator;
 declare function within(selector: LocatorOrString, callback: Function): Promise<any>;
-declare function session(selector: LocatorOrString, callback: Function): Promise<any>;
-declare function session(selector: LocatorOrString, config: any, callback: Function): Promise<any>;
+declare function session(selector: string, callback: Function): Promise<any>;
+declare function session(selector: string, config: any, callback: Function): Promise<any>;
 declare function pause(): void;
 
 declare const codeceptjs: any;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -60,7 +60,7 @@ function guessParamTypes(paramName) {
     case 'field':
     case 'context':
     case 'select':
-      return ['ILocator', 'string'];
+      return ['LocatorOrString'];
     case 'num':
     case 'sec':
     case 'width':

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -61,6 +61,64 @@ describe('Locator', () => {
     doc = new Dom().parseFromString(xml);
   });
 
+  describe('constructor', () => {
+    describe('with string argument', () => {
+      it('should create css locator', () => {
+        const l = new Locator('#foo');
+        expect(l.type).to.equal('css');
+        expect(l.value).to.equal('#foo');
+        expect(l.toString()).to.equal('#foo');
+      });
+
+      it('should create xpath locator', () => {
+        const l = new Locator('//foo[@bar="baz"]/*');
+        expect(l.type).to.equal('xpath');
+        expect(l.value).to.equal('//foo[@bar="baz"]/*');
+        expect(l.toString()).to.equal('//foo[@bar="baz"]/*');
+      });
+
+      it('should create fuzzy locator', () => {
+        const l = new Locator('foo');
+        expect(l.type).to.equal('fuzzy');
+        expect(l.value).to.equal('foo');
+        expect(l.toString()).to.equal('foo');
+      });
+
+      it('should create described custom default type locator', () => {
+        const l = new Locator('foo', 'defaultLocator');
+        expect(l.type).to.equal('defaultLocator');
+        expect(l.value).to.equal('foo');
+        expect(l.toString()).to.equal('foo');
+      });
+    });
+
+    describe('with object argument', () => {
+      it('should create id locator', () => {
+        const l = new Locator({ id: 'foo' });
+        expect(l.type).to.equal('id');
+        expect(l.value).to.equal('foo');
+        expect(l.toString()).to.equal('{id: foo}');
+      });
+
+      it('should create described custom locator', () => {
+        const l = new Locator({ customLocator: '=foo' });
+        expect(l.type).to.equal('customLocator');
+        expect(l.value).to.equal('=foo');
+        expect(l.toString()).to.equal('{customLocator: =foo}');
+      });
+    });
+
+    describe('with Locator object argument', () => {
+      it('should create id locator', () => {
+        const l = new Locator(new Locator({ id: 'foo' }));
+        expect(l).to.eql(new Locator({ id: 'foo' }));
+        expect(l.type).to.equal('id');
+        expect(l.value).to.equal('foo');
+        expect(l.toString()).to.equal('{id: foo}');
+      });
+    });
+  });
+
   it('should transform CSS to xpath', () => {
     const l = new Locator('p > #user', 'css');
     const nodes = xpath.select(l.toXPath(), doc);

--- a/test/unit/parser_test.js
+++ b/test/unit/parser_test.js
@@ -28,30 +28,22 @@ describe('parser', () => {
   describe('#toTypeDef', () => {
     it('should transform function to TS types', () => {
       const res = parser.toTypeDef(obj.method1);
-      expect(res).to.include('    method1(locator: ILocator, sec: number) : void');
-      expect(res).to.include('    method1(locator: string, sec: number) : void');
+      expect(res).to.include('    method1(locator: LocatorOrString, sec: number) : void');
     });
 
     it('should transform function to TS types', () => {
       const res = parser.toTypeDef(obj.method2);
-      expect(res).to.include('method2(locator: ILocator, value: string, sec: number) : void');
-      expect(res).to.include('method2(locator: string, value: string, sec: number) : void');
+      expect(res).to.include('method2(locator: LocatorOrString, value: string, sec: number) : void');
     });
 
     it('should transform function to TS types', () => {
       const res = parser.toTypeDef(obj.method3);
-      expect(res).to.include('method3(locator: ILocator, context: ILocator) : void');
-      expect(res).to.include('method3(locator: ILocator, context: string) : void');
-      expect(res).to.include('method3(locator: string, context: ILocator) : void');
-      expect(res).to.include('method3(locator: string, context: string) : void');
+      expect(res).to.include('method3(locator: LocatorOrString, context: LocatorOrString) : void');
     });
 
     it('should transform function to TS types', () => {
       const res = parser.toTypeDef(obj.method4);
-      expect(res).to.include('method4(locator: ILocator, context: ILocator) : void');
-      expect(res).to.include('method4(locator: ILocator, context: string) : void');
-      expect(res).to.include('method4(locator: string, context: ILocator) : void');
-      expect(res).to.include('method4(locator: string, context: string) : void');
+      expect(res).to.include('method4(locator: LocatorOrString, context: LocatorOrString) : void');
     });
   });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -36,6 +36,8 @@ declare module NodeJS {
     session: any;
     DataTable: any;
     locate: Locator,
+    inject: any,
+    secret: any,
     by: any;
 
     // Used by Protractor helper


### PR DESCRIPTION
Updated `ILocator` definition (not founded use of `value` and removed it, added `id`)

Simplify TS definitions for functions with `locator`.

Fixed tests for parser.
Added tests for locator constructor (not necessary, but why not).

Need some TS developers review for errors, style and improvements