### PR TITLE
Support remote connections for TestCafe helper

### DIFF
--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -42,6 +42,23 @@ This helper should be configured in codecept.json or codecept.conf.js
 }
 ```
 
+ To use remote device you can provide 'remote' as browser parameter this will display a link with QR Code
+ See [https://devexpress.github.io/testcafe/documentation/recipes/test-on-remote-computers-and-mobile-devices.html][3]
+
+#### Example #2: Remote browser connection
+
+```js
+{
+   helpers: {
+     TestCafe : {
+       url: "http://localhost",
+       waitForTimeout: 15000,
+       browser: "remote"
+     }
+   }
+}
+```
+
 ## Access From Helpers
 
 Call Testcafe methods directly using the testcafe controller.
@@ -86,7 +103,7 @@ I.amOnPage('/login'); // opens a login page
 
 #### Parameters
 
--   `url` [string][3] url path or global url.
+-   `url` [string][4] url path or global url.
     
 
 
@@ -102,7 +119,7 @@ I.appendField('#myTextField', 'appended');
 #### Parameters
 
 -   `field` CodeceptJS.LocatorOrString located by label|name|CSS|XPath|strict locator
--   `value` [string][3] text value to append.
+-   `value` [string][4] text value to append.
     
 
 
@@ -120,7 +137,7 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 #### Parameters
 
 -   `field`  
--   `pathToFile` [string][3] local file path relative to codecept.json config file.
+-   `pathToFile` [string][4] local file path relative to codecept.json config file.
     
 
 -   `locator` CodeceptJS.LocatorOrString field located by label|name|CSS|XPath|strict locator.
@@ -158,7 +175,7 @@ I.clearCookie('test');
 #### Parameters
 
 -   `cookieName`  
--   `cookie` [string][3]? (optional, `null` by default) cookie name
+-   `cookie` [string][4]? (optional, `null` by default) cookie name
     
  
 
@@ -175,7 +192,7 @@ I.clearField('#email');
 #### Parameters
 
 -   `field`  
--   `editable` ([string][3] \| [object][4]) field located by label|name|CSS|XPath|strict locator.
+-   `editable` ([string][4] \| [object][5]) field located by label|name|CSS|XPath|strict locator.
     
 
 
@@ -222,7 +239,7 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 #### Parameters
 
--   `text` [string][3] which is not present.
+-   `text` [string][4] which is not present.
 -   `context` CodeceptJS.LocatorOrString? (optional) element located by CSS|XPath|strict locator in which to perfrom search.
     
  
@@ -253,7 +270,7 @@ I.dontSeeCookie('auth'); // no auth cookie
 
 #### Parameters
 
--   `name` [string][3] cookie name.
+-   `name` [string][4] cookie name.
     
 
 
@@ -269,7 +286,7 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 #### Parameters
 
--   `url` [string][3] value to check.
+-   `url` [string][4] value to check.
     
 
 
@@ -307,7 +324,7 @@ Checks that current url does not contain a provided fragment.
 
 #### Parameters
 
--   `url` [string][3] value to check.
+-   `url` [string][4] value to check.
     
 
 
@@ -324,7 +341,7 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 #### Parameters
 
 -   `field` CodeceptJS.LocatorOrString located by label|name|CSS|XPath|strict locator.
--   `value` [string][3] value to check.
+-   `value` [string][4] value to check.
     
 
 
@@ -339,7 +356,7 @@ I.dontSeeInSource('<!--'); // no comments in source
 #### Parameters
 
 -   `text`  
--   `value` [string][3] to check.
+-   `value` [string][4] to check.
     
 
 
@@ -390,9 +407,10 @@ let date = await I.executeScript(function(el) {
 
 #### Parameters
 
--   `fn` ([string][3] \| [function][5]) function to be executed in browser context.
+-   `fn` ([string][4] \| [function][6]) function to be executed in browser context.
 -   `args` ...any to be passed to function.
-    
+
+Returns [Promise][7]&lt;any> 
 If a function returns a Promise It will wait for it resolution.
 
 ### fillField
@@ -414,7 +432,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` CodeceptJS.LocatorOrString located by label|name|CSS|XPath|strict locator.
--   `value` [string][3] text value to fill.
+-   `value` [string][4] text value to fill.
     
 
 
@@ -431,9 +449,9 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `attr` [string][3] attribute name.
+-   `attr` [string][4] attribute name.
 
-Returns [Promise][6]&lt;[string][3]> attribute value
+Returns [Promise][7]&lt;[string][4]> attribute value
 
 
 
@@ -460,9 +478,9 @@ assert(cookie.value, '123456');
 
 #### Parameters
 
--   `name` [string][3]? cookie name. 
+-   `name` [string][4]? cookie name. 
 
-Returns [Promise][6]&lt;[string][3]> attribute value
+Returns [Promise][7]&lt;[string][4]> attribute value
 
 Returns cookie in JSON format. If name not passed returns all cookies for this domain.
 
@@ -476,7 +494,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns [Promise][6]&lt;[string][3]> current URL
+Returns [Promise][7]&lt;[string][4]> current URL
 
 
 
@@ -492,7 +510,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` CodeceptJS.LocatorOrString located by CSS|XPath|strict locator.
 
-Returns [Promise][6]&lt;[number][7]> number of visible elements
+Returns [Promise][7]&lt;[number][8]> number of visible elements
 
 
 
@@ -505,7 +523,7 @@ Resumes test execution, so should be used inside an async function with `await` 
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns [Promise][6]&lt;[Object][4]&lt;[string][3], any>> scroll position
+Returns [Promise][7]&lt;[Object][5]&lt;[string][4], any>> scroll position
 
 
 
@@ -518,7 +536,7 @@ Resumes test execution, so should be used inside an async function.
 let pageSource = await I.grabSource();
 ```
 
-Returns [Promise][6]&lt;[string][3]> source code
+Returns [Promise][7]&lt;[string][4]> source code
 
 
 
@@ -537,7 +555,7 @@ If multiple elements found returns an array of texts.
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
 
-Returns [Promise][6]&lt;([string][3] \| [Array][8]&lt;[string][3]>)> attribute value
+Returns [Promise][7]&lt;([string][4] \| [Array][9]&lt;[string][4]>)> attribute value
 
 
 
@@ -554,7 +572,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` CodeceptJS.LocatorOrString field located by label|name|CSS|XPath|strict locator.
 
-Returns [Promise][6]&lt;[string][3]> attribute value
+Returns [Promise][7]&lt;[string][4]> attribute value
 
 
 
@@ -571,15 +589,15 @@ I.moveCursorTo('#submit', 5,5);
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString located by CSS|XPath|strict locator.
--   `offsetX` [number][7] (optional, `0` by default) X-axis offset. 
--   `offsetY` [number][7] (optional, `0` by default) Y-axis offset.
+-   `offsetX` [number][8] (optional, `0` by default) X-axis offset. 
+-   `offsetY` [number][8] (optional, `0` by default) Y-axis offset.
     
  
 
 ### pressKey
 
 Presses a key on a focused element.
-Special keys like 'Enter', 'Control', [etc][9]
+Special keys like 'Enter', 'Control', [etc][10]
 will be replaced with corresponding unicode.
 If modifier key is used (Control, Command, Alt, Shift) in array, it will be released afterwards.
 
@@ -590,7 +608,7 @@ I.pressKey(['Control','a']);
 
 #### Parameters
 
--   `key` ([string][3] \| [Array][8]&lt;[string][3]>) key or array of keys to press.
+-   `key` ([string][4] \| [Array][9]&lt;[string][4]>) key or array of keys to press.
     
 
 
@@ -645,8 +663,8 @@ First parameter can be set to `maximize`.
 
 #### Parameters
 
--   `width` [number][7] width in pixels or `maximize`.
--   `height` [number][7] height in pixels.
+-   `width` [number][8] width in pixels or `maximize`.
+-   `height` [number][8] height in pixels.
     
 
 
@@ -683,8 +701,8 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 
 #### Parameters
 
--   `fileName` [string][3] file name to save.
--   `fullPage` [boolean][10] (optional, `false` by default) flag to enable fullscreen screenshot mode.
+-   `fileName` [string][4] file name to save.
+-   `fullPage` [boolean][11] (optional, `false` by default) flag to enable fullscreen screenshot mode.
     
  
 
@@ -723,8 +741,8 @@ I.scrollTo('#submit', 5, 5);
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString located by CSS|XPath|strict locator.
--   `offsetX` [number][7] (optional, `0` by default) X-axis offset. 
--   `offsetY` [number][7] (optional, `0` by default) Y-axis offset.
+-   `offsetX` [number][8] (optional, `0` by default) X-axis offset. 
+-   `offsetY` [number][8] (optional, `0` by default) Y-axis offset.
     
  
 
@@ -741,7 +759,7 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 
 #### Parameters
 
--   `text` [string][3] expected on page.
+-   `text` [string][4] expected on page.
 -   `context` CodeceptJS.LocatorOrString? (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text.
     
  
@@ -772,7 +790,7 @@ I.seeCookie('Auth');
 
 #### Parameters
 
--   `name` [string][3] cookie name.
+-   `name` [string][4] cookie name.
     
 
 
@@ -789,7 +807,7 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 #### Parameters
 
--   `url` [string][3] value to check.
+-   `url` [string][4] value to check.
     
 
 
@@ -833,7 +851,7 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 
 #### Parameters
 
--   `url` [string][3] a fragment to check
+-   `url` [string][4] a fragment to check
     
 
 
@@ -852,7 +870,7 @@ I.seeInField('#searchform input','Search');
 #### Parameters
 
 -   `field` CodeceptJS.LocatorOrString located by label|name|CSS|XPath|strict locator.
--   `value` [string][3] value to check.
+-   `value` [string][4] value to check.
     
 
 
@@ -866,7 +884,7 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 #### Parameters
 
--   `text` [string][3] value to check.
+-   `text` [string][4] value to check.
     
 
 
@@ -882,7 +900,7 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `num` [number][7] number of elements.
+-   `num` [number][8] number of elements.
     
 
 
@@ -923,7 +941,7 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 #### Parameters
 
 -   `select` CodeceptJS.LocatorOrString field located by label|name|CSS|XPath|strict locator.
--   `option` ([string][3] \| [Array][8]&lt;any>) visible text or value of option.
+-   `option` ([string][4] \| [Array][9]&lt;any>) visible text or value of option.
     
 
 
@@ -937,7 +955,7 @@ I.setCookie({name: 'auth', value: true});
 
 #### Parameters
 
--   `cookie` [object][4] a cookie object.
+-   `cookie` [object][5] a cookie object.
     
 
 
@@ -986,7 +1004,7 @@ I.wait(2); // wait 2 secs
 
 #### Parameters
 
--   `sec` [number][7] number of second to wait.
+-   `sec` [number][8] number of second to wait.
     
 
 
@@ -1003,7 +1021,7 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `sec` [number][7]? (optional, `1` by default) time in seconds to wait
+-   `sec` [number][8]? (optional, `1` by default) time in seconds to wait
     
 
 
@@ -1024,9 +1042,9 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` ([string][3] \| [function][5]) to be executed in browser context.
--   `argsOrSec` ([Array][8]&lt;any> | [number][7])? (optional, `1` by default) arguments for function or seconds. 
--   `sec` [number][7]? (optional, `1` by default) time in seconds to wait
+-   `fn` ([string][4] \| [function][6]) to be executed in browser context.
+-   `argsOrSec` ([Array][9]&lt;any> | [number][8])? (optional, `1` by default) arguments for function or seconds. 
+-   `sec` [number][8]? (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1042,7 +1060,7 @@ I.waitForInvisible('#popup');
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1059,8 +1077,8 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 
 #### Parameters
 
--   `text` [string][3] to wait for.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait 
+-   `text` [string][4] to wait for.
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait 
 -   `context` CodeceptJS.LocatorOrString? (optional) element located by CSS|XPath|strict locator.
     
  
@@ -1077,7 +1095,7 @@ I.waitForVisible('#popup');
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1091,8 +1109,8 @@ I.waitInUrl('/info', 2);
 
 #### Parameters
 
--   `urlPart` [string][3] value to check.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait
+-   `urlPart` [string][4] value to check.
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1107,8 +1125,8 @@ I.waitNumberOfVisibleElements('a', 3);
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `num` [number][7] number of elements.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait
+-   `num` [number][8] number of elements.
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1124,7 +1142,7 @@ I.waitToHide('#popup');
 #### Parameters
 
 -   `locator` CodeceptJS.LocatorOrString element located by CSS|XPath|strict locator.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1139,8 +1157,8 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 #### Parameters
 
--   `urlPart` [string][3] value to check.
--   `sec` [number][7] (optional, `1` by default) time in seconds to wait
+-   `urlPart` [string][4] value to check.
+-   `sec` [number][8] (optional, `1` by default) time in seconds to wait
     
  
 
@@ -1156,18 +1174,20 @@ Client Functions
 
 [2]: https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/browsers/browser-support.html
 
-[3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[3]: https://devexpress.github.io/testcafe/documentation/recipes/test-on-remote-computers-and-mobile-devices.html
 
-[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[9]: https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[10]: https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value
+
+[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -146,7 +146,7 @@ class TestCafe extends Helper {
     ];
   }
 
-  async _startBrowser() {
+  async _configureAndStartBrowser() {
     this.dummyTestcafeFile = createTestFile(global.output_dir); // create a dummy test file to get hold of the test controller
 
     this.iteration += 2; // Use different ports for each test run
@@ -160,51 +160,7 @@ class TestCafe extends Helper {
     // TODO Do we have to cleanup the runner?
     const runner = this.testcafe.createRunner();
 
-    if (this.options.browser !== 'remote') {
-      runner
-        .src(this.dummyTestcafeFile)
-        .screenshots(global.output_dir, !this.options.disableScreenshots)
-        // .video(global.output_dir) // TODO Make this configurable
-        .browsers(this.options.show ? this.options.browser : `${this.options.browser}:headless`)
-        .reporter('minimal')
-        .run({
-          skipJsErrors: true,
-          skipUncaughtErrors: true,
-          quarantineMode: false,
-          // debugMode: true,
-          // debugOnFail: true,
-          // developmentMode: true,
-          pageLoadTimeout: this.options.getPageTimeout,
-          selectorTimeout: this.options.waitForTimeout,
-          assertionTimeout: this.options.waitForTimeout,
-          takeScreenshotsOnFails: true,
-        })
-        .catch((err) => {
-          this.debugSection('_before', `Error ${err.toString()}`);
-          this.isRunning = false;
-          this.testcafe.close();
-        });
-    } else {
-      const remoteConnection = await this.testcafe.createBrowserConnection();
-      console.log('Connect your device to the following URL or scan QR Code: ', remoteConnection.url);
-      qrcode.generate(remoteConnection.url);
-      remoteConnection.once('ready', () => {
-        runner
-          .src(this.dummyTestcafeFile)
-          .browsers(remoteConnection)
-          .reporter('minimal')
-          .run({
-            selectorTimeout: this.options.waitForTimeout,
-            skipJsErrors: true,
-            skipUncaughtErrors: true,
-          })
-          .catch((err) => {
-            this.debugSection('_before', `Error ${err.toString()}`);
-            this.isRunning = false;
-            this.testcafe.close();
-          });
-      });
-    }
+    this.options.browser !== 'remote' ? this._startBrowser(runner) : this._startRemoteBrowser(runner);
 
     this.t = await testControllerHolder.get();
     assert(this.t, 'Expected to have the testcafe test controller');
@@ -214,6 +170,55 @@ class TestCafe extends Helper {
       await this.t.resizeWindow(parseInt(dimensions[0], 10), parseInt(dimensions[1], 10));
     }
   }
+
+  async _startBrowser(runner) {
+    runner
+      .src(this.dummyTestcafeFile)
+      .screenshots(global.output_dir, !this.options.disableScreenshots)
+      // .video(global.output_dir) // TODO Make this configurable
+      .browsers(this.options.show ? this.options.browser : `${this.options.browser}:headless`)
+      .reporter('minimal')
+      .run({
+        skipJsErrors: true,
+        skipUncaughtErrors: true,
+        quarantineMode: false,
+        // debugMode: true,
+        // debugOnFail: true,
+        // developmentMode: true,
+        pageLoadTimeout: this.options.getPageTimeout,
+        selectorTimeout: this.options.waitForTimeout,
+        assertionTimeout: this.options.waitForTimeout,
+        takeScreenshotsOnFails: true,
+      })
+      .catch((err) => {
+        this.debugSection('_before', `Error ${err.toString()}`);
+        this.isRunning = false;
+        this.testcafe.close();
+      });
+  }
+
+  async _startRemoteBrowser(runner) {
+    const remoteConnection = await this.testcafe.createBrowserConnection();
+    console.log('Connect your device to the following URL or scan QR Code: ', remoteConnection.url);
+    qrcode.generate(remoteConnection.url);
+    remoteConnection.once('ready', () => {
+      runner
+        .src(this.dummyTestcafeFile)
+        .browsers(remoteConnection)
+        .reporter('minimal')
+        .run({
+          selectorTimeout: this.options.waitForTimeout,
+          skipJsErrors: true,
+          skipUncaughtErrors: true,
+        })
+        .catch((err) => {
+          this.debugSection('_before', `Error ${err.toString()}`);
+          this.isRunning = false;
+          this.testcafe.close();
+        });
+    });
+  }
+
 
   async _stopBrowser() {
     this.debugSection('_after', 'Stopping testcafe browser...');
@@ -229,19 +234,20 @@ class TestCafe extends Helper {
     this.isRunning = false;
   }
 
-  _init() {}
+  _init() {
+  }
 
   async _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {
       this.debugSection('Session', 'Starting singleton browser session');
-      return this._startBrowser();
+      return this._configureAndStartBrowser();
     }
   }
 
 
   async _before() {
-    if (this.options.restart && !this.options.manualStart) return this._startBrowser();
-    if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
+    if (this.options.restart && !this.options.manualStart) return this._configureAndStartBrowser();
+    if (!this.isRunning && !this.options.manualStart) return this._configureAndStartBrowser();
     this.context = null;
   }
 

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const assert = require('assert');
 const path = require('path');
+const qrcode = require('qrcode-terminal');
 const requireg = require('requireg');
 const createTestCafe = require('testcafe');
 const { Selector, ClientFunction } = require('testcafe');
@@ -67,6 +68,21 @@ const getHtmlSource = t => ClientFunction(() => document.getElementsByTagName('h
  * }
  * ```
  *
+ *  To use remote device you can provide 'remote' as browser parameter this will display a link with QR Code
+ *  See https://devexpress.github.io/testcafe/documentation/recipes/test-on-remote-computers-and-mobile-devices.html
+ *  #### Example #2: Remote browser connection
+ *
+ * ```js
+ * {
+ *    helpers: {
+ *      TestCafe : {
+ *        url: "http://localhost",
+ *        waitForTimeout: 15000,
+ *        browser: "remote"
+ *      }
+ *    }
+ * }
+ * ```
  *
  * ## Access From Helpers
  *
@@ -99,7 +115,6 @@ class TestCafe extends Helper {
     this.options = Object.assign({
       url: 'http://localhost',
       show: false,
-      browser: 'chrome',
       restart: true, // TODO Test if restart false works
       manualStart: false,
       keepBrowserState: false,
@@ -135,7 +150,7 @@ class TestCafe extends Helper {
 
     this.iteration += 2; // Use different ports for each test run
     // @ts-ignore
-    this.testcafe = await createTestCafe('localhost', null, null);
+    this.testcafe = await createTestCafe('', null, null);
 
     this.debugSection('_before', 'Starting testcafe browser...');
 
@@ -143,29 +158,52 @@ class TestCafe extends Helper {
 
     // TODO Do we have to cleanup the runner?
     const runner = this.testcafe.createRunner();
-    runner
-      .src(this.dummyTestcafeFile)
-      .screenshots(global.output_dir, !this.options.disableScreenshots)
-      // .video(global.output_dir) // TODO Make this configurable
-      .browsers(this.options.show ? this.options.browser : `${this.options.browser}:headless`)
-      .reporter('minimal')
-      .run({
-        skipJsErrors: true,
-        skipUncaughtErrors: true,
-        quarantineMode: false,
-        // debugMode: true,
-        // debugOnFail: true,
-        // developmentMode: true,
-        pageLoadTimeout: this.options.getPageTimeout,
-        selectorTimeout: this.options.waitForTimeout,
-        assertionTimeout: this.options.waitForTimeout,
-        takeScreenshotsOnFails: true,
-      })
-      .catch((err) => {
-        this.debugSection('_before', `Error ${err.toString()}`);
-        this.isRunning = false;
-        this.testcafe.close();
+
+    if (this.options.browser !== 'remote') {
+      runner
+        .src(this.dummyTestcafeFile)
+        .screenshots(global.output_dir, !this.options.disableScreenshots)
+        // .video(global.output_dir) // TODO Make this configurable
+        .browsers(this.options.show ? this.options.browser : `${this.options.browser}:headless`)
+        .reporter('minimal')
+        .run({
+          skipJsErrors: true,
+          skipUncaughtErrors: true,
+          quarantineMode: false,
+          // debugMode: true,
+          // debugOnFail: true,
+          // developmentMode: true,
+          pageLoadTimeout: this.options.getPageTimeout,
+          selectorTimeout: this.options.waitForTimeout,
+          assertionTimeout: this.options.waitForTimeout,
+          takeScreenshotsOnFails: true,
+        })
+        .catch((err) => {
+          this.debugSection('_before', `Error ${err.toString()}`);
+          this.isRunning = false;
+          this.testcafe.close();
+        });
+    } else {
+      const remoteConnection = await this.testcafe.createBrowserConnection();
+      console.log('Connect your device to the following URL or scan QR Code: ', remoteConnection.url);
+      qrcode.generate(remoteConnection.url);
+      remoteConnection.once('ready', () => {
+        runner
+          .src(this.dummyTestcafeFile)
+          .browsers(remoteConnection)
+          .reporter('minimal')
+          .run({
+            selectorTimeout: this.options.waitForTimeout,
+            skipJsErrors: true,
+            skipUncaughtErrors: true,
+          })
+          .catch((err) => {
+            this.debugSection('_before', `Error ${err.toString()}`);
+            this.isRunning = false;
+            this.testcafe.close();
+          });
       });
+    }
 
     this.t = await testControllerHolder.get();
     assert(this.t, 'Expected to have the testcafe test controller');
@@ -190,7 +228,8 @@ class TestCafe extends Helper {
     this.isRunning = false;
   }
 
-  _init() {}
+  _init() {
+  }
 
   async _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {
@@ -495,8 +534,9 @@ class TestCafe extends Helper {
           await this.t.click(optEl, clickOpts).catch(mapError);
           continue;
         }
-      // eslint-disable-next-line no-empty
-      } catch (err) {}
+        // eslint-disable-next-line no-empty
+      } catch (err) {
+      }
 
       try {
         const sel = `[value="${opt}"]`;
@@ -504,8 +544,9 @@ class TestCafe extends Helper {
         if (await optEl.count) {
           await this.t.click(optEl, clickOpts).catch(mapError);
         }
-      // eslint-disable-next-line no-empty
-      } catch (err) {}
+        // eslint-disable-next-line no-empty
+      } catch (err) {
+      }
     }
   }
 
@@ -517,22 +558,22 @@ class TestCafe extends Helper {
   }
 
   /**
-    * {{> dontSeeInCurrentUrl }}
-    */
+   * {{> dontSeeInCurrentUrl }}
+   */
   async dontSeeInCurrentUrl(url) {
     stringIncludes('url').negate(url, await getPageUrl(this.t)().catch(mapError));
   }
 
   /**
-    * {{> seeCurrentUrlEquals }}
-    */
+   * {{> seeCurrentUrlEquals }}
+   */
   async seeCurrentUrlEquals(url) {
     urlEquals(this.options.url).assert(url, await getPageUrl(this.t)().catch(mapError));
   }
 
   /**
-    * {{> dontSeeCurrentUrlEquals }}
-    */
+   * {{> dontSeeCurrentUrlEquals }}
+   */
   async dontSeeCurrentUrlEquals(url) {
     urlEquals(this.options.url).negate(url, await getPageUrl(this.t)().catch(mapError));
   }
@@ -1077,7 +1118,7 @@ async function waitForFunction(browserFn, waitTimeout) {
     let result;
     try {
       result = await browserFn();
-    // eslint-disable-next-line no-empty
+      // eslint-disable-next-line no-empty
     } catch (err) {
       throw new Error(`Error running function ${err.toString()}`);
     }

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -115,6 +115,7 @@ class TestCafe extends Helper {
     this.options = Object.assign({
       url: 'http://localhost',
       show: false,
+      browser: 'chrome',
       restart: true, // TODO Test if restart false works
       manualStart: false,
       keepBrowserState: false,
@@ -228,8 +229,7 @@ class TestCafe extends Helper {
     this.isRunning = false;
   }
 
-  _init() {
-  }
+  _init() {}
 
   async _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "nodemon": "^1.19.2",
     "protractor": "^5.4.1",
     "puppeteer": "^1.20.0",
+    "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.14.0",


### PR DESCRIPTION
## Motivation/Description of the PR
Saw this very nice functionality of TestCafe was not supported yet, so I have implemented it. You can now configure your TestCafe helper with browser: 'remote' that results in a testcafe remote connection. It will print the url and a QR-Code to automatically scan and navigate to it via the browser of the remote device. 

For more information/background about remote test see: 
https://devexpress.github.io/testcafe/documentation/recipes/test-on-remote-computers-and-mobile-devices.html

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [x] TestCafe

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [X] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [x] Documentation has been added (Run `robo docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)