### PR TITLE
Fix #1903 make a copy of page objects config per step although it is deprecated

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -180,7 +180,7 @@ function loadSupportObjects() {
   const config = require('./config');
   const path = require('path');
   support = {
-    ...config.get('include', {})
+    ...config.get('include', {}),
   };
   if (support) {
     for (const name in support) {

--- a/lib/step.js
+++ b/lib/step.js
@@ -179,7 +179,9 @@ function detectMetaStep(stack) {
 function loadSupportObjects() {
   const config = require('./config');
   const path = require('path');
-  support = {...config.get('include', {})};
+  support = {
+    ...config.get('include', {})
+  };
   if (support) {
     for (const name in support) {
       const file = support[name];

--- a/lib/step.js
+++ b/lib/step.js
@@ -179,7 +179,7 @@ function detectMetaStep(stack) {
 function loadSupportObjects() {
   const config = require('./config');
   const path = require('path');
-  support = config.get('include', {});
+  support = {...config.get('include', {})};
   if (support) {
     for (const name in support) {
       const file = support[name];


### PR DESCRIPTION
This creates a deep copy of the `include` part from configuration.