### PR TITLE
Custom locators playwright 0.12.1

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -19,9 +19,9 @@ Uses [Playwright][1] library to run tests inside:
 
 This helper works with a browser out of the box with no additional tools required to install.
 
-Requires `playwright` package version ^0.11.0 to be installed:
+Requires `playwright` package version ^0.12.1 to be installed:
 
-    npm i playwright@^0.11.0 --save
+    npm i playwright@^0.12.1 --save
 
 ## Configuration
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -28,7 +28,7 @@ It's readable and simple and working using Playwright API!
 To start you need CodeceptJS with Playwright packages installed
 
 ```bash
-npm install codeceptjs playwright@^0.10.0 --save
+npm install codeceptjs playwright@^0.12.1 --save
 ```
 
 Or see [alternative installation options](http://codecept.io/installation/)
@@ -202,7 +202,7 @@ CodeceptJS allows you to implement custom actions like `I.createTodo` or use **P
 
 ## Extending
 
-Playwright has a very [rich and flexible API](https://github.com/microsoft/playwright/blob/v0.10.0/docs/api.md). Sure, you can extend your test suites to use the methods listed there. CodeceptJS already prepares some objects for you and you can use them from your you helpers.
+Playwright has a very [rich and flexible API](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md). Sure, you can extend your test suites to use the methods listed there. CodeceptJS already prepares some objects for you and you can use them from your you helpers.
 
 Start with creating an `MyPlaywright` helper using `generate:helper` or `gh` command:
 
@@ -238,7 +238,7 @@ async setPermissions() {
   return context.setPermissions('https://html5demos.com', ['geolocation']);
 }
 
-> [▶ Learn more about BrowserContext](https://github.com/microsoft/playwright/blob/v0.10.0/docs/api.md#class-browsercontext)
+> [▶ Learn more about BrowserContext](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md#class-browsercontext)
 
 > [▶ Learn more about Helpers](http://codecept.io/helpers/)
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1606,7 +1606,7 @@ class Playwright extends Helper {
     const context = await this._getContext();
     if (!locator.isXPath()) {
       // uses a custom selector engine for finding value properties on elements
-      waiter = context.waitForSelector(`${locator.type}=${locator.value} >> __value=${value}`, { timeout: waitTimeout, waitFor: 'visible' });
+      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> __value=${value}`, { timeout: waitTimeout, waitFor: 'visible' });
     } else {
       const valueFn = function (locator, $XPath, value) {
         eval($XPath); // eslint-disable-line no-eval
@@ -1676,7 +1676,7 @@ class Playwright extends Helper {
     locator = new Locator(locator, 'css');
 
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout });
+    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1691,7 +1691,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'visible' });
+    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'visible' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1704,7 +1704,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'hidden' });
+    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'hidden' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1717,7 +1717,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    return context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'hidden' }).catch((err) => {
+    return context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'hidden' }).catch((err) => {
       throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`);
     });
   }
@@ -1934,7 +1934,7 @@ class Playwright extends Helper {
     let waiter;
     const context = await this._getContext();
     if (!locator.isXPath()) {
-      waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'detached' });
+      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'detached' });
     } else {
       const visibleFn = function (locator, $XPath) {
         eval($XPath); // eslint-disable-line no-eval

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1974,7 +1974,11 @@ module.exports = Playwright;
 
 async function findElements(matcher, locator) {
   locator = new Locator(locator, 'css');
-  if (!locator.isXPath()) return matcher.$$(`${locator.type}=${locator.value}`);
+  if (locator.isCustom()) {
+    return matcher.$$(`${locator.type}=${locator.value}`);
+  } if (!locator.isXPath()) {
+    return matcher.$$(locator.simplify());
+  }
   return matcher.$$(`xpath=${locator.value}`);
 }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1986,7 +1986,7 @@ module.exports = Playwright;
 
 async function findElements(matcher, locator) {
   locator = new Locator(locator, 'css');
-  if (!locator.isXPath()) return matcher.$$(locator.simplify());
+  if (!locator.isXPath()) return matcher.$$(`${locator.type}=${locator.value}`);
   return matcher.$$(`xpath=${locator.value}`);
 }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -47,10 +47,10 @@ const { createValueEngine } = require('./extras/PlaywrightPropEngine');
  *
  * This helper works with a browser out of the box with no additional tools required to install.
  *
- * Requires `playwright` package version ^0.11.0 to be installed:
+ * Requires `playwright` package version ^0.12.1 to be installed:
  *
  * ```
- * npm i playwright@^0.11.0 --save
+ * npm i playwright@^0.12.1 --save
  * ```
  *
  * ## Configuration
@@ -251,8 +251,7 @@ class Playwright extends Helper {
     try {
       requireg('playwright');
     } catch (e) {
-      // TODO need to wait for next playwright release
-      return ['playwright@^0.10'];
+      return ['playwright@^0.12.1'];
     }
   }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1536,7 +1536,7 @@ class Playwright extends Helper {
     const array = [];
 
     for (let index = 0; index < els.length; index++) {
-      const a = await this._evaluateHandeInContext((el, attr) => el[attr] || el.getAttribute(attr), els[index], attr);
+      const a = await this._evaluateHandeInContext(([el, attr]) => el[attr] || el.getAttribute(attr), [els[index], attr]);
       array.push(await a.jsonValue());
     }
 
@@ -1584,11 +1584,11 @@ class Playwright extends Helper {
       // playwright combined selectors
       waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> :not([disabled])`, { timeout: waitTimeout });
     } else {
-      const enabledFn = function (locator, $XPath) {
+      const enabledFn = function ([locator, $XPath]) {
         eval($XPath); // eslint-disable-line no-eval
         return $XPath(null, locator).filter(el => !el.disabled).length > 0;
       };
-      waiter = context.waitForFunction(enabledFn, { timeout: waitTimeout }, locator.value, $XPath.toString());
+      waiter = context.waitForFunction(enabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
     }
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`);
@@ -1608,11 +1608,11 @@ class Playwright extends Helper {
       // uses a custom selector engine for finding value properties on elements
       waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> __value=${value}`, { timeout: waitTimeout, waitFor: 'visible' });
     } else {
-      const valueFn = function (locator, $XPath, value) {
+      const valueFn = function ([locator, $XPath, value]) {
         eval($XPath); // eslint-disable-line no-eval
         return $XPath(null, locator).filter(el => (el.value || '').indexOf(value) !== -1).length > 0;
       };
-      waiter = context.waitForFunction(valueFn, { timeout: waitTimeout }, locator.value, $XPath.toString(), value);
+      waiter = context.waitForFunction(valueFn, [locator.value, $XPath.toString(), value], { timeout: waitTimeout });
     }
     return waiter.catch((err) => {
       const loc = locator.toString();
@@ -1631,20 +1631,20 @@ class Playwright extends Helper {
     let waiter;
     const context = await this._getContext();
     if (locator.isCSS()) {
-      const visibleFn = function (locator, num) {
+      const visibleFn = function ([locator, num]) {
         const els = document.querySelectorAll(locator);
         if (!els || els.length === 0) {
           return false;
         }
         return Array.prototype.filter.call(els, el => el.offsetParent !== null).length === num;
       };
-      waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, num);
+      waiter = context.waitForFunction(visibleFn, [locator.value, num], { timeout: waitTimeout });
     } else {
-      const visibleFn = function (locator, $XPath, num) {
+      const visibleFn = function ([locator, $XPath, num]) {
         eval($XPath); // eslint-disable-line no-eval
         return $XPath(null, locator).filter(el => el.offsetParent !== null).length === num;
       };
-      waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, $XPath.toString(), num);
+      waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString(), num], { timeout: waitTimeout });
     }
     return waiter.catch((err) => {
       throw new Error(`The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`);
@@ -1738,7 +1738,7 @@ class Playwright extends Helper {
     return this.page.waitForFunction((urlPart) => {
       const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
       return currUrl.indexOf(urlPart) > -1;
-    }, { timeout: waitTimeout }, urlPart).catch(async (e) => {
+    }, urlPart, { timeout: waitTimeout }).catch(async (e) => {
       const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
       if (/failed: timeout/i.test(e.message)) {
         throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`);
@@ -1762,7 +1762,7 @@ class Playwright extends Helper {
     return this.page.waitForFunction((urlPart) => {
       const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
       return currUrl.indexOf(urlPart) > -1;
-    }, { timeout: waitTimeout }, urlPart).catch(async (e) => {
+    }, urlPart, { timeout: waitTimeout }).catch(async (e) => {
       const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
       if (/failed: timeout/i.test(e.message)) {
         throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`);
@@ -1788,17 +1788,16 @@ class Playwright extends Helper {
       }
 
       if (locator.isXPath()) {
-        waiter = contextObject.waitForFunction((locator, text, $XPath) => {
+        waiter = contextObject.waitForFunction(([locator, text, $XPath]) => {
           eval($XPath); // eslint-disable-line no-eval
           const el = $XPath(null, locator);
           if (!el.length) return false;
           return el[0].innerText.indexOf(text) > -1;
-        }, { timeout: waitTimeout }, locator.value, text, $XPath.toString());
+        }, [locator.value, text, $XPath.toString()], { timeout: waitTimeout });
       }
     } else {
-      waiter = contextObject.waitForFunction(text => document.body && document.body.innerText.indexOf(text) > -1, { timeout: waitTimeout }, text);
+      waiter = contextObject.waitForFunction(text => document.body && document.body.innerText.indexOf(text) > -1, text, { timeout: waitTimeout });
     }
-
     return waiter.catch((err) => {
       throw new Error(`Text "${text}" was not found on page after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1888,7 +1887,7 @@ class Playwright extends Helper {
     }
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     const context = await this._getContext();
-    return context.waitForFunction(fn, { timeout: waitTimeout }, ...args);
+    return context.waitForFunction(fn, args, { timeout: waitTimeout });
   }
 
   /**
@@ -1936,11 +1935,11 @@ class Playwright extends Helper {
     if (!locator.isXPath()) {
       waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'detached' });
     } else {
-      const visibleFn = function (locator, $XPath) {
+      const visibleFn = function ([locator, $XPath]) {
         eval($XPath); // eslint-disable-line no-eval
         return $XPath(null, locator).length === 0;
       };
-      waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, $XPath.toString());
+      waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
     }
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${err.message}`);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1603,7 +1603,7 @@ class Playwright extends Helper {
     const context = await this._getContext();
     if (!locator.isXPath()) {
       // uses a custom selector engine for finding value properties on elements
-      waiter = context.waitForSelector(`${locator.type}=${locator.value} >> __value=${value}`, { timeout: waitTimeout });
+      waiter = context.waitForSelector(`${locator.type}=${locator.value} >> __value=${value}`, { timeout: waitTimeout, waitFor: 'visible' });
     } else {
       const valueFn = function (locator, $XPath, value) {
         eval($XPath); // eslint-disable-line no-eval
@@ -1781,7 +1781,7 @@ class Playwright extends Helper {
     if (context) {
       const locator = new Locator(context, 'css');
       if (!locator.isXPath()) {
-        waiter = contextObject.waitForSelector(`${locator.type}=${locator.value} >> text="${text}"`, { timeout: waitTimeout });
+        waiter = contextObject.waitFor(`${locator.type}=${locator.value} >> text=${text}`, { timeout: waitTimeout, waitFor: 'visible' });
       }
 
       if (locator.isXPath()) {

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -206,7 +206,7 @@ class Playwright extends Helper {
       restart: false,
       keepCookies: false,
       keepBrowserState: false,
-      show: false,
+      show: true,
       defaultPopupAction: 'accept',
     };
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -206,7 +206,7 @@ class Playwright extends Helper {
       restart: false,
       keepCookies: false,
       keepBrowserState: false,
-      show: true,
+      show: false,
       defaultPopupAction: 'accept',
     };
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1582,7 +1582,7 @@ class Playwright extends Helper {
     const context = await this._getContext();
     if (!locator.isXPath()) {
       // playwright combined selectors
-      waiter = context.waitForSelector(`${locator.type}=${locator.value} >> :not([disabled])`, { timeout: waitTimeout });
+      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> :not([disabled])`, { timeout: waitTimeout });
     } else {
       const enabledFn = function (locator, $XPath) {
         eval($XPath); // eslint-disable-line no-eval

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -37,6 +37,7 @@ const popupStore = new Popup();
 const consoleLogStore = new Console();
 const availableBrowsers = ['chromium', 'webkit', 'firefox'];
 
+const { createValueEngine } = require('./extras/PlaywrightPropEngine');
 /**
  * Uses [Playwright](https://github.com/microsoft/playwright) library to run tests inside:
  *
@@ -250,6 +251,7 @@ class Playwright extends Helper {
     try {
       requireg('playwright');
     } catch (e) {
+      // TODO need to wait for next playwright release
       return ['playwright@^0.10'];
     }
   }
@@ -266,6 +268,8 @@ class Playwright extends Helper {
 
 
   async _before() {
+    // register an internal selector engine for reading value property of elements in a selector
+    await playwright.selectors.register('__value', createValueEngine);
     recorder.retry({
       retries: 5,
       when: err => err.message.indexOf('context') > -1, // ignore context errors
@@ -1573,15 +1577,9 @@ class Playwright extends Helper {
     const matcher = await this.context;
     let waiter;
     const context = await this._getContext();
-    if (locator.isCSS()) {
-      const enabledFn = function (locator) {
-        const els = document.querySelectorAll(locator);
-        if (!els || els.length === 0) {
-          return false;
-        }
-        return Array.prototype.filter.call(els, el => !el.disabled).length > 0;
-      };
-      waiter = context.waitForFunction(enabledFn, { timeout: waitTimeout }, locator.value);
+    if (!locator.isXPath()) {
+      // playwright combined selectors
+      waiter = context.waitForSelector(`${locator.type}=${locator.value} >> :not([disabled])`, { timeout: waitTimeout });
     } else {
       const enabledFn = function (locator, $XPath) {
         eval($XPath); // eslint-disable-line no-eval
@@ -1603,15 +1601,9 @@ class Playwright extends Helper {
     const matcher = await this.context;
     let waiter;
     const context = await this._getContext();
-    if (locator.isCSS()) {
-      const valueFn = function (locator, value) {
-        const els = document.querySelectorAll(locator);
-        if (!els || els.length === 0) {
-          return false;
-        }
-        return Array.prototype.filter.call(els, el => (el.value || '').indexOf(value) !== -1).length > 0;
-      };
-      waiter = context.waitForFunction(valueFn, { timeout: waitTimeout }, locator.value, value);
+    if (!locator.isXPath()) {
+      // uses a custom selector engine for finding value properties on elements
+      waiter = context.waitForSelector(`${locator.type}=${locator.value} >> __value=${value}`, { timeout: waitTimeout });
     } else {
       const valueFn = function (locator, $XPath, value) {
         eval($XPath); // eslint-disable-line no-eval
@@ -1696,7 +1688,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, visibility: 'visible' });
+    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'visible' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1709,7 +1701,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, visibility: 'hidden' });
+    const waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'hidden' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1722,7 +1714,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    return context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, visibility: 'hidden' }).catch((err) => {
+    return context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'hidden' }).catch((err) => {
       throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`);
     });
   }
@@ -1788,12 +1780,8 @@ class Playwright extends Helper {
 
     if (context) {
       const locator = new Locator(context, 'css');
-      if (locator.isCSS()) {
-        waiter = contextObject.waitForFunction((locator, text) => {
-          const el = document.querySelector(locator);
-          if (!el) return false;
-          return el.innerText.indexOf(text) > -1;
-        }, { timeout: waitTimeout }, locator.value, text);
+      if (!locator.isXPath()) {
+        waiter = contextObject.waitForSelector(`${locator.type}=${locator.value} >> text="${text}"`, { timeout: waitTimeout });
       }
 
       if (locator.isXPath()) {
@@ -1942,11 +1930,8 @@ class Playwright extends Helper {
 
     let waiter;
     const context = await this._getContext();
-    if (locator.isCSS()) {
-      const visibleFn = function (locator) {
-        return document.querySelector(locator) === null;
-      };
-      waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value);
+    if (!locator.isXPath()) {
+      waiter = context.waitForSelector(`${locator.type}=${locator.value}`, { timeout: waitTimeout, waitFor: 'detached' });
     } else {
       const visibleFn = function (locator, $XPath) {
         eval($XPath); // eslint-disable-line no-eval

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -573,7 +573,7 @@ class Playwright extends Helper {
 
     if (this.config.basicAuth && (this.isAuthenticated !== true)) {
       if (url.includes(this.options.url)) {
-        await this.page.authenticate(this.config.basicAuth);
+        await this.browserContext.setHTTPCredentials(this.config.basicAuth);
         this.isAuthenticated = true;
       }
     }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1784,7 +1784,7 @@ class Playwright extends Helper {
     if (context) {
       const locator = new Locator(context, 'css');
       if (!locator.isXPath()) {
-        waiter = contextObject.waitFor(`${locator.type}=${locator.value} >> text=${text}`, { timeout: waitTimeout, waitFor: 'visible' });
+        waiter = contextObject.waitFor(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> text=${text}`, { timeout: waitTimeout, waitFor: 'visible' });
       }
 
       if (locator.isXPath()) {

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -255,7 +255,13 @@ class Playwright extends Helper {
     }
   }
 
-  _init() {
+  async _init() {
+    // register an internal selector engine for reading value property of elements in a selector
+    try {
+      await playwright.selectors.register('__value', createValueEngine);
+    } catch (e) {
+      console.warn(e);
+    }
   }
 
   _beforeSuite() {
@@ -267,8 +273,6 @@ class Playwright extends Helper {
 
 
   async _before() {
-    // register an internal selector engine for reading value property of elements in a selector
-    await playwright.selectors.register('__value', createValueEngine);
     recorder.retry({
       retries: 5,
       when: err => err.message.indexOf('context') > -1, // ignore context errors

--- a/lib/helper/extras/PlaywrightPropEngine.js
+++ b/lib/helper/extras/PlaywrightPropEngine.js
@@ -1,0 +1,25 @@
+module.exports.createValueEngine = () => {
+  return {
+    // Creates a selector that matches given target when queried at the root.
+    // Can return undefined if unable to create one.
+    create(root, target) {
+      return null;
+    },
+
+    // Returns the first element matching given selector in the root's subtree.
+    query(root, selector) {
+      if (!root) {
+        return null;
+      }
+      return `${root.value}` === selector;
+    },
+
+    // Returns all elements matching given selector in the root's subtree.
+    queryAll(root, selector) {
+      if (!root) {
+        return null;
+      }
+      return `${root.value}` === selector;
+    },
+  };
+};

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -3,6 +3,7 @@ const sprintf = require('sprintf-js').sprintf;
 
 const xpathLocator = require('./utils').xpathLocator;
 
+const locatorTypes = ['css', 'by', 'xpath', 'id', 'name', 'fuzzy', 'frame'];
 /** @class */
 class Locator {
   /**
@@ -94,6 +95,10 @@ class Locator {
 
   isXPath() {
     return this.type === 'xpath';
+  }
+
+  isCustom() {
+    return this.type && !locatorTypes.includes(this.type);
   }
 
   isStrict() {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "mocha-parallel-tests": "^2.2.2",
     "nightmare": "^3.0.2",
     "nodemon": "^1.19.4",
-    "playwright": "^0.11.0",
+    "playwright": "^0.12.1",
     "protractor": "^5.4.1",
     "puppeteer": "^1.20.0",
     "qrcode-terminal": "^0.12.0",

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -27,7 +27,7 @@ describe('Playwright', function () {
     I = new Playwright({
       url: siteUrl,
       windowSize: '500x700',
-      show: false,
+      show: true,
       waitForTimeout: 5000,
       waitForAction: 500,
       restart: true,

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -611,43 +611,6 @@ describe('Playwright', function () {
       .then(() => I.see('button was clicked', '#message')));
   });
 
-  describe('#waitForVisible', () => {
-    beforeEach(() => I.amOnPage('/form/wait_visible'));
-
-    it('wait for element', async () => {
-      await I.dontSee('Step One Button');
-      await I.dontSeeElement('#step_1');
-      await I.waitForVisible('#step_1', 2);
-      await I.seeElement('#step_1');
-      await I.click('#step_1');
-      await I.waitForVisible('#step_2', 2);
-      await I.see('Step Two Button');
-    });
-  });
-
-  describe('#waitForInvisible', () => {
-    beforeEach(() => I.amOnPage('/form/wait_invisible'));
-    it('should wait for a specified element to be invisible', async () => {
-      await I.waitForInvisible('#step1', 3);
-      await I.dontSeeElement('#step1');
-    });
-  });
-
-  describe('#waitToHide', () => {
-    beforeEach(() => I.amOnPage('/form/wait_invisible'));
-    it('should wait for a specified element to be hidden', async () => {
-      await I.waitToHide('#step1', 3);
-      await I.dontSeeElement('#step1');
-    });
-  });
-
-  describe('#waitForText', () => {
-    it('should wait for text after load body', async () => {
-      await I.amOnPage('/redirect_long');
-      await I.waitForText('Hi there and greetings!', 5);
-    });
-  });
-
   describe('#waitForValue', () => {
     it('should wait for expected value for given locator', () => I.amOnPage('/info')
       .then(() => I.waitForValue('//input[@name= "rus"]', 'Верно'))

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -27,7 +27,7 @@ describe('Playwright', function () {
     I = new Playwright({
       url: siteUrl,
       windowSize: '500x700',
-      show: true,
+      show: false,
       waitForTimeout: 5000,
       waitForAction: 500,
       restart: true,

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -611,6 +611,43 @@ describe('Playwright', function () {
       .then(() => I.see('button was clicked', '#message')));
   });
 
+  describe('#waitForVisible', () => {
+    beforeEach(() => I.amOnPage('/form/wait_visible'));
+
+    it('wait for element', async () => {
+      await I.dontSee('Step One Button');
+      await I.dontSeeElement('#step_1');
+      await I.waitForVisible('#step_1', 2);
+      await I.seeElement('#step_1');
+      await I.click('#step_1');
+      await I.waitForVisible('#step_2', 2);
+      await I.see('Step Two Button');
+    });
+  });
+
+  describe('#waitForInvisible', () => {
+    beforeEach(() => I.amOnPage('/form/wait_invisible'));
+    it('should wait for a specified element to be invisible', async () => {
+      await I.waitForInvisible('#step1', 3);
+      await I.dontSeeElement('#step1');
+    });
+  });
+
+  describe('#waitToHide', () => {
+    beforeEach(() => I.amOnPage('/form/wait_invisible'));
+    it('should wait for a specified element to be hidden', async () => {
+      await I.waitToHide('#step1', 3);
+      await I.dontSeeElement('#step1');
+    });
+  });
+
+  describe('#waitForText', () => {
+    it('should wait for text after load body', async () => {
+      await I.amOnPage('/redirect_long');
+      await I.waitForText('Hi there and greetings!', 5);
+    });
+  });
+
   describe('#waitForValue', () => {
     it('should wait for expected value for given locator', () => I.amOnPage('/info')
       .then(() => I.waitForValue('//input[@name= "rus"]', 'Верно'))


### PR DESCRIPTION
## Motivation/Description of the PR
- Following on from https://github.com/Codeception/CodeceptJS/pull/2274
- Blocked until playwright release for: https://github.com/microsoft/playwright/issues/1238
- Haven't updated: `waitNumberOfVisibleElements` not sure what to do here. Might need to put the waitFor/retry logic into the Playwright.js and make use of $$eval which will return an array of elements,
- Need to look at what I might have broken
- Needs tests

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [X] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
