### PR TITLE
fix #1874 Can not open more than one tab with webdriver helper

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -25,6 +25,7 @@ const ConnectionRefused = require('./errors/ConnectionRefused');
 const Locator = require('../locator');
 
 const webRoot = 'body';
+const uuidv4 = require('uuid/v4');
 
 /**
  * WebDriver helper which wraps [webdriverio](http://webdriver.io/) library to
@@ -1966,9 +1967,12 @@ class WebDriver extends Helper {
    * I.openNewTab();
    * ```
    */
-  async openNewTab() {
+  async openNewTab(url = 'about:blank', windowName = null) {
     const client = this.browser;
-    return client.newWindow('about:blank');
+    if (windowName == null) {
+      windowName = uuidv4();
+    }
+    return client.newWindow(url, windowName);
   }
 
   /**

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -25,7 +25,6 @@ const ConnectionRefused = require('./errors/ConnectionRefused');
 const Locator = require('../locator');
 
 const webRoot = 'body';
-const uuidv4 = require('uuid/v4');
 
 /**
  * WebDriver helper which wraps [webdriverio](http://webdriver.io/) library to
@@ -1969,8 +1968,9 @@ class WebDriver extends Helper {
    */
   async openNewTab(url = 'about:blank', windowName = null) {
     const client = this.browser;
+    const crypto = require('crypto');
     if (windowName == null) {
-      windowName = uuidv4();
+      windowName = crypto.randomBytes(32);
     }
     return client.newWindow(url, windowName);
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1970,7 +1970,7 @@ class WebDriver extends Helper {
     const client = this.browser;
     const crypto = require('crypto');
     if (windowName == null) {
-      windowName = crypto.randomBytes(32);
+      windowName = crypto.randomBytes(32).toString('hex');
     }
     return client.newWindow(url, windowName);
   }

--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "requireg": "^0.1.8",
     "resq": "^1.5.0",
     "semver": "^6.2.0",
-    "sprintf-js": "^1.1.1",
-    "uuid": "^3.3.3"
+    "sprintf-js": "^1.1.1"
   },
   "devDependencies": {
     "@codeceptjs/detox-helper": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "requireg": "^0.1.8",
     "resq": "^1.5.0",
     "semver": "^6.2.0",
-    "sprintf-js": "^1.1.1"
+    "sprintf-js": "^1.1.1",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@codeceptjs/detox-helper": "^1.0.1",


### PR DESCRIPTION
When using client.newWindow function in openNewTab, windowName parameter is not set. This makes impossible to open a second tab.

Adding optional parameters to openNewTab allows to fix this issue without having a breaking change