### PR TITLE
Improved retryFailedStep plugin

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -218,7 +218,7 @@ class Puppeteer extends Helper {
 
   async _before() {
     recorder.retry({
-      retries: 3,
+      retries: 5,
       when: err => err.message.indexOf('context') > -1, // ignore context errors
     });
     if (this.options.restart && !this.options.manualStart) return this._startBrowser();

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -72,7 +72,7 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.test.before, (test) => {
-    if (test.disableRetryFailedStep) return; // disable retry when a test is not active
+    if (test && test.disableRetryFailedStep) return; // disable retry when a test is not active
     recorder.retry(config);
   });
 };

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -3,6 +3,15 @@ const recorder = require('../recorder');
 
 const defaultConfig = {
   retries: 5,
+  defaultIgnoredSteps: [
+    'amOnPage',
+    'wait*',
+    'send*',
+    'execute*',
+    'run*',
+    'have*',
+  ],
+  ignoredSteps: [],
 };
 
 /**
@@ -33,8 +42,32 @@ const defaultConfig = {
  * * `minTimeout` - The number of milliseconds before starting the first retry. Default is 1000.
  * * `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
  * * `randomize` - Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
+ * * `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
+ *     * `amOnPage`
+ *     * `wait*`
+ *     * `send*`
+ *     * `execute*`
+ *     * `run*`
+ *     * `have*`
+ * * `ignoredSteps` - an array for custom steps to ignore on retry. Use it to append custom steps to ignored list.
+ * You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
+ * To append your own steps to ignore list - copy and paste a default steps list. Regexp values are accepted as well.
  *
- * ### Disable Per Test
+ * ##### Example
+ *
+ * ```js
+ * plugins: {
+ *     retryFailedStep: {
+ *         enabled: true,
+ *         ignoreSteps: [
+ *           'scroll*', // ignore all scroll steps
+ *           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
+ *         ]
+ *     }
+ * }
+ * ```
+ *
+ * ##### Disable Per Test
  *
  * This plugin can be disabled per test. In this case you will need to stet `I.retry()` to all flaky steps:
  *
@@ -49,6 +82,7 @@ const defaultConfig = {
  */
 module.exports = (config) => {
   config = Object.assign(defaultConfig, config);
+  config.ignoredSteps = config.ignoredSteps.concat(config.defaultIgnoredSteps);
   const customWhen = config.when;
 
   let enableRetry = false;
@@ -63,7 +97,12 @@ module.exports = (config) => {
   config.when = when;
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (step.name.startsWith('wait')) return;
+    // if a step is ignored - return
+    for (const ignored of config.ignoredSteps) {
+      if (step.name === ignored) return;
+      if (ignored instanceof RegExp && step.name.match(ignored)) return;
+      if (ignored.indexOf('*') && step.name.startsWith(ignored.slice(0, -1))) return;
+    }
     enableRetry = true; // enable retry for a step
   });
 

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -22,7 +22,7 @@ const defaultConfig = {
  * Run tests with plugin enabled:
  *
  * ```
- * codeceptjs run --plugins retryFailedStep
+ * npx codeceptjs run --plugins retryFailedStep
  * ```
  *
  * ##### Configuration:
@@ -34,14 +34,27 @@ const defaultConfig = {
  * * `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
  * * `randomize` - Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
  *
- * This plugin is very basic so it's recommended to improve it to match your custom needs.
+ * ### Disable Per Test
+ *
+ * This plugin can be disabled per test. In this case you will need to stet `I.retry()` to all flaky steps:
+ *
+ * Use scenario configuration to disable plugin for a test
+ *
+ * ```js
+ * Scenario('scenario tite', () => {
+ *    // test goes here
+ * }).config(test => test.disableRetryFailedStep = true)
+ * ```
  *
  */
 module.exports = (config) => {
   config = Object.assign(defaultConfig, config);
   const customWhen = config.when;
 
+  let enableRetry = false;
+
   const when = (err) => {
+    if (!enableRetry) return;
     const store = require('../store');
     if (store.debugMode) return false;
     if (customWhen) return customWhen(err);
@@ -49,7 +62,17 @@ module.exports = (config) => {
   };
   config.when = when;
 
+  event.dispatcher.on(event.step.started, (step) => {
+    if (step.name.startsWith('wait')) return;
+    enableRetry = true; // enable retry for a step
+  });
+
+  event.dispatcher.on(event.step.finished, (step) => {
+    enableRetry = false;
+  });
+
   event.dispatcher.on(event.test.before, (test) => {
+    if (test.disableRetryFailedStep) return; // disable retry when a test is not active
     recorder.retry(config);
   });
 };

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -88,7 +88,7 @@ module.exports = function (config) {
         fileName = fileName.substr(0, (fileName.indexOf('{') - 3)).trim();
       }
       if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
-      if (options.uniqueScreenshotNames) {
+      if (options.uniqueScreenshotNames && test) {
         const uuid = test.uuid || test.ctx.test.uuid || Math.floor(new Date().getTime() / 1000);
         fileName = `${fileName.substring(0, 10)}_${uuid}.failed.png`;
       } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,6 +140,7 @@ module.exports.chunkArray = function (arr, chunk) {
 };
 
 module.exports.clearString = function (str) {
+  if (!str) return '';
   /* Replace forbidden symbols in string
    */
   return str

--- a/test/data/sandbox/codecept.retryFailed.json
+++ b/test/data/sandbox/codecept.retryFailed.json
@@ -1,0 +1,19 @@
+{
+  "tests": "./*_test.retryFailed.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "Retry": {
+      "require": "./retry_helper.js"
+    }
+  },
+  "plugins": {
+    "retryFailedStep": {
+      "enabled": true,
+      "retries": 5
+    }
+  },
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/flaky_test.retryFailed.js
+++ b/test/data/sandbox/flaky_test.retryFailed.js
@@ -33,4 +33,3 @@ Scenario('no retries if disabled per test @test3', async (I) => {
 After(() => {
   console.log(`[T] Retries: ${tries}`);
 });
-

--- a/test/data/sandbox/flaky_test.retryFailed.js
+++ b/test/data/sandbox/flaky_test.retryFailed.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+
+let tries = 0;
+
+Feature('Retry');
+
+Scenario('auto repeat failing step @test1', async (I) => {
+  tries++;
+  await I.failWhen(() => {
+    tries++;
+    return tries < 5;
+  });
+  assert.equal(tries, 5);
+  console.log(`[T] Retries: ${tries}`);
+});
+
+Scenario('no repeat for waiter @test2', async (I) => {
+  await I.waitForFail(() => {
+    tries++;
+    return tries < 5;
+  });
+  assert.equal(tries, 1);
+});
+
+Scenario('no retries if disabled per test @test3', async (I) => {
+  await I.failWhen(() => {
+    tries++;
+    return tries < 5;
+  });
+  assert.equal(tries, 1);
+}).config(test => test.disableRetryFailedStep = true);
+
+After(() => {
+  console.log(`[T] Retries: ${tries}`);
+});
+

--- a/test/data/sandbox/retry_helper.js
+++ b/test/data/sandbox/retry_helper.js
@@ -4,6 +4,10 @@ class Retry extends Helper {
   failWhen(fn) {
     if (fn()) throw new Error('ups, error');
   }
+
+  waitForFail(fn) {
+    if (fn()) throw new Error('ups, error');
+  }
 }
 
 module.exports = Retry;

--- a/test/runner/interface_test.js
+++ b/test/runner/interface_test.js
@@ -36,6 +36,35 @@ describe('CodeceptJS Interface', () => {
   });
 
 
+  it('should use retryFailedStep plugin for failed steps', (done) => {
+    exec(`${config_run_config('codecept.retryFailed.json')} --grep @test1`, (err, stdout, stderr) => {
+      stdout.should.include('Retry'); // feature
+      stdout.should.include('Retries: 5'); // test name
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should not retry wait* steps in retryFailedStep plugin', (done) => {
+    exec(`${config_run_config('codecept.retryFailed.json')} --grep @test2`, (err, stdout, stderr) => {
+      stdout.should.include('Retry'); // feature
+      stdout.should.not.include('Retries: 5');
+      stdout.should.include('Retries: 1');
+      assert(err);
+      done();
+    });
+  });
+
+  it('should not retry steps if retryFailedStep plugin disabled', (done) => {
+    exec(`${config_run_config('codecept.retryFailed.json')} --grep @test3`, (err, stdout, stderr) => {
+      stdout.should.include('Retry'); // feature
+      stdout.should.not.include('Retries: 5');
+      stdout.should.include('Retries: 1');
+      assert(err);
+      done();
+    });
+  });
+
   it('should include grep option tests', (done) => {
     exec(config_run_config('codecept.grep.json'), (err, stdout, stderr) => {
       stdout.should.include('Got login davert and password'); // feature

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -16,9 +16,15 @@ describe('retryFailedStep', () => {
     });
     recorder.start();
   });
+
+  afterEach(() => {
+    event.dispatcher.emit(event.step.finished, { });
+  });
+
   it('should retry failed step', async () => {
     retryFailedStep({ retries: 2, minTimeout: 1 });
-    event.dispatcher.emit(event.test.before);
+    event.dispatcher.emit(event.test.before, {});
+    event.dispatcher.emit(event.step.started, { name: 'click' });
 
     let counter = 0;
     recorder.add(() => {
@@ -31,10 +37,10 @@ describe('retryFailedStep', () => {
   });
   it('should not retry within', async () => {
     retryFailedStep({ retries: 1, minTimeout: 1 });
-    event.dispatcher.emit(event.test.before);
+    event.dispatcher.emit(event.test.before, {});
 
     let counter = 0;
-
+    event.dispatcher.emit(event.step.started, { name: 'click' });
     try {
       within('foo', () => {
         recorder.add(() => {
@@ -50,10 +56,34 @@ describe('retryFailedStep', () => {
     // expects to retry only once
     counter.should.equal(2);
   });
+
+  it('should not retry steps with wait*', async () => {
+    retryFailedStep({ retries: 2, minTimeout: 1 });
+    event.dispatcher.emit(event.test.before, {});
+
+    let counter = 0;
+    event.dispatcher.emit(event.step.started, { name: 'waitForElement' });
+    try {
+      recorder.add(() => {
+        counter++;
+        if (counter < 3) {
+          throw new Error();
+        }
+      });
+      await recorder.promise();
+    } catch (e) {
+      recorder.catchWithoutStop((err) => {
+      });
+    }
+
+    counter.should.equal(1);
+    // expects to retry only once
+  });
+
   it('should not retry session', async () => {
     retryFailedStep({ retries: 1, minTimeout: 1 });
-    event.dispatcher.emit(event.test.before);
-
+    event.dispatcher.emit(event.test.before, {});
+    event.dispatcher.emit(event.step.started, { name: 'click' });
     let counter = 0;
 
     try {

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -80,6 +80,53 @@ describe('retryFailedStep', () => {
     // expects to retry only once
   });
 
+  it('should not retry steps with amOnPage', async () => {
+    retryFailedStep({ retries: 2, minTimeout: 1 });
+    event.dispatcher.emit(event.test.before, {});
+
+    let counter = 0;
+    event.dispatcher.emit(event.step.started, { name: 'amOnPage' });
+    try {
+      recorder.add(() => {
+        counter++;
+        if (counter < 3) {
+          throw new Error();
+        }
+      });
+      await recorder.promise();
+    } catch (e) {
+      recorder.catchWithoutStop((err) => {
+      });
+    }
+
+    counter.should.equal(1);
+    // expects to retry only once
+  });
+
+
+  it('should add custom steps to ignore', async () => {
+    retryFailedStep({ retries: 2, minTimeout: 1, ignoredSteps: ['somethingNew*'] });
+    event.dispatcher.emit(event.test.before, {});
+
+    let counter = 0;
+    event.dispatcher.emit(event.step.started, { name: 'somethingNew' });
+    try {
+      recorder.add(() => {
+        counter++;
+        if (counter < 3) {
+          throw new Error();
+        }
+      });
+      await recorder.promise();
+    } catch (e) {
+      recorder.catchWithoutStop((err) => {
+      });
+    }
+
+    counter.should.equal(1);
+    // expects to retry only once
+  });
+
   it('should not retry session', async () => {
     retryFailedStep({ retries: 1, minTimeout: 1 });
     event.dispatcher.emit(event.test.before, {});


### PR DESCRIPTION
Got some improvements to retryFailedStep plugin.

* is activated only for tests
* contains blacklist of steps to ignore
* can be turned off for a specific test 