### PR TITLE
fix: puppeteer basic auth fix

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -36,7 +36,6 @@ const findReact = require('./extras/React');
 
 let puppeteer;
 let perfTiming;
-let isAuthenticated = false;
 const popupStore = new Popup();
 const consoleLogStore = new Console();
 
@@ -173,6 +172,7 @@ class Puppeteer extends Helper {
     // set defaults
     this.isRemoteBrowser = false;
     this.isRunning = false;
+    this.isAuthenticated = false;
 
     // override defaults with config
     this._setConfig(config);
@@ -475,7 +475,7 @@ class Puppeteer extends Helper {
     this._setPage(null);
     this.context = null;
     popupStore.clear();
-    isAuthenticated = false;
+    this.isAuthenticated = false;
     if (this.isRemoteBrowser) {
       await this.browser.disconnect();
     } else {
@@ -544,10 +544,10 @@ class Puppeteer extends Helper {
       url = this.options.url + url;
     }
 
-    if (this.config.basicAuth && (isAuthenticated !== true)) {
+    if (this.config.basicAuth && (this.isAuthenticated !== true)) {
       if (url.includes(this.options.url)) {
         await this.page.authenticate(this.config.basicAuth);
-        isAuthenticated = true;
+        this.isAuthenticated = true;
       }
     }
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -475,6 +475,7 @@ class Puppeteer extends Helper {
     this._setPage(null);
     this.context = null;
     popupStore.clear();
+    isAuthenticated = false;
     if (this.isRemoteBrowser) {
       await this.browser.disconnect();
     } else {
@@ -545,7 +546,7 @@ class Puppeteer extends Helper {
 
     if (this.config.basicAuth && (isAuthenticated !== true)) {
       if (url.includes(this.options.url)) {
-        this.page.authenticate(this.config.basicAuth);
+        await this.page.authenticate(this.config.basicAuth);
         isAuthenticated = true;
       }
     }

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -22,7 +22,7 @@ describe('Puppeteer - BasicAuth', () => {
     global.codecept_dir = path.join(__dirname, '/../data');
 
     I = new Puppeteer({
-      url: 'http://localhost:8000',
+      url: siteUrl,
       windowSize: '500x700',
       show: false,
       waitForTimeout: 5000,

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -56,6 +56,10 @@ describe('Puppeteer - BasicAuth', () => {
       await I.amOnPage('/basic_auth');
       await I.see('You entered admin as your password.');
     });
+    it('should be authenticated on second run', async () => {
+      await I.amOnPage('/basic_auth');
+      await I.see('You entered admin as your password.');
+    });
   });
 });
 


### PR DESCRIPTION
## Motivation/Description of the PR
Noticed an issue with basic auth in the puppeteer helper when running multiple sessions.  The authentication would be sent in the first scenario, but in subsequent scenarios it wouldn't get sent.  

Applicable helpers:

- [ ] Webdriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
I found that the `isAuthenticated` boolean wasn't getting reset to `false`, so this adds that reset in `_stopBrowser`.  This also adds an `await` to the `authenticate` call so that it doesn't set `isAutheticated` before successfully authenticating.

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
