### PR TITLE
Add NodeJS scope for EventEmitter

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -84,7 +84,7 @@ declare class Recorder {
 }
 
 declare class CodeceptJSEvent {
-  dispatcher: EventEmitter
+  dispatcher: NodeJS.EventEmitter
   test: {
     started: string
     before: string


### PR DESCRIPTION
Error `Cannot find name 'EventEmitter'.ts(2304)` ocures without fix

was added in https://github.com/Codeception/CodeceptJS/pull/1800