### PR TITLE
fix: add Promise support to avoid UnhandledPromiseRejectionWarning

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2181,10 +2181,10 @@ function $XPath(element, selector) {
 function targetCreatedHandler(page) {
   if (!page) return;
   this.withinLocator = null;
-  page.on('load', frame => {
+  page.on('load', (frame) => {
     page.$('body')
       .catch(() => null)
-      .then(context => this.context = context)
+      .then(context => this.context = context);
   });
   page.on('console', (msg) => {
     this.debugSection(`Browser:${ucfirst(msg.type())}`, (msg._text || '') + msg.args().join(' '));

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2181,7 +2181,11 @@ function $XPath(element, selector) {
 function targetCreatedHandler(page) {
   if (!page) return;
   this.withinLocator = null;
-  page.on('load', frame => this.context = page.$('body'));
+  page.on('load', frame => {
+    page.$('body')
+      .catch(() => null)
+      .then(context => this.context = context)
+  });
   page.on('console', (msg) => {
     this.debugSection(`Browser:${ucfirst(msg.type())}`, (msg._text || '') + msg.args().join(' '));
     consoleLogStore.add(msg);


### PR DESCRIPTION
 fix: add Promise support to avoid UnhandledPromiseRejectionWarning on #page.on('load')# when #page.$('body')#