### PR TITLE
Fix: Add beforeExit listener in exit.js

### DIFF
--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -23,4 +23,10 @@ module.exports = function () {
       process.exitCode = 1;
     }
   });
+  
+  process.on('beforeExit', (code) => {
+    if (code) {
+      process.exit(code);
+    }
+  });
 };

--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -23,7 +23,7 @@ module.exports = function () {
       process.exitCode = 1;
     }
   });
-  
+
   process.on('beforeExit', (code) => {
     if (code) {
       process.exit(code);


### PR DESCRIPTION
## Motivation/Description of the PR
TestCafe returns 0 exit code on test failure. In this PR `beforeExit` listener is registered which will exit the process with appropriate exit code

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [X] TestCafe

Fixes #2090

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [X] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)