### PR TITLE
Add --profile Support for run-multiple and run workers

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -622,7 +622,7 @@ within('.js-signup-form', () => {
 I.see('There were problems creating your account.');
 ```
 
-> ⚠ `within` can cause problems when used incorrectly. If you see a weired behavior of a test try to refactor it to not use `within`. It is recommended to keep within for simplest cases when possible.
+> ⚠ `within` can cause problems when used incorrectly. If you see a weird behavior of a test try to refactor it to not use `within`. It is recommended to keep within for simplest cases when possible.
 
 `within` can also work with IFrames. A special `frame` locator is required to locate the iframe and get into its context.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,7 @@ exports.config = {
 
 ## Profile
 
-Using values from `process.profile` you can change the config dynamically.
+Using `process.env.profile` you can change the config dynamically.
 It provides value of `--profile` option passed to runner.
 Use its value to change config value on the fly.
 
@@ -134,7 +134,7 @@ exports.config = {
     WebDriver: {
       url: 'http://localhost:3000',
       // load value from `profile`
-      browser: process.profile || 'firefox'
+      browser: process.env.profile || 'firefox'
 
     }
   }

--- a/examples/codecept.conf.example.js
+++ b/examples/codecept.conf.example.js
@@ -1,6 +1,6 @@
 console.log('Use JS config file');
 
-console.log(process.profile);
+console.log(process.env.profile);
 
 exports.config = {
   tests: './*_test.js',
@@ -9,7 +9,7 @@ exports.config = {
   helpers: {
     WebDriverIO: {
       url: 'http://localhost',
-      browser: process.profile || 'firefox',
+      browser: process.env.profile || 'firefox',
       restart: true,
     },
   },

--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -6,6 +6,8 @@ const event = require('../event');
 const output = require('../output');
 
 module.exports = function (path, options) {
+  // Backward compatibility for --profile
+  process.profile = options.profile;
   process.env.profile = options.profile;
 
   const testsPath = getTestRoot(path);

--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -6,7 +6,7 @@ const event = require('../event');
 const output = require('../output');
 
 module.exports = function (path, options) {
-  process.profile = options.profile;
+  process.env.profile = options.profile;
 
   const testsPath = getTestRoot(path);
   const config = getConfig(testsPath);

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -29,7 +29,7 @@ let processesDone;
 
 module.exports = function (selectedRuns, options) {
   // registering options globally to use in config
-  process.profile = options.profile;
+  process.env.profile = options.profile;
   const configFile = options.config;
   let codecept;
 

--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -9,6 +9,7 @@ module.exports = function (test, options) {
   // registering options globally to use in config
   // Backward compatibility for --profile
   process.profile = options.profile;
+  process.env.profile = options.profile;
   const configFile = options.config;
   let codecept;
 

--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -7,7 +7,7 @@ const Codecept = require('../rerun');
 
 module.exports = function (test, options) {
   // registering options globally to use in config
-  process.profile = options.profile;
+  process.env.profile = options.profile;
   const configFile = options.config;
   let codecept;
 

--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -7,7 +7,8 @@ const Codecept = require('../rerun');
 
 module.exports = function (test, options) {
   // registering options globally to use in config
-  process.env.profile = options.profile;
+  // Backward compatibility for --profile
+  process.profile = options.profile;
   const configFile = options.config;
   let codecept;
 

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -32,7 +32,7 @@ module.exports = function (workers, options) {
     'Required minimum Node version of 11.7.0 to work with "run-workers"',
   );
 
-  process.profile = options.profile;
+  process.env.profile = options.profile;
 
   const { Worker } = require('worker_threads');
 

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -10,7 +10,7 @@ const Codecept = require('../codecept');
 
 module.exports = function (test, options) {
   // registering options globally to use in config
-  process.profile = options.profile;
+  process.env.profile = options.profile;
   const configFile = options.config;
   let codecept;
 

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -10,6 +10,8 @@ const Codecept = require('../codecept');
 
 module.exports = function (test, options) {
   // registering options globally to use in config
+  // Backward compatibility for --profile
+  process.profile = options.profile;
   process.env.profile = options.profile;
   const configFile = options.config;
   let codecept;

--- a/test/data/sandbox/config.js
+++ b/test/data/sandbox/config.js
@@ -1,4 +1,4 @@
-const profile = process.profile;
+const profile = process.env.profile;
 
 exports.config = {
   tests: './*_test.js',

--- a/test/data/sandbox/config.js
+++ b/test/data/sandbox/config.js
@@ -1,4 +1,4 @@
-const profile = process.env.profile;
+const profile = process.env.profile || process.profile;
 
 exports.config = {
   tests: './*_test.js',


### PR DESCRIPTION
## Motivation/Description of the PR

Add --profile Support for run-multiple and run workers.

Resolves #1968 #1315

- [x] :rocket: New functionality
- [x] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`) -> Docu in .md changes, running `npm run docs` brings unrelated changes -> not commited
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`) -> failing unrelatedly
