### PR TITLE
Update attachFile doc in TestCafe helper doc

### DIFF
--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -108,19 +108,16 @@ I.appendField('#myTextField', 'appended');
 
 ### attachFile
 
-Appends text to a input field or textarea.
-Field is located by name, label, CSS or XPath
+Attaches a file to element located by label, name, CSS or XPath. Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located). File will be uploaded to remote system (if tests are running remotely).
 
 ```js
-I.appendField('#myTextField', 'appended');
+I.attachFile('#myTextField', '/path/to/image_file.jpg');
 ```
 
 #### Parameters
 
 -   `field` ([string][3] \| [object][4]) located by label|name|CSS|XPath|strict locator
--   `pathToFile`  
--   `value` [string][3] text value to append.
-    
+-   `pathToFile` ([string][3]) local file path relative to codecept.json config file.
 
 
 ### checkOption

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -111,7 +111,7 @@ I.appendField('#myTextField', 'appended');
 Attaches a file to element located by label, name, CSS or XPath. Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located). File will be uploaded to remote system (if tests are running remotely).
 
 ```js
-I.attachFile('#myTextField', '/path/to/image_file.jpg');
+I.attachFile('#myTextField', 'data/avatar.jpg');
 ```
 
 #### Parameters


### PR DESCRIPTION
Used documentation from WebdriverIO helper doc to fill in the blanks/update TestCafe's own `attachFile` documentation.