### PR TITLE
Introduce key alias for pressing modifier depending on operating system

### DIFF
--- a/docs/webapi/pressKeyDown.mustache
+++ b/docs/webapi/pressKeyDown.mustache
@@ -9,4 +9,3 @@ I.pressKeyUp('Control');
 ```
 
 @param {string} key name of key to press down.
-@param {boolean} detectOS (optional, `true` by default) change operation modifier key based on operating system.

--- a/docs/webapi/pressKeyUp.mustache
+++ b/docs/webapi/pressKeyUp.mustache
@@ -9,4 +9,3 @@ I.pressKeyUp('Control');
 ```
 
 @param {string} key name of key to release.
-@param {boolean} detectOS (optional, `true` by default) change operation modifier key based on operating system.

--- a/docs/webapi/pressKeyWithDetectOS.mustache
+++ b/docs/webapi/pressKeyWithDetectOS.mustache
@@ -59,4 +59,3 @@ Some of the supported key names are:
 - `'Tab'`
 
 @param {string|array} key key or array of keys to press.
-@param {boolean} detectOS (optional, `true` by default) change operation modifier key based on operating system.

--- a/docs/webapi/pressKeyWithKeyNormalization.mustache
+++ b/docs/webapi/pressKeyWithKeyNormalization.mustache
@@ -12,15 +12,11 @@ To press a key in combination with modifier keys, pass the sequence as an array.
 I.pressKey(['Control', 'Z']);
 ```
 
-By default `pressKey` will change operation modifier key based on operating system.
-Mapping `'Control'` to `'Meta'` (also known as `'Command'`) on macOS machines or mapping `'Meta'` to `'Control'` on non-macOS machines.
-
-In order to use disable changing of operation modifier key based on operating system, specify the second argument as `false`.
+For specifying operation modifier key based on operating system it is suggested to use `'CommandOrControl'`.
+This will press `'Command'` (also known as `'Meta'`) on macOS machines and `'Control'` on non-macOS machines.
 
 ```js
-// On macOS this will actually press 'Control + Z' instead of
-// default behavior which would change keys to 'Meta + Z'
-I.pressKey(['Control', 'Z'], false);
+I.pressKey(['CommandOrControl', 'Z']);
 ```
 
 Some of the supported key names are:
@@ -34,6 +30,8 @@ Some of the supported key names are:
 - `'Clear'`
 - `'ControlLeft'` or `'Control'`
 - `'ControlRight'`
+- `'Command'`
+- `'CommandOrControl'`
 - `'Delete'`
 - `'End'`
 - `'Enter'`

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1046,8 +1046,8 @@ class Puppeteer extends Helper {
   /**
    * {{> pressKeyDown }}
    */
-  async pressKeyDown(key, detectOS) {
-    key = getNormalizedKey.call(this, key, detectOS);
+  async pressKeyDown(key) {
+    key = getNormalizedKey.call(this, key);
     await this.page.keyboard.down(key);
     return this._waitForAction();
   }
@@ -1055,8 +1055,8 @@ class Puppeteer extends Helper {
   /**
    * {{> pressKeyUp }}
    */
-  async pressKeyUp(key, detectOS) {
-    key = getNormalizedKey.call(this, key, detectOS);
+  async pressKeyUp(key) {
+    key = getNormalizedKey.call(this, key);
     await this.page.keyboard.up(key);
     return this._waitForAction();
   }
@@ -1066,11 +1066,11 @@ class Puppeteer extends Helper {
    *
    * _Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/puppeteer#1313](https://github.com/GoogleChrome/puppeteer/issues/1313)).
    */
-  async pressKey(key, detectOS) {
+  async pressKey(key) {
     const modifiers = [];
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k, detectOS);
+        k = getNormalizedKey.call(this, k);
         if (isModifierKey(k)) {
           modifiers.push(k);
         } else {
@@ -1079,7 +1079,7 @@ class Puppeteer extends Helper {
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key, detectOS);
+      key = getNormalizedKey.call(this, key);
     }
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier);
@@ -2411,8 +2411,8 @@ const keyDefinitionMap = {
   /* eslint-enable quote-props */
 };
 
-function getNormalizedKey(key, detectOS) {
-  const normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
+function getNormalizedKey(key) {
+  const normalizedKey = getNormalizedKeyAttributeValue(key);
   if (key !== normalizedKey) {
     this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
   }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1062,7 +1062,7 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * {{> pressKeyWithDetectOS }}
+   * {{> pressKeyWithKeyNormalization }}
    *
    * _Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/puppeteer#1313](https://github.com/GoogleChrome/puppeteer/issues/1313)).
    */

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1495,8 +1495,8 @@ class WebDriver extends Helper {
   /**
    * {{> pressKeyDown }}
    */
-  async pressKeyDown(key, detectOS) {
-    key = getNormalizedKey.call(this, key, detectOS);
+  async pressKeyDown(key) {
+    key = getNormalizedKey.call(this, key);
     if (!this.browser.isW3C) {
       return this.browser.sendKeys([key]);
     }
@@ -1513,8 +1513,8 @@ class WebDriver extends Helper {
   /**
    * {{> pressKeyUp }}
    */
-  async pressKeyUp(key, detectOS) {
-    key = getNormalizedKey.call(this, key, detectOS);
+  async pressKeyUp(key) {
+    key = getNormalizedKey.call(this, key);
     if (!this.browser.isW3C) {
       return this.browser.sendKeys([key]);
     }
@@ -1533,11 +1533,11 @@ class WebDriver extends Helper {
    *
    * _Note:_ In case a text field or textarea is focused be aware that some browsers do not respect active modifier when combining modifier keys with other keys.
    */
-  async pressKey(key, detectOS) {
+  async pressKey(key) {
     const modifiers = [];
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k, detectOS);
+        k = getNormalizedKey.call(this, k);
         if (isModifierKey(k)) {
           modifiers.push(k);
         } else {
@@ -1546,7 +1546,7 @@ class WebDriver extends Helper {
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key, detectOS);
+      key = getNormalizedKey.call(this, key);
     }
     for (const modifier of modifiers) {
       await this.pressKeyDown(modifier);
@@ -2557,8 +2557,8 @@ function convertKeyToRawKey(key) {
   return key;
 }
 
-function getNormalizedKey(key, detectOS) {
-  let normalizedKey = getNormalizedKeyAttributeValue(key, detectOS);
+function getNormalizedKey(key) {
+  let normalizedKey = getNormalizedKeyAttributeValue(key);
   // Always use "left" modifier keys for non-W3C sessions,
   // as JsonWireProtocol does not support "right" modifier keys
   if (!this.browser.isW3C) {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1529,7 +1529,7 @@ class WebDriver extends Helper {
   }
 
   /**
-   * {{> pressKeyWithDetectOS }}
+   * {{> pressKeyWithKeyNormalization }}
    *
    * _Note:_ In case a text field or textarea is focused be aware that some browsers do not respect active modifier when combining modifier keys with other keys.
    */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -394,14 +394,14 @@ module.exports.getNormalizedKeyAttributeValue = function (key) {
   // Selection of keys (https://www.w3.org/TR/uievents-key/#named-key-attribute-values)
   // which can be written in various ways and should be normalized.
   // For example 'LEFT ALT', 'ALT_Left', 'alt left' or 'LeftAlt' will be normalized as 'AltLeft'.
-  key = key.replace(/^\s*(?:(Down|Left|Right|Up)[ _]?)?(Arrow|Alt|Ctrl|Control|Command|Meta|Option|Page|Shift)(?:[ _]?(Down|Left|Right|Up))?\s*$/i, normalizeKeyReplacer);
+  key = key.replace(/^\s*(?:(Down|Left|Right|Up)[ _]?)?(Arrow|Alt|Ctrl|Control|Cmd|Command|Meta|Option|OS|Page|Shift|Super)(?:[ _]?(Down|Left|Right|Up|Gr(?:aph)?))?\s*$/i, normalizeKeyReplacer);
   // Map alias to corresponding key value
   key = key.replace(/^(Add|Divide|Decimal|Multiply|Subtract)$/, 'Numpad$1');
-  key = key.replace('AltGr', 'AltGraph');
-  key = key.replace('Command', 'Meta');
+  key = key.replace(/^AltGr$/, 'AltGraph');
+  key = key.replace(/^(Cmd|Command|Os|Super)/, 'Meta');
   key = key.replace('Ctrl', 'Control');
   key = key.replace('Option', 'Alt');
-  key = key.replace(/^NumpadComma|Separator$/, 'Comma');
+  key = key.replace(/^(NumpadComma|Separator)$/, 'Comma');
   return key;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 const getFunctionArguments = require('fn-args');
 const deepClone = require('lodash.clonedeep');
@@ -391,7 +390,7 @@ function normalizeKeyReplacer(match, prefix, key, suffix, offset, string) {
   return normalizedKey + position.charAt(0).toUpperCase() + position.substr(1).toLowerCase();
 }
 
-module.exports.getNormalizedKeyAttributeValue = function (key, detectOS = true) {
+module.exports.getNormalizedKeyAttributeValue = function (key) {
   // Selection of keys (https://www.w3.org/TR/uievents-key/#named-key-attribute-values)
   // which can be written in various ways and should be normalized.
   // For example 'LEFT ALT', 'ALT_Left', 'alt left' or 'LeftAlt' will be normalized as 'AltLeft'.
@@ -403,14 +402,6 @@ module.exports.getNormalizedKeyAttributeValue = function (key, detectOS = true) 
   key = key.replace('Ctrl', 'Control');
   key = key.replace('Option', 'Alt');
   key = key.replace(/^NumpadComma|Separator$/, 'Comma');
-  // Change operation modifier key based on operating system
-  if (detectOS) {
-    if (os.platform() === 'darwin') {
-      key = key.replace('Control', 'Meta');
-    } else {
-      key = key.replace('Meta', 'Control');
-    }
-  }
   return key;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const getFunctionArguments = require('fn-args');
 const deepClone = require('lodash.clonedeep');
@@ -391,6 +392,8 @@ function normalizeKeyReplacer(match, prefix, key, suffix, offset, string) {
 }
 
 module.exports.getNormalizedKeyAttributeValue = function (key) {
+  // Use operation modifier key based on operating system
+  key = key.replace(/(Ctrl|Control|Cmd|Command)[ _]?Or[ _]?(Ctrl|Control|Cmd|Command)/i, os.platform() === 'darwin' ? 'Meta' : 'Control');
   // Selection of keys (https://www.w3.org/TR/uievents-key/#named-key-attribute-values)
   // which can be written in various ways and should be normalized.
   // For example 'LEFT ALT', 'ALT_Left', 'alt left' or 'LeftAlt' will be normalized as 'AltLeft'.

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -451,18 +451,13 @@ describe('Puppeteer', function () {
       await I.seeInField('Name', '!ABC123');
     });
 
-    it('should not change operator modifier key', async () => {
+    it('should use modifier key based on operating system', async () => {
       await I.amOnPage('/form/field');
-      await I.appendField('Name', '-');
+      await I.fillField('Name', 'value that is cleared using select all shortcut');
 
-      // Does nothing, because operator modifier key is not changed for operating system
-      await I.pressKey(['Right Meta', 'a'], false); // Select all
+      await I.pressKey(['ControlOrCommand', 'a']);
       await I.pressKey('Backspace');
-      await I.seeInField('Name', 'OLD_VALUE');
-
-      await I.pressKey(['Right Meta', 'a']); // Select all ('Meta' is changed to 'Control')
-      await I.pressKey('Backspace');
-      await I.dontSeeInField('Name', 'OLD_VALUE');
+      await I.dontSeeInField('Name', 'value that is cleared using select all shortcut');
     });
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -190,18 +190,13 @@ describe('WebDriver', function () {
       await wd.seeInField('Name', '!ABC123');
     });
 
-    it('should not change operator modifier key', async () => {
+    it('should use modifier key based on operating system', async () => {
       await wd.amOnPage('/form/field');
-      await wd.appendField('Name', '-');
+      await wd.fillField('Name', 'value that is cleared using select all shortcut');
 
-      // Does nothing, because operator modifier key is not changed for operating system
-      await wd.pressKey(['Right Meta', 'a'], false); // Select all
+      await wd.pressKey(['CommandOrControl', 'A']);
       await wd.pressKey('Backspace');
-      await wd.seeInField('Name', 'OLD_VALUE');
-
-      await wd.pressKey(['Right Meta', 'a']); // Select all ('Meta' is changed to 'Control')
-      await wd.pressKey('Backspace');
-      await wd.dontSeeInField('Name', 'OLD_VALUE');
+      await wd.dontSeeInField('Name', 'value that is cleared using select all shortcut');
     });
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1,5 +1,7 @@
 const utils = require('../../lib/utils');
 const assert = require('assert');
+const os = require('os');
+const sinon = require('sinon');
 
 describe('utils', () => {
   describe('#fileExists', () => {
@@ -266,6 +268,22 @@ describe('utils', () => {
       utils.getNormalizedKeyAttributeValue('Divide').should.equal('NumpadDivide');
       utils.getNormalizedKeyAttributeValue('Multiply').should.equal('NumpadMultiply');
       utils.getNormalizedKeyAttributeValue('Subtract').should.equal('NumpadSubtract');
+    });
+
+    it('should normalize modifier key based on operating system', () => {
+      sinon.stub(os, 'platform', () => { return 'notdarwin'; });
+      utils.getNormalizedKeyAttributeValue('CmdOrCtrl').should.equal('Control');
+      utils.getNormalizedKeyAttributeValue('COMMANDORCONTROL').should.equal('Control');
+      utils.getNormalizedKeyAttributeValue('ControlOrCommand').should.equal('Control');
+      utils.getNormalizedKeyAttributeValue('left ctrl or command').should.equal('ControlLeft');
+      os.platform.restore();
+
+      sinon.stub(os, 'platform', () => { return 'darwin'; });
+      utils.getNormalizedKeyAttributeValue('CtrlOrCmd').should.equal('Meta');
+      utils.getNormalizedKeyAttributeValue('CONTROLORCOMMAND').should.equal('Meta');
+      utils.getNormalizedKeyAttributeValue('CommandOrControl').should.equal('Meta');
+      utils.getNormalizedKeyAttributeValue('right command or ctrl').should.equal('MetaRight');
+      os.platform.restore();
     });
   });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -233,4 +233,39 @@ describe('utils', () => {
       });
     });
   });
+
+  describe('#getNormalizedKeyAttributeValue', () => {
+    it('should normalize key (alias) to key attribute value', () => {
+      utils.getNormalizedKeyAttributeValue('Arrow down').should.equal('ArrowDown');
+      utils.getNormalizedKeyAttributeValue('RIGHT_ARROW').should.equal('ArrowRight');
+      utils.getNormalizedKeyAttributeValue('leftarrow').should.equal('ArrowLeft');
+      utils.getNormalizedKeyAttributeValue('Up arrow').should.equal('ArrowUp');
+
+      utils.getNormalizedKeyAttributeValue('Left Alt').should.equal('AltLeft');
+      utils.getNormalizedKeyAttributeValue('RIGHT_ALT').should.equal('AltRight');
+      utils.getNormalizedKeyAttributeValue('alt').should.equal('Alt');
+
+      utils.getNormalizedKeyAttributeValue('oPTION left').should.equal('AltLeft');
+      utils.getNormalizedKeyAttributeValue('ALTGR').should.equal('AltGraph');
+      utils.getNormalizedKeyAttributeValue('alt graph').should.equal('AltGraph');
+
+      utils.getNormalizedKeyAttributeValue('Control Left').should.equal('ControlLeft');
+      utils.getNormalizedKeyAttributeValue('RIGHT_CTRL').should.equal('ControlRight');
+      utils.getNormalizedKeyAttributeValue('Ctrl').should.equal('Control');
+
+      utils.getNormalizedKeyAttributeValue('Cmd').should.equal('Meta');
+      utils.getNormalizedKeyAttributeValue('LeftCommand').should.equal('MetaLeft');
+      utils.getNormalizedKeyAttributeValue('os right').should.equal('MetaRight');
+      utils.getNormalizedKeyAttributeValue('SUPER').should.equal('Meta');
+
+      utils.getNormalizedKeyAttributeValue('NumpadComma').should.equal('Comma');
+      utils.getNormalizedKeyAttributeValue('Separator').should.equal('Comma');
+
+      utils.getNormalizedKeyAttributeValue('Add').should.equal('NumpadAdd');
+      utils.getNormalizedKeyAttributeValue('Decimal').should.equal('NumpadDecimal');
+      utils.getNormalizedKeyAttributeValue('Divide').should.equal('NumpadDivide');
+      utils.getNormalizedKeyAttributeValue('Multiply').should.equal('NumpadMultiply');
+      utils.getNormalizedKeyAttributeValue('Subtract').should.equal('NumpadSubtract');
+    });
+  });
 });


### PR DESCRIPTION
* Replacing `detectOS` option with key alias (e.g. `'CommandOrControl'`) which will press `'Control'` or `'Meta'` depending on operating system.
* Additional aliases for `'Meta'` (`'Cmd'`, `'OS'`, `'Super'`) and properly detect `'AltGraph'`.
