### PR TITLE
Improve handling of xpath locators with round brackets

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -111,17 +111,17 @@ class Locator {
   }
 
   find(locator) {
-    const xpath = sprintf('%s//%s', this.toXPath(), removePrefix((new Locator(locator, 'css')).toXPath()));
+    const xpath = sprintf('%s//%s', this.toXPath(), convertToSubSelector(locator));
     return new Locator({ xpath });
   }
 
   withChild(locator) {
-    const xpath = sprintf('%s[./child::%s]', this.toXPath(), removePrefix((new Locator(locator, 'css')).toXPath()));
+    const xpath = sprintf('%s[./child::%s]', this.toXPath(), convertToSubSelector(locator));
     return new Locator({ xpath });
   }
 
   withDescendant(locator) {
-    const xpath = sprintf('%s[./descendant::%s]', this.toXPath(), removePrefix((new Locator(locator, 'css')).toXPath()));
+    const xpath = sprintf('%s[./descendant::%s]', this.toXPath(), convertToSubSelector(locator));
     return new Locator({ xpath });
   }
 
@@ -166,17 +166,17 @@ class Locator {
   }
 
   inside(locator) {
-    const xpath = sprintf('%s[ancestor::%s]', this.toXPath(), removePrefix((new Locator(locator, 'css')).toXPath()));
+    const xpath = sprintf('%s[ancestor::%s]', this.toXPath(), convertToSubSelector(locator));
     return new Locator({ xpath });
   }
 
   after(locator) {
-    const xpath = sprintf('%s[preceding-sibling::%s]', this.toXPath(), removePrefix((new Locator(locator, 'css')).toXPath()));
+    const xpath = sprintf('%s[preceding-sibling::%s]', this.toXPath(), convertToSubSelector(locator));
     return new Locator({ xpath });
   }
 
   before(locator) {
-    const xpath = sprintf('%s[following-sibling::%s]', this.toXPath(), removePrefix((new Locator(locator, 'css')).toXPath()));
+    const xpath = sprintf('%s[following-sibling::%s]', this.toXPath(), convertToSubSelector(locator));
     return new Locator({ xpath });
   }
 }
@@ -273,7 +273,20 @@ function isXPath(locator) {
   return trimmed === '//' || trimmed === './';
 }
 
+function isXPathStartingWithRoundBrackets(locator) {
+  return isXPath(locator) && locator[0] === '(';
+}
+
 function removePrefix(xpath) {
   return xpath
     .replace(/^(\.|\/)+/, '');
+}
+
+function convertToSubSelector(locator) {
+  const xpath = (new Locator(locator, 'css')).toXPath();
+  if (isXPathStartingWithRoundBrackets(xpath)) {
+    throw new Error('XPath with round brackets is not possible here! '
+      + 'May be a nested locator with at() last() or first() causes this error.');
+  }
+  return removePrefix(xpath);
 }

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -269,7 +269,8 @@ function isAccessibility(locator) {
 }
 
 function isXPath(locator) {
-  return locator.substr(0, 2) === '//' || locator.substr(0, 2) === './';
+  const trimmed = locator.replace(/^\(+/, '').substr(0, 2);
+  return trimmed === '//' || trimmed === './';
 }
 
 function removePrefix(xpath) {

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -156,7 +156,7 @@ describe('Locator', () => {
       .find('td')
       .first();
     const nodes = xpath.select(l.toXPath(), doc);
-    expect(nodes).to.have.length(1);
+    expect(nodes).to.have.length(1, l.toXPath());
     expect(nodes[0].firstChild.data).to.eql('Show');
   });
 
@@ -186,6 +186,18 @@ describe('Locator', () => {
         .withText('Also Edit'));
     const nodes = xpath.select(l.toXPath(), doc);
     expect(nodes).to.have.length(1, l.toXPath());
+  });
+
+  it('should throw an error when xpath with round brackets is nested', () => {
+    assert.throws(() => {
+      Locator.build('tr').find('(./td)[@id="id"]');
+    }, /round brackets/);
+  });
+
+  it('should throw an error when locator with specific position is nested', () => {
+    assert.throws(() => {
+      Locator.build('tr').withChild(Locator.build('td').first());
+    }, /round brackets/);
   });
 
   it('should not select element by deep nested siblings', () => {


### PR DESCRIPTION
After #1829 the locator functions `.at(i)`, `.first()` and `.last()` create xpath locators with round brackets. This may lead to "is not a valid XPath expression" exceptions (see #1866).

The changes of this PR
 * "allows xpath locators to start with round brackets" for the `isXPath()`-method
 * "prevents round brackets for nested selectors" by refactoring the old six times used  `removePrefix((new Locator(locator, 'css')).toXPath()))` expression to a new method called `convertToSubSelector(locator)` which also throws a specific error if the locator `isXPathStartingWithRoundBrackets`