### PR TITLE
Fix for snippets command with a .feature file that has special characters

### DIFF
--- a/lib/command/gherkin/snippets.js
+++ b/lib/command/gherkin/snippets.js
@@ -8,6 +8,7 @@ const { Parser } = require('gherkin');
 const glob = require('glob');
 const fsPath = require('path');
 const fs = require('fs');
+const escapeStringRegexp = require('escape-string-regexp');
 
 const parser = new Parser();
 parser.stopAtFirstError = false;
@@ -62,11 +63,21 @@ module.exports = function (genPath, options) {
       try {
         matchStep(step.text);
       } catch (err) {
-        let stepLine = step.text
-          .replace(/\"(.*?)\"/g, '{string}')
-          .replace(/(\d+\.\d+)/, '{float}')
-          .replace(/ (\d+) /, ' {int} ');
-        stepLine = Object.assign(stepLine, { type: step.keyword.trim(), location: step.location });
+        let stepLine;
+        if (/[{}()/]/.test(step.text)) {
+          stepLine = escapeStringRegexp(step.text)
+            .replace(/\//g, '\\/')
+            .replace(/\"(.*?)\"/g, '"(.*?)"')
+            .replace(/(\d+\\\.\d+)/, '(\\d+\\.\\d+)')
+            .replace(/ (\d+) /, ' (\\d+) ');
+          stepLine = Object.assign(stepLine, { type: step.keyword.trim(), location: step.location, regexp: true });
+        } else {
+          stepLine = step.text
+            .replace(/\"(.*?)\"/g, '{string}')
+            .replace(/(\d+\.\d+)/, '{float}')
+            .replace(/ (\d+) /, ' {int} ');
+          stepLine = Object.assign(stepLine, { type: step.keyword.trim(), location: step.location, regexp: false });
+        }
         newSteps.push(stepLine);
       }
     }
@@ -99,7 +110,7 @@ module.exports = function (genPath, options) {
     .filter((value, index, self) => self.indexOf(value) === index)
     .map((step) => {
       return `
-${step.type}('${step}', () => {
+${step.type}(${step.regexp ? '/^' + step + '$/' : "'" + step + "'"}, () => {
   // From "${step.file}" ${JSON.stringify(step.location)}
   throw new Error('Not implemented yet');
 });`;

--- a/lib/command/gherkin/snippets.js
+++ b/lib/command/gherkin/snippets.js
@@ -110,7 +110,7 @@ module.exports = function (genPath, options) {
     .filter((value, index, self) => self.indexOf(value) === index)
     .map((step) => {
       return `
-${step.type}(${step.regexp ? '/^' + step + '$/' : "'" + step + "'"}, () => {
+${step.type}(${step.regexp ? '/^' : "'"}${step}${step.regexp ? '$/' : "'"}, () => {
   // From "${step.file}" ${JSON.stringify(step.location)}
   throw new Error('Not implemented yet');
 });`;

--- a/test/data/sandbox/support/dummy.feature
+++ b/test/data/sandbox/support/dummy.feature
@@ -6,3 +6,11 @@ Feature: Login
     And I enter username "davert" and password "wow"
     And I submit 1 form
     Then I should log in
+    When I define a step with an opening paren ( only
+    And I define a step with a closing paren ) only
+    And I define a step with a opening brace { only
+    And I define a step with a closing brace } only
+    And I define a step with a slash http://example.com/foo
+    And I define a step with a ( paren and an 32 int
+    And I define a step with a ( paren and a 32.2 float
+    And I define a step with a ( paren and a "foo" string

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -222,42 +222,42 @@ Then('I should log in', () => {
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with an opening paren \( only$/, () => {
+When(/^I define a step with an opening paren \\( only$/, () => {
   // From "support/dummy.feature" {"line":9,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a closing paren \) only$/, () => {
+When(/^I define a step with a closing paren \\) only$/, () => {
   // From "support/dummy.feature" {"line":10,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a opening brace \{ only$/, () => {
+When(/^I define a step with a opening brace \\{ only$/, () => {
   // From "support/dummy.feature" {"line":11,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a closing brace \} only$/, () => {
+When(/^I define a step with a closing brace \\} only$/, () => {
   // From "support/dummy.feature" {"line":12,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a slash http:\/\/example\.com\/foo$/, () => {
+When(/^I define a step with a slash http:\\/\\/example\\.com\\/foo$/, () => {
   // From "support/dummy.feature" {"line":13,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a \( paren and an (\d+) int$/, () => {
+When(/^I define a step with a \\( paren and an (\\d+) int$/, () => {
   // From "support/dummy.feature" {"line":14,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a \( paren and a (\d+\.\d+) float$/, () => {
+When(/^I define a step with a \\( paren and a (\\d+\\.\\d+) float$/, () => {
   // From "support/dummy.feature" {"line":15,"column":5}
   throw new Error('Not implemented yet');
 });
 
-When(/^I define a step with a \( paren and a "(.*?)" string$/, () => {
+When(/^I define a step with a \\( paren and a "(.*?)" string$/, () => {
   // From "support/dummy.feature" {"line":16,"column":5}
   throw new Error('Not implemented yet');
 });`);

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -220,6 +220,46 @@ When('I submit {int} form', () => {
 Then('I should log in', () => {
   // From "support/dummy.feature" {"line":8,"column":5}
   throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with an opening paren \( only$/, () => {
+  // From "support/dummy.feature" {"line":9,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a closing paren \) only$/, () => {
+  // From "support/dummy.feature" {"line":10,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a opening brace \{ only$/, () => {
+  // From "support/dummy.feature" {"line":11,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a closing brace \} only$/, () => {
+  // From "support/dummy.feature" {"line":12,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a slash http:\/\/example\.com\/foo$/, () => {
+  // From "support/dummy.feature" {"line":13,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a \( paren and an (\d+) int$/, () => {
+  // From "support/dummy.feature" {"line":14,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a \( paren and a (\d+\.\d+) float$/, () => {
+  // From "support/dummy.feature" {"line":15,"column":5}
+  throw new Error('Not implemented yet');
+});
+
+When(/^I define a step with a \( paren and a "(.*?)" string$/, () => {
+  // From "support/dummy.feature" {"line":16,"column":5}
+  throw new Error('Not implemented yet');
 });`);
       assert(!err);
       done();


### PR DESCRIPTION
Fix issue when running snippets command with a .feature file that has steps with Gherkin special characters (any of  { } ( ) / )
Instead of creating strings, create regular expressions that will match
This fixes the problem where the generated snippets won't match the steps from the original .feature file