### PR TITLE
fix: Crash when using  xScenario & Scenario.skip with tag

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -138,7 +138,7 @@ module.exports = function (suite) {
      * Pending test case.
      */
     context.xScenario = context.Scenario.skip = function (title) {
-      context.Scenario(title, {});
+      return context.Scenario(title, {});
     };
 
     addDataContext(context);


### PR DESCRIPTION
By returning the object of Scenario it continues to support other methods provided by Scenario.

resolves #1751