### PR TITLE
Fix TestCafe SwitchTo

### DIFF
--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -854,7 +854,9 @@ class TestCafe extends Helper {
     if (!locator) {
       return this.t.switchToMainWindow();
     }
-    return this.t.switchToIframe(findElements.call(this, this.context, locator));
+
+    const el = await findElements.call(this, this.context, locator);
+    return this.t.switchToIframe(el);
   }
 
   // TODO Add url assertions


### PR DESCRIPTION
Testcafe tests were failing sometimes due to a promise being passed to `this.t.switchToIframe`. By adding the await, we make sure that the promise is resolved before passing it.