### PR TITLE
Fix: waitForClickable: Timeout doesn't work, method call fails immediately

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1782,7 +1782,7 @@ class WebDriver extends Helper {
     assertElementExists(res, locator);
 
     return res.waitForClickable({
-      timeout: waitTimeout,
+      timeout: waitTimeout * 1000,
       timeoutMsg: `element ${res.selector} still not clickable after ${waitTimeout} sec`,
     });
   }


### PR DESCRIPTION
Fixed timeout, native webdriverio method requires timeout in ms

I verified the fix manually, on the example attached in the issue, with default WebDriver timeout and with timeout passed to `waitForClickable()`.

## Motivation/Description of the PR

Applicable helpers:

- [x] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- Resolves #2166  (if applicable).

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
