### PR TITLE
bump puppeteer to v2

### DIFF
--- a/docs/helpers/Puppeteer-firefox.md
+++ b/docs/helpers/Puppeteer-firefox.md
@@ -21,7 +21,7 @@ If you want to use puppeteer-firefox, you should add it in Puppeteer section in 
 ```js
 helpers: {
         Puppeteer: {
-            browser: process.env.BROWSER || 'firefox',            
+            browser: process.env.BROWSER || 'firefox',
             url: process.env.BASE_URL || 'https://example.com',
             chrome: {
                 args: [
@@ -39,6 +39,7 @@ helpers: {
 ## Run-multiple
 
 Example multiple section in codecept.conf.js:
+
 ```js
  multiple: {
         parallel: {
@@ -52,4 +53,34 @@ Example multiple section in codecept.conf.js:
             }],
         },
     },
+```
+
+## Puppeteer v2.1.0 onwards
+
+Historically, Puppeteer supported Firefox indirectly through puppeteer-firefox, which relied on a custom, patched version of Firefox. This approach was also known as “Juggler”. After discussions with Mozilla, we collectively concluded that relying on custom patches was infeasible. Since then, we have been collaborating with Mozilla on supporting Puppeteer on “stock” Firefox. From Puppeteer v2.1.0 onwards, as an experimental feature, you can specify puppeteer.launch({product: 'firefox'}) to run your Puppeteer scripts in Firefox Nightly, without any additional custom patches.
+
+```sh
+npm i puppeteer@v2.1.0
+```
+
+If you want to try this expirement within CodeceptJS, you should add it in Puppeteer section in codecept.conf.js.
+
+- browser: 'chrome' OR 'firefox', 'chrome' is default value
+
+```js
+helpers: {
+        Puppeteer: {
+            browser: process.env.BROWSER || 'firefox',
+            url: process.env.BASE_URL || 'https://example.com',
+            chrome: {
+                args: [
+                    '--ignore-certificate-errors',
+                ],
+            },
+            firefox: {
+                args: [
+                    '--ignore-certificate-errors'
+                ],
+            },
+        },
 ```

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -167,7 +167,7 @@ class Puppeteer extends Helper {
   constructor(config) {
     super(config);
 
-    puppeteer = requireg(config.browser === 'firefox' ? 'puppeteer-firefox' : 'puppeteer');
+    puppeteer = requireg('puppeteer');
 
     // set defaults
     this.isRemoteBrowser = false;
@@ -201,7 +201,7 @@ class Puppeteer extends Helper {
   }
 
   _getOptions(config) {
-    return config.browser === 'firefox' ? this.options.firefox : this.options.chrome;
+    return config.browser === 'firefox' ? { product: 'firefox' } : this.options.chrome;
   }
 
   _setConfig(config) {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -201,7 +201,7 @@ class Puppeteer extends Helper {
   }
 
   _getOptions(config) {
-    return config.browser === 'firefox' ? { product: 'firefox' } : this.options.chrome;
+    return config.browser === 'firefox' ? Object.assign(this.options.firefox, { product: 'firefox' }) : this.options.chrome;
   }
 
   _setConfig(config) {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "nodemon": "^1.19.4",
     "playwright": "^0.11.0",
     "protractor": "^5.4.1",
-    "puppeteer": "^1.20.0",
+    "puppeteer": "^2.1.1",
     "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
     "runio.js": "^1.0.20",


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump puppeteer to v2 which is supporting running tests with firefox instead of using `puppeteer-firefox`
- Resolves #2282.

Applicable helpers:

- [x] Puppeteer

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

## Notes:
- Currently there are only 2 failed tests. I logged that issue in Puppeteer https://github.com/puppeteer/puppeteer/issues/5543
- I don't expect any breaking changes for any one is using `puppeteer-firefox` but yeah, probably there is.