### PR TITLE
Fix extra comma in definition without pages

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -19,8 +19,8 @@ declare class FeatureConfig {
 }
 
 declare class ScenarioConfig {
-  throws(err: any) : ScenarioConfig;
-  fails() : ScenarioConfig;
+  throws(err: any): ScenarioConfig;
+  fails(): ScenarioConfig;
   retry(times: number): ScenarioConfig
   timeout(timeout: number): ScenarioConfig
   inject(inject: object): ScenarioConfig
@@ -117,13 +117,13 @@ declare interface IScenario {
 }
 declare function xScenario(title: string, callback: ICodeceptCallback): ScenarioConfig;
 declare function xScenario(title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;
-declare function Data(data: any): IData;
 declare interface IData {
   Scenario(title: string, callback: ICodeceptCallback): ScenarioConfig;
   Scenario(title: string, opts: {}, callback: ICodeceptCallback): ScenarioConfig;
   only: IScenario;
 }
-declare function xData(data: any): IScenario;
+declare function Data(data: any): IData;
+declare function xData(data: any): IData;
 declare function Before(callback: ICodeceptCallback): void;
 declare function BeforeSuite(callback: ICodeceptCallback): void;
 declare function After(callback: ICodeceptCallback): void;

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const path = require('path');
 
 const template = `
-type ICodeceptCallback = (i: CodeceptJS.{{I}}{{callbackParams}}, ...args: any) => void;
+type ICodeceptCallback = (i: CodeceptJS.{{I}}{{callbackParams}}) => void;
 
 declare class FeatureConfig {
   retry(times: number): FeatureConfig
@@ -194,7 +194,7 @@ module.exports = function (genPath, options) {
 
   let definitionsTemplate = template.replace('{{methods}}', methods.join(''));
   definitionsTemplate = definitionsTemplate.replace('{{exportPageObjects}}', exportPageObjects.join('\n'));
-  definitionsTemplate = definitionsTemplate.replace('{{callbackParams}}', `, ${callbackParams.join(', ')}`);
+  definitionsTemplate = definitionsTemplate.replace('{{callbackParams}}', `, ${[...callbackParams, '...args: any'].join(', ')}`);
   if (translations) {
     definitionsTemplate = definitionsTemplate.replace(/\{\{I\}\}/g, translations.I);
   }


### PR DESCRIPTION
Fixed a silly error made in #1687 

Without pages it generates double commas:
```js
type ICodeceptCallback = (i: CodeceptJS.I, , ...args: any) => void;
```

Also added `IData` interface for `xData` and fixed a couple of linter errors