### PR TITLE
Use WebDriver capabilities config in wdio plugin

### DIFF
--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -203,7 +203,7 @@ module.exports = (config) => {
     if (launcher.onPrepare) {
       event.dispatcher.on(event.all.before, () => {
         recorder.add(`launcher ${name} start`, async () => {
-          await launcher.onPrepare(config);
+          await launcher.onPrepare(config, config.capabilities);
           output.debug(`Started ${name}`);
         });
       });
@@ -212,7 +212,7 @@ module.exports = (config) => {
     if (launcher.onComplete) {
       event.dispatcher.on(event.all.after, () => {
         recorder.add(`launcher ${name} start`, async () => {
-          await launcher.onComplete(process.exitCode, config);
+          await launcher.onComplete(process.exitCode, config, config.capabilities);
           output.debug(`Stopped ${name}`);
         });
       });


### PR DESCRIPTION
Currently the `wdio` plugin isn't passing in all the arguments it can and should according to the launcher construction method signature as [specified by webdriverio](https://webdriver.io/docs/customservices.html). This PR seeks to rectify that.

Fixes #1868 