### PR TITLE
fix: update JSDoc for `say`

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -212,7 +212,7 @@ module.exports = {
    *
    * Print a text in console log
    * @param {string} message
-   * @param {string} color
+   * @param {string} [color]
    */
   say(message, color = 'cyan') {
     if (outputLevel >= 1) print(`   ${colors[color].bold(message)}`);


### PR DESCRIPTION
## Motivation/Description of the PR

`say` require 2 arguments, instead of 1

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [ ] Bug fix
- [x] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)