### PR TITLE
Allow Control between Specified Window Handles with WebDriver

### DIFF
--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -364,3 +364,47 @@ Function passed into session can use `I`, page objects, and any objects declared
 This function can also be declared as async (but doesn't work as generator).
 
 Also, you can use `within` inside a session but you can't call session from inside `within`.
+
+## Multiple Windows
+
+CodeceptJS allows to use several browser windows inside a test. 
+
+
+```js
+const assert = require('assert');
+
+Scenario('should open main page of configured site, open a popup, switch to main page, then switch to popup, close popup, and go back to main page', async (I) => {
+    I.amOnPage('/');
+    const handleBeforePopup = await I.grabCurrentWindowHandle();
+    const urlBeforePopup = await I.grabCurrentUrl();
+    const allHandlesBeforePopup = await I.grabAllWindowHandles();
+    assert.equal(allHandlesBeforePopup.length, 1, 'Single Window');
+
+    await I.executeScript(() => {
+        window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400');
+    });
+
+    const allHandlesAfterPopup = await I.grabAllWindowHandles();    
+    assert.equal(allHandlesAfterPopup.length, 2, 'Two Windows');
+
+    await I.switchToWindow(allHandlesAfterPopup[1]);
+    const urlAfterPopup = await I.grabCurrentUrl();    
+    assert.equal(urlAfterPopup, 'https://www.w3schools.com/', 'Expected URL: Popup');
+    
+    assert.equal(handleBeforePopup, allHandlesAfterPopup[0], 'Expected Window: Main Window');
+    await I.switchToWindow(handleBeforePopup);
+    const currentURL = await I.grabCurrentUrl();
+    assert.equal(currentURL, urlBeforePopup, 'Expected URL: Main URL');    
+
+    await I.switchToWindow(allHandlesAfterPopup[1]);
+    const urlAfterSwitchBack = await I.grabCurrentUrl();
+    assert.equal(urlAfterSwitchBack, 'https://www.w3schools.com/', 'Expected URL: Popup');        
+    await I.closeCurrentTab();
+
+    const allHandlesAfterPopupClosed = await I.grabAllWindowHandles();    
+    assert.equal(allHandlesAfterPopupClosed.length, 1, 'Single Window');
+    const currentWindowHandle = await I.grabCurrentWindowHandle();    
+    assert.equal(currentWindowHandle, allHandlesAfterPopup[0], 'Expected Window: Main Window');
+
+}).tag('@ProofOfConcept').tag('@grabAllWindowHandles').tag('@grabCurrentWindowHandle').tag('@switchToWindow');
+```

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -367,8 +367,7 @@ Also, you can use `within` inside a session but you can't call session from insi
 
 ## Multiple Windows
 
-CodeceptJS allows to use several browser windows inside a test. 
-
+CodeceptJS allows to use several browser windows inside a test. Sometimes we are testing the functionality of websites that we cannot control, such as a closed-source managed package, and there are popups that either remain open for configuring data on the screen, or close as a result of clicking a window. We can use these functions in order to gain more control over which page is being tested with Codecept at any given time. For example:
 
 ```js
 const assert = require('assert');

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1581,6 +1581,41 @@ class WebDriver extends Helper {
     await browser.buttonUp(0);
   }
 
+  /**
+   * Get all Window Handles.
+   * Useful for referencing a specific handle when calling `I.switchToWindow(handle)`
+   *
+   * ```js
+   * const handles = await I.getWindowHandles();
+   * ```
+   */
+  async getWindowHandles() {
+    return this.browser.getWindowHandles();
+  }
+
+  /**
+   * Get the current Window Handle.
+   * Useful for referencing it when calling `I.switchToWindow(handle)`
+   *
+   * ```js
+   * const handle = await I.getWindowHandle();
+   * ```
+   */
+  async getWindowHandle() {
+    return this.browser.getWindowHandle();
+  }
+
+  /**
+   * Switch to the window with a specified handle.
+   *
+   * ```js
+   * await I.switchToWindow( handle );
+   * ```
+   */
+  async switchToWindow(handle) {
+    await this.browser.switchToWindow(handle);
+  }
+
 
   /**
    * Close all tabs except for the current one.

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1586,10 +1586,10 @@ class WebDriver extends Helper {
    * Useful for referencing a specific handle when calling `I.switchToWindow(handle)`
    *
    * ```js
-   * const handles = await I.getWindowHandles();
+   * const windows = await I.grabAllWindowHandles();
    * ```
    */
-  async getWindowHandles() {
+  async grabAllWindowHandles() {
     return this.browser.getWindowHandles();
   }
 
@@ -1598,10 +1598,10 @@ class WebDriver extends Helper {
    * Useful for referencing it when calling `I.switchToWindow(handle)`
    *
    * ```js
-   * const handle = await I.getWindowHandle();
+   * const window = await I.grabCurrentWindowHandle();
    * ```
    */
-  async getWindowHandle() {
+  async grabCurrentWindowHandle() {
     return this.browser.getWindowHandle();
   }
 
@@ -1609,11 +1609,17 @@ class WebDriver extends Helper {
    * Switch to the window with a specified handle.
    *
    * ```js
-   * await I.switchToWindow( handle );
+   * const windows = await I.grabAllWindowHandles();
+   * // ... do something
+   * await I.switchToWindow( windows[0] );
+   *
+   * const window = await.grabCurrentWindowHandle();
+   * // ... do something
+   * await I.switchToWindow( window );
    * ```
    */
-  async switchToWindow(handle) {
-    await this.browser.switchToWindow(handle);
+  async switchToWindow(window) {
+    await this.browser.switchToWindow(window);
   }
 
 

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -693,4 +693,39 @@ describe('WebDriver', function () {
       await wd.dontSeeCheckboxIsChecked('interesting');
     });
   });
+
+  describe('allow back and forth between handles: #getWindowHandles #getWindowHandle #switchToWindow', () => {
+    it('should open main page of configured site, open a popup, switch to main page, then switch to popup, close popup, and go back to main page', function* () {
+      yield wd.amOnPage('/');
+      const handleBeforePopup = yield wd.getWindowHandle();
+      const urlBeforePopup = yield wd.grabCurrentUrl();
+
+      const allHandlesBeforePopup = yield wd.getWindowHandles();
+      allHandlesBeforePopup.length.should.eql(1);
+
+      yield wd.executeScript(() => {
+        window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400');
+      });
+
+      const allHandlesAfterPopup = yield wd.getWindowHandles();
+      allHandlesAfterPopup.length.should.eql(2);
+
+      yield wd.switchToWindow(allHandlesAfterPopup[1]);
+      const urlAfterPopup = yield wd.grabCurrentUrl();
+      urlAfterPopup.should.eql('https://www.w3schools.com/');
+
+      handleBeforePopup.should.eql(allHandlesAfterPopup[0]);
+      yield wd.switchToWindow(handleBeforePopup);
+      const currentURL = yield wd.grabCurrentUrl();
+      currentURL.should.eql(urlBeforePopup);
+
+      yield wd.switchToWindow(allHandlesAfterPopup[1]);
+      const urlAfterSwitchBack = yield wd.grabCurrentUrl();
+      urlAfterSwitchBack.should.eql('https://www.w3schools.com/');
+      yield wd.closeCurrentTab();
+
+      const allHandlesAfterPopupClosed = yield wd.getWindowHandles();
+      allHandlesAfterPopupClosed.length.should.eql(1);
+    });
+  });
 });

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -694,20 +694,20 @@ describe('WebDriver', function () {
     });
   });
 
-  describe('allow back and forth between handles: #getWindowHandles #getWindowHandle #switchToWindow', () => {
+  describe('allow back and forth between handles: #grabAllWindowHandles #grabCurrentWindowHandle #switchToWindow', () => {
     it('should open main page of configured site, open a popup, switch to main page, then switch to popup, close popup, and go back to main page', function* () {
       yield wd.amOnPage('/');
-      const handleBeforePopup = yield wd.getWindowHandle();
+      const handleBeforePopup = yield wd.grabCurrentWindowHandle();
       const urlBeforePopup = yield wd.grabCurrentUrl();
 
-      const allHandlesBeforePopup = yield wd.getWindowHandles();
+      const allHandlesBeforePopup = yield wd.grabAllWindowHandles();
       allHandlesBeforePopup.length.should.eql(1);
 
       yield wd.executeScript(() => {
         window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400');
       });
 
-      const allHandlesAfterPopup = yield wd.getWindowHandles();
+      const allHandlesAfterPopup = yield wd.grabAllWindowHandles();
       allHandlesAfterPopup.length.should.eql(2);
 
       yield wd.switchToWindow(allHandlesAfterPopup[1]);
@@ -724,8 +724,10 @@ describe('WebDriver', function () {
       urlAfterSwitchBack.should.eql('https://www.w3schools.com/');
       yield wd.closeCurrentTab();
 
-      const allHandlesAfterPopupClosed = yield wd.getWindowHandles();
+      const allHandlesAfterPopupClosed = yield wd.grabAllWindowHandles();
       allHandlesAfterPopupClosed.length.should.eql(1);
+      const currentWindowHandle = yield wd.grabCurrentWindowHandle();
+      currentWindowHandle.should.eql(handleBeforePopup);
     });
   });
 });


### PR DESCRIPTION
Sometimes we are testing the functionality of websites that we cannot control, such as a closed-source managed package of Salesforce, like ZQuotes within our instance. There are popups that either remain open for configuring data on the screen, or that close as a result of clicking a window, and we need more control over which page is being tested with Codecept at any given time. We use WebDriver to accomplish this. We have a workaround in place by using a custom helper, but it would be nice if these methods to control window handle properties on the Webdriver browser object were available in the core WebDeriver API.

- added methods to WebDriver and mocha test to WebDriver_test
- added mocha test 'allow back and forth between handles: #getWindowHandles #getWindowHandle #switchToWindow'