### PR TITLE
Fix the --path option on gherkin:snippets

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -56,6 +56,7 @@ program.command('gherkin:snippets [path]')
   .description('Generate step defintions from steps.')
   .option('--dry-run', "don't save snippets to file")
   .option('-c, --config [file]', 'configuration file to be used')
+  .option('--path [file]', 'file in which to place the new snippets')
   .action(require('../lib/command/gherkin/snippets'));
 
 


### PR DESCRIPTION
PR https://github.com/Codeception/CodeceptJS/pull/1688 added support to direct new snippets to a specific file, but forgot to add the `--path` option to the command line parser.  Without this fix, `codeceptjs gherkin:snippets --path=foo` results in an error "error: unknown option `--path'"