### PR TITLE
upgrade parse-function to 5.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mocha": "^6.2.0",
     "mocha-junit-reporter": "^1.23.1",
     "ms": "^2.1.2",
-    "parse-function": "5.2.11",
+    "parse-function": "^5.4.3",
     "promise-retry": "^1.1.1",
     "requireg": "^0.1.8",
     "resq": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mocha": "^6.2.0",
     "mocha-junit-reporter": "^1.23.1",
     "ms": "^2.1.2",
-    "parse-function": "^5.4.3",
+    "parse-function": "5.4.3",
     "promise-retry": "^1.1.1",
     "requireg": "^0.1.8",
     "resq": "^1.6.0",


### PR DESCRIPTION
`parse-function` has been fix the [issue][] that cause `Cannot find module './utils'` error, so we don't need to keep version in 5.2.x 🎉

[issue]: https://github.com/Codeception/CodeceptJS/issues/1976