### PR TITLE
#1911 - Regex for step Def file

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -287,7 +287,7 @@ function loadGherkinSteps(paths) {
   // If gherkin.steps includes only one *.js, then this will iterate through that folder and send all step def js files to loadSupportObject
   // This is done so that we need not enter all Step Definition files under config.gherkin.steps
   // This works only for one level folder, not for subfolders
-  if (paths.length === 1 && paths[0] === './step_definitions/*.js'){
+  if (paths.length === 1 && paths[0] === './step_definitions/*.js') {
     let folderPath = paths[0];
     if (folderPath.charAt(0) === '.') {
       folderPath = path.join(global.codecept_dir, folderPath);

--- a/lib/container.js
+++ b/lib/container.js
@@ -308,9 +308,6 @@ function loadGherkinSteps(paths) {
       loadSupportObject(path, `Step Definition from ${path}`);
     }
   }
-  // for (const path of paths) {
-  //   loadSupportObject(path, `Step Definition from ${path}`);
-  // }
 
   delete global.Before;
   delete global.After;

--- a/lib/container.js
+++ b/lib/container.js
@@ -284,21 +284,21 @@ function loadGherkinSteps(paths) {
   global.After = fn => event.dispatcher.on(event.test.finished, fn);
   global.Fail = fn => event.dispatcher.on(event.test.failed, fn);
 
-  //If gherkin.steps includes only one *.js, then this will iterate through that folder and send all step def js files to loadSupportObject
-  //This is done so that we need not enter all Step Definition files under config.gherkin.steps
-  //This works only for one level folder, not for subfolders
-  if(paths.length == 1 && paths[0] == './step_definitions/*.js'){
+  // If gherkin.steps includes only one *.js, then this will iterate through that folder and send all step def js files to loadSupportObject
+  // This is done so that we need not enter all Step Definition files under config.gherkin.steps
+  // This works only for one level folder, not for subfolders
+  if (paths.length === 1 && paths[0] === './step_definitions/*.js'){
     let folderPath = paths[0];
     if (folderPath.charAt(0) === '.') {
       folderPath = path.join(global.codecept_dir, folderPath);
     }
-    if(folderPath != "") {
+    if (folderPath !== '') {
       glob(folderPath, function(err, files){
-        if(err){
+        if (err) {
           console.log(err);
         }
-        else{
-          for(const file of files){
+        else {
+          for (const file of files) {
             loadSupportObject(file, `Step Definition from ${file}`);
           }
         }

--- a/lib/container.js
+++ b/lib/container.js
@@ -294,14 +294,8 @@ function loadGherkinSteps(paths) {
   } else {
     const folderPath = paths.startsWith('.') ? path.join(global.codecept_dir, paths) : '';
     if (folderPath !== '') {
-      glob(folderPath, (err, files) => {
-        if (err) {
-          console.log(err);
-        } else {
-          for (const file of files) {
-            loadSupportObject(file, `Step Definition from ${file}`);
-          }
-        }
+      glob.sync(folderPath).forEach((file) => {
+        loadSupportObject(file, `Step Definition from ${file}`);
       });
     }
   }

--- a/lib/container.js
+++ b/lib/container.js
@@ -284,15 +284,19 @@ function loadGherkinSteps(paths) {
   global.After = fn => event.dispatcher.on(event.test.finished, fn);
   global.Fail = fn => event.dispatcher.on(event.test.failed, fn);
 
-  // If gherkin.steps includes only one *.js, then this will iterate through that folder and send all step def js files to loadSupportObject
-  // This is done so that we need not enter all Step Definition files under config.gherkin.steps
-  // This works only for one level folder, not for subfolders
-  if (paths.length === 1 && paths[0] === './step_definitions/*.js') {
-    let folderPath = paths[0];
-    if (folderPath.charAt(0) === '.') {
-      folderPath = path.join(global.codecept_dir, folderPath);
+  //If gherkin.steps is string, then this will iterate through that folder and send all step def js files to loadSupportObject
+  //If gherkin.steps is Array, it will go the old way
+  //This is done so that we need not enter all Step Definition files under config.gherkin.steps
+  if (Array.isArray(paths)) {
+    for (const path of paths) {
+      loadSupportObject(path, `Step Definition from ${path}`);
     }
-    if (folderPath !== '') {
+  } else {
+    let folderPath;
+    if (paths.charAt(0) === '.') {
+      folderPath = path.join(global.codecept_dir, paths);
+    }
+    if (folderPath !== "") {
       glob(folderPath, (err, files) => {
         if (err) {
           console.log(err);
@@ -302,10 +306,6 @@ function loadGherkinSteps(paths) {
           }
         }
       });
-    }
-  } else {
-    for (const path of paths) {
-      loadSupportObject(path, `Step Definition from ${path}`);
     }
   }
 

--- a/lib/container.js
+++ b/lib/container.js
@@ -292,10 +292,7 @@ function loadGherkinSteps(paths) {
       loadSupportObject(path, `Step Definition from ${path}`);
     }
   } else {
-    let folderPath;
-    if (paths.charAt(0) === '.') {
-      folderPath = path.join(global.codecept_dir, paths);
-    }
+    const folderPath = paths.startsWith('.') ? path.join(global.codecept_dir, paths) : '';
     if (folderPath !== '') {
       glob(folderPath, (err, files) => {
         if (err) {

--- a/lib/container.js
+++ b/lib/container.js
@@ -293,19 +293,17 @@ function loadGherkinSteps(paths) {
       folderPath = path.join(global.codecept_dir, folderPath);
     }
     if (folderPath !== '') {
-      glob(folderPath, function(err, files){
+      glob(folderPath, (err, files) => {
         if (err) {
           console.log(err);
-        }
-        else {
+        } else {
           for (const file of files) {
             loadSupportObject(file, `Step Definition from ${file}`);
           }
         }
       });
     }
-  }
-  else {
+  } else {
     for (const path of paths) {
       loadSupportObject(path, `Step Definition from ${path}`);
     }

--- a/lib/container.js
+++ b/lib/container.js
@@ -284,9 +284,9 @@ function loadGherkinSteps(paths) {
   global.After = fn => event.dispatcher.on(event.test.finished, fn);
   global.Fail = fn => event.dispatcher.on(event.test.failed, fn);
 
-  //If gherkin.steps is string, then this will iterate through that folder and send all step def js files to loadSupportObject
-  //If gherkin.steps is Array, it will go the old way
-  //This is done so that we need not enter all Step Definition files under config.gherkin.steps
+  // If gherkin.steps is string, then this will iterate through that folder and send all step def js files to loadSupportObject
+  // If gherkin.steps is Array, it will go the old way
+  // This is done so that we need not enter all Step Definition files under config.gherkin.steps
   if (Array.isArray(paths)) {
     for (const path of paths) {
       loadSupportObject(path, `Step Definition from ${path}`);
@@ -296,7 +296,7 @@ function loadGherkinSteps(paths) {
     if (paths.charAt(0) === '.') {
       folderPath = path.join(global.codecept_dir, paths);
     }
-    if (folderPath !== "") {
+    if (folderPath !== '') {
       glob(folderPath, (err, files) => {
         if (err) {
           console.log(err);

--- a/lib/container.js
+++ b/lib/container.js
@@ -4,6 +4,7 @@ const Translation = require('./translation');
 const MochaFactory = require('./mochaFactory');
 const recorder = require('./recorder');
 const event = require('./event');
+const glob = require('glob');
 
 let container = {
   helpers: {},
@@ -283,9 +284,35 @@ function loadGherkinSteps(paths) {
   global.After = fn => event.dispatcher.on(event.test.finished, fn);
   global.Fail = fn => event.dispatcher.on(event.test.failed, fn);
 
-  for (const path of paths) {
-    loadSupportObject(path, `Step Definition from ${path}`);
+  //If gherkin.steps includes only one *.js, then this will iterate through that folder and send all step def js files to loadSupportObject
+  //This is done so that we need not enter all Step Definition files under config.gherkin.steps
+  //This works only for one level folder, not for subfolders
+  if(paths.length == 1 && paths[0] == './step_definitions/*.js'){
+    let folderPath = paths[0];
+    if (folderPath.charAt(0) === '.') {
+      folderPath = path.join(global.codecept_dir, folderPath);
+    }
+    if(folderPath != "") {
+      glob(folderPath, function(err, files){
+        if(err){
+          console.log(err);
+        }
+        else{
+          for(const file of files){
+            loadSupportObject(file, `Step Definition from ${file}`);
+          }
+        }
+      });
+    }
   }
+  else {
+    for (const path of paths) {
+      loadSupportObject(path, `Step Definition from ${path}`);
+    }
+  }
+  // for (const path of paths) {
+  //   loadSupportObject(path, `Step Definition from ${path}`);
+  // }
 
   delete global.Before;
   delete global.After;


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [x] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- This feature deals with the Steps config under Gherkin Key of codecept.conf.js. Previously, we had to enter all Step Definition files. In order to permit users to specify single *.js file so that all files under that folders will be read, this feature has been added to lib/container.js code.
- [https://github.com/Codeception/CodeceptJS/issues/1911]

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `robo docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)