### PR TITLE
workaround for selenium standalone chrome issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ addons:
 services:
 - docker
 before_install:
-- docker pull selenium/standalone-chrome:latest
+- docker pull selenium/standalone-chrome:3.141.59-oxygen
 before_script:
-- docker run -d --net=host --shm-size=2g selenium/standalone-chrome:latest
+- docker run -d --net=host --shm-size=2g selenium/standalone-chrome:3.141.59-oxygen
 - export DBUS_SESSION_BUS_ADDRESS=/dev/null
 - export DISPLAY=:99.0
 - chmod -R 777 test/data


### PR DESCRIPTION
for some reason, using latest chrome fails the webdriver tests.
Stick to a version of selenium standalone + chrome which is known to work.