### PR TITLE
Screenshots path correction

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -99,7 +99,7 @@ module.exports = function (config) {
       try {
         if (options.reportDir) {
           fileName = path.join(options.reportDir, fileName);
-          const mochaReportDir = path.join(process.cwd(), options.reportDir);
+          const mochaReportDir = path.resolve(process.cwd(), options.reportDir);
           if (!fileExists(mochaReportDir)) {
             fs.mkdirSync(mochaReportDir);
           }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -270,13 +270,17 @@ module.exports.deleteDir = function (dir_path) {
   }
 };
 
+/**
+ * Returns absolute filename to save screenshot.
+ * @param fileName {string} - filename.
+ */
 module.exports.screenshotOutputFolder = function (fileName) {
   const fileSep = path.sep;
 
   if (!fileName.includes(fileSep) || fileName.includes('record_')) {
     return path.join(global.output_dir, fileName);
   }
-  return path.join(global.codecept_dir, fileName);
+  return path.resolve(global.codecept_dir, fileName);
 };
 
 module.exports.beautify = function (code) {

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -286,4 +286,32 @@ describe('utils', () => {
       os.platform.restore();
     });
   });
+
+  describe('#screenshotOutputFolder', () => {
+    let _oldGlobalOutputDir;
+    let _oldGlobalCodeceptDir;
+
+    before(() => {
+      _oldGlobalOutputDir = global.output_dir;
+      _oldGlobalCodeceptDir = global.codecept_dir;
+
+      global.output_dir = '/Users/someuser/workbase/project1/test_output';
+      global.codecept_dir = '/Users/someuser/workbase/project1/tests/e2e';
+    });
+
+    after(() => {
+      global.output_dir = _oldGlobalOutputDir;
+      global.codecept_dir = _oldGlobalCodeceptDir;
+    });
+
+    it('returns the joined filename for filename only', () => {
+      const _path = utils.screenshotOutputFolder('screenshot1.failed.png');
+      _path.should.eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
+    });
+
+    it('returns the given filename for absolute one', () => {
+      const _path = utils.screenshotOutputFolder('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
+      _path.should.eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png');
+    });
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR

Cannot use absolute directory and absolute filenames for screenshots.

I have config in e2e folder path:
`/Users/<username>/workbase/<project>/src/ts/specs/E2E/codecept.conf.js`

And I want to save reports and screenshots in project folder:
`/Users/<username>/workbase/<project>/test_output/mochawesome`
`/Users/<username>/workbase/<project>/test_output/screenshots`

So I set in codecept config:
```
  output: path.resolve(process.cwd(), "test_output/screenshots"),
...
  mocha: {
    reporterOptions: {
      reportDir: path.resolve(process.cwd(), "./test_output/mochawesome"),
...
```

(Also tests run form project folder: `NODE_ENV=test TS_NODE_PROJECT='./src/ts/specs/E2E/tsconfig.json' codeceptjs run -c ./src/ts/specs/E2E/codecept.conf.js --reporter mochawesome`)

`screenshotOutputFolder` generates screenshot file name with `path.join` function:
So I receive filenames with duplicated path in them:
```
/Users/<username>/workbase/<project>/src/ts/specs/E2E/Users/<username>/workbase/<project>/test_output/mochawesome/should_log_66ba4373-121a-4de2-b4b2-1596cd7ac008.failed.png 
```

And `reportOnFail` try to generate this folder:
```
/Users/<username>/workbase/<project>/Users/<username>/workbase/<project>/test_output/mochawesome
```

```
exports.config = {
  tests: "./tests/*.spec.ts",
  timeout: 10000,
  output: path.resolve(process.cwd(), "test_output/screenshots"),
  helpers: {
    WebDriver: {
      uniqueScreenshotNames: true,
      url: "https://someurl,
      browser: "chrome",
      restart: false,
      smartWait: 8000,
      timeouts: {
        script: 15000,
        pageLoad: 25000,
      },
      windowSize: "1280x1024",
      desiredCapabilities: {
        acceptInsecureCerts: true,
      }
    },
    ...
    Mochawesome: {
      uniqueScreenshotNames: true
    }
  },
  include: {},
  mocha: {
    reporterOptions: {
      reportDir: path.resolve(process.cwd(), "./test_output/mochawesome"),
      reportFilename: "mochawesome_e2e_",// + Math.round(Math.random() * 10000),
      reportPageTitle: "title",
    }
  },
  name: "name",
  require: ["ts-node/register"],
};
```


Applicable helpers:
- [x] Webdriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [x] Appium
- [x] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves

- A link to the corresponding issue (if applicable).
Maybe related:
#1465
#1422

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `./runio docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)