### PR TITLE
Fix url autocompletion for REST helper

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -101,7 +101,7 @@ class REST extends Helper {
    * @param {*} url
    */
   _url(url) {
-    return url.indexOf('http') === -1 ? this.options.endpoint + url : url;
+    return /^\w+\:\/\//.test(url) ? url : this.options.endpoint + url;
   }
 
   /**

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -113,4 +113,18 @@ describe('REST', () => {
       });
     });
   });
+
+  describe('_url autocompletion', () => {
+    it('should not prepend base url, when url is absolute', () => {
+      I._url('https://bla.bla/blabla').should.eql('https://bla.bla/blabla');
+    });
+
+    it('should prepend base url, when url is not absolute', () => {
+      I._url('/blabla').should.eql(`${api_url}/blabla`);
+    });
+
+    it('should prepend base url, when url is not absolute, and "http" in request', () => {
+      I._url('/blabla&p=http://bla.bla').should.eql(`${api_url}/blabla&p=http://bla.bla`);
+    });
+  });
 });


### PR DESCRIPTION
Fix detection of urls without protocols in REST helper.

Fixes #1658

@DavertMik not sure, that tests for REST helper are running anywhere. Is it true?
