### PR TITLE
add missing JSDoc parameter for seeInPopup method, update documentation

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -1269,7 +1269,7 @@ given string.
 
 #### Parameters
 
--   `text`  
+-   `text` **[string][7]** value to check.
 
 ### seeInSource
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -1267,6 +1267,10 @@ I.seeInField('#searchform input','Search');
 Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
 given string.
 
+```js
+I.seeInPopup('Popup text');
+```
+
 #### Parameters
 
 -   `text` **[string][7]** value to check.

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -1096,7 +1096,7 @@ given string.
 
 #### Parameters
 
--   `text`  
+-   `text` **[string][9]** value to check.
 
 ### seeInSource
 

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -1094,6 +1094,10 @@ I.seeInField('#searchform input','Search');
 Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
 given string.
 
+```js
+I.seeInPopup('Popup text');
+```
+
 #### Parameters
 
 -   `text` **[string][9]** value to check.

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1366,6 +1366,10 @@ I.seeInField('#searchform input','Search');
 Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
 given string.
 
+```js
+I.seeInPopup('Popup text');
+```
+
 #### Parameters
 
 -   `text` **[string][8]** value to check.

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1368,7 +1368,7 @@ given string.
 
 #### Parameters
 
--   `text`  
+-   `text` **[string][8]** value to check.
 
 ### seeInSource
 

--- a/docs/webapi/seeInPopup.mustache
+++ b/docs/webapi/seeInPopup.mustache
@@ -1,0 +1,7 @@
+Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
+given string.
+
+```js
+I.seeInPopup('Popup text');
+```
+@param {string} text value to check.

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -390,9 +390,7 @@ class Playwright extends Helper {
   }
 
   /**
-   * Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
-   * given string.
-   * @param {string} text value to check.
+   * {{> seeInPopup }}
    */
   async seeInPopup(text) {
     popupStore.assertPopupVisible();

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -392,6 +392,7 @@ class Playwright extends Helper {
   /**
    * Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
    * given string.
+   * @param {string} text value to check.
    */
   async seeInPopup(text) {
     popupStore.assertPopupVisible();

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -1056,6 +1056,7 @@ class Protractor extends Helper {
   /**
    * Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
    * given string.
+   * @param {string} text value to check.
    */
   async seeInPopup(text) {
     const popupAlert = await this.browser.switchTo().alert();

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -1054,9 +1054,7 @@ class Protractor extends Helper {
   }
 
   /**
-   * Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
-   * given string.
-   * @param {string} text value to check.
+   * {{> seeInPopup }}
    */
   async seeInPopup(text) {
     const popupAlert = await this.browser.switchTo().alert();

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -363,6 +363,7 @@ class Puppeteer extends Helper {
   /**
    * Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
    * given string.
+   * @param {string} text value to check.
    */
   async seeInPopup(text) {
     popupStore.assertPopupVisible();

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -361,9 +361,7 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
-   * given string.
-   * @param {string} text value to check.
+   * {{> seeInPopup }}
    */
   async seeInPopup(text) {
     popupStore.assertPopupVisible();


### PR DESCRIPTION
## Motivation/Description of the PR
I noticed that the typescript interface of the seeInPopup was missing the input parameter, so I went ahead and added it in the JSDoc from which type definitions are generated.

Applicable helpers:

- [ ] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
