### PR TITLE
Fix issue 1161

### DIFF
--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -95,21 +95,33 @@ module.exports.test = (test) => {
  */
 module.exports.injected = function (fn, suite, hookName) {
   return function (done) {
-    recorder.errHandler((err) => {
+
+    const errHandler = (err) => {
       recorder.session.start('teardown');
       recorder.cleanAsyncErr();
       event.emit(event.test.failed, suite, err);
       if (hookName === 'after') event.emit(event.test.after, suite);
       if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
       recorder.add(() => done(err));
+    };
+
+    recorder.errHandler((err) => {
+      errHandler(err);
     });
 
     if (!fn) throw new Error('fn is not defined');
 
-    if (isAsyncFunction(fn)) {
       event.emit(event.hook.started, suite);
-      recorder.startUnlessRunning();
+    if(!recorder.isRunning()) {
+      recorder.start();
+      recorder.errHandler((err) => {
+        errHandler(err);
+      });
+    }
+
       this.test.body = fn.toString();
+
+    if (isAsyncFunction(fn)) {
       fn.apply(this, getInjectedArguments(fn)).then(() => {
         recorder.add('fire hook.passed', () => event.emit(event.hook.passed, suite));
         recorder.add(`finish ${hookName} hook`, () => done());
@@ -118,28 +130,23 @@ module.exports.injected = function (fn, suite, hookName) {
         recorder.throw(e);
         recorder.catch((e) => {
           const err = (recorder.getAsyncErr() === null) ? e : recorder.getAsyncErr();
-          recorder.session.start('teardown');
-          recorder.cleanAsyncErr();
-          event.emit(event.test.failed, suite, err);
-          if (hookName === 'after') event.emit(event.test.after, suite);
-          if (hookName === 'afterSuite') event.emit(event.suite.after, suite);
-          recorder.add(() => done(err));
+          errHandler(err);
         });
       });
       return;
     }
 
     try {
-      event.emit(event.hook.started, suite);
-      recorder.startUnlessRunning();
-      this.test.body = fn.toString();
-      const res = fn.apply(this, getInjectedArguments(fn));
-    } catch (err) {
-      recorder.throw(err);
-    } finally {
+      fn.apply(this, getInjectedArguments(fn));
       recorder.add('fire hook.passed', () => event.emit(event.hook.passed, suite));
       recorder.add(`finish ${hookName} hook`, () => done());
       recorder.catch();
+    } catch (err) {
+      recorder.throw(err);
+      recorder.catch((e) => {
+        const err = (recorder.getAsyncErr() === null) ? e : recorder.getAsyncErr();
+        errHandler(err);
+      });
     }
   };
 };

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -112,7 +112,7 @@ module.exports.injected = function (fn, suite, hookName) {
     if (!fn) throw new Error('fn is not defined');
 
       event.emit(event.hook.started, suite);
-    if(!recorder.isRunning()) {
+    if (!recorder.isRunning()) {
       recorder.start();
       recorder.errHandler((err) => {
         errHandler(err);


### PR DESCRIPTION
Root cause:
- Throwing an error in Scenario make recorder stopped. Then "after each" hook will restart recorder by using recorder.startUnlessRunning() and its error handler also will be reset to null. Finally, the hook cannot done and hang at this time.

Solution:
- Fix logic code