### PR TITLE
(fix): undefined in screenshot name

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -129,7 +129,7 @@ module.exports = function (config) {
       return test.uuid;
     }
 
-    if (test.ctx) {
+    if (test.ctx && test.ctx.test.uuid) {
       return test.ctx.test.uuid;
     }
 

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -43,7 +43,7 @@ describe('screenshotOnFail', () => {
     assert.ok(screenshotSaved.called);
     assert.equal('test1_1.failed.png', screenshotSaved.getCall(0).args[0]);
   });
-  
+
   it('should create screenshot with unique name when uuid is null', async () => {
     screenshotOnFail({ uniqueScreenshotNames: true });
     event.dispatcher.emit(event.test.failed, { title: 'test1' });

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -43,6 +43,17 @@ describe('screenshotOnFail', () => {
     assert.ok(screenshotSaved.called);
     assert.equal('test1_1.failed.png', screenshotSaved.getCall(0).args[0]);
   });
+  
+  it('should create screenshot with unique name when uuid is null', async () => {
+    screenshotOnFail({ uniqueScreenshotNames: true });
+    event.dispatcher.emit(event.test.failed, { title: 'test1' });
+    await recorder.promise();
+    assert.ok(screenshotSaved.called);
+    const fileName = screenshotSaved.getCall(0).args[0];
+    const regexpFileName = /test1_[0-9]{10}.failed.png/;
+    assert.equal(fileName.match(regexpFileName).length, 1);
+  });
+
 
   // TODO: write more tests for different options
 });

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -54,6 +54,5 @@ describe('screenshotOnFail', () => {
     assert.equal(fileName.match(regexpFileName).length, 1);
   });
 
-
   // TODO: write more tests for different options
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- Fix issue when having the flag `uniqueScreenshotNames` true of `screenshotOnFail` plugin results undefined in screenshot file name.
- Resolves #2301.

## Applicable plugins:

- [x] screenshotOnFail

## Type of change

- [x] :bug: Bug fix