### PR TITLE
Fix 'ERROR: ENAMETOOLONG' when creating screenshots directory

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -3,6 +3,7 @@ const {
 } = require('./utils');
 const fork = require('child_process').fork;
 const path = require('path');
+const crypto = require('crypto');
 const runHook = require('../hooks');
 const event = require('../event');
 const collection = require('./run-multiple/collection');
@@ -121,7 +122,9 @@ function executeRun(runName, runConfig) {
   if (browserConfig.outputName) {
     outputDir += typeof browserConfig.outputName === 'function' ? browserConfig.outputName() : browserConfig.outputName;
   } else {
-    outputDir += JSON.stringify(browserConfig).replace(/[^\d\w]+/g, '_');
+    const hash = crypto.createHash('md5');
+    hash.update(JSON.stringify(browserConfig));
+    outputDir += hash.digest('hex');
   }
   outputDir += `_${runId}`;
 


### PR DESCRIPTION
Issue https://github.com/Codeception/CodeceptJS/issues/1636
When browser config has many settings, it would try to create output folder with too long name. With this PR, it will hash the `browserConfig` object and use it as a part of output folder name.