### PR TITLE
handle beforesuite failures when allure enabled and report beforesuite failures

### DIFF
--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -219,7 +219,7 @@ module.exports = (config) => {
       reporter.endCase('failed', err);
     } else if (err) {
       // this means before suite failed, we should report this.
-      reporter.startCase('Suite setup failed');
+      reporter.startCase('BeforeSuite failed');
       reporter.endCase('failed', err);
     }
   });

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -215,7 +215,9 @@ module.exports = (config) => {
     }
 
     err.message = err.message.replace(ansiRegExp(), '');
-    reporter.endCase('failed', err);
+    if (reporter.getCurrentTest()) {
+      reporter.endCase('failed', err);
+    }
   });
 
   event.dispatcher.on(event.test.passed, () => {

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -219,7 +219,7 @@ module.exports = (config) => {
       reporter.endCase('failed', err);
     } else if (err) {
       // this means before suite failed, we should report this.
-      reporter.startCase('BeforeSuite failed');
+      reporter.startCase(`${reporter.getCurrentSuite().name} BeforeSuite failed`);
       reporter.endCase('failed', err);
     }
   });

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -217,6 +217,10 @@ module.exports = (config) => {
     err.message = err.message.replace(ansiRegExp(), '');
     if (reporter.getCurrentTest()) {
       reporter.endCase('failed', err);
+    } else if (err) {
+      // this means before suite failed, we should report this.
+      reporter.startCase('Suite setup failed');
+      reporter.endCase('failed', err);
     }
   });
 

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -217,9 +217,9 @@ module.exports = (config) => {
     err.message = err.message.replace(ansiRegExp(), '');
     if (reporter.getCurrentTest()) {
       reporter.endCase('failed', err);
-    } else if (err) {
+    } else {
       // this means before suite failed, we should report this.
-      reporter.startCase(`${reporter.getCurrentSuite().name} BeforeSuite failed`);
+      reporter.startCase(`BeforeSuite of suite ${reporter.getCurrentSuite().name} failed.`);
       reporter.endCase('failed', err);
     }
   });

--- a/test/data/sandbox/configs/allure/allure-failed.conf.js
+++ b/test/data/sandbox/configs/allure/allure-failed.conf.js
@@ -1,0 +1,16 @@
+exports.config = {
+  tests: './*_test_failed.js',
+  timeout: 10000,
+  output: './output/failed',
+  helpers: {
+    FileSystem: {},
+  },
+  include: {},
+  plugins: {
+    allure: {
+      enabled: true,
+    },
+  },
+  mocha: {},
+  name: 'sandbox',
+};

--- a/test/data/sandbox/configs/allure/before_suite_test_failed.conf.js
+++ b/test/data/sandbox/configs/allure/before_suite_test_failed.conf.js
@@ -1,5 +1,5 @@
 exports.config = {
-  tests: './*_test_failed.js',
+  tests: './before_suite_test_failed.js',
   timeout: 10000,
   output: './output/failed',
   helpers: {

--- a/test/data/sandbox/configs/allure/before_suite_test_failed.js
+++ b/test/data/sandbox/configs/allure/before_suite_test_failed.js
@@ -1,0 +1,14 @@
+Feature('failing setup');
+
+let number;
+BeforeSuite(async () => {
+  throw new Error('the before suite setup failed');
+});
+
+Scenario('failing setup test 1', async I => {
+  I.say('Test was fine.');
+});
+
+Scenario('failing setup test 2', async I => {
+  I.say('Test was fine.');
+});

--- a/test/data/sandbox/configs/allure/before_suite_test_failed.js
+++ b/test/data/sandbox/configs/allure/before_suite_test_failed.js
@@ -1,4 +1,4 @@
-Feature('failing setup');
+Feature('failing setup test suite');
 
 let number;
 BeforeSuite(async () => {

--- a/test/runner/allure_test.js
+++ b/test/runner/allure_test.js
@@ -7,18 +7,22 @@ const { deleteDir } = require('../../lib/utils');
 const runner = path.join(__dirname, '/../../bin/codecept.js');
 const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/allure');
 const codecept_run = `${runner} run`;
+const codecept_workers = `${runner} run-workers 2`;
 const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep ${grep}` : ''}`;
+const codecept_workers_config = (config, grep) => `${codecept_workers} --config ${codecept_dir}/${config} ${grep ? `--grep ${grep}` : ''}`;
 
 
 describe('CodeceptJS Allure Plugin', () => {
   beforeEach(() => {
     deleteDir(path.join(codecept_dir, 'output/ansi'));
     deleteDir(path.join(codecept_dir, 'output/success'));
+    deleteDir(path.join(codecept_dir, 'output/failed'));
   });
 
   afterEach(() => {
     deleteDir(path.join(codecept_dir, 'output/ansi'));
     deleteDir(path.join(codecept_dir, 'output/success'));
+    deleteDir(path.join(codecept_dir, 'output/failed'));
   });
 
   it('should enable allure reports', (done) => {
@@ -36,6 +40,36 @@ describe('CodeceptJS Allure Plugin', () => {
       const files = fs.readdirSync(path.join(codecept_dir, 'output/ansi'));
       assert(files[0].match(/\.xml$/), 'not a xml file');
       assert.equal(files.length, 1);
+      done();
+    });
+  });
+
+  it('before suite errors are reported when running', (done) => {
+    exec(codecept_run_config('allure-failed.conf.js'), (err, stdout) => {
+      stdout.should.not.include('OK  | 0 passed');
+      stdout.should.include('FAIL  | 0 passed, 1 failed');
+
+      const files = fs.readdirSync(path.join(codecept_dir, 'output/failed'));
+      const testResultPath = files[0];
+      assert(testResultPath.match(/\.xml$/), 'not a xml file');
+      const file = fs.readFileSync(path.join(codecept_dir, 'output/failed', testResultPath), 'utf8');
+      file.should.include('BeforeSuite failed');
+      file.should.include('the before suite setup failed');
+      done();
+    });
+  });
+
+  it('before suite errors are reported when running in workers', (done) => {
+    exec(codecept_workers_config('allure-failed.conf.js'), (err, stdout) => {
+      stdout.should.not.include('OK  | 0 passed');
+      stdout.should.include('FAIL  | 0 passed, 1 failed');
+
+      const files = fs.readdirSync(path.join(codecept_dir, 'output/failed'));
+      const testResultPath = files[0];
+      assert(testResultPath.match(/\.xml$/), 'not a xml file');
+      const file = fs.readFileSync(path.join(codecept_dir, 'output/failed', testResultPath), 'utf8');
+      file.should.include('BeforeSuite failed');
+      file.should.include('the before suite setup failed');
       done();
     });
   });

--- a/test/runner/allure_test.js
+++ b/test/runner/allure_test.js
@@ -45,7 +45,7 @@ describe('CodeceptJS Allure Plugin', () => {
   });
 
   it('before suite errors are reported when running', (done) => {
-    exec(codecept_run_config('allure-failed.conf.js'), (err, stdout) => {
+    exec(codecept_run_config('before_suite_test_failed.conf.js'), (err, stdout) => {
       stdout.should.not.include('OK  | 0 passed');
       stdout.should.include('FAIL  | 0 passed, 1 failed');
 
@@ -53,14 +53,14 @@ describe('CodeceptJS Allure Plugin', () => {
       const testResultPath = files[0];
       assert(testResultPath.match(/\.xml$/), 'not a xml file');
       const file = fs.readFileSync(path.join(codecept_dir, 'output/failed', testResultPath), 'utf8');
-      file.should.include('BeforeSuite failed');
+      file.should.include('failing setup test suite: BeforeSuite failed');
       file.should.include('the before suite setup failed');
       done();
     });
   });
 
   it('before suite errors are reported when running in workers', (done) => {
-    exec(codecept_workers_config('allure-failed.conf.js'), (err, stdout) => {
+    exec(codecept_workers_config('before_suite_test_failed.conf.js'), (err, stdout) => {
       stdout.should.not.include('OK  | 0 passed');
       stdout.should.include('FAIL  | 0 passed, 1 failed');
 
@@ -68,7 +68,7 @@ describe('CodeceptJS Allure Plugin', () => {
       const testResultPath = files[0];
       assert(testResultPath.match(/\.xml$/), 'not a xml file');
       const file = fs.readFileSync(path.join(codecept_dir, 'output/failed', testResultPath), 'utf8');
-      file.should.include('BeforeSuite failed');
+      file.should.include('failing setup test suite: BeforeSuite failed');
       file.should.include('the before suite setup failed');
       done();
     });

--- a/test/runner/allure_test.js
+++ b/test/runner/allure_test.js
@@ -44,31 +44,29 @@ describe('CodeceptJS Allure Plugin', () => {
     });
   });
 
-  it('before suite errors are reported when running', (done) => {
+  it('should report BeforeSuite errors when executing via run command', (done) => {
     exec(codecept_run_config('before_suite_test_failed.conf.js'), (err, stdout) => {
-      stdout.should.not.include('OK  | 0 passed');
       stdout.should.include('FAIL  | 0 passed, 1 failed');
 
       const files = fs.readdirSync(path.join(codecept_dir, 'output/failed'));
       const testResultPath = files[0];
       assert(testResultPath.match(/\.xml$/), 'not a xml file');
       const file = fs.readFileSync(path.join(codecept_dir, 'output/failed', testResultPath), 'utf8');
-      file.should.include('failing setup test suite: BeforeSuite failed');
+      file.should.include('BeforeSuite of suite failing setup test suite: failed.');
       file.should.include('the before suite setup failed');
       done();
     });
   });
 
-  it('before suite errors are reported when running in workers', (done) => {
+  it('should report BeforeSuite errors when executing via run-workers command', (done) => {
     exec(codecept_workers_config('before_suite_test_failed.conf.js'), (err, stdout) => {
-      stdout.should.not.include('OK  | 0 passed');
       stdout.should.include('FAIL  | 0 passed, 1 failed');
 
       const files = fs.readdirSync(path.join(codecept_dir, 'output/failed'));
       const testResultPath = files[0];
       assert(testResultPath.match(/\.xml$/), 'not a xml file');
       const file = fs.readFileSync(path.join(codecept_dir, 'output/failed', testResultPath), 'utf8');
-      file.should.include('failing setup test suite: BeforeSuite failed');
+      file.should.include('BeforeSuite of suite failing setup test suite: failed.');
       file.should.include('the before suite setup failed');
       done();
     });


### PR DESCRIPTION
## Motivation/Description of the PR
- Fixes issue with allure when BeforeSuite fails in parallel workers codeceptjs still output success when allure is enabled. Observe this is marked as `OK` rather than failed:
![image](https://user-images.githubusercontent.com/9056958/75780987-4422f880-5d54-11ea-80fa-7d2b9d40108b.png)

This underlying error is masked in workers mode, but if you run in non workers mode you'll see this error:
```
   TypeError: Cannot read property 'end' of undefined
    at Allure.endCase (/Users/myuser/Code/codecepttest/node_modules/allure-js-commons/index.js:50:26)
    at EventEmitter.<anonymous> (/Users/myuser/Code/codecepttest/node_modules/codeceptjs/lib/plugin/allure.js:219:16)
    at EventEmitter.emit (events.js:208:15)
    at Object.emit (/Users/myuser/Code/codecepttest/node_modules/codeceptjs/lib/event.js:115:28)
    at errHandler (/Users/myuser/Code/codecepttest/node_modules/codeceptjs/lib/scenario.js:101:13)
    at /Users/myuser/Code/codecepttest/node_modules/codeceptjs/lib/scenario.js:132:11
    at /Users/myuser/Code/codecepttest/node_modules/codeceptjs/lib/recorder.js:227:9
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
    [1] <teardown> Stopping recording promises
```


- Resolves https://github.com/Codeception/CodeceptJS/issues/2247

Also fixes: BeforeSuite failures do not appear in allure report:


Prior to my fix: 
![image](https://user-images.githubusercontent.com/9056958/75786820-c4019080-5d5d-11ea-83cd-71c6c73441c1.png)


> This fixes a broken case at the moment where if a `BeforeSuite` fails there is nothing in the allure report indicate a problem. This is especially problematic when running parallel.
> 
> I wasn't sure it it was possible to generate name here rather than hard coding a blank test case.
> BeforeSuite failed'.
> 
> The result here is that:
*NOTE IN IMAGES I TYPED BEFOREACH INSTEAD OF BEFORESUITE*
> ![image](https://user-images.githubusercontent.com/9056958/75786507-55243780-5d5d-11ea-8212-2ae75d86cc02.png)
> 
> How does this impact run-workers where `BeforeSuite` can be run multiple time? see below
> The setup failure is correctly reported:
*NOTE IN IMAGES I TYPED BEFOREACH INSTEAD OF BEFORESUITE*
> ![image](https://user-images.githubusercontent.com/9056958/75786403-24dc9900-5d5d-11ea-8365-fd5dd97ba2f6.png)
> (WRONG NUMBER HERE error message comes from my test where i'm randomly generating number between 0 and 1 so i can fail the beforesuite in one or more threads)



Applicable plugins:

- [X] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
