### PR TITLE
Add ts definition of secret function

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -124,6 +124,7 @@ declare function within(selector: LocatorOrString, callback: Function): Promise<
 declare function session(selector: string, callback: Function): Promise<any>;
 declare function session(selector: string, config: any, callback: Function): Promise<any>;
 declare function pause(): void;
+declare function secret(secret: any): string;
 
 declare const codeceptjs: any;
 


### PR DESCRIPTION
Add typescript definition of `secret` function for #1598 

In ideal, it should looks like `declare function secret<T>(secret: T): T;`
Because it get any param and return it as is. Only `humanizeArgs` change it to `"*****"`

But `fillField` in definitions requires string as argument:
 `fillField(field: LocatorOrString, value: string): void`

But it's not required in code - it use `value.toString()` (code from WebDriver helper):
```
  async fillField(field, value) {
    const res = await findFields.call(this, field);
    assertElementExists(res, field, 'Field');
    const elem = usingFirstElement(res);
    return elem.setValue(value.toString());
  }
```

Possible, it's better to change `toTypeDef` to generate `any` for `value` or in default case.
But it will require to do a correction of some helpers to make them using of `.toString`.

Anyway, I'll glad to see a review and suggestion.

Also, as a variant, it could be a `declare function secret(secret: any): any;` until changed described upper are made