### PR TITLE
feat: add possibility to ignore doclet with 'ignore' and 'private' tags

### DIFF
--- a/typings/jsdoc.namespace.js
+++ b/typings/jsdoc.namespace.js
@@ -14,7 +14,7 @@ module.exports = {
       }
     },
     newDoclet: ({ doclet }) => {
-      if (doclet.undocumented || doclet.memberof || !kinds.includes(doclet.kind)) return;
+      if (doclet.undocumented || doclet.memberof || doclet.ignore || doclet.private || !kinds.includes(doclet.kind)) return;
       doclet.memberof = namespace;
       doclet.longname = `${doclet.memberof}.${doclet.longname}`;
       if (doclet.scope === 'global') doclet.scope = 'static';


### PR DESCRIPTION
## Motivation/Description of the PR

- Description of this PR, which problem it solves
- A link to the corresponding issue (if applicable).

Added possibility to ignore JSDoc doclet in doc/typings.
Now `@private` and `@ignore` JSDoc annotations will allow not to build doc/typings for code.

Added to allow not to build typings for internatl methods, such as `filterAsync`/`forEachAsync` in WebDriver helper.


## Type of change

- [x] New functionality
- [x] Dev functionality


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)