### PR TITLE
feat : Add grabCssPropertyFrom method for Nightmare

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -837,7 +837,7 @@ class Nightmare extends Helper {
   }
 
   /**
-   * {{> grabHTMLFrom }}
+   * {{> grabCssPropertyFrom }}
    */
   async grabCssPropertyFrom(locator, cssProperty) {
     locator = new Locator(locator, 'css');

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -850,8 +850,7 @@ class Nightmare extends Helper {
       }, el))[toCamelCase(prop)];
     };
 
-    for (let index = 0; index < els.length; index++) {
-      const el = els[index];
+    for (const el of els) {
       assertElementExists(el, locator);
       const cssValue = await getCssPropForElement(el, cssProperty);
       array.push(cssValue);

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -13,6 +13,7 @@ const {
   xpathLocator,
   fileExists,
   screenshotOutputFolder,
+  toCamelCase,
 } = require('../utils');
 
 const specialKeys = {
@@ -833,6 +834,31 @@ class Nightmare extends Helper {
     this.debugSection('HTML', array);
 
     return array.length === 1 ? array[0] : array;
+  }
+
+  /**
+   * {{> grabHTMLFrom }}
+   */
+  async grabCssPropertyFrom(locator, cssProperty) {
+    locator = new Locator(locator, 'css');
+    const els = await this.browser.findElements(locator.toStrict());
+    const array = [];
+
+    const getCssPropForElement = async (el, prop) => {
+      return (await this.browser.evaluate((el) => {
+        return window.getComputedStyle(window.codeceptjs.fetchElement(el));
+      }, el))[toCamelCase(prop)];
+    };
+
+    for (let index = 0; index < els.length; index++) {
+      const el = els[index];
+      assertElementExists(el, locator);
+      const cssValue = await getCssPropForElement(el, cssProperty);
+      array.push(cssValue);
+    }
+    this.debugSection('HTML', array);
+
+    return array.length > 1 ? array : array[0];
   }
 
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -1133,7 +1133,6 @@ module.exports.tests = function () {
 
   describe('#grabCssPropertyFrom', () => {
     it('should grab css property for given element', async function () {
-      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) this.skip();
 
       await I.amOnPage('/form/doubleclick');
@@ -1142,7 +1141,6 @@ module.exports.tests = function () {
     });
 
     it('should grab camelcased css properies', async () => {
-      if (isHelper('Nightmare')) return;
       if (isHelper('TestCafe')) return;
 
       await I.amOnPage('/form/doubleclick');


### PR DESCRIPTION
## Motivation/Description of the PR
Added grabCssPropertyFrom support for Nightmare helper.

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [X] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

fixes #642

## Type of change

- [ ] Breaking changes
- [X] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)