### PR TITLE
Fix Run-Multiple when `tests` is undefined

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -66,7 +66,9 @@ module.exports = function (selectedRuns, options) {
   runHook(config.bootstrapAll, done, 'bootstrapAll');
 
   if (options.config) { // update paths to config path
-    config.tests = path.resolve(testRoot, config.tests);
+    if (config.tests) {
+      config.tests = path.resolve(testRoot, config.tests);
+    }
     if (config.gherkin && config.gherkin.features) {
       config.gherkin.features = path.resolve(testRoot, config.gherkin.features);
     }


### PR DESCRIPTION
`config.tests` can be Undefined if the test suite only has Gherkin Files. 

When it's undefined, it throws an error: 

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at assertPath (path.js:39:11)
    at Object.resolve (path.js:1088:7)```