### PR TITLE
(fix): wait for text instead of waiting for 2 secs

### DIFF
--- a/test/acceptance/mock_test.js
+++ b/test/acceptance/mock_test.js
@@ -58,7 +58,7 @@ Scenario(
     I.stopMocking();
 
     I.click('GET COMMENTS');
-    I.wait(2);
+    I.waitForText('laudantium');
     I.dontSee('_uniqueId_u4805sd23', '#data');
   },
 );


### PR DESCRIPTION
## Motivation/Description of the PR
Fix circle-ci tests to fail intermittently

```sh
  1) Mocking
       should request for original data after mocking stopped @Puppeteer @WebDriver:
      expected element #data not to include "_uniqueId_u4805sd23"
      + expected - actual
      -------
      -comment	CUSTOM _uniqueId_u4805sd23
      -------
      +_uniqueId_u4805sd23
```