### PR TITLE
Fix small typo (accoross => across)

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -277,7 +277,7 @@ within({frame: [".content", "#editor"]}, () => {
 
 ## Auto Login
 
-To share the same user session accoross different tests CodeceptJS provides [autoLogin plugin](https://codecept.io/plugins#autologin). It simplifies login management and reduces time consuming login operations. Instead of filling in login form before each test it saves the cookies of a valid user session and reuses it for next tests. If a session expires or doesn't exist, logs in a user again.
+To share the same user session across different tests CodeceptJS provides [autoLogin plugin](https://codecept.io/plugins#autologin). It simplifies login management and reduces time consuming login operations. Instead of filling in login form before each test it saves the cookies of a valid user session and reuses it for next tests. If a session expires or doesn't exist, logs in a user again.
 
 This plugin requires some configuration but is very simple in use:
 

--- a/docs/best.md
+++ b/docs/best.md
@@ -61,7 +61,7 @@ Scenario('editing a metric', async (I, loginAs, metricPage) => {
 
 ## Refactoring and PageObjects
 
-When a project is growing and more and more tests are required, it's time to think about reusing test code accoross the tests. Some common actions should be moved from tests to other files so to be accessible from different tests.
+When a project is growing and more and more tests are required, it's time to think about reusing test code across the tests. Some common actions should be moved from tests to other files so to be accessible from different tests.
 
 Here is a recommended strategy what to store where:
 


### PR DESCRIPTION
This PR fixes a small typo in the docs (accoross => across).