### PR TITLE
Fix documentation of puppeteerCoverage plugin

### DIFF
--- a/lib/plugin/puppeteerCoverage.js
+++ b/lib/plugin/puppeteerCoverage.js
@@ -56,7 +56,7 @@ function buildFileName(test, uniqueFileName) {
  *
  * Possible config options:
  *
- * * `outputDir`: directory to dump coverage files
+ * * `coverageDir`: directory to dump coverage files
  * * `uniqueFileName`: generate a unique filename by adding uuid
  *
  *  First of all, your mileage may vary!


### PR DESCRIPTION
Docs were talking about `outputDir` while in reality `coverageDir` was used.