### PR TITLE
Remove default script timeout config.

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -393,9 +393,6 @@ class WebDriver extends Helper {
       keepCookies: false,
       keepBrowserState: false,
       deprecationWarnings: false,
-      timeouts: {
-        script: 1000, // ms
-      },
     };
 
 


### PR DESCRIPTION
On BrowserStack and current latest Appium available `v1.9.1` the following occurs when trying to run a test on a real iOS device:

`Parameters were incorrect. We wanted "MJSONWP protocol requires type and ms" and you sent {"script":1000}`.

I think this is a bug related to Appium on iOS. BrowserStack does not give any ETA when a newer Appium version will be available for iOS on their platform.

In the WebDriver spec the default script timeout is set to `30000 ms`, I think it is safe to fallback to that value. See https://w3c.github.io/webdriver/#timeouts.

Fix #1529