### PR TITLE
Enable to show `toString()` in the each scenario names when it is defined

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -58,6 +58,13 @@ function replaceTitle(title, dataRow) {
     return `${title} | {${JSON.stringify(dataRow.data)}}`;
   }
 
+  // if `dataRow` is object and has own `toString()` method,
+  // it should be printed
+  if (Object.prototype.toString.call(dataRow.data) === (Object()).toString() &&
+    dataRow.data.toString() !== (Object()).toString()) {
+    return `${title} | ${dataRow.data}`;
+  }
+
   return `${title} | ${JSON.stringify(dataRow.data)}`;
 }
 

--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -60,8 +60,8 @@ function replaceTitle(title, dataRow) {
 
   // if `dataRow` is object and has own `toString()` method,
   // it should be printed
-  if (Object.prototype.toString.call(dataRow.data) === (Object()).toString() &&
-    dataRow.data.toString() !== (Object()).toString()) {
+  if (Object.prototype.toString.call(dataRow.data) === (Object()).toString()
+    && dataRow.data.toString() !== (Object()).toString()) {
     return `${title} | ${dataRow.data}`;
   }
 

--- a/test/unit/data/ui_test.js
+++ b/test/unit/data/ui_test.js
@@ -78,5 +78,21 @@ describe('ui', () => {
 
       dataScenarioConfig.scenarios.forEach(scenario => should.equal(helper, scenario.test.config[helperName]));
     });
+
+    it("should shows object's toString() method in each scenario's name if the toString() method is overrided", () => {
+      const data = [
+        {
+          toString: () => 'test case title',
+        },
+      ];
+      const dataScenarioConfig = context.Data(data).Scenario('scenario', () => {});
+      should.equal('scenario | test case title', dataScenarioConfig.scenarios[0].test.title);
+    });
+
+    it("should shows JSON.stringify() in each scenario's name if the toString() method isn't overrided", () => {
+      const data = [{ name: 'John Do' }];
+      const dataScenarioConfig = context.Data(data).Scenario('scenario', () => {});
+      should.equal(`scenario | ${JSON.stringify(data[0])}`, dataScenarioConfig.scenarios[0].test.title);
+    });
   });
 });


### PR DESCRIPTION
The [document](https://codecept.io/advanced#data-driven-tests) says:

> HINT: If you don't use DataTable. add toString() method to each object added to data set, so the data could be pretty printed in a test name



but it doesn't works, so this PR will fix it :)