### PR TITLE
(fix): add missing supported helpers

### DIFF
--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -4,7 +4,7 @@ const recorder = require('../recorder');
 const event = require('../event');
 const log = require('../output').log;
 
-const supportedHelpers = require('./supportedHelpersList');
+const supportedHelpers = require('./standardActingHelpers');
 
 const methodsToDelay = [
   'click',

--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -11,6 +11,8 @@ const supportedHelpers = [
   'Appium',
   'Nightmare',
   'Puppeteer',
+  'Playwright'
+  'TestCafe',
 ];
 
 const methodsToDelay = [

--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -4,16 +4,7 @@ const recorder = require('../recorder');
 const event = require('../event');
 const log = require('../output').log;
 
-const supportedHelpers = [
-  'WebDriver',
-  'WebDriverIO',
-  'Protractor',
-  'Appium',
-  'Nightmare',
-  'Puppeteer',
-  'Playwright',
-  'TestCafe',
-];
+const supportedHelpers = require('./supportedHelpersList');
 
 const methodsToDelay = [
   'click',

--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -11,7 +11,7 @@ const supportedHelpers = [
   'Appium',
   'Nightmare',
   'Puppeteer',
-  'Playwright'
+  'Playwright',
   'TestCafe',
 ];
 

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -14,15 +14,7 @@ const defaultConfig = {
   fullPageScreenshots: false,
 };
 
-const supportedHelpers = [
-  'Mochawesome',
-  'WebDriverIO',
-  'WebDriver',
-  'Protractor',
-  'Appium',
-  'Nightmare',
-  'Puppeteer',
-];
+const supportedHelpers = require('./supportedHelpersList');
 
 /**
  * Creates screenshot on failure. Screenshot is saved into `output` directory.

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -14,7 +14,7 @@ const defaultConfig = {
   fullPageScreenshots: false,
 };
 
-const supportedHelpers = require('./supportedHelpersList');
+const supportedHelpers = require('./standardActingHelpers');
 
 /**
  * Creates screenshot on failure. Screenshot is saved into `output` directory.

--- a/lib/plugin/standardActingHelpers.js
+++ b/lib/plugin/standardActingHelpers.js
@@ -1,4 +1,4 @@
-const supportedHelper = [
+const standardActingHelpers = [
   'Mochawesome',
   'WebDriver',
   'WebDriverIO',
@@ -10,4 +10,4 @@ const supportedHelper = [
   'TestCafe',
 ];
 
-module.exports = supportedHelper;
+module.exports = standardActingHelpers;

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -19,7 +19,7 @@ const supportedHelpers = [
   'Nightmare',
   'Puppeteer',
   'Playwright',
-  'TestCafe'
+  'TestCafe',
 ];
 
 const defaultConfig = {

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -11,7 +11,7 @@ const event = require('../event');
 const output = require('../output');
 const { template, deleteDir } = require('../utils');
 
-const supportedHelpers = require('./supportedHelpersList');
+const supportedHelpers = require('./standardActingHelpers');
 
 const defaultConfig = {
   deleteSuccessful: true,

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -11,16 +11,7 @@ const event = require('../event');
 const output = require('../output');
 const { template, deleteDir } = require('../utils');
 
-const supportedHelpers = [
-  'WebDriverIO',
-  'WebDriver',
-  'Protractor',
-  'Appium',
-  'Nightmare',
-  'Puppeteer',
-  'Playwright',
-  'TestCafe',
-];
+const supportedHelpers = require('./supportedHelpersList');
 
 const defaultConfig = {
   deleteSuccessful: true,

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -18,6 +18,8 @@ const supportedHelpers = [
   'Appium',
   'Nightmare',
   'Puppeteer',
+  'Playwright',
+  'TestCafe'
 ];
 
 const defaultConfig = {

--- a/lib/plugin/supportedHelpersList.js
+++ b/lib/plugin/supportedHelpersList.js
@@ -1,0 +1,13 @@
+const supportedHelper = [
+  'Mochawesome',
+  'WebDriver',
+  'WebDriverIO',
+  'Protractor',
+  'Appium',
+  'Nightmare',
+  'Puppeteer',
+  'Playwright',
+  'TestCafe',
+];
+
+module.exports = supportedHelper;


### PR DESCRIPTION
## Motivation/Description of the PR
We have added 2 more helpers and forgot to add them to supported helpers array of this plugin. 

By separating the supported helpers into a file, we could prevent the missing update on many places, in another words, we just update the new support helper into the list in file and we are all good. One place to update.

Applicable helpers:

- [ ] Webdriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] Appium
- [ ] Protractor
- [x] TestCafe
- [x] Playwright


## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [x] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code

## Checklist:
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
