### PR TITLE
fix: use filename for uploadFile in webdriver

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -15,7 +15,6 @@ const {
   chunkArray,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
-  fileToBase64Zip,
 } = require('../utils');
 const {
   isColorProperty,
@@ -852,12 +851,11 @@ class WebDriver extends Helper {
     assertElementExists(res, locator, 'File field');
     const el = usingFirstElement(res);
 
-    // Remote Uplaod (when running Selenium Server)
+    // Remote Upload (when running Selenium Server)
     if (this.options.remoteFileUpload) {
-      const fileCompressed = await fileToBase64Zip(file);
       try {
         this.debugSection('File', 'Uploading file to remote server');
-        file = await this.browser.uploadFile(fileCompressed);
+        file = await this.browser.uploadFile(file);
       } catch (err) {
         throw new Error(`File can't be transferred to remote server. Set \`remoteFileUpload: false\` in config to upload file locally.\n${err.message}`);
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -281,26 +281,6 @@ module.exports.screenshotOutputFolder = function (fileName) {
   return path.join(global.codecept_dir, fileName);
 };
 
-module.exports.fileToBase64Zip = async function (localPath) {
-  const archiver = require('archiver');
-
-  const zipData = [];
-  const source = fs.createReadStream(localPath);
-
-  return new Promise((resolve, reject) => {
-    archiver('zip')
-      .on('error', (e) => { throw new Error(e); })
-      .on('data', data => zipData.push(data))
-      .on('end', () => resolve(Buffer.concat(zipData).toString('base64')))
-      .append(source, { name: path.basename(localPath) })
-      .finalize((err) => {
-        if (err) {
-          reject(err);
-        }
-      });
-  });
-};
-
 module.exports.beautify = function (code) {
   const format = require('js-beautify').js;
   return format(code, { indent_size: 2, space_in_empty_paren: true });


### PR DESCRIPTION
#### Problem
Using file content in base64 as an argument to `uploadFile`.
` Error: ENAMETOOLONG: name too long, open... `

#### Solution
Use filename as an argument to `uploadFile`.
#### Why?
Checkout official [doc](https://webdriver.io/blog/2019/06/25/file-upload.html)

