### PR TITLE
Fixed screenshot on failure for active session of WebDriver

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -594,6 +594,7 @@ class WebDriver extends Helper {
         return browser;
       },
       stop: async (browser) => {
+        if (!browser) return;
         return browser.deleteSession();
       },
       loadVars: async (browser) => {

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -118,6 +118,7 @@ module.exports = function (config) {
             || err.message.indexOf('no such window: target window already closed') > -1
           )
         ) {
+          output.log(`Can't make screenshot, ${err}`);
           helper.isRunning = false;
         }
       }

--- a/lib/session.js
+++ b/lib/session.js
@@ -58,7 +58,9 @@ function session(sessionName, config, fn) {
       delete savedSessions[sessionName];
     };
 
-    event.dispatcher.once(event.test.finished, () => closeBrowsers());
+    event.dispatcher.once(event.test.after, () => {
+      recorder.add('close session browsers', closeBrowsers);
+    });
 
     if (!savedSessions[sessionName]) {
       throw new Error('Configured helpers do not support starting sessions. Please use a helper with session support.');

--- a/test/acceptance/codecept.Playwright.js
+++ b/test/acceptance/codecept.Playwright.js
@@ -19,6 +19,11 @@ module.exports.config = {
   include: {},
   bootstrap: false,
   mocha: {},
+  plugins: {
+    screenshotOnFail: {
+      enabled: true,
+    },
+  },
   name: 'acceptance',
   gherkin: {
     features: './gherkin/*.feature',

--- a/test/acceptance/codecept.Puppeteer.js
+++ b/test/acceptance/codecept.Puppeteer.js
@@ -24,6 +24,11 @@ module.exports.config = {
   include: {},
   bootstrap: false,
   mocha: {},
+  plugins: {
+    screenshotOnFail: {
+      enabled: true,
+    },
+  },
   name: 'acceptance',
   gherkin: {
     features: './gherkin/*.feature',

--- a/test/acceptance/codecept.WebDriver.js
+++ b/test/acceptance/codecept.WebDriver.js
@@ -27,6 +27,11 @@ module.exports.config = {
   bootstrap: done => setTimeout(done, 5000), // let's wait for selenium
   mocha: {},
   name: 'acceptance',
+  plugins: {
+    screenshotOnFail: {
+      enabled: true,
+    },
+  },
   gherkin: {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
-const path = require('path');
-const event = require('../../lib/event');
-const { clearString } = require('../../lib/utils');
+
+const { event } = codeceptjs;
 
 Feature('Session');
 
@@ -91,11 +90,11 @@ Scenario('should throw exception and close correctly @WebDriverIO @Protractor @P
 }).fails();
 
 Scenario('should save screenshot for active session @WebDriverIO @Puppeteer @Playwright', async function (I) {
-  I.amOnPage('/info');
+  I.amOnPage('/form/bug1467');
   I.saveScreenshot('original.png');
   I.amOnPage('/');
   session('john', async () => {
-    await I.amOnPage('/info');
+    await I.amOnPage('/form/bug1467');
     event.dispatcher.emit(event.test.failed, this);
   });
 
@@ -226,3 +225,11 @@ Scenario('should return a value @WebDriverIO @Protractor @Puppeteer @Playwright 
   I.click('Submit');
   I.see('[description] => Information');
 });
+
+function clearString(str) {
+  if (!str) return '';
+  /* Replace forbidden symbols in string
+     */
+  return str
+    .replace(/ /g, '_');
+}

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -77,17 +77,6 @@ Scenario('Different cookies for different sessions @WebDriverIO @Protractor @Pla
   assert.notEqual(cookies.john, cookies.mary);
 });
 
-Scenario('should throw exception and close correctly @WebDriverIO @Protractor @Puppeteer @Playwright', (I) => {
-  I.amOnPage('/form/bug1467#session1');
-  I.checkOption('Yes');
-  session('john', () => {
-    I.amOnPage('/form/bug1467#session2');
-    I.checkOption('No1');
-    I.seeCheckboxIsChecked({ css: 'input[value=No]' });
-  });
-  I.seeCheckboxIsChecked({ css: 'input[value=Yes]' });
-  I.amOnPage('/info');
-}).fails();
 
 Scenario('should save screenshot for active session @WebDriverIO @Puppeteer @Playwright', async function (I) {
   I.amOnPage('/form/bug1467');
@@ -108,6 +97,19 @@ Scenario('should save screenshot for active session @WebDriverIO @Puppeteer @Pla
   // Assert that screenshots of same page in same session are equal
   assert.equal(original, failed);
 });
+
+
+Scenario('should throw exception and close correctly @WebDriverIO @Protractor @Puppeteer @Playwright', (I) => {
+  I.amOnPage('/form/bug1467#session1');
+  I.checkOption('Yes');
+  session('john', () => {
+    I.amOnPage('/form/bug1467#session2');
+    I.checkOption('No1');
+    I.seeCheckboxIsChecked({ css: 'input[value=No]' });
+  });
+  I.seeCheckboxIsChecked({ css: 'input[value=Yes]' });
+  I.amOnPage('/info');
+}).fails();
 
 Scenario('async/await @WebDriverIO @Protractor', (I) => {
   I.amOnPage('/form/bug1467#session1');

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -13,7 +13,7 @@ describe('screenshotOnFail', () => {
     recorder.reset();
     screenshotSaved = sinon.spy();
     container.clear({
-      WebDriverIO: {
+      WebDriver: {
         options: {},
         saveScreenshot: screenshotSaved,
       },


### PR DESCRIPTION
In multi-session mode when test failed screenshot was not taken because browser of a session was already closed at that point. 

This PR changes event when sessions are closed (from test.finished to test.after) and adds a test.