### PR TITLE
fix: replace console.print with console.log

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -124,7 +124,7 @@ module.exports = function (initPath) {
     // append file mask to the end of tests
     if (!config.tests.match(/\*(.*?)$/)) {
       config.tests = `${config.tests.replace(/\/+$/, '')}/*_test.js`;
-      console.print(`Adding default test mask: ${config.tests}`);
+      console.log(`Adding default test mask: ${config.tests}`);
     }
 
     if (result.translation !== noTranslation) config.translation = result.translation;


### PR DESCRIPTION
Since `console.print()` does not exists 😄

## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [x] TestCafe

- Description of this PR, which problem it solves

`console.print()` does not exists

- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)