### PR TITLE
Fixing typo in email testing guide

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -53,7 +53,7 @@ mailbox object contains:
 * `id` - which is used in next commands
 * `emailAddress` - randomly generated address of a created mailbox.
 
-> See [Mailslsurp Guide](https://www.mailslurp.com/developers/guides/#create-email-addresses) for details.
+> See [MailSlurp's guide](https://www.mailslurp.com/guides/getting-started/#create-email-addresses) for details.
 
 Mailbox is opened on creation. If you need more than one mailboxes and you want to switch between them use `openMailbox` method:
 


### PR DESCRIPTION
MailSlurp was spelled wrong in one place, and the link associated with their guide went to a 404 page. This fixes those issues.