### PR TITLE
fix: check for done is not falsy value

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -41,7 +41,9 @@ function loadCustomHook(module) {
 function callSync(callable, done) {
   if (isAsync(callable)) {
     callAsync(callable, done);
-    if (!hasArguments(callable)) done();
+    if (!hasArguments(callable) && done) {
+      done();
+    }
   } else if (hasArguments(callable)) {
     callable(done);
   } else {


### PR DESCRIPTION
**Why issue occurred?**
* `done` is being called as a function, while the value of it is `undefined`.


resolves #1745