### PR TITLE
fix: missing support object definition in steps.d.ts

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -182,15 +182,16 @@ module.exports = function (genPath, options) {
   const supports = container.support(); // return all support objects
   const exportPageObjects = [];
   const callbackParams = [];
-  for (const name in supports) {
-    if (name === 'I') continue;
-    callbackParams.push(`${name}:CodeceptJS.${name}`);
+  // See #1795 and #1799, there's no obvious way to use for-in with Proxies
+  Reflect.ownKeys(supports).forEach((name) => {
+    if (name === 'I') return;
+    callbackParams.push(`${String(name)}:CodeceptJS.${String(name)}`);
     const pageObject = supports[name];
     const pageMethods = addAllMethodsInObject(pageObject, {}, []);
     let pageObjectExport = pageObjectTemplate.replace('{{methods}}', pageMethods.join(''));
-    pageObjectExport = pageObjectExport.replace('{{name}}', name);
+    pageObjectExport = pageObjectExport.replace('{{name}}', String(name));
     exportPageObjects.push(pageObjectExport);
-  }
+  });
 
   let definitionsTemplate = template.replace('{{methods}}', methods.join(''));
   definitionsTemplate = definitionsTemplate.replace('{{exportPageObjects}}', exportPageObjects.join('\n'));

--- a/lib/container.js
+++ b/lib/container.js
@@ -162,6 +162,12 @@ function createHelpers(config) {
 
 function createSupportObjects(config) {
   const objects = container.support = new Proxy({}, {
+    has(target, key) {
+      return key in config;
+    },
+    ownKeys() {
+      return Reflect.ownKeys(config);
+    },
     get(target, key) {
       // configured but not in support object, yet: load the module
       if (key in config && !(key in target)) target[key] = lazyLoad(key);

--- a/test/runner/list_test.js
+++ b/test/runner/list_test.js
@@ -47,4 +47,19 @@ describe('list/def commands', () => {
       done();
     });
   });
+
+  it('def should create definition file with support object', (done) => {
+    try {
+      fs.unlinkSync(`${codecept_dir}/steps.d.ts`);
+    } catch (e) {
+      // continue regardless of error
+    }
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, () => {
+      const content = fs.readFileSync(`${codecept_dir}/steps.d.ts`).toString();
+      content.should.include('    openDir() : void');
+      content.should.include('  export interface MyPage {');
+      content.should.include('    hasFile() : void');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Provide more proxy traps to inspect support object, so generating the definitions file works fine, again.

Fixes #1795 