### PR TITLE
Add ability to pass variables to pause()

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -422,7 +422,8 @@ Try to perform your scenario step by step. Then copy succesful commands and inse
 
 ### Pause
 
-Test execution can be paused in any place of a test with `pause()` call.
+Test execution can be paused in any place of a test with `pause()` call. 
+Variables can also be passed to `pause({data: 'hi', func: () => console.log('hello')})` which can be accessed in Interactive shell.
 
 This launches the interactive console where you can call any action from the `I` object.
 
@@ -432,8 +433,17 @@ This launches the interactive console where you can call any action from the `I`
  - Use JavaScript syntax to try steps in action
  - Press TAB twice to see all available commands
  - Enter next to run the next step
- I.click
+ - Prefix => to run js commands
 
+ Registered variables : data, func
+
+ I.click
+ I.see(data)
+```
+
+To run any JS commands prefix `=>` and execute the command.
+```
+I.=> func()
 ```
 
 Type in different actions to try them, copy and paste successful ones into the test file.

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -14,7 +14,7 @@ let rl;
 let nextStep;
 let finish;
 let next;
-
+let registeredVariables;
 /**
  * Pauses test execution and starts interactive shell
  */
@@ -23,7 +23,7 @@ const pause = function (passedObject) {
 
   next = false;
   // add listener to all next steps to provide next() functionality
-  setPassedVariables(passedObject);
+  registeredVariables = setPassedVariables(passedObject);
   event.dispatcher.on(event.step.after, () => {
     recorder.add('Start next pause session', () => {
       if (!next) return;
@@ -41,6 +41,11 @@ function pauseSession() {
     output.print(colors.yellow(` - Press ${colors.bold('ENTER')} to run the next step`));
     output.print(colors.yellow(` - Press ${colors.bold('TAB')} twice to see all available commands`));
     output.print(colors.yellow(` - Type ${colors.bold('exit')} + Enter to exit the interactive shell`));
+    output.print(colors.yellow(` - Prefix ${colors.bold('=>')} to run js commands`));
+    if (registeredVariables) {
+      output.print();
+      output.print(colors.yellow(` Registered variables : ${colors.bold(registeredVariables)}`));
+    }
   }
   rl = readline.createInterface(process.stdin, process.stdout, completer);
 
@@ -71,7 +76,11 @@ function parseInput(cmd) {
   try {
     const locate = global.locate; // enable locate in this context
     const I = container.support('I');
-
+    if (cmd.includes('=>')) {
+      cmd = cmd.substring(cmd.indexOf('=>') + 2, cmd.length);
+    } else {
+      cmd = `I.${cmd}`;
+    }
     const executeCommand = eval(cmd); // eslint-disable-line no-eval
 
     const result = executeCommand instanceof Promise ? executeCommand : Promise.resolve(executeCommand);
@@ -109,7 +118,7 @@ function parseInput(cmd) {
 function askForStep() {
   return new Promise(((resolve) => {
     nextStep = resolve;
-    rl.setPrompt(' > ', 0);
+    rl.setPrompt(' I.', 3);
     rl.resume();
     rl.prompt([false]);
   }));
@@ -128,14 +137,18 @@ function completer(line) {
 }
 
 const setPassedVariables = (passedObject) => {
+  const registeredVariables = [];
   if (passedObject) {
     for (const key of Object.keys(passedObject)) {
+      registeredVariables.push(key);
       if (typeof passedObject[key] === 'string') {
         eval(`${key} = '${passedObject[key]}'`); // eslint-disable-line no-eval
       } else {
         eval(`${key} = ${passedObject[key]}`); // eslint-disable-line no-eval
       }
     }
+
+    return registeredVariables;
   }
 };
 

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -42,7 +42,7 @@ function pauseSession() {
     output.print(colors.yellow(` - Press ${colors.bold('TAB')} twice to see all available commands`));
     output.print(colors.yellow(` - Type ${colors.bold('exit')} + Enter to exit the interactive shell`));
     output.print(colors.yellow(` - Prefix ${colors.bold('=>')} to run js commands`));
-    if (registeredVariables) {
+    if (registeredVariables && registeredVariables.length > 0) {
       output.print();
       output.print(colors.yellow(` Registered variables : ${colors.bold(registeredVariables.join(', '))}`));
     }
@@ -128,7 +128,7 @@ function completer(line) {
   const I = container.support('I');
   const completions = methodsOfObject(I);
   const hits = completions.filter((c) => {
-    if (`I.${c}`.indexOf(line) === 0) {
+    if (c.indexOf(line) === 0) {
       return c;
     }
     return null;

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -44,7 +44,7 @@ function pauseSession() {
     output.print(colors.yellow(` - Prefix ${colors.bold('=>')} to run js commands`));
     if (registeredVariables) {
       output.print();
-      output.print(colors.yellow(` Registered variables : ${colors.bold(registeredVariables)}`));
+      output.print(colors.yellow(` Registered variables : ${colors.bold(registeredVariables.join(', '))}`));
     }
   }
   rl = readline.createInterface(process.stdin, process.stdout, completer);
@@ -76,8 +76,8 @@ function parseInput(cmd) {
   try {
     const locate = global.locate; // enable locate in this context
     const I = container.support('I');
-    if (cmd.includes('=>')) {
-      cmd = cmd.substring(cmd.indexOf('=>') + 2, cmd.length);
+    if (cmd.trim().startsWith('=>')) {
+      cmd = cmd.trim().substring(2, cmd.length);
     } else {
       cmd = `I.${cmd}`;
     }

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -18,11 +18,12 @@ let next;
 /**
  * Pauses test execution and starts interactive shell
  */
-const pause = function () {
+const pause = function (passedObject) {
   if (store.dryRun) return;
 
   next = false;
   // add listener to all next steps to provide next() functionality
+  setPassedVariables(passedObject);
   event.dispatcher.on(event.step.after, () => {
     recorder.add('Start next pause session', () => {
       if (!next) return;
@@ -71,14 +72,15 @@ function parseInput(cmd) {
     const locate = global.locate; // enable locate in this context
     const I = container.support('I');
 
-    const fullCommand = `I.${cmd}`;
-    const result = eval(fullCommand); // eslint-disable-line no-eval
+    const executeCommand = eval(cmd); // eslint-disable-line no-eval
+
+    const result = executeCommand instanceof Promise ? executeCommand : Promise.resolve(executeCommand);
     result.then((val) => {
-      if (cmd.startsWith('see') || cmd.startsWith('dontSee')) {
+      if (cmd.startsWith('I.see') || cmd.startsWith('I.dontSee')) {
         output.print(output.styles.success('  OK  '), cmd);
         return;
       }
-      if (cmd.startsWith('grab')) {
+      if (cmd.startsWith('I.grab')) {
         output.print(output.styles.debug(val));
       }
     }).catch((err) => {
@@ -86,7 +88,7 @@ function parseInput(cmd) {
       lastError = err.message;
     });
 
-    history.push(fullCommand); // add command to history when successful
+    history.push(cmd); // add command to history when successful
   } catch (err) {
     if (!lastError) output.print(output.styles.error(' ERROR '), err.message);
     lastError = err.message;
@@ -107,9 +109,9 @@ function parseInput(cmd) {
 function askForStep() {
   return new Promise(((resolve) => {
     nextStep = resolve;
-    rl.setPrompt(' I.', 3);
+    rl.setPrompt(' > ', 0);
     rl.resume();
-    rl.prompt();
+    rl.prompt([false]);
   }));
 }
 
@@ -117,12 +119,24 @@ function completer(line) {
   const I = container.support('I');
   const completions = methodsOfObject(I);
   const hits = completions.filter((c) => {
-    if (c.indexOf(line) === 0) {
+    if (`I.${c}`.indexOf(line) === 0) {
       return c;
     }
     return null;
   });
   return [hits && hits.length ? hits : completions, line];
 }
+
+const setPassedVariables = (passedObject) => {
+  if (passedObject) {
+    for (const key of Object.keys(passedObject)) {
+      if (typeof passedObject[key] === 'string') {
+        eval(`${key} = '${passedObject[key]}'`); // eslint-disable-line no-eval
+      } else {
+        eval(`${key} = ${passedObject[key]}`); // eslint-disable-line no-eval
+      }
+    }
+  }
+};
 
 module.exports = pause;


### PR DESCRIPTION
## Motivation/Description of the PR
Ability to add and use variables in pause() interactive CLI.

### Usage 
```js
I.click('xxx');
pause({
   variable1, variable2, pageObject1 // pass in all objects as parameters into pause
})
```
Prefix `=>` to run JS commands
### In Cli
```
=>console.log(variable1);
=> pageObject1.open();
```

- Fixes #2132 Fixes #1184 Fixes #396

## Type of change
- [X] New functionality

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)

![pause](https://user-images.githubusercontent.com/24666922/72325920-26ca9a00-36d4-11ea-80ea-4c8c07d62809.gif)
