### PR TITLE
Improved interactive pause

### DIFF
--- a/lib/pause.js
+++ b/lib/pause.js
@@ -68,7 +68,18 @@ function parseInput(cmd) {
     const I = container.support('I');
 
     const fullCommand = `I.${cmd}`;
-    eval(fullCommand); // eslint-disable-line no-eval
+    const result = eval(fullCommand); // eslint-disable-line no-eval
+    result.then((val) => {
+      if (cmd.startsWith('see') || cmd.startsWith('dontSee')) {
+        output.print(output.styles.success('  OK  '), cmd);
+        return;
+      }
+      if (cmd.startsWith('grab')) {
+        output.print(output.styles.debug(val));
+      }
+    }).catch((err) => {
+      if (err.message) output.print(output.styles.error(' ERROR '), err.message);
+    });
 
     history.push(fullCommand); // add command to history when successful
   } catch (err) {


### PR DESCRIPTION
* show results for `grab*` methods
* show when assertions pass