### PR TITLE
fix run-multiple with typescript

### DIFF
--- a/lib/command/run-multiple/chunk.js
+++ b/lib/command/run-multiple/chunk.js
@@ -52,7 +52,7 @@ const grepFile = (file, grep) => {
 const mapFileFormats = (files) => {
   return {
     gherkin: files.filter(file => file.match(/\.feature$/)),
-    js: files.filter(file => file.match(/\.js$/)),
+    js: files.filter(file => file.match(/\.t|js$/)),
   };
 };
 


### PR DESCRIPTION
Currently, it is impossible to run tests in parallel with TS, as regex finds only `.js` files. 

I've just updated the regex.