### PR TITLE
#2224 Rest helper should respect content type header

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -75,7 +75,9 @@ class REST extends Helper {
     }
 
     if ((typeof request.data) === 'string') {
-      request.headers = Object.assign(request.headers, { 'Content-Type': 'application/x-www-form-urlencoded' });
+      if (!request.headers || !request.headers['Content-Type']) {
+        request.headers = Object.assign(request.headers, { 'Content-Type': 'application/x-www-form-urlencoded' });
+      }
     }
 
     if (this.config.onRequest) {

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -128,6 +128,27 @@ describe('REST', () => {
       response.config.headers.should.have.property('HTTP_X_REQUESTED_WITH');
       response.config.headers.HTTP_X_REQUESTED_WITH.should.eql('xmlhttprequest');
     });
+
+    it('should set Content-Type header if data is string and Content-Type is omitted', async () => {
+      const response = await I.sendPostRequest(
+        '/user',
+        'string of data',
+      );
+
+      response.config.headers.should.have.property('Content-Type');
+      response.config.headers['Content-Type'].should.eql('application/x-www-form-urlencoded');
+    });
+
+    it('should respect any passsed in Content-Type header', async () => {
+      const response = await I.sendPostRequest(
+        '/user',
+        'bad json data',
+        { 'Content-Type': 'application/json' },
+      );
+
+      response.config.headers.should.have.property('Content-Type');
+      response.config.headers['Content-Type'].should.eql('application/json');
+    });
   });
 
   describe('_url autocompletion', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- Adds check for if Content-Type header is already set by user before defaulting to x-url-encoded when data is string. Also adds tests for this. Let me know if I should add documentation as well for this
- Resolves #2224 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
