### PR TITLE
Streamlined return values from grab*

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -912,14 +912,9 @@ class WebDriver extends Helper {
   async grabTextFrom(locator) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    let val;
-    if (res.length > 1) {
-      val = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
-    } else {
-      val = await this.browser.getElementText(getElementId(res[0]));
-    }
-    this.debugSection('Grab', val);
-    return val;
+    const val = await forEachAsync(res, el => this.browser.getElementText(getElementId(el)));
+    this.debugSection('Grab', String(val));
+    return val.length > 1 ? val : val[0];
   }
 
   /**
@@ -929,12 +924,9 @@ class WebDriver extends Helper {
   async grabHTMLFrom(locator) {
     const elems = await this._locate(locator, true);
     assertElementExists(elems, locator);
-    const values = await Promise.all(elems.map(elem => elem.getHTML(false)));
-    this.debugSection('Grab', values);
-    if (Array.isArray(values) && values.length === 1) {
-      return values[0];
-    }
-    return values;
+    const val = await forEachAsync(elems, elem => elem.getHTML(false));
+    this.debugSection('Grab', String(val));
+    return val.length > 1 ? val : val[0];
   }
 
   /**
@@ -944,8 +936,9 @@ class WebDriver extends Helper {
   async grabValueFrom(locator) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-
-    return forEachAsync(res, async el => el.getValue());
+    const val = await forEachAsync(res, el => el.getValue());
+    this.debugSection('Grab', String(val));
+    return val.length > 1 ? val : val[0];
   }
 
   /**
@@ -954,7 +947,9 @@ class WebDriver extends Helper {
   async grabCssPropertyFrom(locator, cssProperty) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    return forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
+    const val = await forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
+    this.debugSection('Grab', String(val));
+    return val.length > 1 ? val : val[0];
   }
 
   /**
@@ -964,7 +959,9 @@ class WebDriver extends Helper {
   async grabAttributeFrom(locator, attr) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    return forEachAsync(res, async el => el.getAttribute(attr));
+    const val = await forEachAsync(res, async el => el.getAttribute(attr));
+    this.debugSection('Grab', String(val));
+    return val.length > 1 ? val : val[0];
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [x] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

I just stumbled upon the issue, that the return values from certain grab*-functions are different in webdriver and puppeteer, when just a single element has been found. This PR affects the functions `grabValueFrom`, `grabCssPropertyFrom` and `grabAttributeFrom` for webdriver. As Puppeteer always returns just the element when the selector just found one. `grabTextFrom` and `grabHTMLFrom` webdriver does the same thing. Therefore, I applied this functionality also to the above mentioned functions. 

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)