### PR TITLE
TestCafe port's management removed (left on TestCafe itself)

### DIFF
--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -86,7 +86,6 @@ class TestCafe extends Helper {
   constructor(config) {
     super(config);
 
-    this.iteration = 1;
     this.testcafe = undefined; // testcafe instance
     this.t = undefined; // testcafe test controller
     this.dummyTestcafeFile; // generated testcafe test file
@@ -136,7 +135,7 @@ class TestCafe extends Helper {
 
     this.iteration += 2; // Use different ports for each test run
     // @ts-ignore
-    this.testcafe = await createTestCafe('localhost', 1338 + this.iteration, 1339 + this.iteration);
+    this.testcafe = await createTestCafe('localhost', null, null);
 
     this.debugSection('_before', 'Starting testcafe browser...');
 


### PR DESCRIPTION
Resolves #1934