### PR TITLE
(fix): wdio plugin issue with wdio v6

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -521,7 +521,7 @@ class WebDriver extends Helper {
         delete this.options.capabilities.hostname;
         delete this.options.capabilities.port;
         delete this.options.capabilities.path;
-
+        
         this.browser = await webdriverio.remote(this.options);
       }
     } catch (err) {
@@ -600,6 +600,7 @@ class WebDriver extends Helper {
         return browser;
       },
       stop: async (browser) => {
+        if (!browser) return;
         return browser.deleteSession();
       },
       loadVars: async (browser) => {
@@ -1882,10 +1883,16 @@ class WebDriver extends Helper {
    */
   async waitForElement(locator, sec = null) {
     const aSec = sec || this.options.waitForTimeout;
+    if (isWebDriver5()) {
+      return this.browser.waitUntil(async () => {
+        const res = await this.$$(withStrictLocator(locator));
+        return res && res.length;
+      }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
+    }
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       return res && res.length;
-    }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
+    }, { timeout: aSec * 1000, timeoutMsg: `element (${locator}) still not present on page after ${aSec} sec` });
   }
 
   /**

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -521,7 +521,6 @@ class WebDriver extends Helper {
         delete this.options.capabilities.hostname;
         delete this.options.capabilities.port;
         delete this.options.capabilities.path;
-        
         this.browser = await webdriverio.remote(this.options);
       }
     } catch (err) {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -516,6 +516,12 @@ class WebDriver extends Helper {
       if (this.options.multiremote) {
         this.browser = await webdriverio.multiremote(this.options.multiremote);
       } else {
+        // remove non w3c capabilities
+        delete this.options.capabilities.protocol;
+        delete this.options.capabilities.hostname;
+        delete this.options.capabilities.port;
+        delete this.options.capabilities.path;
+
         this.browser = await webdriverio.remote(this.options);
       }
     } catch (err) {
@@ -594,7 +600,6 @@ class WebDriver extends Helper {
         return browser;
       },
       stop: async (browser) => {
-        if (!browser) return;
         return browser.deleteSession();
       },
       loadVars: async (browser) => {
@@ -1877,16 +1882,10 @@ class WebDriver extends Helper {
    */
   async waitForElement(locator, sec = null) {
     const aSec = sec || this.options.waitForTimeout;
-    if (isWebDriver5()) {
-      return this.browser.waitUntil(async () => {
-        const res = await this.$$(withStrictLocator(locator));
-        return res && res.length;
-      }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
-    }
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       return res && res.length;
-    }, { timeout: aSec * 1000, timeoutMsg: `element (${locator}) still not present on page after ${aSec} sec` });
+    }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
   }
 
   /**

--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -1,4 +1,6 @@
 const debug = require('debug')('codeceptjs:plugin:wdio');
+const path = require('path');
+const fs = require('fs');
 
 const container = require('../container');
 const mainConfig = require('../config');
@@ -99,8 +101,14 @@ module.exports = (config) => {
     if (Service) {
       if (Service.launcher && typeof Service.launcher === 'function') {
         const Launcher = Service.launcher;
-        const options = { logPath: global.output_dir, installArgs: {}, args: {} };
-        launchers.push(new Launcher(options, [config.capabilities], config));
+
+        const version = JSON.parse(fs.readFileSync(path.join(require.resolve('webdriverio'), '/../../', 'package.json')).toString()).version;
+        if (version.indexOf('5') === 0) {
+          launchers.push(new Launcher(config));
+        } else {
+          const options = { logPath: global.output_dir, installArgs: {}, args: {} };
+          launchers.push(new Launcher(options, [config.capabilities], config));
+        }
       }
       if (typeof Service === 'function') {
         services.push(new Service(config, config.capabilities));

--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -99,7 +99,8 @@ module.exports = (config) => {
     if (Service) {
       if (Service.launcher && typeof Service.launcher === 'function') {
         const Launcher = Service.launcher;
-        launchers.push(new Launcher(config));
+        const options = { logPath: global.output_dir, installArgs: {}, args: {} };
+        launchers.push(new Launcher(options, [config.capabilities], config));
       }
       if (typeof Service === 'function') {
         services.push(new Service(config, config.capabilities));


### PR DESCRIPTION
## Motivation/Description of the PR
- Due to the changes on the way how services is initialized in wdio, we need to update our wdio plugin to make it work again with wdio v6.
- Resolves #2315, #2288.

Applicable helpers:

- [x] WebDriver

Applicable plugins:

- [x] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
