### PR TITLE
fix: dynamic config applied for multiple helpers

### DIFF
--- a/lib/listener/config.js
+++ b/lib/listener/config.js
@@ -34,7 +34,7 @@ module.exports = function () {
         for (let name in context.config) {
           const config = context.config[name];
           if (name === '0') { // first helper
-            name = Object.keys(helpers);
+            name = Object.keys(helpers)[0];
           }
           const helper = helpers[name];
           updateHelperConfig(helper, config);


### PR DESCRIPTION
**type:** bug

**What was the exact problem:**
When dynamic config was set on default to picking `helper[0]`. At that time for multiple helpers, to apply config for the first helper ( `helper[0]` ), it was using an array of `helpers` as name to find `helpers[name]`.

In short,

```js
   if (name === '0') { // first helper
      name = Object.keys(helpers);
     // Now, typeof name is Array.
   }
   const helper = helpers[name];  // here, you can't use array to get particular helper
```


resolve #1742