### PR TITLE
CSS check to include `[` to determine if locator is CSS or not

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -261,7 +261,7 @@ module.exports = Locator;
 
 
 function isCSS(locator) {
-  return locator[0] === '#' || locator[0] === '.';
+  return locator[0] === '#' || locator[0] === '.' || locator[0] === '[';
 }
 
 function isAccessibility(locator) {


### PR DESCRIPTION
Many CSS starts with "[", specifically with `data` attributes. For an example "[data-automation="some-automation-attributes"]". Adding one more check to the CSS strategy.