### PR TITLE
improve the codeceptjs info

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -175,7 +175,7 @@ program.command('info [path]')
     const configPath = path ? `${process.cwd()}/${path}` : `${process.cwd()}/codecept.conf.js`;
     if (fs.existsSync(configPath)) {
       const { helpers, plugins } = require(configPath).config;
-      info.helpers = helpers;
+      info.helpers = helpers || "You don't use any helpers";
       info.plugins = plugins || "You don't have any enabled plugins";
     }
     for (const [key, value] of Object.entries(info)) {

--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -158,16 +158,35 @@ program.command('run-multiple [suites...]')
 
 program.command('info')
   .description('Print debugging information concerning the local environment')
-  .action(() => {
+  .action(async () => {
+    const info = {};
     console.log('\n Environment information:-\n');
-    envinfo
-      .run({
-        System: ['OS', 'CPU'],
-        Binaries: ['Node', 'Yarn', 'npm'],
-        Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
-        npmGlobalPackages: ['codeceptjs'],
-      })
-      .then(console.log);
+    info.codeceptVersion = Codecept.version();
+    info.nodeInfo = await envinfo.helpers.getNodeInfo();
+    info.osInfo = await envinfo.helpers.getOSInfo();
+    info.cpuInfo = await envinfo.helpers.getCPUInfo();
+    info.chromeInfo = await envinfo.helpers.getChromeInfo();
+    info.edgeInfo = await envinfo.helpers.getEdgeInfo();
+    info.firefoxInfo = await envinfo.helpers.getFirefoxInfo();
+    info.safariInfo = await envinfo.helpers.getSafariInfo();
+    const fs = require('fs');
+    const config_path = `${process.cwd()}/codecept.conf.js`;
+    if (fs.existsSync(config_path)) {
+      const { helpers, plugins } = require(`${process.cwd()}/codecept.conf.js`).config;
+      info.helpers = helpers;
+      info.plugins = plugins || 'You don\'t have any enabled plugins';
+    }
+    for (const [key, value] of Object.entries(info)) {
+      if (Array.isArray(value)) {
+        console.log(`${key}:  ${value[1]}`);
+      } else {
+        console.log(`${key}:  ${JSON.stringify(value, null, ' ')}`);
+      }
+    }
+    console.log('***************************************');
+    console.log(`\nIf you have questions ask them in our Slack: shorturl.at/cuKU8
+    \nOr ask them on our discussion board: https://codecept.discourse.group/
+    \nIf you found a bug, an improvements, you can report it to GitHub issues: https://github.com/Codeception/CodeceptJS/issues`);
   });
 
 program.command('dry-run [test]')

--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const envinfo = require('envinfo');
 const program = require('commander');
 const Codecept = require('../lib/codecept');
 const { print, error } = require('../lib/output');
@@ -158,38 +157,8 @@ program.command('run-multiple [suites...]')
 
 program.command('info [path]')
   .description('Print debugging information concerning the local environment')
-  .option('-p, --path', 'your config file path')
-  .action(async (path) => {
-    const info = {};
-    console.log('\n Environment information:-\n');
-    info.codeceptVersion = Codecept.version();
-    info.nodeInfo = await envinfo.helpers.getNodeInfo();
-    info.osInfo = await envinfo.helpers.getOSInfo();
-    info.cpuInfo = await envinfo.helpers.getCPUInfo();
-    info.chromeInfo = await envinfo.helpers.getChromeInfo();
-    info.edgeInfo = await envinfo.helpers.getEdgeInfo();
-    info.firefoxInfo = await envinfo.helpers.getFirefoxInfo();
-    info.safariInfo = await envinfo.helpers.getSafariInfo();
-    const fs = require('fs');
-
-    const configPath = path ? `${process.cwd()}/${path}` : `${process.cwd()}/codecept.conf.js`;
-    if (fs.existsSync(configPath)) {
-      const { helpers, plugins } = require(configPath).config;
-      info.helpers = helpers || "You don't use any helpers";
-      info.plugins = plugins || "You don't have any enabled plugins";
-    }
-    for (const [key, value] of Object.entries(info)) {
-      if (Array.isArray(value)) {
-        console.log(`${key}:  ${value[1]}`);
-      } else {
-        console.log(`${key}:  ${JSON.stringify(value, null, ' ')}`);
-      }
-    }
-    console.log('***************************************');
-    console.log(`\nIf you have questions ask them in our Slack: shorturl.at/cuKU8
-    \nOr ask them on our discussion board: https://codecept.discourse.group/
-    \nIf you found a bug, an improvements, you can report it to GitHub issues: https://github.com/Codeception/CodeceptJS/issues`);
-  });
+  .option('-c, --config', 'your config file path')
+  .action(require('../lib/command/info'));
 
 program.command('dry-run [test]')
   .description('Prints step-by-step scenario for a test without actually running it')

--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -156,9 +156,10 @@ program.command('run-multiple [suites...]')
 
   .action(require('../lib/command/run-multiple'));
 
-program.command('info')
+program.command('info [path]')
   .description('Print debugging information concerning the local environment')
-  .action(async () => {
+  .option('-p, --path', 'your config file path')
+  .action(async (path) => {
     const info = {};
     console.log('\n Environment information:-\n');
     info.codeceptVersion = Codecept.version();
@@ -170,11 +171,12 @@ program.command('info')
     info.firefoxInfo = await envinfo.helpers.getFirefoxInfo();
     info.safariInfo = await envinfo.helpers.getSafariInfo();
     const fs = require('fs');
-    const config_path = `${process.cwd()}/codecept.conf.js`;
-    if (fs.existsSync(config_path)) {
-      const { helpers, plugins } = require(`${process.cwd()}/codecept.conf.js`).config;
+
+    const configPath = path ? `${process.cwd()}/${path}` : `${process.cwd()}/codecept.conf.js`;
+    if (fs.existsSync(configPath)) {
+      const { helpers, plugins } = require(configPath).config;
       info.helpers = helpers;
-      info.plugins = plugins || 'You don\'t have any enabled plugins';
+      info.plugins = plugins || "You don't have any enabled plugins";
     }
     for (const [key, value] of Object.entries(info)) {
       if (Array.isArray(value)) {

--- a/lib/command/info.js
+++ b/lib/command/info.js
@@ -1,0 +1,39 @@
+const getConfig = require('./utils').getConfig;
+const getTestRoot = require('./utils').getTestRoot;
+const Codecept = require('../codecept');
+const output = require('../output');
+const envinfo = require('envinfo');
+
+module.exports = async function (path) {
+  const testsPath = getTestRoot(path);
+  const config = getConfig(testsPath);
+  const codecept = new Codecept(config, {});
+  codecept.init(testsPath);
+
+  output.print('\n Environment information:-\n');
+  const info = {};
+  info.codeceptVersion = Codecept.version();
+  info.nodeInfo = await envinfo.helpers.getNodeInfo();
+  info.osInfo = await envinfo.helpers.getOSInfo();
+  info.cpuInfo = await envinfo.helpers.getCPUInfo();
+  info.chromeInfo = await envinfo.helpers.getChromeInfo();
+  info.edgeInfo = await envinfo.helpers.getEdgeInfo();
+  info.firefoxInfo = await envinfo.helpers.getFirefoxInfo();
+  info.safariInfo = await envinfo.helpers.getSafariInfo();
+  const { helpers, plugins } = config;
+  info.helpers = helpers || "You don't use any helpers";
+  info.plugins = plugins || "You don't have any enabled plugins";
+
+  for (const [key, value] of Object.entries(info)) {
+    if (Array.isArray(value)) {
+      output.print(`${key}:  ${value[1]}`);
+    } else {
+      output.print(`${key}:  ${JSON.stringify(value, null, ' ')}`);
+    }
+  }
+  output.print('***************************************');
+  output.print('If you have questions ask them in our Slack: shorturl.at/cuKU8');
+  output.print('Or ask them on our discussion board: https://codecept.discourse.group/');
+  output.print('Please copy environment info when you report issues on GitHub: https://github.com/Codeception/CodeceptJS/issues');
+  output.print('***************************************');
+};


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

This gives more info when using `npx codeceptjs info`

```sh
$npx codeceptjs info

 Environment information:-

codeceptVersion:  "2.3.0"
nodeInfo:  10.15.0
osInfo:  macOS Mojave 10.14.6
cpuInfo:  (8) x64 Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
chromeInfo:  78.0.3904.108
edgeInfo:  N/A
firefoxInfo:  65.0.1
safariInfo:  13.0.4
helpers:  {
 "WebDriver": {
  "url": "https://www.amazon.de",
  "browser": "chrome",
  "desiredCapabilities": {
   "chromeOptions": {
    "args": [
     "--headless",
     "--disable-gpu",
     "--window-size=1440,700"
    ]
   }
  },
  "windowSize": "1440x700"
 }
}
plugins:  "You don't have any enabled plugins"
***************************************

If you have questions ask them in our Slack: shorturl.at/cuKU8
    
Or ask them on our discussion board: https://codecept.discourse.group/
    
If you found a bug, an improvements, you can report it to GitHub issues: https://github.com/Codeception/CodeceptJS/issues
```


## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `robo docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)