### PR TITLE
providing a parsed DataTable in steps' arguments

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -221,14 +221,14 @@ Steps in background are defined the same way as in scenarios.
 Scenarios can become more descriptive when you represent repeating data as tables. Instead of writing several steps "I have product with :num1 $ price in my cart" we can have one step with multiple values in it.
 
 ```gherkin
-  Given i have products in my cart
+  Given I have products in my cart
     | name         | category    | price  |
     | Harry Potter | Books       | 5      |
     | iPhone 5     | Smartphones | 1200   |
     | Nuclear Bomb | Weapons     | 100000 |
 ```
 
-Tables is a recommended ways to pass arrays into test scenarios.
+Tables are the recommended way to pass arrays into test scenarios.
 Inside a step definition data is stored in argument passed as `DataTable` JavaScript object.
 You can iterate on it like this:
 
@@ -245,7 +245,29 @@ Given('I have products in my cart', (table) => { // eslint-disable-line
     // take values
     const name = cells[0].value;
     const category = cells[1].value;
-    const price = cells[1].value;
+    const price = cells[2].value;
+    // ...
+  }
+});
+```
+
+You can also use the parse() function to obtain an object that allow you to get a simple version of the table parsed by column or row, with header (or not) : 
+- raw(): returns the table as a 2-D array
+- rows(): returns the table as a 2-D array, without the first row
+- hashes(): returns an array of objects where each row is converted to an object (column header is the key)
+
+If we use hashes() with the previous exemple :
+
+```js
+Given('I have products in my cart', (table) => { // eslint-disable-line
+  //parse the table by header
+  const tableByHeader = table.parse().hashes();
+  for (const row in tableByHeader) {
+
+    // take values
+    const name = row.name;
+    const category = row.category;
+    const price = row.price;
     // ...
   }
 });

--- a/lib/data/dataTableArgument.js
+++ b/lib/data/dataTableArgument.js
@@ -1,0 +1,27 @@
+class DataTableArgument {
+  constructor(gherkinDataTable) {
+    this.rawData = gherkinDataTable.rows.map(row => row.cells.map(cell => cell.value));
+  }
+
+  raw() {
+    return this.rawData.slice(0);
+  }
+
+  rows() {
+    const copy = this.raw();
+    copy.shift();
+    return copy;
+  }
+
+  hashes() {
+    const copy = this.raw();
+    const header = copy.shift();
+    return copy.map((row) => {
+      const r = {};
+      row.forEach((cell, index) => r[header[index]] = cell);
+      return r;
+    });
+  }
+}
+
+module.exports = DataTableArgument;

--- a/lib/data/dataTableArgument.js
+++ b/lib/data/dataTableArgument.js
@@ -1,6 +1,10 @@
 class DataTableArgument {
   constructor(gherkinDataTable) {
-    this.rawData = gherkinDataTable.rows.map(row => row.cells.map(cell => cell.value));
+    this.rawData = gherkinDataTable.rows.map((row) => {
+      return row.cells.map((cell) => {
+        return cell.value;
+      });
+    });
   }
 
   raw() {

--- a/lib/helper/FileSystem.js
+++ b/lib/helper/FileSystem.js
@@ -70,8 +70,10 @@ class FileSystem extends Helper {
   * ```
   */
   seeFileNameMatching(text) {
-    assert.ok(this.grabFileNames().some(file => file.includes(text)),
-      `File name which contains ${text} not found in ${this.dir}`);
+    assert.ok(
+      this.grabFileNames().some(file => file.includes(text)),
+      `File name which contains ${text} not found in ${this.dir}`,
+    );
   }
 
   /**

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -6,6 +6,7 @@ const { isAsyncFunction } = require('../utils');
 const event = require('../event');
 const scenario = require('../scenario');
 const Step = require('../step');
+const DataTableArgument = require('../data/dataTableArgument');
 
 const parser = new Parser();
 parser.stopAtFirstError = false;
@@ -36,6 +37,9 @@ module.exports = (text) => {
       };
       const fn = matchStep(step.text);
       if (step.argument) {
+        step.argument.parse = () => {
+          return new DataTableArgument(step.argument);
+        };
         fn.params.push(step.argument);
         if (step.argument.type === 'DataTable') metaStep.comment = `\n${transformTable(step.argument)}`;
         if (step.argument.content) metaStep.comment = `\n${step.argument.content}`;

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -251,4 +251,45 @@ describe('BDD', () => {
       });
     });
   });
+
+  it('should provide a parsed DataTable', (done) => {
+    const text = `
+    @awesome @cool
+    Feature: checkout process
+
+    @super
+    Scenario: order products
+      Given I have the following products :
+        | label   | price  |
+        | beer    | 9      |
+        | cookies | 12     |
+      Then I should see the following products :
+        | label   | price  |
+        | beer    | 9      |
+        | cookies | 12     |
+    `;
+
+    let givenParsedRows;
+    let thenParsedRows;
+
+    Given('I have the following products :', (products) => {
+      givenParsedRows = products.parse();
+    });
+    Then('I should see the following products :', (products) => {
+      thenParsedRows = products.parse();
+    });
+
+    const suite = run(text);
+
+    const expectedParsedDataTable = [
+      ['label', 'price'],
+      ['beer', '9'],
+      ['cookies', '12'],
+    ];
+    suite.tests[0].fn(() => {
+      assert.deepEqual(givenParsedRows.rawData, expectedParsedDataTable);
+      assert.deepEqual(thenParsedRows.rawData, expectedParsedDataTable);
+      done();
+    });
+  });
 });

--- a/test/unit/data/dataTableArgument_test.js
+++ b/test/unit/data/dataTableArgument_test.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+const DataTableArgument = require('../../../lib/data/dataTableArgument');
+
+describe('DataTableArgument', () => {
+  const gherkinDataTable = {
+    rows: [
+      {
+        type: 'TableRow',
+        location: { line: 59, column: 13 },
+        cells: [
+          { type: 'TableCell', location: [Object], value: 'John' },
+          { type: 'TableCell', location: [Object], value: 'Doe' },
+        ],
+      },
+      {
+        type: 'TableRow',
+        location: { line: 59, column: 13 },
+        cells: [
+          { type: 'TableCell', location: [Object], value: 'Chuck' },
+          { type: 'TableCell', location: [Object], value: 'Norris' },
+        ],
+      },
+    ],
+  };
+
+  const gherkinDataTableWithHeader = {
+    rows: [
+      {
+        type: 'TableRow',
+        location: { line: 59, column: 13 },
+        cells: [
+          { type: 'TableCell', location: [Object], value: 'firstName' },
+          { type: 'TableCell', location: [Object], value: 'lastName' },
+        ],
+      },
+      {
+        type: 'TableRow',
+        location: { line: 59, column: 13 },
+        cells: [
+          { type: 'TableCell', location: [Object], value: 'Chuck' },
+          { type: 'TableCell', location: [Object], value: 'Norris' },
+        ],
+      },
+    ],
+  };
+
+  it('should return a 2D array containing each row', () => {
+    const dta = new DataTableArgument(gherkinDataTable);
+    const raw = dta.raw();
+    const expectedRaw = [['John', 'Doe'], ['Chuck', 'Norris']];
+    assert.deepEqual(raw, expectedRaw);
+  });
+
+  it('should return a 2D array containing each row without the header (first one)', () => {
+    const dta = new DataTableArgument(gherkinDataTableWithHeader);
+    const rows = dta.rows();
+    const expectedRows = [['Chuck', 'Norris']];
+    assert.deepEqual(rows, expectedRows);
+  });
+
+  it('should return an of object where properties is the header', () => {
+    const dta = new DataTableArgument(gherkinDataTableWithHeader);
+    const rows = dta.hashes();
+    const expectedRows = [{ firstName: 'Chuck', lastName: 'Norris' }];
+    assert.deepEqual(rows, expectedRows);
+  });
+});


### PR DESCRIPTION
providing datable by header in steps' arguments

parsed DataTable in steps arguments

## Motivation/Description of the PR

**Description of this PR, which problem it solves**
A 'parse' method in the DataTable object that provide a simplidied version of it. It also provides methods for using it with headers : 

- raw : returns the table as a 2-D array
- rows : returns the table as a 2-D array, without the first row
- hashes : returns an array of objects where each row is converted to an object (column header is the key)

this work is inspired by the same feature from cucumber-js module : https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/data_table_interface.md

**A link to the corresponding issue (if applicable).**
https://github.com/Codeception/CodeceptJS/issues/2081

## Type of change

- [ ] Breaking changes
- [x] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)