### PR TITLE
fix: Avoid failiure report on successful retry in worker

### DIFF
--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -22,7 +22,7 @@ const stats = {
 let numberOfWorkersClosed = 0;
 const hasFailures = () => stats.failures || errors.length;
 const pathToWorker = path.join(__dirname, 'workers', 'runTests.js');
-const finishedTests = [];
+const finishedTests = {};
 const errors = [];
 
 module.exports = function (workers, options) {
@@ -87,10 +87,12 @@ module.exports = function (workers, options) {
 
       switch (message.event) {
         case event.test.failed:
-          finishedTests.push(repackTest(message.data));
+          updateFinishedTests(repackTest(message.data));
           output.test.failed(repackTest(message.data));
           break;
-        case event.test.passed: output.test.passed(repackTest(message.data)); break;
+        case event.test.passed: output.test.passed(repackTest(message.data));
+          updateFinishedTests(repackTest(message.data));
+          break;
         case event.suite.before: output.suite.started(message.data); break;
         case event.all.after: appendStats(message.data); break;
       }
@@ -125,7 +127,10 @@ function printResults() {
   if (stats.failures) {
     output.print();
     output.print('-- FAILURES:');
-    Base.list(finishedTests.filter(t => t.err));
+    const failedList = Object.keys(finishedTests)
+      .filter(key => finishedTests[key].err)
+      .map(key => finishedTests[key]);
+    Base.list(failedList);
   }
 }
 
@@ -209,3 +214,12 @@ function simplifyObject(object) {
       return obj;
     }, {});
 }
+
+const updateFinishedTests = (test) => {
+  const { id } = test;
+  if (finishedTests[id]) {
+    const stats = { passes: 0, failures: -1, tests: 0 };
+    appendStats(stats);
+  }
+  finishedTests[id] = test;
+};

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -78,6 +78,7 @@ function initializeListeners() {
     }
 
     return {
+      id: test.id,
       workerIndex,
       title: test.title,
       status: test.status,

--- a/test/data/sandbox/workers/retry_test.workers.js
+++ b/test/data/sandbox/workers/retry_test.workers.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+Feature('Retry Workers');
+
+let tries = 0;
+
+Scenario('retry a test', { retries: 2 }, (I) => {
+  tries++;
+  assert.equal(tries, 2);
+});

--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -102,4 +102,13 @@ describe('CodeceptJS Workers Runner', function () {
       done();
     });
   });
+
+  it('should retry test', function (done) {
+    if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
+    exec(`${codecept_run} 2 --grep "retry"`, (err, stdout, stderr) => {
+      stdout.should.include('CodeceptJS'); // feature
+      stdout.should.include('OK  | 1 passed');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
Tests are not reported as passed if the test is passed in a retry while using run-workers.

While appending test status, passing of already failed test is not accounted for. So adding a map with `test.id` and appending status accordingly fixes the issue.

- Fixes #1985 

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [X] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)