### PR TITLE
introduce grabAccessibilityTestResults method

### DIFF
--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -371,6 +371,32 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field`  located by label|name|CSS|XPath|strict locator.
 -   `value`  text value to fill.
 
+### grabAccessibilityTestResults
+
+Retrieves accessibility test results of given URL.
+If no URL is given, the URL in the config will be used.
+
+```js
+let results = await I.grabAccessibilityTestResults('http://localhost:8000/');
+
+//Returned results
+{ documentTitle: 'TestEd Beta 2.0',
+pageUrl: 'http://localhost:8000/',
+issues:
+[ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+context: '<html><head><title>TestEd Beta 2.0</t...</html>',
+message:
+'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+type: 'error',
+typeCode: 1,
+selector: 'html' } ] }
+```
+
+#### Parameters
+
+-   `url`   (optional, default url in the config file)
+-   `string`  url to grab accessibility test results
+
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -517,6 +517,32 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field`  located by label|name|CSS|XPath|strict locator.
 -   `value`  text value to fill.
 
+### grabAccessibilityTestResults
+
+Retrieves accessibility test results of given URL.
+If no URL is given, the URL in the config will be used.
+
+```js
+let results = await I.grabAccessibilityTestResults('http://localhost:8000/');
+
+//Returned results
+{ documentTitle: 'TestEd Beta 2.0',
+pageUrl: 'http://localhost:8000/',
+issues:
+[ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+context: '<html><head><title>TestEd Beta 2.0</t...</html>',
+message:
+'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+type: 'error',
+typeCode: 1,
+selector: 'html' } ] }
+```
+
+#### Parameters
+
+-   `url`   (optional, default url in the config file)
+-   `string`  url to grab accessibility test results
+
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -595,6 +595,32 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field`  located by label|name|CSS|XPath|strict locator.
 -   `value`  text value to fill.
 
+### grabAccessibilityTestResults
+
+Retrieves accessibility test results of given URL.
+If no URL is given, the URL in the config will be used.
+
+```js
+let results = await I.grabAccessibilityTestResults('http://localhost:8000/');
+
+//Returned results
+{ documentTitle: 'TestEd Beta 2.0',
+pageUrl: 'http://localhost:8000/',
+issues:
+[ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+context: '<html><head><title>TestEd Beta 2.0</t...</html>',
+message:
+'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+type: 'error',
+typeCode: 1,
+selector: 'html' } ] }
+```
+
+#### Parameters
+
+-   `url`   (optional, default url in the config file)
+-   `string`  url to grab accessibility test results
+
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -725,6 +725,32 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field`  located by label|name|CSS|XPath|strict locator.
 -   `value`  text value to fill.-   _Appium_: supported
 
+### grabAccessibilityTestResults
+
+Retrieves accessibility test results of given URL.
+If no URL is given, the URL in the config will be used.
+
+```js
+let results = await I.grabAccessibilityTestResults('http://localhost:8000/');
+
+//Returned results
+{ documentTitle: 'TestEd Beta 2.0',
+pageUrl: 'http://localhost:8000/',
+issues:
+[ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+context: '<html><head><title>TestEd Beta 2.0</t...</html>',
+message:
+'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+type: 'error',
+typeCode: 1,
+selector: 'html' } ] }
+```
+
+#### Parameters
+
+-   `url`   (optional, default url in the config file)
+-   `string`  url to grab accessibility test results
+
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.

--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -626,6 +626,32 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field`  located by label|name|CSS|XPath|strict locator.
 -   `value`  text value to fill.Appium: support
 
+### grabAccessibilityTestResults
+
+Retrieves accessibility test results of given URL.
+If no URL is given, the URL in the config will be used.
+
+```js
+let results = await I.grabAccessibilityTestResults('http://localhost:8000/');
+
+//Returned results
+{ documentTitle: 'TestEd Beta 2.0',
+pageUrl: 'http://localhost:8000/',
+issues:
+[ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+context: '<html><head><title>TestEd Beta 2.0</t...</html>',
+message:
+'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+type: 'error',
+typeCode: 1,
+selector: 'html' } ] }
+```
+
+#### Parameters
+
+-   `url`   (optional, default url in the config file)
+-   `string`  url to grab accessibility test results
+
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.

--- a/docs/webapi/grabAccessibilityTestResults.mustache
+++ b/docs/webapi/grabAccessibilityTestResults.mustache
@@ -1,0 +1,19 @@
+Retrieves accessibility test results of given URL.
+If no URL is given, the URL in the config will be used.
+
+```js
+let results = await I.grabAccessibilityTestResults('http://localhost:8000/');
+
+//Returned results
+{ documentTitle: 'TestEd Beta 2.0',
+  pageUrl: 'http://localhost:8000/',
+  issues:
+   [ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+       context: '<html><head><title>TestEd Beta 2.0</t...</html>',
+       message:
+        'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+       type: 'error',
+       typeCode: 1,
+       selector: 'html' } ] }
+```
+@param string url to grab accessibility test results

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -1157,6 +1157,15 @@ class Nightmare extends Helper {
     /* eslint-enable comma-dangle */
     return this.executeScript(getScrollPosition);
   }
+
+  /**
+   * {{> ../webapi/grabAccessibilityTestResults }}
+   */
+  async grabAccessibilityTestResults(url = this.options.url) {
+    const pa11y = requireg('pa11y');
+    const res = await pa11y(url);
+    return res;
+  }
 }
 
 module.exports = Nightmare;

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -1572,6 +1572,15 @@ class Protractor extends Helper {
   setCookie(cookie) {
     return this.browser.manage().addCookie(cookie);
   }
+
+  /**
+   * {{> ../webapi/grabAccessibilityTestResults }}
+   */
+  async grabAccessibilityTestResults(url = this.options.url) {
+    const pa11y = requireg('pa11y');
+    const res = await pa11y(url);
+    return res;
+  }
 }
 
 module.exports = Protractor;

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1887,6 +1887,15 @@ class Puppeteer extends Helper {
   async _waitForAction() {
     return this.wait(this.options.waitForAction / 1000);
   }
+
+  /**
+   * {{> ../webapi/grabAccessibilityTestResults }}
+   */
+  async grabAccessibilityTestResults(url = this.options.url) {
+    const pa11y = requireg('pa11y');
+    const res = await pa11y(url);
+    return res;
+  }
 }
 
 module.exports = Puppeteer;

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2064,6 +2064,15 @@ class WebDriver extends Helper {
   runInWeb(fn) {
     return fn();
   }
+
+  /**
+   * {{> ../webapi/grabAccessibilityTestResults }}
+   */
+  async grabAccessibilityTestResults(url = this.options.url) {
+    const pa11y = requireg('pa11y');
+    const res = await pa11y(url);
+    return res;
+  }
 }
 
 async function proceedSee(assertType, text, context, strict = false) {

--- a/lib/helper/WebDriverIO.js
+++ b/lib/helper/WebDriverIO.js
@@ -1838,6 +1838,15 @@ class WebDriverIO extends Helper {
   runInWeb(fn) {
     return fn();
   }
+
+  /**
+   * {{> ../webapi/grabAccessibilityTestResults }}
+   */
+  async grabAccessibilityTestResults(url = this.options.url) {
+    const pa11y = requireg('pa11y');
+    const res = await pa11y(url);
+    return res;
+  }
 }
 
 async function proceedSee(assertType, text, context, strict = false) {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "json-server": "^0.10.1",
     "nightmare": "^3.0.0",
     "nyc": "^11.9.0",
+    "pa11y": "^5.1.0",
     "protractor": "^5.4.1",
     "puppeteer": "^1.14.0",
     "rosie": "^1.6.0",

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -50,6 +50,19 @@ module.exports.tests = function () {
     });
   });
 
+  describe('#grabAccessibilityTestResults', () => {
+    it('should return results of url in config if no url is given', async () => {
+      const results = await I.grabAccessibilityTestResults();
+      assert.equal(results.pageUrl, `${siteUrl}/`);
+    });
+
+    it('should return results of given url', async () => {
+      const url = 'https://codecept.io';
+      const results = await I.grabAccessibilityTestResults(url);
+      assert.equal(results.pageUrl, `${url}/`);
+    });
+  });
+
   describe('#waitInUrl, #waitUrlEquals', () => {
     it('should wait part of the URL to match the expected', async () => {
       if (isHelper('Nightmare')) return;


### PR DESCRIPTION
**grabAccessibilityTestResults**
Retrieves accessibility test results of given URL. If no URL is given, the URL in the config will be used.


```javascript
let results = await I.grabAccessibilityTestResults('http://localhost:8000/');

//Returned results
{ documentTitle: 'TestEd Beta 2.0',
pageUrl: 'http://localhost:8000/',
issues:
[ { code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
context: '<html><head><title>TestEd Beta 2.0</t...</html>',
message:
'The html element should have a lang or xml:lang attribute which describes the language of the document.',
type: 'error',
typeCode: 1,
selector: 'html' } ] }
```

**Parameters**
- url (optional, default url in the config file)
- string url to grab accessibility test results