### PR TITLE
Fixing path already exists error

### DIFF
--- a/lib/plugin/puppeteerCoverage.js
+++ b/lib/plugin/puppeteerCoverage.js
@@ -130,7 +130,12 @@ module.exports = function (config) {
               process.cwd(),
               options.coverageDir,
             );
-            fs.mkdirSync(coverageDir, { recursive: true });
+
+            // Checking if coverageDir already exists, if not, create new one
+
+            if (!fs.existsSync(coverageDir)) {
+              fs.mkdirSync(coverageDir, { recursive: true });
+            }
 
             const coveragePath = path.resolve(
               coverageDir,


### PR DESCRIPTION
When running multiple testing scenarios, the output coverage test fail with already exist error