### PR TITLE
Fix: Missing colors in output from run-multiple in docker

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -190,6 +190,9 @@ program.command('run-multiple [suites...]')
   .option('-R, --reporter <name>', 'specify the reporter to use')
   .option('--recursive', 'include sub directories')
 
+  // mocha options
+  .option('--colors', 'force enabling of colors')
+
   .action(require('../lib/command/run-multiple'));
 
 program.command('info [path]')

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -14,7 +14,7 @@ const {
 const runner = path.join(__dirname, '/../../bin/codecept');
 let config;
 const childOpts = {};
-const copyOptions = ['override', 'steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'invert', 'debug', 'plugins'];
+const copyOptions = ['override', 'steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'invert', 'debug', 'plugins', 'colors'];
 let overrides = {};
 
 // codeceptjs run-multiple smoke:chrome regression:firefox - will launch smoke run in chrome and regression in firefox

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1782,7 +1782,7 @@ class WebDriver extends Helper {
     assertElementExists(res, locator);
 
     return res.waitForClickable({
-      timeout: waitTimeout,
+      timeout: waitTimeout * 1000,
       timeoutMsg: `element ${res.selector} still not clickable after ${waitTimeout} sec`,
     });
   }


### PR DESCRIPTION
## Motivation/Description of the PR
I want to have colors in console output when running parallel tests in dockerized environment.
The fix allows passing the option `--colors` to child processes. If you omit `--colors`, it works as before - in docker, colors won't work. In non-docker env, colors will work.

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
- Resolves #1876 

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
