### PR TITLE
Allows overriding default Polly config in MockRequest

### DIFF
--- a/lib/helper/MockRequest.js
+++ b/lib/helper/MockRequest.js
@@ -101,13 +101,15 @@ class MockRequest extends Helper {
     }
     await page.setRequestInterception(true);
 
-    this.polly = new PollyJS(title, {
+    const defaultConfig = {
       mode: 'passthrough',
       adapters: ['puppeteer'],
       adapterOptions: {
         puppeteer: { page },
       },
-    });
+    };
+
+    this.polly = new PollyJS(title, { ...defaultConfig, ...this.options });
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR

I wanted to configure Polly to use `mode: replay`.

The [docs](https://codecept.io/helpers/MockRequest) indicate that you can pass a config object to `MockRequest`, but this isn't used when instantiating Polly.

In this PR, the default configuration passed to Polly is merged with the config from `MockRequest`, making it possible to have something like this and instantiating Polly in `replay` mode.
```js
helpers: {
   Puppeteer: {
     // regular Puppeteer config here
   },
   MockRequest: {
      mode: 'replay',
   },
}
```

I wanted to add tests but wasn't sure if there were any tests for `MockRequest` and how I could add one. Just tell me how and where if you need one.

Applicable helpers:

- [x] Webdriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [x] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)