### PR TITLE
fix: puppeteer scroll to locator

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -599,7 +599,7 @@ class Puppeteer extends Helper {
    * {{> scrollPageToTop }}
    */
   scrollPageToTop() {
-    return this.page.evaluate(() => {
+    return this.executeScript(() => {
       window.scrollTo(0, 0);
     });
   }
@@ -608,7 +608,7 @@ class Puppeteer extends Helper {
    * {{> scrollPageToBottom }}
    */
   scrollPageToBottom() {
-    return this.page.evaluate(() => {
+    return this.executeScript(() => {
       const body = document.body;
       const html = document.documentElement;
       window.scrollTo(0, Math.max(
@@ -638,9 +638,9 @@ class Puppeteer extends Helper {
       y = elementCoordinates.y;
     }
 
-    await this.page.evaluate((x, y) => {
-      window.scrollTo(x, y);
-    }, x + offsetX, y + offsetY);
+    await this.executeScript((scrollMethod, x, y) => {
+      window[scrollMethod](x, y);
+    }, locator ? 'scrollBy' : 'scrollTo', x + offsetX, y + offsetY);
     return this._waitForAction();
   }
 
@@ -1900,7 +1900,7 @@ class Puppeteer extends Helper {
         throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath');
       }
       return;
-    } else if (!locator) {
+    } if (!locator) {
       this.context = await this.page.mainFrame().$('body');
       return;
     }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -627,20 +627,16 @@ class Puppeteer extends Helper {
       offsetX = locator;
       locator = null;
     }
-    let x = 0;
-    let y = 0;
+
     if (locator) {
       const els = await this._locate(locator);
       assertElementExists(els, locator, 'Element');
       await els[0]._scrollIntoViewIfNeeded();
       const elementCoordinates = await els[0]._clickablePoint();
-      x = elementCoordinates.x;
-      y = elementCoordinates.y;
+      await this.executeScript((x, y) => window.scrollBy(x, y), elementCoordinates.x + offsetX, elementCoordinates.y + offsetY);
+    } else {
+      await this.executeScript((x, y) => window.scrollTo(x, y), offsetX, offsetY);
     }
-
-    await this.executeScript((scrollMethod, x, y) => {
-      window[scrollMethod](x, y);
-    }, locator ? 'scrollBy' : 'scrollTo', x + offsetX, y + offsetY);
     return this._waitForAction();
   }
 
@@ -1900,7 +1896,7 @@ class Puppeteer extends Helper {
         throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath');
       }
       return;
-    } if (!locator) {
+    } else if (!locator) {
       this.context = await this.page.mainFrame().$('body');
       return;
     }


### PR DESCRIPTION
**Problem** 
With the puppeteer helper using `I.scrollTo()` on an element that's well below the viewport won't scroll to the element. The browser will remain in the upper area of the page instead.

**Solution**
The `elementCoordinates` returned by `_clickablePoint()` are **viewport** coordinates  (not window coordinates). Since we have already scrolled to the element via `_scrollIntoViewIfNeeded()`, we need scrollBy (not scrollTo) those coordinates to bring the element to the top the way webdriver does.


**Problem 2** 
When switching to an iframe, scroll is not correctly applied. 

**Solution 2**
Using `executeScript` instead of `this.page.evaluate`, since `executeScript` uses the current context (`_locate`, `_scrollIntoViewIfNeeded` and `_clickablePoint` use the it as well).