### PR TITLE
Adding optional path parameter to bdd:snippets command

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -138,11 +138,11 @@ This scenarios are nice as live documentation but they do not test anything yet.
 Steps can be defined by executing `gherkin:snippets` command:
 
 ```bash
-codeceptjs gherkin:snippets
+codeceptjs gherkin:snippets [--path=PATH]
 ```
 
 This will produce code templates for all undefined steps in all feature files of this suite.
-It will also place stub definitions into `step_definitions/steps.js` file.
+It will also place stub definitions into `step_definitions/steps.js` file. However, you may also target a specific file to place all undefined steps in. This file must exist and be placed in the gherkin steps in the current config.
 Our next step will be to define those steps and transforming feature-file into a valid test.
 
 ### Step Definitions

--- a/lib/command/gherkin/snippets.js
+++ b/lib/command/gherkin/snippets.js
@@ -18,6 +18,7 @@ module.exports = function (genPath, options) {
   const testsPath = getTestRoot(configFile);
   const config = getConfig(configFile);
   if (!config) return;
+  output.print('Options.path: ', config);
 
   const codecept = new Codecept(config, {});
   codecept.init(testsPath);
@@ -34,6 +35,10 @@ module.exports = function (genPath, options) {
     output.error('No gherkin features defined in config. Exiting');
     process.exit(1);
   }
+  if(options.path && !config.gherkin.steps.includes(options.path)) {
+    output.error(`You must include ${options.path} to the gherkin steps in your config file`);
+    process.exit(1);
+  }
 
   const files = [];
   glob.sync(config.gherkin.features, { cwd: global.codecept_dir }).forEach((file) => {
@@ -42,6 +47,7 @@ module.exports = function (genPath, options) {
     }
     files.push(fsPath.resolve(file));
   });
+  output.print(`Loaded ${files}`);
   output.print(`Loaded ${files.length} files`);
 
   let newSteps = [];
@@ -81,7 +87,12 @@ module.exports = function (genPath, options) {
 
   files.forEach(file => parseFile(file));
 
-  let stepFile = config.gherkin.steps[0];
+  let stepFile = options.path || config.gherkin.steps[0];  
+  if (!fs.existsSync(stepFile)) {
+    output.error('Please enter a valid step file path ', stepFile);
+    process.exit(1);
+  }
+
   if (!fsPath.isAbsolute(stepFile)) {
     stepFile = fsPath.join(global.codecept_dir, stepFile);
   }
@@ -108,3 +119,4 @@ ${step.type}('${step}', () => {
     fs.writeFileSync(stepFile, fs.readFileSync(stepFile).toString() + snippets.join('\n') + '\n'); // eslint-disable-line
   }
 };
+

--- a/lib/command/gherkin/snippets.js
+++ b/lib/command/gherkin/snippets.js
@@ -18,7 +18,6 @@ module.exports = function (genPath, options) {
   const testsPath = getTestRoot(configFile);
   const config = getConfig(configFile);
   if (!config) return;
-  output.print('Options.path: ', config);
 
   const codecept = new Codecept(config, {});
   codecept.init(testsPath);
@@ -47,7 +46,6 @@ module.exports = function (genPath, options) {
     }
     files.push(fsPath.resolve(file));
   });
-  output.print(`Loaded ${files}`);
   output.print(`Loaded ${files.length} files`);
 
   let newSteps = [];
@@ -119,4 +117,3 @@ ${step.type}('${step}', () => {
     fs.writeFileSync(stepFile, fs.readFileSync(stepFile).toString() + snippets.join('\n') + '\n'); // eslint-disable-line
   }
 };
-

--- a/lib/command/gherkin/snippets.js
+++ b/lib/command/gherkin/snippets.js
@@ -34,7 +34,7 @@ module.exports = function (genPath, options) {
     output.error('No gherkin features defined in config. Exiting');
     process.exit(1);
   }
-  if(options.path && !config.gherkin.steps.includes(options.path)) {
+  if (options.path && !config.gherkin.steps.includes(options.path)) {
     output.error(`You must include ${options.path} to the gherkin steps in your config file`);
     process.exit(1);
   }
@@ -85,7 +85,7 @@ module.exports = function (genPath, options) {
 
   files.forEach(file => parseFile(file));
 
-  let stepFile = options.path || config.gherkin.steps[0];  
+  let stepFile = options.path || config.gherkin.steps[0];
   if (!fs.existsSync(stepFile)) {
     output.error('Please enter a valid step file path ', stepFile);
     process.exit(1);


### PR DESCRIPTION
In reference to #1171 this would allow a user to target a specific file to upload snippets do rather than the first file in the steps array. 

Usage "codeceptjs  bdd:snippets [--path=PATH]"

For this to work the file must already exist and be included in the config steps. 