### PR TITLE
Revert "Streamlined return values from grab* (#2054)"

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -912,9 +912,14 @@ class WebDriver extends Helper {
   async grabTextFrom(locator) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    const val = await forEachAsync(res, el => this.browser.getElementText(getElementId(el)));
-    this.debugSection('Grab', String(val));
-    return val.length > 1 ? val : val[0];
+    let val;
+    if (res.length > 1) {
+      val = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
+    } else {
+      val = await this.browser.getElementText(getElementId(res[0]));
+    }
+    this.debugSection('Grab', val);
+    return val;
   }
 
   /**
@@ -924,9 +929,12 @@ class WebDriver extends Helper {
   async grabHTMLFrom(locator) {
     const elems = await this._locate(locator, true);
     assertElementExists(elems, locator);
-    const val = await forEachAsync(elems, elem => elem.getHTML(false));
-    this.debugSection('Grab', String(val));
-    return val.length > 1 ? val : val[0];
+    const values = await Promise.all(elems.map(elem => elem.getHTML(false)));
+    this.debugSection('Grab', values);
+    if (Array.isArray(values) && values.length === 1) {
+      return values[0];
+    }
+    return values;
   }
 
   /**
@@ -936,9 +944,8 @@ class WebDriver extends Helper {
   async grabValueFrom(locator) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    const val = await forEachAsync(res, el => el.getValue());
-    this.debugSection('Grab', String(val));
-    return val.length > 1 ? val : val[0];
+
+    return forEachAsync(res, async el => el.getValue());
   }
 
   /**
@@ -947,9 +954,7 @@ class WebDriver extends Helper {
   async grabCssPropertyFrom(locator, cssProperty) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    const val = await forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
-    this.debugSection('Grab', String(val));
-    return val.length > 1 ? val : val[0];
+    return forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
   }
 
   /**
@@ -959,9 +964,7 @@ class WebDriver extends Helper {
   async grabAttributeFrom(locator, attr) {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
-    const val = await forEachAsync(res, async el => el.getAttribute(attr));
-    this.debugSection('Grab', String(val));
-    return val.length > 1 ? val : val[0];
+    return forEachAsync(res, async el => el.getAttribute(attr));
   }
 
   /**


### PR DESCRIPTION
This reverts commit 4a769f144c9b02708f3e2c6f30590aaafeb0756c.

Previous PR broke backwards compatibility. 

We will change how grab* methods work but once we will be releasing 3.0

## Motivation/Description of the PR

Applicable helpers:

- [ x ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)