### PR TITLE
Add Playwright support on screenshotOnFail plugin

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -22,6 +22,7 @@ const supportedHelpers = [
   'Appium',
   'Nightmare',
   'Puppeteer',
+  'Playwright',
 ];
 
 /**


### PR DESCRIPTION
## Motivation/Description of the PR

Applicable helpers:

- [x] Playwright
- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe

- Description of this PR, which problem it solves
  - The `screenshotOnFail` plugin doesn't work on the Playwright helper. The fix is simple by just adding the helper to the helper list.

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code
