### PR TITLE
feat: add 'run-workers' command

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -138,6 +138,15 @@ program.command('run-multiple [suites...]')
 
   .action(require('../lib/command/run-multiple'));
 
+program.command('run-workers [otherOptions...]')
+  .description('Executes tests in workers')
+  .option('-n, --workers <value>', 'number of workers', 3)
+  .option('-c, --config [file]', 'configuration file to be used')
+  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-o, --override [value]', 'override current config options')
+
+  .action(require('../lib/command/run-workers'));
+
 if (process.argv.length <= 2) {
   console.log(`CodeceptJS v${Codecept.version()}`);
   program.outputHelp();

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -10,6 +10,7 @@ const Codecept = require('../codecept');
 const Container = require('../container');
 const { Worker } = require('worker_threads');
 const { tryOrDefault } = require('../utils');
+const output = require('../output');
 
 const result = {};
 const TYPE = {
@@ -68,14 +69,15 @@ function createGroupsOfTests(files, numberOfGroups) {
 const pathToWorker = path.join(__dirname, 'workers', 'runTests.js');
 
 function createWorkers(groups, config, testRoot) {
-  const workers = groups.map(tests =>
-    new Worker(pathToWorker, {
+  const workers = groups.map((tests) => {
+    return new Worker(pathToWorker, {
       workerData: {
         config,
         tests,
         testRoot,
       },
-    }));
+    });
+  });
 
   return workers;
 }

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -98,8 +98,7 @@ function assignWorkerMethods(worker, totalWorkers) {
   worker.on('exit', () => {
     numberOfWorkersClosed++;
     if (numberOfWorkersClosed >= totalWorkers) {
-      Object.values(result).forEach(tests =>
-        tests.forEach(log => console.log(log)));
+      Object.values(result).forEach(tests => tests.forEach(log => console.log(log)));
     }
   });
 }

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -1,0 +1,111 @@
+const { satisfyNodeVersion, getConfig, getTestRoot } = require('./utils');
+// For Node version >=10.5.0, have to use experimental flag
+satisfyNodeVersion(
+  '>=11.7.0',
+  'Required minimum Node version of 11.7.0 to work with "run-workers"',
+);
+
+const path = require('path');
+const Codecept = require('../codecept');
+const Container = require('../container');
+const { Worker } = require('worker_threads');
+const { tryOrDefault } = require('../utils');
+
+const result = {};
+const TYPE = {
+  TEST_RESULT: 'test_result',
+};
+
+module.exports = function (_, options) {
+  const { workers, config: configPath, override = '' } = options;
+
+  const overrideConfigs = tryOrDefault(() => JSON.parse(override), {});
+  const numberOfWorkers = stringToNumber(workers, 3);
+
+  const config = {
+    ...getConfig(configPath),
+    ...overrideConfigs,
+  };
+  const testRoot = getTestRoot(configPath);
+  config.tests = path.resolve(testRoot, config.tests);
+
+  const testFiles = getTestFiles(config, testRoot);
+  const groups = createGroupsOfTests(testFiles, numberOfWorkers);
+
+  const workerList = createWorkers(groups, config, testRoot);
+  workerList.forEach(worker => assignWorkerMethods(worker, groups.length));
+};
+
+function getTestFiles(config, testRoot) {
+  const codecept = new Codecept(config, {});
+  codecept.init(testRoot);
+  codecept.loadTests();
+  return codecept.testFiles;
+}
+
+function createGroupsOfTests(files, numberOfGroups) {
+  const mocha = Container.mocha();
+  mocha.files = files;
+  mocha.loadFiles();
+
+  const groups = [];
+  let groupCounter = 0;
+
+  for (const suite of mocha.suite.suites) {
+    for (const test of suite.tests) {
+      const i = groupCounter % numberOfGroups;
+      if (groups[i] === undefined) groups[i] = [];
+      if (test) {
+        const { file, title } = test;
+        groups[i].push({ file, title });
+        groupCounter++;
+      }
+    }
+  }
+  return groups;
+}
+
+const pathToWorker = path.join(__dirname, 'workers', 'runTests.js');
+
+function createWorkers(groups, config, testRoot) {
+  const workers = groups.map(tests =>
+    new Worker(pathToWorker, {
+      workerData: {
+        config,
+        tests,
+        testRoot,
+      },
+    }));
+
+  return workers;
+}
+
+let numberOfWorkersClosed = 0;
+
+function assignWorkerMethods(worker, totalWorkers) {
+  worker.on('message', (message) => {
+    const { type, log, test } = message;
+
+    if (type === TYPE.TEST_RESULT) {
+      const { file } = test;
+      if (result[file] === undefined) result[file] = [];
+      result[file].push(log);
+    }
+  });
+
+  worker.on('exit', () => {
+    numberOfWorkersClosed++;
+    if (numberOfWorkersClosed >= totalWorkers) {
+      Object.values(result).forEach(tests =>
+        tests.forEach(log => console.log(log)));
+    }
+  });
+}
+
+const stringToNumber = (str, defaultValue) => {
+  const num = parseInt(str, 10);
+  if (Number.isNaN(num)) {
+    return defaultValue;
+  }
+  return num;
+};

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -3,6 +3,7 @@ const path = require('path');
 const output = require('../output');
 const { fileExists, beautify } = require('../utils');
 const util = require('util');
+const semver = require('semver');
 
 // alias to deep merge
 module.exports.deepMerge = require('../utils').deepMerge;
@@ -57,3 +58,29 @@ function safeFileWrite(file, contents) {
 }
 
 module.exports.safeFileWrite = safeFileWrite;
+
+module.exports.satisfyNodeVersion = (
+  version,
+  failureMessage = `Required Node version: ${version}`,
+) => {
+  if (!semver.satisfies(process.version, version)) {
+    fail(failureMessage);
+  }
+};
+
+module.exports.captureStream = (stream) => {
+  let oldStream;
+  let buffer = '';
+
+  return {
+    startCapture() {
+      buffer = '';
+      oldStream = stream.write.bind(stream);
+      stream.write = chunk => (buffer += chunk);
+    },
+    stopCapture() {
+      if (oldStream !== undefined) stream.write = oldStream;
+    },
+    getData: () => buffer,
+  };
+};

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -70,4 +70,3 @@ function onAllTestsCompleted() {
   event.dispatcher.removeListener(event.all.after, onTestComplete);
   parentPort.close();
 }
-

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -1,0 +1,73 @@
+const { parentPort, workerData } = require('worker_threads');
+const { captureStream } = require('../utils');
+const event = require('../../event');
+const tty = require('tty');
+
+if (!tty.getWindowSize) {
+  // this is really old method, long removed from Node, but Mocha
+  // reporters fall back on it if they cannot use `process.stdout.getWindowSize`
+  // we need to polyfill it.
+  tty.getWindowSize = () => [40, 80];
+}
+
+// Requiring of Codecept need to be after tty.getWindowSize is available.
+const Codecept = require('../../codecept');
+
+const { config, tests, testRoot } = workerData;
+const TYPE = { TEST_RESULT: 'test_result' };
+const captureLogs = captureStream(process.stdout);
+
+let n = 0;
+function runTest() {
+  if (n >= tests.length) {
+    return onAllTestsCompleted();
+  }
+
+  const { file, title } = tests[n];
+  config.grep = title;
+  const currentConfig = {
+    ...config,
+    tests: file,
+  };
+
+  // Load test and run
+  const codecept = new Codecept(currentConfig, {});
+  codecept.init(testRoot);
+  codecept.loadTests();
+
+  captureLogs.startCapture();
+  codecept.run();
+}
+runTest();
+
+// Adds listener for every test ends.
+event.dispatcher.on(event.all.after, onTestComplete);
+
+function onTestComplete() {
+  captureLogs.stopCapture();
+  const logs = captureLogs.getData();
+
+  /*  Removes lines like below-
+      > CodeceptJS v2.2.0
+      > Using test root "/home/User/Documents/CodeceptJS/test/"
+   */
+  const finalLogs = logs.replace(/((CodeceptJS|Using test root).*?\n)/gi, '');
+
+  sendToParentThread({
+    type: TYPE.TEST_RESULT,
+    log: finalLogs,
+    test: tests[n],
+  });
+  n++;
+  runTest();
+}
+
+function sendToParentThread(data) {
+  parentPort.postMessage(data);
+}
+
+function onAllTestsCompleted() {
+  event.dispatcher.removeListener(event.all.after, onTestComplete);
+  parentPort.close();
+}
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -363,3 +363,11 @@ module.exports.replaceValueDeep = function replaceValueDeep(obj, key, value) {
   }
   return obj;
 };
+
+module.exports.tryOrDefault = function (fn, defaultValue) {
+  try {
+    return fn();
+  } catch (_) {
+    return defaultValue;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "promise-retry": "^1.1.1",
     "requireg": "^0.1.8",
     "resq": "^1.5.0",
+    "semver": "^6.2.0",
     "sprintf-js": "^1.1.1"
   },
   "devDependencies": {

--- a/test/data/sandbox/codecept.workers.json
+++ b/test/data/sandbox/codecept.workers.json
@@ -1,0 +1,15 @@
+{
+  "tests": "./workers/*.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "FileSystem": {},
+    "Within": {
+      "require": "./within_helper"
+    }
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/workers/base_test.workers.js
+++ b/test/data/sandbox/workers/base_test.workers.js
@@ -1,0 +1,11 @@
+Feature('Workers');
+
+Scenario('say something', (I) => {
+  I.say('Hello Workers');
+});
+
+Scenario('glob current dir', (I) => {
+  I.amInPath('.');
+  I.say('hello world');
+  I.seeFile('codecept.glob.json');
+});

--- a/test/data/sandbox/workers/test_grep.workers.js
+++ b/test/data/sandbox/workers/test_grep.workers.js
@@ -1,9 +1,9 @@
-Feature('@feature_grep');
+Feature('@feature_grep in worker');
 
-Scenario('@1_grep print message 1', (I) => {
-  console.log('grep message 1');
+Scenario('From worker @1_grep print message 1', (I) => {
+  console.log('message 1');
 });
 
-Scenario('@2_grep print message 2', (I) => {
-  console.log('grep message 2');
+Scenario('From worker @2_grep print message 2', (I) => {
+  console.log('message 2');
 });

--- a/test/data/sandbox/workers/test_grep.workers.js
+++ b/test/data/sandbox/workers/test_grep.workers.js
@@ -1,0 +1,9 @@
+Feature('@feature_grep');
+
+Scenario('@1_grep print message 1', (I) => {
+  console.log('grep message 1');
+});
+
+Scenario('@2_grep print message 2', (I) => {
+  console.log('grep message 2');
+});


### PR DESCRIPTION
## What it includes?
- Added command `run-workers` to run tests in [workers](https://nodejs.org/docs/latest-v12.x/api/worker_threads.html).

## Description: 
Using `run-workers` command, you will be able to run tests in parallel with workers.
Tests will be divided into groups to run in each worker, and the result from each worker will be combined and shown by each file.



### Other
resolves #1775