### PR TITLE
fix(Puppeteer): checkRequirements failed when use only puppeteer-firefox

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -193,10 +193,12 @@ class Puppeteer extends Helper {
   }
 
   static _checkRequirements() {
+    const config = require('../config');
+    const browser = config.get('helpers').Puppeteer.browser || 'chrome';
     try {
-      requireg('puppeteer');
+      requireg(browser === 'firefox' ? 'puppeteer-firefox' : 'puppeteer');
     } catch (e) {
-      return ['puppeteer@^1.6.0'];
+      return [browser === 'firefox' ? 'puppeteer-firefox@^0.5.0' : 'puppeteer@^1.6.0'];
     }
   }
 

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -176,7 +176,6 @@ describe('CodeceptJS Multiple Runner', function () {
     const _codecept_run = `run-multiple --config ${codecept_dir}`;
     it('should be executed from async function in config', (done) => {
       exec(`${runner} ${_codecept_run}/codecept.async.bootstrapall.multiple.code.js default`, (err, stdout, stderr) => {
-        console.log(stdout);
         stdout.should.include('CodeceptJS'); // feature
         stdout.should.include('Results: inside Promise\n"event.multiple.before" is called');
         stdout.should.include('"teardownAll" is called.');


### PR DESCRIPTION
When require Puppeteer with puppeteer-firefox and not install puppeteer - I obtains exception:

```
Could not load helper Puppeteer from module '...':
Cannot read property 'browser' of undefined
```