### PR TITLE
Updated to click the firstVisibleElement

### DIFF
--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -1208,7 +1208,7 @@ async function proceedClick(locator, context = null) {
     await assertElementExists(els, locator, 'Clickable element');
   }
 
-  const firstElement = await els.nth(0);
+  const firstElement = await els.filterVisible().nth(0);
 
   return this.t
     .click(firstElement)


### PR DESCRIPTION
Earlier it seems like it was clicking the first element. Now it clicks the first visible element,

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves https://github.com/Codeception/CodeceptJS/issues/2226

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [x] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
