### PR TITLE
Gherkin: avoid creating duplicated steps

### DIFF
--- a/lib/command/gherkin/snippets.js
+++ b/lib/command/gherkin/snippets.js
@@ -49,7 +49,7 @@ module.exports = function (genPath, options) {
   });
   output.print(`Loaded ${files.length} files`);
 
-  let newSteps = [];
+  const newSteps = new Map();
 
   const parseSteps = (steps) => {
     const newSteps = [];
@@ -88,9 +88,9 @@ module.exports = function (genPath, options) {
     const ast = parser.parse(fs.readFileSync(file).toString());
     for (const child of ast.feature.children) {
       if (child.type === 'ScenarioOutline') continue; // skip scenario outline
-      newSteps = newSteps.concat(parseSteps(child.steps).map((step) => {
+      parseSteps(child.steps).map((step) => {
         return Object.assign(step, { file: file.replace(global.codecept_dir, '').slice(1) });
-      }));
+      }).map((step) => newSteps.set(`${step.type}(${step})`, step));
     }
   };
 
@@ -106,7 +106,7 @@ module.exports = function (genPath, options) {
     stepFile = fsPath.join(global.codecept_dir, stepFile);
   }
 
-  const snippets = newSteps
+  const snippets = [...newSteps.values()]
     .filter((value, index, self) => self.indexOf(value) === index)
     .map((step) => {
       return `

--- a/test/data/sandbox/codecept.duplicate.bdd.json
+++ b/test/data/sandbox/codecept.duplicate.bdd.json
@@ -8,7 +8,7 @@
     }
   },
   "gherkin": {
-    "features": "./support/dummy.feature",
+    "features": "./support/duplicate.feature",
     "steps": [
       "./features/step_definitions/my_steps.js",
       "./features/step_definitions/my_other_steps.js"

--- a/test/data/sandbox/support/duplicate.feature
+++ b/test/data/sandbox/support/duplicate.feature
@@ -1,0 +1,13 @@
+Feature: Auth
+
+  Scenario: Login to website
+    Given I open a browser on a site
+    When I click login button at 1.2
+    Then I see welcome message
+
+  Scenario: Logout from website
+    Given I open a browser on a site
+    And I click login button at 1.2
+    And I see welcome message
+    When I click logout
+    Then I see goodbye message

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -278,4 +278,12 @@ When(/^I define a step with a \\( paren and a "(.*?)" string$/, () => {
       done();
     });
   });
+
+  it('should not generate duplicated steps', (done) => {
+    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.duplicate.bdd.json`, (err, stdout, stderr) => { //eslint-disable-line
+      assert.equal(stdout.match(/I open a browser on a site/g).length, 1);
+      assert(!err);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- Avoid generating duplicated steps with `gherkin:snippets` command
- Resolves #2316

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
