### PR TITLE
Enable to use autoLogin without await

### DIFF
--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -1107,7 +1107,7 @@ I.scrollTo('#submit', 5, 5);
 
 -   `locator`  located by CSS|XPath|strict locator.
 -   `offsetX`  (optional) X-axis offset.
--   `offsetY`  (optional) Y-axis offset.-   _Appium_: supported only for web testing
+-   `offsetY`  (optional) Y-axis offset.
 
 ### scrollTo
 
@@ -1123,7 +1123,7 @@ I.scrollTo('#submit', 5, 5);
 
 -   `locator`  located by CSS|XPath|strict locator.
 -   `offsetX`  (optional) X-axis offset.
--   `offsetY`  (optional) Y-axis offset.
+-   `offsetY`  (optional) Y-axis offset.-   _Appium_: supported only for web testing
 
 ### see
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -257,6 +257,38 @@ plugins: {
 }
 ```
 
+#### Tips: Using async function in the autoLogin
+
+If you use async functions in the autoLogin plugin, login function should be used with `await` keyword.
+
+```js
+autoLogin: {
+  enabled: true,
+  saveToFile: true,
+  inject: 'login',
+  users: {
+    admin: {
+      login: async (I) => {  // If you use async function in the autoLogin plugin
+         const phrase = await I.grabTextFrom('#phrase')
+         I.fillField('username', 'admin'),
+         I.fillField('password', 'password')
+         I.fillField('phrase', phrase)
+      },
+      check: (I) => {
+         I.amOnPage('/');
+         I.see('Admin');
+      }
+    }
+  }
+}
+```
+
+```js
+Scenario('login', async (I, login) => {
+  await login('admin') // you should use `await`
+})
+```
+
 ### Parameters
 
 -   `config`  

--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -5,6 +5,7 @@ const container = require('../container');
 const store = require('../store');
 const recorder = require('../recorder');
 const debug = require('../output').debug;
+const isAsyncFunction = require('../utils').isAsyncFunction;
 
 const defaultUser = {
   fetch: I => I.grabCookie(),
@@ -176,6 +177,40 @@ const defaultConfig = {
  * }
  * ```
  *
+ * #### Tips: Using async function in the autoLogin
+ *
+ * If you use async functions in the autoLogin plugin, login function should be used with `await` keyword.
+ *
+ * ```js
+ * autoLogin: {
+ *   enabled: true,
+ *   saveToFile: true,
+ *   inject: 'login',
+ *   users: {
+ *     admin: {
+ *       login: async (I) => {  // If you use async function in the autoLogin plugin
+ *          const phrase = await I.grabTextFrom('#phrase')
+ *          I.fillField('username', 'admin'),
+ *          I.fillField('password', 'password')
+ *          I.fillField('phrase', phrase)
+ *       },
+ *       check: (I) => {
+ *          I.amOnPage('/');
+ *          I.see('Admin');
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * ```js
+ * Scenario('login', async (I, login) => {
+ *   await login('admin') // you should use `await`
+ * })
+ * ```
+ *
+ *
+ *
 */
 module.exports = function (config) {
   config = Object.assign(defaultConfig, config);
@@ -200,9 +235,16 @@ module.exports = function (config) {
     const userSession = config.users[name];
     const I = container.support('I');
     const cookies = store[`${name}_session`];
+    const shouldAwait = isAsyncFunction(userSession.login) ||
+      isAsyncFunction(userSession.restore) ||
+      isAsyncFunction(userSession.check);
 
     const loginAndSave = async () => {
-      await userSession.login(I);
+      if (shouldAwait) {
+        await userSession.login(I);
+      } else {
+        userSession.login(I);
+      }
       store.debugMode = true;
       const cookies = await userSession.fetch(I);
       if (config.saveToFile) {
@@ -218,8 +260,13 @@ module.exports = function (config) {
     store.debugMode = true;
 
     recorder.session.start('check login');
-    await userSession.restore(I, cookies);
-    await userSession.check(I);
+    if (shouldAwait) {
+      await userSession.restore(I, cookies);
+      await userSession.check(I);
+    } else {
+      userSession.restore(I, cookies);
+      userSession.check(I);
+    }
     recorder.session.catch((err) => {
       debug(`Failed auto login for ${name} due to ${err}`);
       debug('Logging in again');

--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -235,9 +235,9 @@ module.exports = function (config) {
     const userSession = config.users[name];
     const I = container.support('I');
     const cookies = store[`${name}_session`];
-    const shouldAwait = isAsyncFunction(userSession.login) ||
-      isAsyncFunction(userSession.restore) ||
-      isAsyncFunction(userSession.check);
+    const shouldAwait = isAsyncFunction(userSession.login)
+      || isAsyncFunction(userSession.restore)
+      || isAsyncFunction(userSession.check);
 
     const loginAndSave = async () => {
       if (shouldAwait) {


### PR DESCRIPTION
From v2.1.0, autologin plugin needs ｀await｀ syntax.

```js
// before v2.0.8
Scenario('login', (I) -> {
  login('foo')
})

//after v2.1.0
Scenario('login', async (I) -> {
  await login('foo')
})
```

Actually, `await` really needs when using async function in the autoLogin.
So that any functions invokes with `await` only if they are async function.
