### PR TITLE
update waitForElement to support waitUntil in webdriverio^6.0

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1876,10 +1876,16 @@ class WebDriver extends Helper {
    */
   async waitForElement(locator, sec = null) {
     const aSec = sec || this.options.waitForTimeout;
+    if (isWebDriver5()) {
+      return this.browser.waitUntil(async () => {
+        const res = await this.$$(withStrictLocator(locator));
+        return res && res.length;
+      }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
+    }
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       return res && res.length;
-    }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
+    }, { timeout: aSec * 1000, timeoutMsg: `element (${locator}) still not present on page after ${aSec} sec` });
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR
- When using WebDriver helper with webdriverio@^6.0, the `waitForElement` function is not applying the optional second argument to override the default timeout length. 
- WebDriverIO v6 updates `waitUntil` method which is used by all of the `wait*` functions. Many of these function were updated, such as `waitForVisible` and `waitInUrl` however `waitForElement` appears to still use the webdriverio@^5.0 code.
- This updates the `waitForElement` function by the same convention used to update `waitForVisible` and `waitInUrl` to be compatible with both WebDriverIO v5 & v6.

Applicable helpers:

- [x] WebDriver

## Type of change

- [x] :bug: Bug fix
- [ ] :hotsprings: Hot fix

## Notes

- I was unable to configure the repo to run the tests in examples directory. I implemented tests for this fix on a branch I use myself, so any guidance in implementing a test for this would be appreciated. 😄 
