### PR TITLE
Improve handling of pressing keys for Puppeteer and WebDriver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,17 +114,20 @@ Please try to add corresponding testcase to runner or unit.
 
 Documentation is stored in `/docs` directory in markdown format.
 
-**Documentation for helpers is a part of a source code**. Whenever you need to update docs for a helper do it inside a .js file. Then run
+**Documentation for helpers is a part of a source code**.
+Whenever you need to update docs for a helper do it inside a .js file.
+
+In order to generate new documentation from source code run the following command with [Robo](https://robo.li/):
 
 ```
-npm run docs
+robo docs:helpers
 ```
 
 To update markdown documentation. Shared documentation for helpers are located in `docs/webapi/*.mustache`. Inside a docblock those files can be included like this:
 
 ```js
   /**
-   * {{> ../webapi/click }}
+   * {{> click }}
    */
   click() {
     // ...

--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -225,9 +225,9 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -252,7 +252,7 @@ I.dontSeeElement('.modal'); // modal is not shown
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -221,9 +221,9 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -302,7 +302,7 @@ Checks that current url does not contain a provided fragment.
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -357,9 +357,9 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -438,7 +438,7 @@ Checks that current url does not contain a provided fragment.
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -203,9 +203,8 @@ libraries][7].
 
 ### amAcceptingPopups
 
-\[existingPages.length -1
-\[existingPages.length -1
-\[existingPages.length -1
+Set the automatic popup response to Accept.
+This must be set before a popup is triggered.
 
 ```js
 I.amAcceptingPopups();
@@ -432,9 +431,9 @@ This action supports [React locators](https://codecept.io/react#locators)
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -518,7 +517,7 @@ Checks that current url does not contain a provided fragment.
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js
@@ -587,7 +586,7 @@ This action supports [React locators](https://codecept.io/react#locators)
 
 ### downloadFile
 
-This method is depreacted.
+This method is deprecated.
 
 Please use `handleDownloads()` instead.
 
@@ -1039,54 +1038,111 @@ I.openNewTab();
 
 ### pressKey
 
-Presses a key on a focused element.
-Special keys like 'Enter', 'Control', [etc][14]
-will be replaced with corresponding unicode.
-If modifier key is used (Control, Command, Alt, Shift) in array, it will be released afterwards.
+Presses a key in the browser (on a focused element).
+
+_Hint:_ For populating text field or textarea, it is recommended to use [`fillField`][14].
 
 ```js
-I.pressKey('Enter');
-I.pressKey(['Control','a']);
+I.pressKey('Backspace');
 ```
+
+To press a key in combination with modifier keys, pass the sequence as an array. All modifier keys (`'Alt'`, `'Control'`, `'Meta'`, `'Shift'`) will be released afterwards.
+
+```js
+I.pressKey(['Control', 'Z']);
+```
+
+By default `pressKey` will change operation modifier key based on operating system.
+Mapping `'Control'` to `'Meta'` (also known as `'Command'`) on macOS machines or mapping `'Meta'` to `'Control'` on non-macOS machines.
+
+In order to use disable changing of operation modifier key based on operating system, specify the second argument as `false`.
+
+```js
+// On macOS this will actually press 'Control + Z' instead of
+// default behavior which would change keys to 'Meta + Z'
+I.pressKey(['Control', 'Z'], false);
+```
+
+Some of the supported key names are:
+
+-   `'AltLeft'` or `'Alt'`
+-   `'AltRight'`
+-   `'ArrowDown'`
+-   `'ArrowLeft'`
+-   `'ArrowRight'`
+-   `'ArrowUp'`
+-   `'Backspace'`
+-   `'Clear'`
+-   `'ControlLeft'` or `'Control'`
+-   `'ControlRight'`
+-   `'Delete'`
+-   `'End'`
+-   `'Enter'`
+-   `'Escape'`
+-   `'F1'` to `'F12'`
+-   `'Home'`
+-   `'Insert'`
+-   `'MetaLeft'` or `'Meta'`
+-   `'MetaRight'`
+-   `'Numpad0'` to `'Numpad9'`
+-   `'NumpadAdd'`
+-   `'NumpadDecimal'`
+-   `'NumpadDivide'`
+-   `'NumpadMultiply'`
+-   `'NumpadSubtract'`
+-   `'PageDown'`
+-   `'PageUp'`
+-   `'Pause'`
+-   `'Return'`
+-   `'ShiftLeft'` or `'Shift'`
+-   `'ShiftRight'`
+-   `'Space'`
+-   `'Tab'`
 
 #### Parameters
 
 -   `key` ([string][8] \| [array][15]) key or array of keys to press.
+-   `detectOS` [boolean][16] (optional, `true` by default) change operation modifier key based on operating system.
+    
+_Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/puppeteer#1313][17]).
+
+### pressKeyDown
+
+Presses a key in the browser and leaves it in a down state.
+
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][18]).
+
+```js
+I.pressKeyDown('Control');
+I.click('#element');
+I.pressKeyUp('Control');
+```
+
+#### Parameters
+
+-   `key` [string][8] name of key to press down.
+-   `detectOS` [boolean][16] (optional, `true` by default) change operation modifier key based on operating system.
     
 
 
+### pressKeyUp
 
-[Valid key names](https://w3c.github.io/webdriver/#keyboard-actions) are:
+Releases a key in the browser which was previously set to a down state.
 
-- `'Add'`,
-- `'Alt'`,
-- `'ArrowDown'` or `'Down arrow'`,
-- `'ArrowLeft'` or `'Left arrow'`,
-- `'ArrowRight'` or `'Right arrow'`,
-- `'ArrowUp'` or `'Up arrow'`,
-- `'Backspace'`,
-- `'Command'`,
-- `'Control'`,
-- `'Del'`,
-- `'Divide'`,
-- `'End'`,
-- `'Enter'`,
-- `'Equals'`,
-- `'Escape'`,
-- `'F1 to F12'`,
-- `'Home'`,
-- `'Insert'`,
-- `'Meta'`,
-- `'Multiply'`,
-- `'Numpad 0'` to `'Numpad 9'`,
-- `'Pagedown'` or `'PageDown'`,
-- `'Pageup'` or `'PageUp'`,
-- `'Pause'`,
-- `'Semicolon'`,
-- `'Shift'`,
-- `'Space'`,
-- `'Subtract'`,
-- `'Tab'`.
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][18]).
+
+```js
+I.pressKeyDown('Control');
+I.click('#element');
+I.pressKeyUp('Control');
+```
+
+#### Parameters
+
+-   `key` [string][8] name of key to release.
+-   `detectOS` [boolean][16] (optional, `true` by default) change operation modifier key based on operating system.
+    
+
 
 ### refreshPage
 
@@ -1767,7 +1823,7 @@ I.waitForVisible('#popup');
 -   `locator` ([string][8] \| [object][6]) element located by CSS|XPath|strict locator.
 -   `sec` [number][9] (optional, `1` by default) time in seconds to wait
     
-This method accepts [React selectors][17].
+This method accepts [React selectors][19].
 
 ### waitInUrl
 
@@ -1880,10 +1936,14 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [13]: https://codecept.io/helpers/FileSystem
 
-[14]: https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value
+[14]: #fillfield
 
 [15]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [16]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[17]: https://codecept.io/react
+[17]: https://github.com/GoogleChrome/puppeteer/issues/1313
+
+[18]: #click
+
+[19]: https://codecept.io/react

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -231,9 +231,9 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -312,7 +312,7 @@ Checks that current url does not contain a provided fragment.
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -592,9 +592,9 @@ This action supports [React locators](https://codecept.io/react#locators)
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -679,7 +679,7 @@ Checks that current url does not contain a provided fragment.
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js
@@ -1136,59 +1136,111 @@ I.openNewTab();
 
 ### pressKey
 
-Presses a key on a focused element.
-Special keys like 'Enter', 'Control', [etc][26]
-will be replaced with corresponding unicode.
-If modifier key is used (Control, Command, Alt, Shift) in array, it will be released afterwards.
+Presses a key in the browser (on a focused element).
+
+_Hint:_ For populating text field or textarea, it is recommended to use [`fillField`][26].
 
 ```js
-I.pressKey('Enter');
-I.pressKey(['Control','a']);
+I.pressKey('Backspace');
 ```
+
+To press a key in combination with modifier keys, pass the sequence as an array. All modifier keys (`'Alt'`, `'Control'`, `'Meta'`, `'Shift'`) will be released afterwards.
+
+```js
+I.pressKey(['Control', 'Z']);
+```
+
+By default `pressKey` will change operation modifier key based on operating system.
+Mapping `'Control'` to `'Meta'` (also known as `'Command'`) on macOS machines or mapping `'Meta'` to `'Control'` on non-macOS machines.
+
+In order to use disable changing of operation modifier key based on operating system, specify the second argument as `false`.
+
+```js
+// On macOS this will actually press 'Control + Z' instead of
+// default behavior which would change keys to 'Meta + Z'
+I.pressKey(['Control', 'Z'], false);
+```
+
+Some of the supported key names are:
+
+-   `'AltLeft'` or `'Alt'`
+-   `'AltRight'`
+-   `'ArrowDown'`
+-   `'ArrowLeft'`
+-   `'ArrowRight'`
+-   `'ArrowUp'`
+-   `'Backspace'`
+-   `'Clear'`
+-   `'ControlLeft'` or `'Control'`
+-   `'ControlRight'`
+-   `'Delete'`
+-   `'End'`
+-   `'Enter'`
+-   `'Escape'`
+-   `'F1'` to `'F12'`
+-   `'Home'`
+-   `'Insert'`
+-   `'MetaLeft'` or `'Meta'`
+-   `'MetaRight'`
+-   `'Numpad0'` to `'Numpad9'`
+-   `'NumpadAdd'`
+-   `'NumpadDecimal'`
+-   `'NumpadDivide'`
+-   `'NumpadMultiply'`
+-   `'NumpadSubtract'`
+-   `'PageDown'`
+-   `'PageUp'`
+-   `'Pause'`
+-   `'Return'`
+-   `'ShiftLeft'` or `'Shift'`
+-   `'ShiftRight'`
+-   `'Space'`
+-   `'Tab'`
 
 #### Parameters
 
 -   `key` ([string][19] \| [array][27]) key or array of keys to press.
+-   `detectOS` [boolean][28] (optional, `true` by default) change operation modifier key based on operating system.
+    
+_Note:_ In case a text field or textarea is focused be aware that some browsers do not respect active modifier when combining modifier keys with other keys.
+
+### pressKeyDown
+
+Presses a key in the browser and leaves it in a down state.
+
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][29]).
+
+```js
+I.pressKeyDown('Control');
+I.click('#element');
+I.pressKeyUp('Control');
+```
+
+#### Parameters
+
+-   `key` [string][19] name of key to press down.
+-   `detectOS` [boolean][28] (optional, `true` by default) change operation modifier key based on operating system.
     
 
+
+### pressKeyUp
+
+Releases a key in the browser which was previously set to a down state.
+
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][29]).
+
+```js
+I.pressKeyDown('Control');
+I.click('#element');
+I.pressKeyUp('Control');
+```
+
+#### Parameters
+
+-   `key` [string][19] name of key to release.
+-   `detectOS` [boolean][28] (optional, `true` by default) change operation modifier key based on operating system.
     
 
-
-[Valid key names](https://w3c.github.io/webdriver/#keyboard-actions) are:
-
-- `'Add'`,
-- `'Alt'`,
-- `'ArrowDown'` or `'Down arrow'`,
-- `'ArrowLeft'` or `'Left arrow'`,
-- `'ArrowRight'` or `'Right arrow'`,
-- `'ArrowUp'` or `'Up arrow'`,
-- `'Backspace'`,
-- `'Command'`,
-- `'Control'`,
-- `'Del'`,
-- `'Divide'`,
-- `'End'`,
-- `'Enter'`,
-- `'Equals'`,
-- `'Escape'`,
-- `'F1 to F12'`,
-- `'Home'`,
-- `'Insert'`,
-- `'Meta'`,
-- `'Multiply'`,
-- `'Numpad 0'` to `'Numpad 9'`,
-- `'Pagedown'` or `'PageDown'`,
-- `'Pageup'` or `'PageUp'`,
-- `'Pause'`,
-- `'Semicolon'`,
-- `'Shift'`,
-- `'Space'`,
-- `'Subtract'`,
-- `'Tab'`.To make combinations with modifier and mouse clicks (like Ctrl+Click) press a modifier, click, then release it.```js
-    I.pressKey('Control');
-    I.click('#someelement');
-    I.pressKey('Control');
-    ```
 
 ### refreshPage
 
@@ -1635,7 +1687,7 @@ I.setCookie({name: 'auth', value: true});
 -   `cookie` [object][20] a cookie object.
     
 Uses Selenium's JSON [cookie
-    format][29].
+    format][30].
 
 ### setGeoLocation
 
@@ -2016,10 +2068,12 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[26]: https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value
+[26]: #fillfield
 
 [27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[29]: https://code.google.com/p/selenium/wiki/JsonWireProtocol#Cookie_JSON_Object
+[29]: #click
+
+[30]: https://code.google.com/p/selenium/wiki/JsonWireProtocol#Cookie_JSON_Object

--- a/docs/helpers/WebDriverIO.md
+++ b/docs/helpers/WebDriverIO.md
@@ -439,9 +439,9 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 #### Parameters
@@ -514,7 +514,7 @@ Checks that current url does not contain a provided fragment.
 
 ### dontSeeInField
 
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js

--- a/docs/webapi/dontSeeCheckboxIsChecked.mustache
+++ b/docs/webapi/dontSeeCheckboxIsChecked.mustache
@@ -1,9 +1,9 @@
 Verifies that the specified checkbox is not checked.
 
 ```js
-I.dontSeeeCheckboxIsChedcked('#agree'); // located by ID
-I.dontSeeeCheckboxIsChedcked('I agree to terms'); // located by label
-I.dontSeeeCheckboxIsChedcked('agree'); // located by name
+I.dontSeeCheckboxIsChecked('#agree'); // located by ID
+I.dontSeeCheckboxIsChecked('I agree to terms'); // located by label
+I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 @param {string|object} field located by label|name|CSS|XPath|strict locator.

--- a/docs/webapi/dontSeeInField.mustache
+++ b/docs/webapi/dontSeeInField.mustache
@@ -1,4 +1,4 @@
-Checks that value of input field or textare doesn't equal to given value
+Checks that value of input field or textarea doesn't equal to given value
 Opposite to `seeInField`.
 
 ```js

--- a/docs/webapi/pressKeyDown.mustache
+++ b/docs/webapi/pressKeyDown.mustache
@@ -1,0 +1,12 @@
+Presses a key in the browser and leaves it in a down state.
+
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`](#click)).
+
+```js
+I.pressKeyDown('Control');
+I.click('#element');
+I.pressKeyUp('Control');
+```
+
+@param {string} key name of key to press down.
+@param {boolean} detectOS (optional, `true` by default) change operation modifier key based on operating system.

--- a/docs/webapi/pressKeyUp.mustache
+++ b/docs/webapi/pressKeyUp.mustache
@@ -1,0 +1,12 @@
+Releases a key in the browser which was previously set to a down state.
+
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`](#click)).
+
+```js
+I.pressKeyDown('Control');
+I.click('#element');
+I.pressKeyUp('Control');
+```
+
+@param {string} key name of key to release.
+@param {boolean} detectOS (optional, `true` by default) change operation modifier key based on operating system.

--- a/docs/webapi/pressKeyWithDetectOS.mustache
+++ b/docs/webapi/pressKeyWithDetectOS.mustache
@@ -1,0 +1,62 @@
+Presses a key in the browser (on a focused element).
+
+_Hint:_ For populating text field or textarea, it is recommended to use [`fillField`](#fillfield).
+
+```js
+I.pressKey('Backspace');
+```
+
+To press a key in combination with modifier keys, pass the sequence as an array. All modifier keys (`'Alt'`, `'Control'`, `'Meta'`, `'Shift'`) will be released afterwards.
+
+```js
+I.pressKey(['Control', 'Z']);
+```
+
+By default `pressKey` will change operation modifier key based on operating system.
+Mapping `'Control'` to `'Meta'` (also known as `'Command'`) on macOS machines or mapping `'Meta'` to `'Control'` on non-macOS machines.
+
+In order to use disable changing of operation modifier key based on operating system, specify the second argument as `false`.
+
+```js
+// On macOS this will actually press 'Control + Z' instead of
+// default behavior which would change keys to 'Meta + Z'
+I.pressKey(['Control', 'Z'], false);
+```
+
+Some of the supported key names are:
+- `'AltLeft'` or `'Alt'`
+- `'AltRight'`
+- `'ArrowDown'`
+- `'ArrowLeft'`
+- `'ArrowRight'`
+- `'ArrowUp'`
+- `'Backspace'`
+- `'Clear'`
+- `'ControlLeft'` or `'Control'`
+- `'ControlRight'`
+- `'Delete'`
+- `'End'`
+- `'Enter'`
+- `'Escape'`
+- `'F1'` to `'F12'`
+- `'Home'`
+- `'Insert'`
+- `'MetaLeft'` or `'Meta'`
+- `'MetaRight'`
+- `'Numpad0'` to `'Numpad9'`
+- `'NumpadAdd'`
+- `'NumpadDecimal'`
+- `'NumpadDivide'`
+- `'NumpadMultiply'`
+- `'NumpadSubtract'`
+- `'PageDown'`
+- `'PageUp'`
+- `'Pause'`
+- `'Return'`
+- `'ShiftLeft'` or `'Shift'`
+- `'ShiftRight'`
+- `'Space'`
+- `'Tab'`
+
+@param {string|array} key key or array of keys to press.
+@param {boolean} detectOS (optional, `true` by default) change operation modifier key based on operating system.

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2327,10 +2327,68 @@ async function targetCreatedHandler(page) {
   }
 }
 
+// List of key values to key definitions
+// https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/lib/USKeyboardLayout.js
+const keyDefinitionMap = {
+  /* eslint-disable quote-props */
+  '0': 'Digit0',
+  '1': 'Digit1',
+  '2': 'Digit2',
+  '3': 'Digit3',
+  '4': 'Digit4',
+  '5': 'Digit5',
+  '6': 'Digit6',
+  '7': 'Digit7',
+  '8': 'Digit8',
+  '9': 'Digit9',
+  'a': 'KeyA',
+  'b': 'KeyB',
+  'c': 'KeyC',
+  'd': 'KeyD',
+  'e': 'KeyE',
+  'f': 'KeyF',
+  'g': 'KeyG',
+  'h': 'KeyH',
+  'i': 'KeyI',
+  'j': 'KeyJ',
+  'k': 'KeyK',
+  'l': 'KeyL',
+  'm': 'KeyM',
+  'n': 'KeyN',
+  'o': 'KeyO',
+  'p': 'KeyP',
+  'q': 'KeyQ',
+  'r': 'KeyR',
+  's': 'KeyS',
+  't': 'KeyT',
+  'u': 'KeyU',
+  'v': 'KeyV',
+  'w': 'KeyW',
+  'x': 'KeyX',
+  'y': 'KeyY',
+  'z': 'KeyZ',
+  ';': 'Semicolon',
+  '=': 'Equal',
+  ',': 'Comma',
+  '-': 'Minus',
+  '.': 'Period',
+  '/': 'Slash',
+  '`': 'Backquote',
+  '[': 'BracketLeft',
+  '\\': 'Backslash',
+  ']': 'BracketRight',
+  '\'': 'Quote',
+  /* eslint-enable quote-props */
+};
+
 function getNormalizedKey(key, detectOS) {
   const normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
   if (key !== normalizedKey) {
     this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
+  }
+  // Use key definition to ensure correct key is displayed when Shift modifier is active
+  if (Object.prototype.hasOwnProperty.call(keyDefinitionMap, normalizedKey)) {
+    return keyDefinitionMap[normalizedKey];
   }
   return normalizedKey;
 }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -14,6 +14,7 @@ const {
   chunkArray,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
+  getNormalizedKeyAttributeValue,
   isModifierKey,
 } = require('../utils');
 const {
@@ -1046,11 +1047,13 @@ class Puppeteer extends Helper {
   }
 
   async pressKeyDown(key) {
+    key = getNormalizedKey.call(this, key);
     await this.page.keyboard.down(key);
     return this._waitForAction();
   }
 
   async pressKeyUp(key) {
+    key = getNormalizedKey.call(this, key);
     await this.page.keyboard.up(key);
     return this._waitForAction();
   }
@@ -1063,7 +1066,8 @@ class Puppeteer extends Helper {
   async pressKey(key) {
     const modifiers = [];
     if (Array.isArray(key)) {
-      for (const k of key) {
+      for (let k of key) {
+        k = getNormalizedKey.call(this, k);
         if (isModifierKey(k)) {
           modifiers.push(k);
         } else {
@@ -1071,6 +1075,8 @@ class Puppeteer extends Helper {
           break;
         }
       }
+    } else {
+      key = getNormalizedKey.call(this, key);
     }
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier);
@@ -2319,4 +2325,12 @@ async function targetCreatedHandler(page) {
     const height = parseInt(dimensions[1], 10);
     await page.setViewport({ width, height });
   }
+}
+
+function getNormalizedKey(key) {
+  const normalizedKey = getNormalizedKeyAttributeValue(key);
+  if (key !== normalizedKey) {
+    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
+  }
+  return normalizedKey;
 }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -275,10 +275,7 @@ class Puppeteer extends Helper {
         // is closed by _after
       },
       loadVars: async (context) => {
-        // if (this.withinLocator)
         const existingPages = context.targets().filter(t => t.type() === 'page');
-        // this.page = await existingPages[0].page();
-        // this.context = await page.$('body');
         return this._setPage(await existingPages[0].page());
       },
       restoreVars: async () => {
@@ -291,9 +288,9 @@ class Puppeteer extends Helper {
   }
 
 
-  /** [existingPages.length -1
-   * [existingPages.length -1
-   * [existingPages.length -1
+  /**
+   * Set the automatic popup response to Accept.
+   * This must be set before a popup is triggered.
    *
    * ```js
    * I.amAcceptingPopups();
@@ -921,7 +918,7 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * This method is **depreacted**.
+   * This method is **deprecated**.
    *
    * Please use `handleDownloads()` instead.
    */
@@ -1046,12 +1043,18 @@ class Puppeteer extends Helper {
     return proceedIsChecked.call(this, 'negate', field);
   }
 
+  /**
+   * {{> pressKeyDown }}
+   */
   async pressKeyDown(key, detectOS) {
     key = getNormalizedKey.call(this, key, detectOS);
     await this.page.keyboard.down(key);
     return this._waitForAction();
   }
 
+  /**
+   * {{> pressKeyUp }}
+   */
   async pressKeyUp(key, detectOS) {
     key = getNormalizedKey.call(this, key, detectOS);
     await this.page.keyboard.up(key);
@@ -1059,9 +1062,9 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * {{> pressKey }}
+   * {{> pressKeyWithDetectOS }}
    *
-   * {{ keys }}
+   * _Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/puppeteer#1313](https://github.com/GoogleChrome/puppeteer/issues/1313)).
    */
   async pressKey(key, detectOS) {
     const modifiers = [];
@@ -1096,7 +1099,6 @@ class Puppeteer extends Helper {
     const els = await findFields.call(this, field);
     assertElementExists(els, field, 'Field');
     const el = els[0];
-    // await el.focus();
     const tag = await el.getProperty('tagName').then(el => el.jsonValue());
     const editable = await el.getProperty('contenteditable').then(el => el.jsonValue());
     if (tag === 'INPUT' || tag === 'TEXTAREA') {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1046,14 +1046,14 @@ class Puppeteer extends Helper {
     return proceedIsChecked.call(this, 'negate', field);
   }
 
-  async pressKeyDown(key) {
-    key = getNormalizedKey.call(this, key);
+  async pressKeyDown(key, detectOS) {
+    key = getNormalizedKey.call(this, key, detectOS);
     await this.page.keyboard.down(key);
     return this._waitForAction();
   }
 
-  async pressKeyUp(key) {
-    key = getNormalizedKey.call(this, key);
+  async pressKeyUp(key, detectOS) {
+    key = getNormalizedKey.call(this, key, detectOS);
     await this.page.keyboard.up(key);
     return this._waitForAction();
   }
@@ -1063,11 +1063,11 @@ class Puppeteer extends Helper {
    *
    * {{ keys }}
    */
-  async pressKey(key) {
+  async pressKey(key, detectOS) {
     const modifiers = [];
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k);
+        k = getNormalizedKey.call(this, k, detectOS);
         if (isModifierKey(k)) {
           modifiers.push(k);
         } else {
@@ -1076,7 +1076,7 @@ class Puppeteer extends Helper {
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key);
+      key = getNormalizedKey.call(this, key, detectOS);
     }
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier);
@@ -2327,8 +2327,8 @@ async function targetCreatedHandler(page) {
   }
 }
 
-function getNormalizedKey(key) {
-  const normalizedKey = getNormalizedKeyAttributeValue(key);
+function getNormalizedKey(key, detectOS) {
+  const normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
   if (key !== normalizedKey) {
     this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
   }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1045,6 +1045,16 @@ class Puppeteer extends Helper {
     return proceedIsChecked.call(this, 'negate', field);
   }
 
+  async pressKeyDown(key) {
+    await this.page.keyboard.down(key);
+    return this._waitForAction();
+  }
+
+  async pressKeyUp(key) {
+    await this.page.keyboard.up(key);
+    return this._waitForAction();
+  }
+
   /**
    * {{> pressKey }}
    *

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -14,6 +14,7 @@ const {
   chunkArray,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
+  isModifierKey,
 } = require('../utils');
 const {
   isColorProperty,
@@ -1051,8 +1052,7 @@ class Puppeteer extends Helper {
    */
   async pressKey(key) {
     let modifier;
-    const modifiers = ['Control', 'Command', 'Shift', 'Alt'];
-    if (Array.isArray(key) && modifiers.indexOf(key[0]) > -1) {
+    if (Array.isArray(key) && isModifierKey(key[0])) {
       modifier = key[0];
       key = key[1];
     }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1051,14 +1051,24 @@ class Puppeteer extends Helper {
    * {{ keys }}
    */
   async pressKey(key) {
-    let modifier;
-    if (Array.isArray(key) && isModifierKey(key[0])) {
-      modifier = key[0];
-      key = key[1];
+    const modifiers = [];
+    if (Array.isArray(key)) {
+      for (const k of key) {
+        if (isModifierKey(k)) {
+          modifiers.push(k);
+        } else {
+          key = k;
+          break;
+        }
+      }
     }
-    if (modifier) await this.page.keyboard.down(modifier);
-    await await this.page.keyboard.press(key);
-    if (modifier) await this.page.keyboard.up(modifier);
+    for (const modifier of modifiers) {
+      await this.page.keyboard.down(modifier);
+    }
+    await this.page.keyboard.press(key);
+    for (const modifier of modifiers) {
+      await this.page.keyboard.up(modifier);
+    }
     return this._waitForAction();
   }
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1491,6 +1491,36 @@ class WebDriver extends Helper {
     }
   }
 
+  async pressKeyDown(key) {
+    key = convertKeyToRawKey(key);
+    if (!this.browser.isW3C) {
+      return this.browser.sendKeys([key]);
+    }
+    return this.browser.performActions([{
+      type: 'key',
+      id: 'keyboard',
+      actions: [{
+        type: 'keyDown',
+        value: key,
+      }],
+    }]);
+  }
+
+  async pressKeyUp(key) {
+    key = convertKeyToRawKey(key);
+    if (!this.browser.isW3C) {
+      return this.browser.sendKeys([key]);
+    }
+    return this.browser.performActions([{
+      type: 'key',
+      id: 'keyboard',
+      actions: [{
+        type: 'keyUp',
+        value: key,
+      }],
+    }]);
+  }
+
   /**
    * {{> pressKey }}
    * {{ keys }}
@@ -1509,31 +1539,36 @@ class WebDriver extends Helper {
     if (Array.isArray(key)) {
       for (const k of key) {
         if (isModifierKey(k)) {
-          modifiers.push(k);
+          modifiers.push(convertKeyToRawKey(k));
         } else {
-          key = k;
+          key = convertKeyToRawKey(k);
           break;
         }
       }
+    } else {
+      key = convertKeyToRawKey(key);
     }
-    const keySequence = [];
     for (const modifier of modifiers) {
-      keySequence.push(convertKeyToRawKey(modifier));
-    }
-    keySequence.push(convertKeyToRawKey(key));
-    for (const modifier of modifiers) {
-      keySequence.push(convertKeyToRawKey(modifier));
+      await this.pressKeyDown(modifier);
     }
     if (!this.browser.isW3C) {
-      return this.browser.sendKeys(keySequence);
+      await this.browser.sendKeys([key]);
+    } else {
+      await this.browser.performActions([{
+        type: 'key',
+        id: 'keyboard',
+        actions: [{
+          type: 'keyDown',
+          value: key,
+        }, {
+          type: 'keyUp',
+          value: key,
+        }],
+      }]);
     }
-    const keyDownActions = keySequence.map(key => ({ type: 'keyDown', key }));
-    const keyUpActions = keySequence.map(key => ({ type: 'keyUp', key }));
-    return this.browser.performActions([{
-      type: 'key',
-      id: 'keyboard',
-      actions: [...keyDownActions, ...keyUpActions],
-    }]);
+    for (const modifier of modifiers) {
+      await this.pressKeyUp(modifier);
+    }
   }
 
   /**

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1505,13 +1505,35 @@ class WebDriver extends Helper {
    * ```
    */
   async pressKey(key) {
-    let modifier;
-    if (Array.isArray(key) && isModifierKey(key[0])) {
-      modifier = key[0];
+    const modifiers = [];
+    if (Array.isArray(key)) {
+      for (const k of key) {
+        if (isModifierKey(k)) {
+          modifiers.push(k);
+        } else {
+          key = k;
+          break;
+        }
+      }
     }
-    await this.browser.keys(key);
-    if (!modifier) return true;
-    return this.browser.keys(modifier); // release modifier
+    const keySequence = [];
+    for (const modifier of modifiers) {
+      keySequence.push(convertKeyToRawKey(modifier));
+    }
+    keySequence.push(convertKeyToRawKey(key));
+    for (const modifier of modifiers) {
+      keySequence.push(convertKeyToRawKey(modifier));
+    }
+    if (!this.browser.isW3C) {
+      return this.browser.sendKeys(keySequence);
+    }
+    const keyDownActions = keySequence.map(key => ({ type: 'keyDown', key }));
+    const keyUpActions = keySequence.map(key => ({ type: 'keyUp', key }));
+    return this.browser.performActions([{
+      type: 'key',
+      id: 'keyboard',
+      actions: [...keyDownActions, ...keyUpActions],
+    }]);
   }
 
   /**
@@ -2334,6 +2356,135 @@ function getElementId(el) {
     return el.ELEMENT;
   }
   return null;
+}
+
+// List of known key values to unicode code points
+// https://www.w3.org/TR/webdriver/#keyboard-actions
+const keyUnicodeMap = {
+  /* eslint-disable quote-props */
+  'Unidentified': '\uE000',
+  'Cancel': '\uE001',
+  'Clear': '\uE005',
+  'Help': '\uE002',
+  'Pause': '\uE00B',
+  'Backspace': '\uE003',
+  'Return': '\uE006',
+  'Enter': '\uE007',
+  'Escape': '\uE00C',
+  'Alt': '\uE00A',
+  'AltLeft': '\uE00A',
+  'AltRight': '\uE052',
+  'Control': '\uE009',
+  'ControlLeft': '\uE009',
+  'ControlRight': '\uE051',
+  'Meta': '\uE03D',
+  'MetaLeft': '\uE03D',
+  'MetaRight': '\uE053',
+  'Shift': '\uE008',
+  'ShiftLeft': '\uE008',
+  'ShiftRight': '\uE050',
+  'Space': '\uE00D',
+  ' ': '\uE00D',
+  'Tab': '\uE004',
+  'Insert': '\uE016',
+  'Delete': '\uE017',
+  'End': '\uE010',
+  'Home': '\uE011',
+  'PageUp': '\uE00E',
+  'PageDown': '\uE00F',
+  'ArrowDown': '\uE015',
+  'ArrowLeft': '\uE012',
+  'ArrowRight': '\uE014',
+  'ArrowUp': '\uE013',
+  'F1': '\uE031',
+  'F2': '\uE032',
+  'F3': '\uE033',
+  'F4': '\uE034',
+  'F5': '\uE035',
+  'F6': '\uE036',
+  'F7': '\uE037',
+  'F8': '\uE038',
+  'F9': '\uE039',
+  'F10': '\uE03A',
+  'F11': '\uE03B',
+  'F12': '\uE03C',
+  'Numpad0': '\uE01A',
+  'Numpad1': '\uE01B',
+  'Numpad2': '\uE01C',
+  'Numpad3': '\uE01D',
+  'Numpad4': '\uE01E',
+  'Numpad5': '\uE01F',
+  'Numpad6': '\uE020',
+  'Numpad7': '\uE021',
+  'Numpad8': '\uE022',
+  'Numpad9': '\uE023',
+  'NumpadMultiply': '\uE024',
+  'NumpadAdd': '\uE025',
+  'NumpadSubtract': '\uE027',
+  'NumpadDecimal': '\uE028',
+  'NumpadDivide': '\uE029',
+  'NumpadEnter': '\uE007',
+  'NumpadInsert': '\uE05C', // 'Numpad0' alternate (when NumLock off)
+  'NumpadDelete': '\uE05D', // 'NumpadDecimal' alternate (when NumLock off)
+  'NumpadEnd': '\uE056', // 'Numpad1' alternate (when NumLock off)
+  'NumpadHome': '\uE057', // 'Numpad7' alternate (when NumLock off)
+  'NumpadPageDown': '\uE055', // 'Numpad3' alternate (when NumLock off)
+  'NumpadPageUp': '\uE054', // 'Numpad9' alternate (when NumLock off)
+  'NumpadArrowDown': '\uE05B', // 'Numpad2' alternate (when NumLock off)
+  'NumpadArrowLeft': '\uE058', // 'Numpad4' alternate (when NumLock off)
+  'NumpadArrowRight': '\uE05A', // 'Numpad6' alternate (when NumLock off)
+  'NumpadArrowUp': '\uE059', // 'Numpad8' alternate (when NumLock off)
+  'Comma': '\uE026', // ',' alias
+  'Digit0': '0', // '0' alias
+  'Digit1': '1', // '1' alias
+  'Digit2': '2', // '2' alias
+  'Digit3': '3', // '3' alias
+  'Digit4': '4', // '4' alias
+  'Digit5': '5', // '5' alias
+  'Digit6': '6', // '6' alias
+  'Digit7': '7', // '7' alias
+  'Digit8': '8', // '8' alias
+  'Digit9': '9', // '9' alias
+  'Equal': '\uE019', // '=' alias
+  'KeyA': 'a', // 'a' alias
+  'KeyB': 'b', // 'b' alias
+  'KeyC': 'c', // 'c' alias
+  'KeyD': 'd', // 'd' alias
+  'KeyE': 'e', // 'e' alias
+  'KeyF': 'f', // 'f' alias
+  'KeyG': 'g', // 'g' alias
+  'KeyH': 'h', // 'h' alias
+  'KeyI': 'i', // 'i' alias
+  'KeyJ': 'j', // 'j' alias
+  'KeyK': 'k', // 'k' alias
+  'KeyL': 'l', // 'l' alias
+  'KeyM': 'm', // 'm' alias
+  'KeyN': 'n', // 'n' alias
+  'KeyO': 'o', // 'o' alias
+  'KeyP': 'p', // 'p' alias
+  'KeyQ': 'q', // 'q' alias
+  'KeyR': 'r', // 'r' alias
+  'KeyS': 's', // 's' alias
+  'KeyT': 't', // 't' alias
+  'KeyU': 'u', // 'u' alias
+  'KeyV': 'v', // 'v' alias
+  'KeyW': 'w', // 'w' alias
+  'KeyX': 'x', // 'x' alias
+  'KeyY': 'y', // 'y' alias
+  'KeyZ': 'z', // 'z' alias
+  'Period': '.', // '.' alias
+  'Semicolon': '\uE018', // ';' alias
+  'Slash': '/', // '/' alias
+  'ZenkakuHankaku': '\uE040',
+  /* eslint-enable quote-props */
+};
+
+function convertKeyToRawKey(key) {
+  if (Object.prototype.hasOwnProperty.call(keyUnicodeMap, key)) {
+    return keyUnicodeMap[key];
+  }
+  // Key is raw key when no representative unicode code point for value
+  return key;
 }
 
 function prepareLocateFn(context) {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -15,7 +15,8 @@ const {
   chunkArray,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
-  isModifierKey,
+  getNormalizedKeyAttributeValue,
+  modifierKeys,
 } = require('../utils');
 const {
   isColorProperty,
@@ -1492,7 +1493,7 @@ class WebDriver extends Helper {
   }
 
   async pressKeyDown(key) {
-    key = convertKeyToRawKey(key);
+    key = getNormalizedKey.call(this, key);
     if (!this.browser.isW3C) {
       return this.browser.sendKeys([key]);
     }
@@ -1507,7 +1508,7 @@ class WebDriver extends Helper {
   }
 
   async pressKeyUp(key) {
-    key = convertKeyToRawKey(key);
+    key = getNormalizedKey.call(this, key);
     if (!this.browser.isW3C) {
       return this.browser.sendKeys([key]);
     }
@@ -1537,16 +1538,17 @@ class WebDriver extends Helper {
   async pressKey(key) {
     const modifiers = [];
     if (Array.isArray(key)) {
-      for (const k of key) {
+      for (let k of key) {
+        k = getNormalizedKey.call(this, k);
         if (isModifierKey(k)) {
-          modifiers.push(convertKeyToRawKey(k));
+          modifiers.push(k);
         } else {
-          key = convertKeyToRawKey(k);
+          key = k;
           break;
         }
       }
     } else {
-      key = convertKeyToRawKey(key);
+      key = getNormalizedKey.call(this, key);
     }
     for (const modifier of modifiers) {
       await this.pressKeyDown(modifier);
@@ -2520,6 +2522,19 @@ function convertKeyToRawKey(key) {
   }
   // Key is raw key when no representative unicode code point for value
   return key;
+}
+
+function getNormalizedKey(key) {
+  const normalizedKey = getNormalizedKeyAttributeValue(key);
+  if (key !== normalizedKey) {
+    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
+  }
+  return convertKeyToRawKey(normalizedKey);
+}
+
+const unicodeModifierKeys = modifierKeys.map(k => convertKeyToRawKey(k));
+function isModifierKey(key) {
+  return unicodeModifierKeys.includes(key);
 }
 
 function prepareLocateFn(context) {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2525,7 +2525,12 @@ function convertKeyToRawKey(key) {
 }
 
 function getNormalizedKey(key, detectOS) {
-  const normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
+  let normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
+  // Always use "left" modifier keys for non-W3C sessions,
+  // as JsonWireProtocol does not support "right" modifier keys
+  if (!this.browser.isW3C) {
+    normalizedKey = normalizedKey.replace(/^(Alt|Control|Meta|Shift)Right$/, '$1');
+  }
   if (key !== normalizedKey) {
     this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -15,6 +15,7 @@ const {
   chunkArray,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
+  isModifierKey,
 } = require('../utils');
 const {
   isColorProperty,
@@ -1505,8 +1506,7 @@ class WebDriver extends Helper {
    */
   async pressKey(key) {
     let modifier;
-    const modifiers = ['Control', 'Command', 'Shift', 'Alt'];
-    if (Array.isArray(key) && modifiers.indexOf(key[0]) > -1) {
+    if (Array.isArray(key) && isModifierKey(key[0])) {
       modifier = key[0];
     }
     await this.browser.keys(key);

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1492,6 +1492,9 @@ class WebDriver extends Helper {
     }
   }
 
+  /**
+   * {{> pressKeyDown }}
+   */
   async pressKeyDown(key, detectOS) {
     key = getNormalizedKey.call(this, key, detectOS);
     if (!this.browser.isW3C) {
@@ -1507,6 +1510,9 @@ class WebDriver extends Helper {
     }]);
   }
 
+  /**
+   * {{> pressKeyUp }}
+   */
   async pressKeyUp(key, detectOS) {
     key = getNormalizedKey.call(this, key, detectOS);
     if (!this.browser.isW3C) {
@@ -1523,17 +1529,9 @@ class WebDriver extends Helper {
   }
 
   /**
-   * {{> pressKey }}
-   * {{ keys }}
+   * {{> pressKeyWithDetectOS }}
    *
-   * To make combinations with modifier and mouse clicks (like Ctrl+Click) press a modifier, click, then release it.
-   *
-   *
-   * ```js
-   * I.pressKey('Control');
-   * I.click('#someelement');
-   * I.pressKey('Control');
-   * ```
+   * _Note:_ In case a text field or textarea is focused be aware that some browsers do not respect active modifier when combining modifier keys with other keys.
    */
   async pressKey(key, detectOS) {
     const modifiers = [];

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1492,8 +1492,8 @@ class WebDriver extends Helper {
     }
   }
 
-  async pressKeyDown(key) {
-    key = getNormalizedKey.call(this, key);
+  async pressKeyDown(key, detectOS) {
+    key = getNormalizedKey.call(this, key, detectOS);
     if (!this.browser.isW3C) {
       return this.browser.sendKeys([key]);
     }
@@ -1507,8 +1507,8 @@ class WebDriver extends Helper {
     }]);
   }
 
-  async pressKeyUp(key) {
-    key = getNormalizedKey.call(this, key);
+  async pressKeyUp(key, detectOS) {
+    key = getNormalizedKey.call(this, key, detectOS);
     if (!this.browser.isW3C) {
       return this.browser.sendKeys([key]);
     }
@@ -1535,11 +1535,11 @@ class WebDriver extends Helper {
    * I.pressKey('Control');
    * ```
    */
-  async pressKey(key) {
+  async pressKey(key, detectOS) {
     const modifiers = [];
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k);
+        k = getNormalizedKey.call(this, k, detectOS);
         if (isModifierKey(k)) {
           modifiers.push(k);
         } else {
@@ -1548,7 +1548,7 @@ class WebDriver extends Helper {
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key);
+      key = getNormalizedKey.call(this, key, detectOS);
     }
     for (const modifier of modifiers) {
       await this.pressKeyDown(modifier);
@@ -2524,8 +2524,8 @@ function convertKeyToRawKey(key) {
   return key;
 }
 
-function getNormalizedKey(key) {
-  const normalizedKey = getNormalizedKeyAttributeValue(key);
+function getNormalizedKey(key, detectOS) {
+  const normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
   if (key !== normalizedKey) {
     this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -376,6 +376,35 @@ module.exports.tryOrDefault = function (fn, defaultValue) {
   }
 };
 
+function normalizeKeyReplacer(match, prefix, key, suffix, offset, string) {
+  if (typeof key !== 'string') {
+    return string;
+  }
+  const normalizedKey = key.charAt(0).toUpperCase() + key.substr(1).toLowerCase();
+  let position = '';
+  if (typeof prefix === 'string') {
+    position = prefix;
+  } else if (typeof suffix === 'string') {
+    position = suffix;
+  }
+  return normalizedKey + position.charAt(0).toUpperCase() + position.substr(1).toLowerCase();
+}
+
+module.exports.getNormalizedKeyAttributeValue = function (key) {
+  // Selection of keys (https://www.w3.org/TR/uievents-key/#named-key-attribute-values)
+  // which can be written in various ways and should be normalized.
+  // For example 'LEFT ALT', 'ALT_Left', 'alt left' or 'LeftAlt' will be normalized as 'AltLeft'.
+  key = key.replace(/^\s*(?:(Down|Left|Right|Up)[ _]?)?(Arrow|Alt|Ctrl|Control|Command|Meta|Option|Page|Shift)(?:[ _]?(Down|Left|Right|Up))?\s*$/i, normalizeKeyReplacer);
+  // Map alias to corresponding key value
+  key = key.replace(/^(Add|Divide|Decimal|Multiply|Subtract)$/, 'Numpad$1');
+  key = key.replace('AltGr', 'AltGraph');
+  key = key.replace('Command', 'Meta');
+  key = key.replace('Ctrl', 'Control');
+  key = key.replace('Option', 'Alt');
+  key = key.replace(/^NumpadComma|Separator$/, 'Comma');
+  return key;
+};
+
 const modifierKeys = [
   'Alt', 'AltGraph', 'AltLeft', 'AltRight',
   'Control', 'ControlLeft', 'ControlRight',
@@ -383,6 +412,7 @@ const modifierKeys = [
   'Shift', 'ShiftLeft', 'ShiftRight',
 ];
 
+module.exports.modifierKeys = modifierKeys;
 module.exports.isModifierKey = function (key) {
   return modifierKeys.includes(key);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const getFunctionArguments = require('fn-args');
 const deepClone = require('lodash.clonedeep');
@@ -390,7 +391,7 @@ function normalizeKeyReplacer(match, prefix, key, suffix, offset, string) {
   return normalizedKey + position.charAt(0).toUpperCase() + position.substr(1).toLowerCase();
 }
 
-module.exports.getNormalizedKeyAttributeValue = function (key) {
+module.exports.getNormalizedKeyAttributeValue = function (key, detectOS = true) {
   // Selection of keys (https://www.w3.org/TR/uievents-key/#named-key-attribute-values)
   // which can be written in various ways and should be normalized.
   // For example 'LEFT ALT', 'ALT_Left', 'alt left' or 'LeftAlt' will be normalized as 'AltLeft'.
@@ -402,6 +403,14 @@ module.exports.getNormalizedKeyAttributeValue = function (key) {
   key = key.replace('Ctrl', 'Control');
   key = key.replace('Option', 'Alt');
   key = key.replace(/^NumpadComma|Separator$/, 'Comma');
+  // Change operation modifier key based on operating system
+  if (detectOS) {
+    if (os.platform() === 'darwin') {
+      key = key.replace('Control', 'Meta');
+    } else {
+      key = key.replace('Meta', 'Control');
+    }
+  }
   return key;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -375,3 +375,14 @@ module.exports.tryOrDefault = function (fn, defaultValue) {
     return defaultValue;
   }
 };
+
+const modifierKeys = [
+  'Alt', 'AltGraph', 'AltLeft', 'AltRight',
+  'Control', 'ControlLeft', 'ControlRight',
+  'Meta', 'MetaLeft', 'MetaRight',
+  'Shift', 'ShiftLeft', 'ShiftRight',
+];
+
+module.exports.isModifierKey = function (key) {
+  return modifierKeys.includes(key);
+};

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - node_modules:/node_modules
 
   selenium.chrome:
-    image: selenium/standalone-chrome:3.9.1-actinium
+    image: selenium/standalone-chrome:3.141.59-oxygen
     shm_size: 2g
     ports:
       - 4444:4444

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -427,6 +427,157 @@ describe('Puppeteer', function () {
     });
   });
 
+  describe('#pressKey, #pressKeyDown, #pressKeyUp', () => {
+    it('should be able to send special keys to element', async () => {
+      await I.amOnPage('/form/field');
+      await I.appendField('Name', '-');
+
+      await I.pressKey(['Right Shift', 'Home']);
+      await I.pressKey('Delete');
+
+      // Sequence only executes up to first non-modifier key ('Digit1')
+      await I.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4']);
+      await I.pressKey('1');
+      await I.pressKey('2');
+      await I.pressKey('3');
+      await I.pressKey('ArrowLeft');
+      await I.pressKey('Left Arrow');
+      await I.pressKey('arrow_left');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('a');
+      await I.pressKey('KeyB');
+      await I.pressKeyUp('ShiftLeft');
+      await I.pressKey('C');
+      await I.seeInField('Name', '!ABC123');
+    });
+
+    it('should not change operator modifier key', async () => {
+      await I.amOnPage('/form/field');
+      await I.appendField('Name', '-');
+
+      // Does nothing, because operator modifier key is not changed for operating system
+      await I.pressKey(['Right Meta', 'a'], false); // Select all
+      await I.pressKey('Backspace');
+      await I.seeInField('Name', 'OLD_VALUE');
+
+      await I.pressKey(['Right Meta', 'a']); // Select all ('Meta' is changed to 'Control')
+      await I.pressKey('Backspace');
+      await I.dontSeeInField('Name', 'OLD_VALUE');
+    });
+
+    it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
+      await I.amOnPage('/form/field');
+      await I.clearField('Name');
+
+      await I.pressKey(';');
+      await I.pressKey(['Shift', ';']);
+      await I.pressKey(['Shift', 'Semicolon']);
+      await I.pressKey('=');
+      await I.pressKey(['Shift', '=']);
+      await I.pressKey(['Shift', 'Equal']);
+      await I.pressKey('*');
+      await I.pressKey(['Shift', '*']);
+      await I.pressKey(['Shift', 'Multiply']);
+      await I.pressKey('+');
+      await I.pressKey(['Shift', '+']);
+      await I.pressKey(['Shift', 'Add']);
+      await I.pressKey(',');
+      await I.pressKey(['Shift', ',']);
+      await I.pressKey(['Shift', 'Comma']);
+      await I.pressKey(['Shift', 'NumpadComma']);
+      await I.pressKey(['Shift', 'Separator']);
+      await I.pressKey('-');
+      await I.pressKey(['Shift', '-']);
+      await I.pressKey(['Shift', 'Subtract']);
+      await I.pressKey('.');
+      await I.pressKey(['Shift', '.']);
+      await I.pressKey(['Shift', 'Decimal']);
+      await I.pressKey(['Shift', 'Period']);
+      await I.pressKey('/');
+      await I.pressKey(['Shift', '/']);
+      await I.pressKey(['Shift', 'Divide']);
+      await I.pressKey(['Shift', 'Slash']);
+
+      await I.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?');
+    });
+
+    it('should show correct number key when Shift modifier is active', async () => {
+      await I.amOnPage('/form/field');
+      await I.clearField('Name');
+
+      await I.pressKey('0');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('0');
+      await I.pressKey('Digit0');
+      await I.pressKey('Numpad0');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('1');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('1');
+      await I.pressKey('Digit1');
+      await I.pressKey('Numpad1');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('2');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('2');
+      await I.pressKey('Digit2');
+      await I.pressKey('Numpad2');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('3');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('3');
+      await I.pressKey('Digit3');
+      await I.pressKey('Numpad3');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('4');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('4');
+      await I.pressKey('Digit4');
+      await I.pressKey('Numpad4');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('5');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('5');
+      await I.pressKey('Digit5');
+      await I.pressKey('Numpad5');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('6');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('6');
+      await I.pressKey('Digit6');
+      await I.pressKey('Numpad6');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('7');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('7');
+      await I.pressKey('Digit7');
+      await I.pressKey('Numpad7');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('8');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('8');
+      await I.pressKey('Digit8');
+      await I.pressKey('Numpad8');
+      await I.pressKeyUp('Shift');
+
+      await I.pressKey('9');
+      await I.pressKeyDown('Shift');
+      await I.pressKey('9');
+      await I.pressKey('Digit9');
+      await I.pressKey('Numpad9');
+      await I.pressKeyUp('Shift');
+
+      await I.seeInField('Name', '0))01!!12@@23##34$$45%%56^^67&&78**89((9');
+    });
+  });
 
   describe('#waitForEnabled', () => {
     it('should wait for input text field to be enabled', () => I.amOnPage('/form/wait_enabled')

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -467,7 +467,7 @@ describe('Puppeteer', function () {
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
       await I.amOnPage('/form/field');
-      await I.clearField('Name');
+      await I.fillField('Name', '');
 
       await I.pressKey(';');
       await I.pressKey(['Shift', ';']);
@@ -503,7 +503,7 @@ describe('Puppeteer', function () {
 
     it('should show correct number key when Shift modifier is active', async () => {
       await I.amOnPage('/form/field');
-      await I.clearField('Name');
+      await I.fillField('Name', '');
 
       await I.pressKey('0');
       await I.pressKeyDown('Shift');

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -165,15 +165,145 @@ describe('WebDriver', function () {
     });
   });
 
-  describe('#pressKey', () => {
+  describe('#pressKey, #pressKeyDown, #pressKeyUp', () => {
     it('should be able to send special keys to element', async () => {
       await wd.amOnPage('/form/field');
       await wd.appendField('Name', '-');
-      await wd.pressKey(['Control', 'a']);
+
+      await wd.pressKey(['Right Shift', 'Home']);
       await wd.pressKey('Delete');
-      await wd.pressKey(['Shift', '111']);
+
+      // Sequence only executes up to first non-modifier key ('Digit1')
+      await wd.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4']);
       await wd.pressKey('1');
-      await wd.seeInField('Name', '!!!1');
+      await wd.pressKey('2');
+      await wd.pressKey('3');
+      await wd.pressKey('ArrowLeft');
+      await wd.pressKey('Left Arrow');
+      await wd.pressKey('arrow_left');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('a');
+      await wd.pressKey('KeyB');
+      await wd.pressKeyUp('ShiftLeft');
+      await wd.pressKey('C');
+      await wd.seeInField('Name', '!ABC123');
+    });
+
+    it('should not change operator modifier key', async () => {
+      await wd.amOnPage('/form/field');
+      await wd.appendField('Name', '-');
+
+      // Does nothing, because operator modifier key is not changed for operating system
+      await wd.pressKey(['Right Meta', 'a'], false); // Select all
+      await wd.pressKey('Backspace');
+      await wd.seeInField('Name', 'OLD_VALUE');
+
+      await wd.pressKey(['Right Meta', 'a']); // Select all ('Meta' is changed to 'Control')
+      await wd.pressKey('Backspace');
+      await wd.dontSeeInField('Name', 'OLD_VALUE');
+    });
+
+    it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
+      await wd.amOnPage('/form/field');
+      await wd.clearField('Name');
+
+      await wd.pressKey(';');
+      await wd.pressKey(['Shift', ';']);
+      await wd.pressKey(['Shift', 'Semicolon']);
+      await wd.pressKey('=');
+      await wd.pressKey(['Shift', '=']);
+      await wd.pressKey(['Shift', 'Equal']);
+      await wd.pressKey('*');
+      await wd.pressKey(['Shift', '*']);
+      await wd.pressKey(['Shift', 'Multiply']);
+      await wd.pressKey('+');
+      await wd.pressKey(['Shift', '+']);
+      await wd.pressKey(['Shift', 'Add']);
+      await wd.pressKey(',');
+      await wd.pressKey(['Shift', ',']);
+      await wd.pressKey(['Shift', 'Comma']);
+      await wd.pressKey(['Shift', 'NumpadComma']);
+      await wd.pressKey(['Shift', 'Separator']);
+      await wd.pressKey('-');
+      await wd.pressKey(['Shift', '-']);
+      await wd.pressKey(['Shift', 'Subtract']);
+      await wd.pressKey('.');
+      await wd.pressKey(['Shift', '.']);
+      await wd.pressKey(['Shift', 'Decimal']);
+      await wd.pressKey(['Shift', 'Period']);
+      await wd.pressKey('/');
+      await wd.pressKey(['Shift', '/']);
+      await wd.pressKey(['Shift', 'Divide']);
+      await wd.pressKey(['Shift', 'Slash']);
+
+      await wd.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?');
+    });
+
+    it('should show correct number key when Shift modifier is active', async () => {
+      await wd.amOnPage('/form/field');
+      await wd.clearField('Name');
+
+      await wd.pressKey('0');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('0');
+      await wd.pressKey('Digit0');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('1');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('1');
+      await wd.pressKey('Digit1');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('2');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('2');
+      await wd.pressKey('Digit2');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('3');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('3');
+      await wd.pressKey('Digit3');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('4');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('4');
+      await wd.pressKey('Digit4');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('5');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('5');
+      await wd.pressKey('Digit5');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('6');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('6');
+      await wd.pressKey('Digit6');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('7');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('7');
+      await wd.pressKey('Digit7');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('8');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('8');
+      await wd.pressKey('Digit8');
+      await wd.pressKeyUp('Shift');
+
+      await wd.pressKey('9');
+      await wd.pressKeyDown('Shift');
+      await wd.pressKey('9');
+      await wd.pressKey('Digit9');
+      await wd.pressKeyUp('Shift');
+
+      await wd.seeInField('Name', '0))1!!2@@3##4$$5%%6^^7&&8**9((');
     });
   });
 

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -205,7 +205,7 @@ describe('WebDriver', function () {
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
       await wd.amOnPage('/form/field');
-      await wd.clearField('Name');
+      await wd.fillField('Name', '');
 
       await wd.pressKey(';');
       await wd.pressKey(['Shift', ';']);
@@ -241,7 +241,7 @@ describe('WebDriver', function () {
 
     it('should show correct number key when Shift modifier is active', async () => {
       await wd.amOnPage('/form/field');
-      await wd.clearField('Name');
+      await wd.fillField('Name', '');
 
       await wd.pressKey('0');
       await wd.pressKeyDown('Shift');


### PR DESCRIPTION
* Changed `pressKey` method to resolve issues and extend functionality.
  * Did not properly recognize `'Meta'` (or `'Command'`) as modifier key.
  * Right modifier keys did not work in WebDriver using JsonWireProtocol.
  * `'Shift'` + `<key>` combination would not reflect actual keyboard behavior.
  * Respect sequence with multiple modifier keys passed to `pressKey`.
  * Add support to automatic change operation modifier key based on operating system.
* Updated `pressKey` documentation to show a proper list of available key names which are available **both** in [Puppeteer](https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/lib/USKeyboardLayout.js) and [WebDriver](https://www.w3.org/TR/webdriver/#keyboard-actions).
* Added `pressKeyDown` and `pressKeyUp` methods with similar functionality as updated `pressKey` method to simplify pressing of modifier key in combination with user operation.