### PR TITLE
Add Interoperable Code for supporting both CJS & ESM environments

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,5 @@
-const parser = require('parse-function')({ ecmaVersion: 2017 });
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+const parser = _interopDefault(require('parse-function'))({ ecmaVersion: 2017 });
 
 module.exports.getParamsToString = function (fn) {
   return getParams(fn).join(', ');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,4 +1,4 @@
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+function _interopDefault(ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex.default : ex; }
 const parser = _interopDefault(require('parse-function'))({ ecmaVersion: 2017 });
 
 module.exports.getParamsToString = function (fn) {


### PR DESCRIPTION
# Add Interoperable Code to support both CJS and ESM environments.

## Motivation/Description of the PR
When running codeceptjs in a CommonJS (CJS) environment, there is an error running the `codecept` command.

Error as below:

```
TypeError: require(...) is not a function
    at Object.<anonymous> (/MyApp/node_modules/codeceptjs/lib/parser.js:1:103)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/MyApp/node_modules/codeceptjs/lib/command/list.js:5:27)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
```


Applicable helpers:

- [x] Nightmare

- Description of this PR, which problem it solves.
This PR solves the `TypeError` when codecept is run in a CJS environment.

## Type of change

- [x] Bug fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)