### PR TITLE
(feat): grab perfermance timing data - puppeteer helper

### DIFF
--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -658,6 +658,23 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
+### grabDataFromPerformanceTiming
+
+Grab the data from performance timing using Navigation Timing API
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+await I.amOnPage('https://example.com');
+let data = await I.grabDataFromPerformanceTiming();
+//Returned data
+{ // all results are in [ms]
+responseEnd: 23,
+domInteractive: 44,
+domContentLoadedEventEnd: 196,
+loadEventEnd: 241
+}
+```
+
 ### grabHTMLFrom
 
 Retrieves the innerHTML from an element located by CSS or XPath and returns it to test.

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -660,8 +660,14 @@ console.log(`Current URL is [${url}]`);
 
 ### grabDataFromPerformanceTiming
 
-Grab the data from performance timing using Navigation Timing API
-Resumes test execution, so **should be used inside an async function with `await`** operator.
+Grab the data from performance timing using Navigation Timing API.
+The returned data will contain following things in ms:
+
+-   responseEnd,
+-   domInteractive,
+-   domContentLoadedEventEnd,
+-   loadEventEnd
+    Resumes test execution, so **should be used inside an async function with `await`** operator.
 
 ```js
 await I.amOnPage('https://example.com');

--- a/docs/webapi/grabDataFromPerformanceTiming.mustache
+++ b/docs/webapi/grabDataFromPerformanceTiming.mustache
@@ -1,0 +1,14 @@
+Grab the data from performance timing using Navigation Timing API
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+await I.amOnPage('https://example.com');
+let data = await I.grabDataFromPerformanceTiming();
+//Returned data
+{ // all results are in [ms]
+  responseEnd: 23,
+  domInteractive: 44,
+  domContentLoadedEventEnd: 196,
+  loadEventEnd: 241
+}
+```

--- a/docs/webapi/grabDataFromPerformanceTiming.mustache
+++ b/docs/webapi/grabDataFromPerformanceTiming.mustache
@@ -1,4 +1,9 @@
-Grab the data from performance timing using Navigation Timing API
+Grab the data from performance timing using Navigation Timing API.
+The returned data will contain following things in ms:
+- responseEnd,
+- domInteractive,
+- domContentLoadedEventEnd,
+- loadEventEnd
 Resumes test execution, so **should be used inside an async function with `await`** operator.
 
 ```js

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -30,6 +30,7 @@ const fs = require('fs');
 
 
 let puppeteer;
+let perfTiming;
 const popupStore = new Popup();
 const consoleLogStore = new Console();
 
@@ -488,6 +489,17 @@ class Puppeteer extends Helper {
     this.context = await this.page.mainFrame().$('body');
   }
 
+  _extractDataFromPerformanceTiming(timing, ...dataNames) {
+    const navigationStart = timing.navigationStart;
+
+    const extractedData = {};
+    dataNames.forEach((name) => {
+      extractedData[name] = timing[name] - navigationStart;
+    });
+
+    return extractedData;
+  }
+
   /**
    * {{> ../webapi/amOnPage }}
    */
@@ -496,6 +508,17 @@ class Puppeteer extends Helper {
       url = this.options.url + url;
     }
     await this.page.goto(url, { waitUntil: this.options.waitForNavigation });
+
+    const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)));
+
+    perfTiming = this._extractDataFromPerformanceTiming(
+      performanceTiming,
+      'responseEnd',
+      'domInteractive',
+      'domContentLoadedEventEnd',
+      'loadEventEnd',
+    );
+
     return this._waitForAction();
   }
 
@@ -1886,6 +1909,13 @@ class Puppeteer extends Helper {
 
   async _waitForAction() {
     return this.wait(this.options.waitForAction / 1000);
+  }
+
+  /**
+   * {{> ../webapi/grabDataFromPerformanceTiming }}
+   */
+  async grabDataFromPerformanceTiming() {
+    return perfTiming;
   }
 }
 

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -2,6 +2,7 @@ const TestHelper = require('../support/TestHelper');
 const Puppeteer = require('../../lib/helper/Puppeteer');
 const puppeteer = require('puppeteer');
 const should = require('chai').should();
+const expect = require('chai').expect;
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
@@ -70,6 +71,17 @@ describe('Puppeteer', function () {
       await I.amOnPage(siteUrl);
       const url = await page.url();
       return url.should.eql(`${siteUrl}/`);
+    });
+  });
+
+  describe('grabDataFromPerformanceTiming', () => {
+    it('should return data from performance timing', async () => {
+      await I.amOnPage('/');
+      const res = await I.grabDataFromPerformanceTiming();
+      expect(res).to.have.property('responseEnd');
+      expect(res).to.have.property('domInteractive');
+      expect(res).to.have.property('domContentLoadedEventEnd');
+      expect(res).to.have.property('loadEventEnd');
     });
   });
 


### PR DESCRIPTION
**grabDataFromPerformanceTiming**
Grab the data from performance timing using Navigation Timing API Resumes test execution, so should be used inside an async function with await operator.

```javascript
await I.amOnPage('https://example.com');
let data = await I.grabDataFromPerformanceTiming();
//Returned data
{ // all results are in [ms]
responseEnd: 23,
domInteractive: 44,
domContentLoadedEventEnd: 196,
loadEventEnd: 241
}
```