### PR TITLE
Update Node version to 12.10 to support new CodeceptJS features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=10.14.0
+ARG NODE_VERSION=12.10.0
 FROM node:${NODE_VERSION}
 
 # Add our user and group first to make sure their IDs get assigned consistently,


### PR DESCRIPTION
Fixes #1900 . Uses NodeJS 12.10.0 because it is currently the latest version.
