### PR TITLE
Fix: Add deepMerge to selenoid options

### DIFF
--- a/lib/plugin/selenoid.js
+++ b/lib/plugin/selenoid.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const axios = require('axios').default;
 const exec = util.promisify(require('child_process').exec);
-const { clearString } = require('../utils');
+const { clearString, deepMerge } = require('../utils');
 const {
   container, event, recorder, output,
 } = require('../index');
@@ -336,7 +336,7 @@ function deletePassedTests(passedTests) {
 
 function setOptionsForWebdriver(config) {
   const WebDriver = container.helpers('WebDriver');
-  WebDriver._setConfig(Object.assign(WebDriver.options, {
+  WebDriver._setConfig(deepMerge(WebDriver.options, {
     capabilities: { 'selenoid:options': config },
   }));
 }


### PR DESCRIPTION
## Motivation/Description of the PR
 If desiredCapabilities is provided selenoid fails to pass options to webdriver. This PR fixes the issue

- Resolves #2183 

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [X] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
