### PR TITLE
Gherkin - including examples tags into test tags

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -74,7 +74,7 @@ module.exports = (text) => {
               return step;
             });
           }
-          const tags = child.tags.map(t => t.name);
+          const tags = child.tags.map(t => t.name).concat(examples.tags.map(t => t.name));
           const title = `${child.name} ${JSON.stringify(current)} ${tags.join(' ')}`.trim();
           const test = new Test(title, async () => runSteps(addExampleInTable(exampleSteps, current)));
           test.tags = suite.tags.concat(tags);

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -214,10 +214,15 @@ describe('BDD', () => {
       Given I have product with price <price>$ in my cart
       And discount is 10 %
       Then I should see price is "<total>" $
-
+      
       Examples:
         | price | total |
         | 10    | 9     |
+
+      @exampleTag1
+      @exampleTag2
+      Examples:
+        | price | total |
         | 20    | 18    |
     `;
     let cart = 0;
@@ -235,9 +240,8 @@ describe('BDD', () => {
     const suite = run(text);
 
     assert.ok(suite.tests[0].tags);
-    assert.equal('@awesome', suite.tests[0].tags[0]);
-    assert.equal('@cool', suite.tests[0].tags[1]);
-    assert.equal('@super', suite.tests[0].tags[2]);
+    assert.deepEqual(['@awesome', '@cool', '@super'], suite.tests[0].tags);
+    assert.deepEqual(['@awesome', '@cool', '@super', '@exampleTag1', '@exampleTag2'], suite.tests[1].tags);
 
     assert.equal(2, suite.tests.length);
     suite.tests[0].fn(() => {


### PR DESCRIPTION
Gherkin allows to set different tags per example https://github.com/cucumber/cucumber/tree/master/gherkin#pickles

In codecept the examples tags are ignored

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
