### PR TITLE
Fix waitForFunction in TestCafe helper

### DIFF
--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -1040,10 +1040,7 @@ class TestCafe extends Helper {
     }
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
 
-    const clientFn = createClientFunction((urlPart) => {
-      const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
-      return currUrl.indexOf(urlPart) > -1;
-    }, args);
+    const clientFn = createClientFunction(fn, args).with({ boundTestRun: this.t });
 
     return waitForFunction(clientFn, waitTimeout);
   }

--- a/test/helper/TestCafe_test.js
+++ b/test/helper/TestCafe_test.js
@@ -63,5 +63,17 @@ describe('TestCafe', function () {
     });
   });
 
+  describe('#waitForFunction', () => {
+    it('should wait for function returns true', () => {
+      return I.amOnPage('/form/wait_js')
+        .then(() => I.waitForFunction(() => window.__waitJs, 3));
+    });
+
+    it('should pass arguments and wait for function returns true', () => {
+      return I.amOnPage('/form/wait_js')
+        .then(() => I.waitForFunction(varName => window[varName], ['__waitJs'], 3));
+    });
+  });
+
   webApiTests.tests();
 });


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [x] TestCafe

`waitForFunction` was breaking when using the TestCafe helper. The error suggested adding `.with({ boundTestRun: this.t })`. Upon inspecting the code, it looks like the function was not doing what I was expecting: it had the same logic as `waitUrlEquals` and the `fn` parameter (the function to wait for) was not being used.

I think now it has the expected functionality. I added the same tests as the Puppeter helper.

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)