### PR TITLE
[Playwright] add support for custom locators in findElements

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1986,7 +1986,7 @@ module.exports = Playwright;
 
 async function findElements(matcher, locator) {
   locator = new Locator(locator, 'css');
-  if (!locator.isXPath()) return matcher.$$(locator.simplify());
+  if (!locator.isXPath()) return matcher.$$(`${locator.type}=${locator.value}`);
   return matcher.$$(`xpath=${locator.value}`);
 }
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Support custom locators in find elements for Playwright.
- Ultimately this is steps towards enabling a plugin I am working on for shadow dom support.

Context: https://github.com/Georgegriff/query-selector-shadow-dom/pull/27

Copied this from corresponding example in `waitForElement` 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
