### PR TITLE
refactor: check typeof arguments for mock requests in Polly

### DIFF
--- a/lib/helper/Polly.js
+++ b/lib/helper/Polly.js
@@ -52,6 +52,14 @@ class Polly extends Helper {
     }
   }
 
+  _validateConfig(config) {
+    const { url = '' } = config;
+    if (typeof url !== 'string') {
+      throw new Error(`Expected type of url(in Polly-config) is string, Found ${typeof url}.`);
+    }
+    return config;
+  }
+
   async _after() {
     await this.stopMocking();
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -306,6 +306,12 @@ function joinUrl(baseUrl, url) {
 }
 
 module.exports.appendBaseUrl = function (baseUrl = '', oneOrMoreUrls) {
+  if (typeof baseUrl !== 'string') {
+    throw new Error(`Invalid value for baseUrl: ${baseUrl}`);
+  }
+  if (!(typeof oneOrMoreUrls === 'string' || Array.isArray(oneOrMoreUrls))) {
+    throw new Error(`Expected type of Urls is 'string' or 'array', Found '${typeof oneOrMoreUrls}'.`);
+  }
   // Remove '/' if it's at the end of baseUrl
   const lastChar = baseUrl.substr(-1);
   if (lastChar === '/') {


### PR DESCRIPTION
Improve code coverage by checking the type of arguments.
resolves #1815