### PR TITLE
added webdriver type function

### DIFF
--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -1496,6 +1496,24 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 -   `fileName` **[string][4]** file name to save.
 -   `fullPage` **[boolean][15]** (optional, `false` by default) flag to enable fullscreen screenshot mode. (optional, default `false`)
 
+### type
+
+Types out the given string or the array of keys provided.
+_Note:_ Should only be used when using [`fillField`][19] is not an option.
+
+```js
+// When passing in a string
+I.type('Type this out.');
+// When passing in an array
+I.type(['T', 'E', 'X', 'T']);
+```
+
+#### Parameters
+
+-   `keys`  
+-   `key` **([string][4] \| [Array][14]&lt;[string][4]>)** or array of keys to type.
+    Type out given array of keys or a string of text
+
 ### dragAndDrop
 
 Drag an item to a destination element.
@@ -1705,3 +1723,5 @@ Returns **[object][6]** Element bounding rectangle
 [17]: https://webdriver.io/docs/timeouts.html
 
 [18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined
+
+[19]: #fillfield

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -1702,6 +1702,24 @@ await I.switchToWindow( window );
 
 -   `window`  
 
+### type
+
+Types out the given string or the array of keys provided.
+_Note:_ Should only be used when using [`fillField`][29] is not an option.
+
+```js
+// When passing in a string
+I.type('Type this out.');
+// When passing in an array
+I.type(['T', 'E', 'X', 'T']);
+```
+
+#### Parameters
+
+-   `keys`  
+-   `key` **([string][18] | [Array][28]&lt;[string][18]>)** or array of keys to type.
+    Type out given array of keys or a string of text
+
 ### uncheckOption
 
 Unselects a checkbox or radio button.

--- a/docs/webapi/type.mustache
+++ b/docs/webapi/type.mustache
@@ -1,0 +1,12 @@
+
+Types out the given string or the array of keys provided.
+_Note:_ Should only be used when using [`fillField`](#fillfield) is not an option.
+
+```js
+// When passing in a string
+I.type('Type this out.');
+// When passing in an array
+I.type(['T', 'E', 'X', 'T']);
+```
+
+@param {string|string[]} key or array of keys to type.

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1605,6 +1605,18 @@ class WebDriver extends Helper {
   }
 
   /**
+   * {{> type }}
+   * Type out given array of keys or a string of text
+   */
+  async type(keys) {
+    if (Array.isArray(keys)) {
+      await this.browser.keys(keys);
+      return;
+    }
+    await this.browser.keys(keys.split(''));
+  }
+
+  /**
    * {{> resizeWindow }}
    * Appium: not tested in web, in apps doesn't work
    */

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -305,7 +305,7 @@ describe('WebDriver', function () {
   describe('#type', () => {
     it('should type into a field', async () => {
       await wd.amOnPage('/form/field');
-      await wd.fillField('Name', '');
+      await wd.click('Name');
 
       await wd.type('Type Test');
       await wd.seeInField('Name', 'Type Test');

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -302,6 +302,21 @@ describe('WebDriver', function () {
     });
   });
 
+  describe('#type', () => {
+    it('should type into a field', async () => {
+      await wd.amOnPage('/form/field');
+      await wd.fillField('Name', '');
+
+      await wd.type('Type Test');
+      await wd.seeInField('Name', 'Type Test');
+
+      await wd.fillField('Name', '');
+
+      await wd.type(['T', 'y', 'p', 'e', '2']);
+      await wd.seeInField('Name', 'Type2');
+    });
+  });
+
   describe('#seeInSource, #grabSource', () => {
     it('should check for text to be in HTML source', async () => {
       await wd.amOnPage('/');


### PR DESCRIPTION
## Motivation/Description of the PR

Adding a type function to Webdriver, when `fillField` is not a valid option to use.

Applicable helpers:

- [x] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [x] Appium
- [ ] Protractor
- [ ] TestCafe

- Resolves #2185 

## Type of change

- [ ] Breaking changes
- [x] New functionality
- [ ] Bug fix
- [x] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
