### PR TITLE
No error stack trace for syntax error #2118

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -171,7 +171,7 @@ class Codecept {
       mocha.run(() => this.teardown(done));
     } catch (e) {
       this.teardown(done);
-      throw new Error(e);
+      throw new Error(e.stack);
     }
   }
 


### PR DESCRIPTION
No error stack trace for syntax error #2118

## Motivation/Description of the PR
Enable stack trace information in the lib/codecept.js file.

- Description of this PR, which problem it solves
No error stack trace for syntax error #2118

## Type of change
throw new Error(e.stack);
- [ X] Bug fix
## Checklist:
