### PR TITLE
fix: mismatch tags from title will cause null tag

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -44,7 +44,7 @@ module.exports = function (suite) {
       const test = new Test(title, fn);
       test.fullTitle = () => `${suite.title}: ${test.title}`;
 
-      test.tags = (suite.tags || []).concat(title.match(/(\@[a-zA-Z0-9-_]+)/g)); // match tags from title
+      test.tags = (suite.tags || []).concat(title.match(/(\@[a-zA-Z0-9-_]+)/g) || []); // match tags from title
       test.file = file;
       if (!test.inject) {
         test.inject = {};

--- a/test/unit/ui_test.js
+++ b/test/unit/ui_test.js
@@ -96,6 +96,7 @@ describe('ui', () => {
       scenarioConfig = context.Scenario('scenario');
       assert.equal(scenarioConfig.test.title, 'scenario');
       assert.equal(scenarioConfig.test.fullTitle(), 'suite: scenario');
+      assert.equal(scenarioConfig.test.tags.length, 0);
     });
 
     it('should contain tags', () => {


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Codecept will always match test case title prefix ‘@’ string and push to test tags array,
If match failed will cause the null tag issue.

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `robo docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)