### PR TITLE
fix: cannot send multiple keys in puppeteer with pressKey

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -33,6 +33,7 @@ const fs = require('fs');
 const fsExtra = require('fs-extra');
 
 let puppeteer;
+let keyDefinitions;
 let perfTiming;
 const popupStore = new Popup();
 const consoleLogStore = new Console();
@@ -148,7 +149,9 @@ class Puppeteer extends Helper {
   constructor(config) {
     super(config);
 
-    puppeteer = requireg(config.browser === 'firefox' ? 'puppeteer-firefox' : 'puppeteer');
+    const module = config.browser === 'firefox' ? 'puppeteer-firefox' : 'puppeteer';
+    puppeteer = requireg(module);
+    keyDefinitions = requireg(`${module}/lib/USKeyboardLayout`);
 
     // set defaults
     this.isRemoteBrowser = false;
@@ -1090,7 +1093,8 @@ class Puppeteer extends Helper {
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier);
     }
-    await this.page.keyboard.press(key);
+    if (keyDefinitions[key]) await this.page.keyboard.press(key);
+    else await this.page.keyboard.type(key);
     for (const modifier of modifiers) {
       await this.page.keyboard.up(modifier);
     }

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -436,6 +436,14 @@ describe('Puppeteer', function () {
   });
 
   describe('#pressKey, #pressKeyDown, #pressKeyUp', () => {
+    it('should be able to send multiple keys as single string', async () => {
+      await I.amOnPage('/form/field');
+      await I.fillField('Name', '');
+
+      await I.pressKey('abc');
+      await I.seeInField('Name', 'abc');
+    });
+
     it('should be able to send special keys to element', async () => {
       await I.amOnPage('/form/field');
       await I.appendField('Name', '-');


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

The following code worked differently in webdriver an puppeteer: `I.pressKey('abc')`. In webdriver, abc is entered in the field whereas puppeteer throws an exception (Unknown key: abc). WebDriver gently uses the given keys if no special key can be identified. Puppeteer needs to know, whether it is a special key (keyboard.press) or if just a string should be typed (keyboard.type). With this fix, both drivers should work the same. 

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)