### PR TITLE
fix(getConfig): threw a non-informative message if the config loading failed

### DIFF
--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -11,7 +11,7 @@ module.exports.getConfig = function (configFile) {
   try {
     return require('../config').load(configFile);
   } catch (err) {
-    fail(err.message);
+    fail(err.stack);
   }
 };
 


### PR DESCRIPTION
When uses config with error, CodeceptJS throw non-informative message, like: 
```sh
$ codeceptjs run --config ./tests/codeceptjs/configs/ts.config.js --debug
Unexpected identifier
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

But with my fix, I get:
```sh
$ codeceptjs run --config ./tests/codeceptjs/configs/ts.config.js --debug
/home/avvorobey/git/form-builder/packages/codeceptjs/setup/bootstrap.ts:2
import codeceptjs from 'codeceptjs'
       ^^^^^^^^^^

SyntaxError: Unexpected identifier
    at Module._compile (internal/modules/cjs/loader.js:721:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/home/avvorobey/git/form-builder/tests/codeceptjs/configs/ts.config.js:54:14)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
```
