### PR TITLE
Add support for puppeteer-core

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -13,7 +13,6 @@ const {
   ucfirst,
   fileExists,
   chunkArray,
-  toCamelCase,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
   getNormalizedKeyAttributeValue,
@@ -149,7 +148,9 @@ class Puppeteer extends Helper {
   constructor(config) {
     super(config);
 
-    puppeteer = requireg(config.browser === 'firefox' ? 'puppeteer-firefox' : 'puppeteer');
+    console.log(config.chrome.browserWSEndpoint)
+    
+    puppeteer = requireg(config.browser === 'firefox' ? 'puppeteer-firefox' : (config.chrome.browserWSEndpoint ? 'puppeteer-core' : 'puppeteer'));
 
     // set defaults
     this.isRemoteBrowser = false;
@@ -205,7 +206,13 @@ class Puppeteer extends Helper {
     try {
       requireg('puppeteer');
     } catch (e) {
-      return ['puppeteer@^1.6.0'];
+      // Before to send error, let's try if this is puppeteer-core
+      // NOTE: anyway to access the config from here to avoid try into catch?
+      try {
+        requireg('puppeteer-core');
+      } catch (e) {
+        return ['puppeteer@^1.6.0'];
+      }
     }
   }
 
@@ -218,7 +225,6 @@ class Puppeteer extends Helper {
       return this._startBrowser();
     }
   }
-
 
   async _before() {
     recorder.retry({
@@ -292,7 +298,6 @@ class Puppeteer extends Helper {
       },
     };
   }
-
 
   /**
    * Set the automatic popup response to Accept.
@@ -1463,7 +1468,7 @@ class Puppeteer extends Helper {
   async grabCssPropertyFrom(locator, cssProperty) {
     const els = await this._locate(locator);
     const res = await Promise.all(els.map(el => el.executionContext().evaluate(el => JSON.parse(JSON.stringify(getComputedStyle(el))), el)));
-    const cssValues = res.map(props => props[toCamelCase(cssProperty)]);
+    const cssValues = res.map(props => props[cssProperty]);
 
     if (res.length > 0) {
       return cssValues;

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -147,8 +147,6 @@ const consoleLogStore = new Console();
 class Puppeteer extends Helper {
   constructor(config) {
     super(config);
-
-    console.log(config.chrome.browserWSEndpoint)
     
     puppeteer = requireg(config.browser === 'firefox' ? 'puppeteer-firefox' : (config.chrome.browserWSEndpoint ? 'puppeteer-core' : 'puppeteer'));
 


### PR DESCRIPTION
## Motivation/Description of the PR

I needed to use with Browserless so only puppeteer-core is required in this case, not need to install 100+Mb of Chromium bundled with puppeteer.

Applicable helpers:

- [ ] Webdriver
- [ X] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [ X] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)