### PR TITLE
Feature: add target folder parameter to def command

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -36,7 +36,7 @@ program.command('list [path]')
 program.command('def [path]')
   .description('Generates TypeScript definitions for all I actions.')
   .option('-c, --config [file]', 'configuration file to be used')
-  .option('--to [file]', 'target folder to paste definitions')
+  .option('-o, --output [folder]', 'target folder to paste definitions')
   .action(require('../lib/command/definitions'));
 
 program.command('gherkin:init [path]')

--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -36,6 +36,7 @@ program.command('list [path]')
 program.command('def [path]')
   .description('Generates TypeScript definitions for all I actions.')
   .option('-c, --config [file]', 'configuration file to be used')
+  .option('--to [file]', 'target folder to paste definitions')
   .action(require('../lib/command/definitions'));
 
 program.command('gherkin:init [path]')

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,6 +155,12 @@ Feature('My new test');
 
 After doing that IDE should provide autocompletion for `I` object inside `Scenario` and `within` blocks.
 
+Add optional parameter `to`, if you want to place your definition file in specific folder:
+
+```sh
+codeceptjs def --to ./tests/typings
+```
+
 ## List Commands
 
 Prints all available methods of `I` to console

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,10 +155,11 @@ Feature('My new test');
 
 After doing that IDE should provide autocompletion for `I` object inside `Scenario` and `within` blocks.
 
-Add optional parameter `to`, if you want to place your definition file in specific folder:
+Add optional parameter `output` (or shortcat `-o`), if you want to place your definition file in specific folder:
 
 ```sh
-codeceptjs def --to ./tests/typings
+codeceptjs def --output ./tests/typings
+codeceptjs def -o ./tests/typings
 ```
 
 ## List Commands

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -151,7 +151,7 @@ module.exports = function (genPath, options) {
   const config = getConfig(configFile);
   if (!config) return;
 
-  const targetFolderPath = options.to && getTestRoot(options.to) || testsPath;
+  const targetFolderPath = options.output && getTestRoot(options.output) || testsPath;
 
   const codecept = new Codecept(config, {});
   codecept.init(testsPath);

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -151,6 +151,8 @@ module.exports = function (genPath, options) {
   const config = getConfig(configFile);
   if (!config) return;
 
+  const targetFolderPath = options.to && getTestRoot(options.to) || testsPath;
+
   const codecept = new Codecept(config, {});
   codecept.init(testsPath);
 
@@ -189,7 +191,7 @@ module.exports = function (genPath, options) {
     definitionsTemplate = definitionsTemplate.replace(/\{\{I\}\}/g, translations.I);
   }
 
-  fs.writeFileSync(path.join(testsPath, 'steps.d.ts'), definitionsTemplate);
+  fs.writeFileSync(path.join(targetFolderPath, 'steps.d.ts'), definitionsTemplate);
   output.print('TypeScript Definitions provide autocompletion in Visual Studio Code and other IDEs');
   output.print('Definitions were generated in steps.d.ts');
   output.print('Load them by adding at the top of a test file:');


### PR DESCRIPTION
Added a param `--to`.
It will allow to generate file directly in described folder:

`codeceptjs def --to ./tests/typings`
will create file `<dir path>/tests/typings/steps.d.ts`

I am not sure about name of parameter, and should it generate file name or leave `steps.d.ts`?