### PR TITLE
fix(Puppeteer): simplify switchTo iframe by selector

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1915,17 +1915,10 @@ class Puppeteer extends Helper {
     // iframe by selector
     const els = await this._locate(locator);
     assertElementExists(els, locator);
+    const contentFrame = await els[0].contentFrame();
 
-    const iframeName = await els[0].getProperty('name').then(el => el.jsonValue());
-    const iframeId = await els[0].getProperty('id').then(el => el.jsonValue());
-    const iframeUrl = await els[0].getProperty('src').then(el => el.jsonValue());
-
-    const searchName = iframeName || iframeId; // Name takes precedence over id, because of puppeteer's Frame.name() function
-    const currentContext = await this._getContext();
-    const resFrame = await findFrame.call(this, currentContext, searchName, iframeUrl);
-
-    if (resFrame) {
-      this.context = resFrame;
+    if (contentFrame) {
+      this.context = contentFrame;
     } else {
       this.context = els[0];
     }
@@ -2027,25 +2020,6 @@ class Puppeteer extends Helper {
 }
 
 module.exports = Puppeteer;
-
-async function findFrame(context, name, url) {
-  if (!context) {
-    return;
-  }
-  let frames = [];
-  if (typeof context.childFrames === 'function') {
-    frames = context.childFrames();
-  } else {
-    frames = this.page.frames();
-  }
-
-  return frames.find((frame) => {
-    if (name || !url) {
-      return frame.name() === name;
-    }
-    return frame.url() === url;
-  });
-}
 
 async function findElements(matcher, locator) {
   if (locator.react) return findReact(matcher, locator);


### PR DESCRIPTION
switchTo did not work as expected in some situations, because the lookup code did not consider every possibility. However, given a ElementHandle, the corresponding frame can be fetched directly using Puppeteer API. This allows to remove a lot of code and should still work as expected.

I tried to add failing tests, but could not come up with a minimal example. I'll try a little harder to come up with something, but wanted to get this PR out of the door.

Fixes: #1439