### PR TITLE
fix: TestCafe grabAttributeFrom method not works

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/data/output

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -801,7 +801,9 @@ class TestCafe extends Helper {
    * {{> grabValueFrom }}
    */
   async grabValueFrom(locator) {
-    return this.grabAttributeFrom(locator, 'value');
+    const sel = await findElements.call(this, this.context, locator);
+    assertElementExists(sel);
+    return (await sel.nth(0)).value;
   }
 
   /**

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -794,7 +794,7 @@ class TestCafe extends Helper {
   async grabAttributeFrom(locator, attr) {
     const sel = await findElements.call(this, this.context, locator);
     assertElementExists(sel);
-    return (await sel.nth(0)).value;
+    return (await sel.nth(0)).getAttribute(attr);
   }
 
   /**

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -672,18 +672,14 @@ module.exports.tests = function () {
       global.output_dir = path.join(global.codecept_dir, 'output');
     });
 
-    it('should create a screenshot file in output dir', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('should create a screenshot file in output dir', async () => {
       const sec = (new Date()).getUTCMilliseconds();
       await I.amOnPage('/');
       await I.saveScreenshot(`screenshot_${sec}.png`);
       assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists');
     });
 
-    it('should create a full page screenshot file in output dir', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('should create a full page screenshot file in output dir', async () => {
       const sec = (new Date()).getUTCMilliseconds();
       await I.amOnPage('/');
       await I.saveScreenshot(`screenshot_full_${+sec}.png`, true);
@@ -751,9 +747,7 @@ module.exports.tests = function () {
       await I.see('Dynamic text');
     });
 
-    it('should fail if no context', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('should fail if no context', async () => {
       let failed = false;
       await I.amOnPage('/dynamic');
       await I.dontSee('Dynamic text');
@@ -765,9 +759,7 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should fail if text doesn\'t contain', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('should fail if text doesn\'t contain', async () => {
       let failed = false;
       await I.amOnPage('/dynamic');
       try {
@@ -778,9 +770,7 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should fail if text is not in element', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('should fail if text is not in element', async () => {
       let failed = false;
       await I.amOnPage('/dynamic');
       try {
@@ -791,9 +781,7 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should wait for text after timeout', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('should wait for text after timeout', async () => {
       await I.amOnPage('/timeout');
       await I.dontSee('Timeout text');
       await I.waitForText('Timeout text', 31, '#text');
@@ -1024,9 +1012,7 @@ module.exports.tests = function () {
       assert.equal(input, '12345');
     });
 
-    it('within should respect context in see', async function () {
-      if (isHelper('TestCafe')) this.skip();
-
+    it('within should respect context in see', async () => {
       await I.amOnPage('/form/example4');
       await I.see('Rejestracja', 'fieldset');
       await I._withinBegin({ css: '.navbar-header' });

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -605,7 +605,6 @@ module.exports.tests = function () {
     });
 
     it('should grab attribute from element', async () => {
-      if (isHelper('TestCafe')) return;
       await I.amOnPage('/search');
       const val = await I.grabAttributeFrom({
         css: 'form',
@@ -614,8 +613,6 @@ module.exports.tests = function () {
     });
 
     it('should grab custom attribute from element', async () => {
-      if (isHelper('TestCafe')) return;
-
       await I.amOnPage('/form/example4');
       const val = await I.grabAttributeFrom({
         css: '.navbar-toggle',
@@ -1010,8 +1007,6 @@ module.exports.tests = function () {
     });
 
     it('should execute within block 2', async () => {
-      if (isHelper('TestCafe')) return;
-
       await I.amOnPage('/form/example4');
       await I.fillField('Hasło', '12345');
       await I._withinBegin({ xpath: '//div[@class="form-group"][2]' });

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -308,6 +308,8 @@ module.exports.tests = function () {
     // testcafe always says "xpath is not defined"
     // const el = Selector(context).find(elementByXPath(Locator.checkable.byText(xpathLocator.literal(field))).with({ boundTestRun: this.t })).with({ boundTestRun: this.t });
     it.skip('should check option by context', async () => {
+      if (isHelper('TestCafe')) this.skip();
+
       await I.amOnPage('/form/example1');
       await I.checkOption('Remember me next time', '.rememberMe');
       await I.click('Login');
@@ -749,6 +751,8 @@ module.exports.tests = function () {
     });
 
     it('should fail if no context', async () => {
+      if (isHelper('TestCafe')) this.skip();
+
       let failed = false;
       await I.amOnPage('/dynamic');
       await I.dontSee('Dynamic text');
@@ -761,6 +765,8 @@ module.exports.tests = function () {
     });
 
     it('should fail if text doesn\'t contain', async () => {
+      if (isHelper('TestCafe')) this.skip();
+
       let failed = false;
       await I.amOnPage('/dynamic');
       try {
@@ -772,6 +778,8 @@ module.exports.tests = function () {
     });
 
     it('should fail if text is not in element', async () => {
+      if (isHelper('TestCafe')) this.skip();
+
       let failed = false;
       await I.amOnPage('/dynamic');
       try {
@@ -1014,6 +1022,8 @@ module.exports.tests = function () {
     });
 
     it('within should respect context in see', async () => {
+      if (isHelper('TestCafe')) this.skip();
+
       await I.amOnPage('/form/example4');
       await I.see('Rejestracja', 'fieldset');
       await I._withinBegin({ css: '.navbar-header' });

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -750,7 +750,7 @@ module.exports.tests = function () {
       await I.see('Dynamic text');
     });
 
-    it('should fail if no context', async () => {
+    it('should fail if no context', async function () {
       if (isHelper('TestCafe')) this.skip();
 
       let failed = false;
@@ -764,7 +764,7 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should fail if text doesn\'t contain', async () => {
+    it('should fail if text doesn\'t contain', async function () {
       if (isHelper('TestCafe')) this.skip();
 
       let failed = false;
@@ -777,7 +777,7 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should fail if text is not in element', async () => {
+    it('should fail if text is not in element', async function () {
       if (isHelper('TestCafe')) this.skip();
 
       let failed = false;
@@ -1021,7 +1021,7 @@ module.exports.tests = function () {
       assert.equal(input, '12345');
     });
 
-    it('within should respect context in see', async () => {
+    it('within should respect context in see', async function () {
       if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/example4');

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -50,8 +50,9 @@ module.exports.tests = function () {
   });
 
   describe('#waitInUrl, #waitUrlEquals', () => {
-    it('should wait part of the URL to match the expected', async () => {
-      if (isHelper('Nightmare')) return;
+    it('should wait part of the URL to match the expected', async function () {
+      if (isHelper('Nightmare')) this.skip();
+
       try {
         await I.amOnPage('/info');
         await I.waitInUrl('/info');
@@ -61,8 +62,9 @@ module.exports.tests = function () {
       }
     });
 
-    it('should wait for the entire URL to match the expected', async () => {
-      if (isHelper('Nightmare')) return;
+    it('should wait for the entire URL to match the expected', async function () {
+      if (isHelper('Nightmare')) this.skip();
+
       try {
         await I.amOnPage('/info');
         await I.waitUrlEquals('/info');
@@ -358,8 +360,8 @@ module.exports.tests = function () {
     });
 
     // Could not get multiselect to work with testcafe
-    it('should select multiple options', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should select multiple options', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/select_multiple');
       await I.selectOption('What do you like the most?', ['Play Video Games', 'Have Sex']);
@@ -384,16 +386,17 @@ module.exports.tests = function () {
     });
 
 
-    it('should return value from sync script in iframe', async () => {
-      if (isHelper('TestCafe') || isHelper('Nightmare')) return; // TODO Not yet implemented
+    it('should return value from sync script in iframe', async function () {
+      if (isHelper('TestCafe') || isHelper('Nightmare')) this.skip(); // TODO Not yet implemented
+
       await I.amOnPage('/iframe');
       await I.switchTo('iframe');
       const val = await I.executeScript(() => document.getElementsByTagName('h1')[0].innerText);
       assert.equal(val, 'Information');
     });
 
-    it('should execute async script', async () => {
-      if (isHelper('TestCafe')) return; // TODO Not yet implemented
+    it('should execute async script', async function () {
+      if (isHelper('TestCafe')) this.skip(); // TODO Not yet implemented
 
       await I.amOnPage('/');
       const val = await I.executeAsyncScript((val, done) => {
@@ -572,8 +575,8 @@ module.exports.tests = function () {
       assert.equal(vals[2], 'Third');
     });
 
-    it('should grab html from page', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should grab html from page', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/info');
       const val = await I.grabHTMLFrom('#grab-multiple');
@@ -622,8 +625,8 @@ module.exports.tests = function () {
   });
 
   describe('page title : #seeTitle, #dontSeeTitle, #grabTitle', () => {
-    it('should check page title', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should check page title', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/');
       await I.seeInTitle('TestEd Beta 2.0');
@@ -632,8 +635,8 @@ module.exports.tests = function () {
       await I.dontSeeInTitle('TestEd Beta 2.0');
     });
 
-    it('should grab page title', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should grab page title', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/');
       const val = await I.grabTitle();
@@ -652,8 +655,9 @@ module.exports.tests = function () {
       formContents().files.avatar.type.should.eql('image/jpeg');
     });
 
-    it('should upload file located by label', async () => {
-      if (isHelper('Nightmare')) return;
+    it('should upload file located by label', async function () {
+      if (isHelper('Nightmare')) this.skip();
+
       await I.amOnPage('/form/file');
       await I.attachFile('Avatar', 'app/avatar.jpg');
       await I.click('Submit');
@@ -668,8 +672,8 @@ module.exports.tests = function () {
       global.output_dir = path.join(global.codecept_dir, 'output');
     });
 
-    it('should create a screenshot file in output dir', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should create a screenshot file in output dir', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       const sec = (new Date()).getUTCMilliseconds();
       await I.amOnPage('/');
@@ -677,8 +681,8 @@ module.exports.tests = function () {
       assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists');
     });
 
-    it('should create a full page screenshot file in output dir', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should create a full page screenshot file in output dir', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       const sec = (new Date()).getUTCMilliseconds();
       await I.amOnPage('/');
@@ -747,8 +751,8 @@ module.exports.tests = function () {
       await I.see('Dynamic text');
     });
 
-    it('should fail if no context', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should fail if no context', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       let failed = false;
       await I.amOnPage('/dynamic');
@@ -761,8 +765,8 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should fail if text doesn\'t contain', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should fail if text doesn\'t contain', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       let failed = false;
       await I.amOnPage('/dynamic');
@@ -774,8 +778,8 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should fail if text is not in element', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should fail if text is not in element', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       let failed = false;
       await I.amOnPage('/dynamic');
@@ -787,8 +791,8 @@ module.exports.tests = function () {
       assert.ok(failed);
     });
 
-    it('should wait for text after timeout', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should wait for text after timeout', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/timeout');
       await I.dontSee('Timeout text');
@@ -907,8 +911,8 @@ module.exports.tests = function () {
   });
 
   describe('#waitForDetached', () => {
-    it('should throw an error if the element still exists in DOM', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should throw an error if the element still exists in DOM', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/wait_detached');
       await I.see('Step One Button');
@@ -922,8 +926,8 @@ module.exports.tests = function () {
       }
     });
 
-    it('should throw an error if the element still exists in DOM by XPath', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should throw an error if the element still exists in DOM by XPath', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/wait_detached');
       await I.see('Step One Button');
@@ -937,8 +941,8 @@ module.exports.tests = function () {
       }
     });
 
-    it('should wait for element to be removed from DOM', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should wait for element to be removed from DOM', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/wait_detached');
       await I.see('Step Two Button');
@@ -947,8 +951,8 @@ module.exports.tests = function () {
       await I.dontSeeElementInDOM('#step_2');
     });
 
-    it('should wait for element to be removed from DOM by XPath', async () => {
-      if (isHelper('TestCafe')) return;
+    it('should wait for element to be removed from DOM by XPath', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/wait_detached');
       await I.seeElement('//div[@id="step_2"]');
@@ -1020,8 +1024,8 @@ module.exports.tests = function () {
       assert.equal(input, '12345');
     });
 
-    it('within should respect context in see', async () => {
-      if (isHelper('TestCafe')) return;
+    it('within should respect context in see', async function () {
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/example4');
       await I.see('Rejestracja', 'fieldset');
@@ -1042,6 +1046,7 @@ module.exports.tests = function () {
 
     it('within should respect context in see when using nested frames', async function () {
       if (isHelper('TestCafe')) this.skip();
+
       await I.amOnPage('/iframe_nested');
       await I._withinBegin({
         frame: ['#wrapperId', '[name=content]'],
@@ -1068,9 +1073,9 @@ module.exports.tests = function () {
   });
 
   describe('scroll: #scrollTo, #scrollPageToTop, #scrollPageToBottom', () => {
-    it('should scroll inside an iframe', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should scroll inside an iframe', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/iframe');
       await I.resizeWindow(500, 700);
@@ -1130,9 +1135,9 @@ module.exports.tests = function () {
   });
 
   describe('#grabCssPropertyFrom', () => {
-    it('should grab css property for given element', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should grab css property for given element', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/doubleclick');
       const css = await I.grabCssPropertyFrom('#block', 'height');
@@ -1141,9 +1146,9 @@ module.exports.tests = function () {
   });
 
   describe('#seeAttributesOnElements', () => {
-    it('should check attributes values for given element', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should check attributes values for given element', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       try {
         await I.amOnPage('/info');
@@ -1163,9 +1168,9 @@ module.exports.tests = function () {
       }
     });
 
-    it('should check attributes values for several elements', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should check attributes values for several elements', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       try {
         await I.amOnPage('/');
@@ -1188,9 +1193,9 @@ module.exports.tests = function () {
   });
 
   describe('#seeCssPropertiesOnElements', () => {
-    it('should check css property for given element', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should check css property for given element', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       try {
         await I.amOnPage('/info');
@@ -1211,9 +1216,9 @@ module.exports.tests = function () {
     });
 
 
-    it('should check css property for several elements', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should check css property for several elements', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       try {
         await I.amOnPage('/');
@@ -1238,9 +1243,9 @@ module.exports.tests = function () {
       }
     });
 
-    it('should normalize css color properties for given element', async () => {
-      if (isHelper('Nightmare')) return;
-      if (isHelper('TestCafe')) return;
+    it('should normalize css color properties for given element', async function () {
+      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/css_colors');
       await I.seeCssPropertiesOnElements('#namedColor', {

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -50,8 +50,8 @@ module.exports.tests = function () {
   });
 
   describe('#waitInUrl, #waitUrlEquals', () => {
-    it('should wait part of the URL to match the expected', async function () {
-      if (isHelper('Nightmare')) this.skip();
+    it('should wait part of the URL to match the expected', async () => {
+      if (isHelper('Nightmare')) return;
 
       try {
         await I.amOnPage('/info');
@@ -62,8 +62,8 @@ module.exports.tests = function () {
       }
     });
 
-    it('should wait for the entire URL to match the expected', async function () {
-      if (isHelper('Nightmare')) this.skip();
+    it('should wait for the entire URL to match the expected', async () => {
+      if (isHelper('Nightmare')) return;
 
       try {
         await I.amOnPage('/info');
@@ -387,7 +387,8 @@ module.exports.tests = function () {
 
 
     it('should return value from sync script in iframe', async function () {
-      if (isHelper('TestCafe') || isHelper('Nightmare')) this.skip(); // TODO Not yet implemented
+      if (isHelper('Nightmare')) return; // TODO Not yet implemented
+      if (isHelper('TestCafe')) this.skip(); // TODO Not yet implemented
 
       await I.amOnPage('/iframe');
       await I.switchTo('iframe');
@@ -655,8 +656,8 @@ module.exports.tests = function () {
       formContents().files.avatar.type.should.eql('image/jpeg');
     });
 
-    it('should upload file located by label', async function () {
-      if (isHelper('Nightmare')) this.skip();
+    it('should upload file located by label', async () => {
+      if (isHelper('Nightmare')) return;
 
       await I.amOnPage('/form/file');
       await I.attachFile('Avatar', 'app/avatar.jpg');
@@ -1060,7 +1061,7 @@ module.exports.tests = function () {
 
   describe('scroll: #scrollTo, #scrollPageToTop, #scrollPageToBottom', () => {
     it('should scroll inside an iframe', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/iframe');
@@ -1122,7 +1123,7 @@ module.exports.tests = function () {
 
   describe('#grabCssPropertyFrom', () => {
     it('should grab css property for given element', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/doubleclick');
@@ -1133,7 +1134,7 @@ module.exports.tests = function () {
 
   describe('#seeAttributesOnElements', () => {
     it('should check attributes values for given element', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       try {
@@ -1155,7 +1156,7 @@ module.exports.tests = function () {
     });
 
     it('should check attributes values for several elements', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       try {
@@ -1180,7 +1181,7 @@ module.exports.tests = function () {
 
   describe('#seeCssPropertiesOnElements', () => {
     it('should check css property for given element', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       try {
@@ -1203,7 +1204,7 @@ module.exports.tests = function () {
 
 
     it('should check css property for several elements', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       try {
@@ -1230,7 +1231,7 @@ module.exports.tests = function () {
     });
 
     it('should normalize css color properties for given element', async function () {
-      if (isHelper('Nightmare')) this.skip();
+      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/css_colors');


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [x] TestCafe

- Description of this PR, which problem it solves
`grabAttributeFrom()` method not returning the attribute value

- A link to the corresponding issue (if applicable).
https://stackoverflow.com/questions/59133688/grabattributefrom-method-not-returning-the-attribute-value


## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)