### PR TITLE
fix(command): respect case generate test 

### DIFF
--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -39,7 +39,7 @@ module.exports.test = function (genPath) {
       message: 'Filename of a test',
       name: 'filename',
       default(answers) {
-        return (answers.feature).replace(' ', '_').toLowerCase() + defaultExt;
+        return (answers.feature).replace(' ', '_') + defaultExt;
       },
     },
   ]).then((result) => {

--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -33,6 +33,9 @@ module.exports.test = function (genPath) {
       type: 'input',
       name: 'feature',
       message: 'Feature which is being tested',
+      default() {
+        return 'Accounts/forgot-password';
+      },
     },
     {
       type: 'input',
@@ -60,7 +63,7 @@ module.exports.test = function (genPath) {
     testContent = testContent.replace('{{actor}}', 'I');
 
     if (!safeFileWrite(testFile, testContent)) return;
-    output.success(`Test for ${result.filename} was created in ${testFile}`);
+    output.success(`\nTest for ${result.filename} was created in ${testFile}`);
   });
 };
 


### PR DESCRIPTION
## Motivation/Description of the PR

`codeceptjs generate:test` is lower casing the input, restricting projects to define their own naming convention for the test files.

Also, for a newbie, it's helpful to have an introductory example showing that it's possible to use paths, and encourage its usage for better categorization of the tests :)

![image](https://user-images.githubusercontent.com/260185/74581686-1bdb8180-4f80-11ea-91ab-5684fe2c34cb.png)

## Type of change

- [ ] Breaking changes
- [x] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)

