### PR TITLE
fix references to support objects when using DI

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -161,23 +161,23 @@ function createHelpers(config) {
 }
 
 function createSupportObjects(config) {
-  const objects = {};
+  const objects = container.support = new Proxy({}, {
+    get(target, key) {
+      // configured but not in support object, yet: load the module
+      if (key in config && !(key in target)) target[key] = lazyLoad(key);
+      return target[key];
+    },
+  });
 
-  for (const name in config) {
-    objects[name] = {}; // placeholders
-  }
-
-  if (!objects.I) {
-    objects.I = require('./actor')();
+  if (!config.I) {
+    container.support.I = require('./actor')();
 
     if (container.translation.I !== 'I') {
-      objects[container.translation.I] = objects.I;
+      container.support[container.translation.I] = container.support.I;
     }
   }
 
-  container.support = objects;
-
-  for (const name in config) {
+  function lazyLoad(name) {
     let newObj = getSupportObject(config, name);
     try {
       if (typeof newObj === 'function') {
@@ -188,7 +188,7 @@ function createSupportObjects(config) {
     } catch (err) {
       throw new Error(`Initialization failed for ${name}: ${newObj}\n${err.message}`);
     }
-    Object.assign(objects[name], newObj);
+    return newObj;
   }
   const asyncWrapper = function (f) {
     return function () {

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -121,6 +121,16 @@ describe('Container', () => {
       assert.ok(container.support('I'));
     });
 
+    it('should load DI and return a reference to the module', () => {
+      container.create({
+        include: {
+          dummyPage: './data/dummy_page',
+        },
+      });
+      const dummyPage = require('../data/dummy_page');
+      container.support('dummyPage').should.be.equal(dummyPage);
+    });
+
     it('should load I from path and execute _init', () => {
       container.create({
         include: {


### PR DESCRIPTION
some change to how the support objects are initialized removed the original
reference to the support object and replaced it a "cloned" object. However,
since Object.assign was used, not all properties have been copied and especially
the original reference was lost.

This implementation uses a proxy object to load the injected modules on demand
and returns the original reference to the module. This should fix all usages
of support objects, where the type is not a plain object.

Fixes: #1679 