### PR TITLE
fix(docs): add info about _after hook in helper

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -209,6 +209,7 @@ Implement corresponding methods to them.
 * `_init` - before all tests
 * `_finishTest` - after all tests
 * `_before` - before a test
+* `_after` - after a test
 * `_beforeStep` - before each step
 * `_afterStep` - after each step
 * `_beforeSuite` - before each suite


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [ ] Bug fix
- [x] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)