### PR TITLE
fix(command): generate test not respecting config

### DIFF
--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -26,7 +26,7 @@ module.exports.test = function (genPath) {
   output.print('Creating a new test...');
   output.print('----------------------');
 
-  const defaultExt = config.tests.match(/([^\*/]*?)$/[1])[0] || '_test.js';
+  const defaultExt = config.tests.match(/([^\*/]*?)$/)[1] || '_test.js';
 
   return inquirer.prompt([
     {


### PR DESCRIPTION
## Motivation/Description of the PR

`codeceptjs generate:test` is not detecting the suffix used in the project config.

I have this in my config:
```
tests: `./tests/**/*.spec.ts`
``` 
but the command still suggests `_test.js`.
This is solved with a small bugfix in the pattern line.

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
