### PR TITLE
fix(plugin): stepByStepReport unique report folder

### DIFF
--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -7,7 +7,8 @@ const fs = require('fs');
 const path = require('path');
 const figures = require('figures');
 const colors = require('chalk');
-const { template, clearString, deleteDir } = require('../utils');
+const crypto = require('crypto');
+const { template, deleteDir } = require('../utils');
 
 const supportedHelpers = [
   'WebDriverIO',
@@ -84,13 +85,13 @@ module.exports = function (config) {
   let slides = {};
   let error;
   let savedStep = null;
-  const uuid = Math.floor(new Date().getTime() / 1000);
   const recordedTests = {};
   const pad = '0000';
   const reportDir = config.output ? path.resolve(global.codecept_dir, config.output) : defaultConfig.output;
 
   event.dispatcher.on(event.test.before, (test) => {
-    dir = path.join(reportDir, `record_${clearString(test.title).substring(0, 20)}_${uuid}`);
+    const md5hash = crypto.createHash('md5').update(test.file + test.title).digest('hex');
+    dir = path.join(reportDir, `record_${md5hash}`);
     mkdirp.sync(dir);
     stepNum = 0;
     error = null;


### PR DESCRIPTION
Currently the generated report folder names collide when tests have similar titles.
For example when you have test titles which start with "As a customer I want to..."

Different tests will end up being reported in same folder:
`<dir>/record_As_a_customer_I_want_1561724771/index.html`

With this fix a `md5 hash` is generated to avoid collisions in the reporting folders.
To calculate the md5 hash, `test.file` and `test.title` is used, just in case duplicate titles exist in a project.

After fix:
`<dir>/record_d43336466a7e65faf417d9ea70b3df70/index.html`