### PR TITLE
docs: add missing async in grab* functions docs

### DIFF
--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -1689,6 +1689,8 @@ Resumes test execution, so **should be used inside async function with `await`**
 let geoLocation = await I.grabGeoLocation();
 ```
 
+Returns **[Promise][13]&lt;{latitude: [number][8], longitude: [number][8], altitude: [number][8]}>** 
+
 ### grabElementBoundingRect
 
 Grab the width, height, location of given locator.

--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -1318,7 +1318,7 @@ Returns **[Promise][13]&lt;[string][4]>** HTML code for an element
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -1385,7 +1385,7 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 ### grabSource
 
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();
@@ -1461,6 +1461,7 @@ I.seeAttributesOnElements('//form', { method: "post"});
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');
@@ -1629,6 +1630,7 @@ I.switchTo(); // switch back to main page
 ### grabNumberOfOpenTabs
 
 Grab number of open tabs.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let tabs = await I.grabNumberOfOpenTabs();
@@ -1681,6 +1683,7 @@ I.setGeoLocation(121.21, 11.56, 10);
 ### grabGeoLocation
 
 Return the current geo location 
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let geoLocation = await I.grabGeoLocation();

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -421,7 +421,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -438,7 +438,7 @@ Returns **[Promise][8]&lt;[string][3]>** attribute value
 
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');
@@ -492,6 +492,7 @@ Returns **[Promise][8]&lt;[string][3]>** HTML code for an element
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -654,7 +654,7 @@ I.forceClick('Click me', '#hidden');
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -682,7 +682,7 @@ Returns **[Promise][9]&lt;[Array][10]&lt;any>>**
 
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');
@@ -794,6 +794,7 @@ Returns **[Promise][9]&lt;[string][7]>** HTML code for an element
 ### grabNumberOfOpenTabs
 
 Grab number of open tabs.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let tabs = await I.grabNumberOfOpenTabs();
@@ -804,6 +805,7 @@ Returns **[Promise][9]&lt;[number][8]>** number of open tabs
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');
@@ -839,7 +841,7 @@ Returns **[Promise][9]&lt;([string][7] | null)>**
 ### grabSource
 
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -569,7 +569,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -598,7 +598,7 @@ Returns **[Promise][13]&lt;[Array][14]&lt;any>>** all browser logs
 
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');
@@ -659,6 +659,7 @@ Returns **[Promise][13]&lt;[string][9]>** HTML code for an element
 ### grabNumberOfOpenTabs
 
 Grab number of open tabs.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let tabs = await I.grabNumberOfOpenTabs();
@@ -669,6 +670,7 @@ Returns **[Promise][13]&lt;[number][7]>** number of open tabs
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');
@@ -702,7 +704,7 @@ await I.grabPopupText();
 ### grabSource
 
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -700,7 +700,7 @@ This action supports [React locators](https://codecept.io/react#locators)
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -733,7 +733,7 @@ Returns **[Promise][13]&lt;[Array][14]&lt;any>>**
 
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');
@@ -850,6 +850,7 @@ Returns **[Promise][13]&lt;[string][8]>** HTML code for an element
 ### grabNumberOfOpenTabs
 
 Grab number of open tabs.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let tabs = await I.grabNumberOfOpenTabs();
@@ -860,6 +861,7 @@ Returns **[Promise][13]&lt;[number][10]>** number of open tabs
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');
@@ -900,7 +902,7 @@ Returns **[Promise][13]&lt;([string][8] | null)>**
 ### grabSource
 
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -405,7 +405,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -431,7 +431,7 @@ console.log(JSON.stringify(logs))
 
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');
@@ -459,6 +459,7 @@ Returns **[Promise][7]&lt;[string][4]>** current URL
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');
@@ -484,7 +485,7 @@ Returns **[Promise][7]&lt;[Object][5]&lt;[string][4], any>>** scroll position
 ### grabSource
 
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -886,7 +886,7 @@ const windows = await I.grabAllWindowHandles();
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');
@@ -915,7 +915,7 @@ Returns **[Promise][25]&lt;([string][19] | [undefined][27])>**
 
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');
@@ -996,6 +996,7 @@ Returns **[object][18]** Element bounding rectangle
 ### grabGeoLocation
 
 Return the current geo location 
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let geoLocation = await I.grabGeoLocation();
@@ -1021,6 +1022,7 @@ Returns **[Promise][25]&lt;[string][19]>** HTML code for an element
 ### grabNumberOfOpenTabs
 
 Grab number of open tabs.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let tabs = await I.grabNumberOfOpenTabs();
@@ -1031,6 +1033,7 @@ Returns **[Promise][25]&lt;[number][22]>** number of open tabs
 ### grabNumberOfVisibleElements
 
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');
@@ -1064,7 +1067,7 @@ await I.grabPopupText();
 ### grabSource
 
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -1002,6 +1002,8 @@ Resumes test execution, so **should be used inside async function with `await`**
 let geoLocation = await I.grabGeoLocation();
 ```
 
+Returns **[Promise][25]&lt;{latitude: [number][22], longitude: [number][22], altitude: [number][22]}>** 
+
 ### grabHTMLFrom
 
 Retrieves the innerHTML from an element located by CSS or XPath and returns it to test.

--- a/docs/webapi/grabAttributeFrom.mustache
+++ b/docs/webapi/grabAttributeFrom.mustache
@@ -1,6 +1,6 @@
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
 An array as a result will be returned if there are more than one matched element.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let hint = await I.grabAttributeFrom('#tooltip', 'title');

--- a/docs/webapi/grabCookie.mustache
+++ b/docs/webapi/grabCookie.mustache
@@ -1,6 +1,6 @@
 Gets a cookie object by name.
 If none provided gets all cookies.
-Resumes test execution, so **should be used inside async with `await`** operator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let cookie = await I.grabCookie('auth');

--- a/docs/webapi/grabGeoLocation.mustache
+++ b/docs/webapi/grabGeoLocation.mustache
@@ -4,3 +4,5 @@ Resumes test execution, so **should be used inside async function with `await`**
 ```js
 let geoLocation = await I.grabGeoLocation();
 ```
+
+@returns {Promise<{ latitude: number, longitude: number, altitude: number }>}

--- a/docs/webapi/grabGeoLocation.mustache
+++ b/docs/webapi/grabGeoLocation.mustache
@@ -1,5 +1,5 @@
 Return the current geo location 
-
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let geoLocation = await I.grabGeoLocation();

--- a/docs/webapi/grabNumberOfOpenTabs.mustache
+++ b/docs/webapi/grabNumberOfOpenTabs.mustache
@@ -1,4 +1,5 @@
 Grab number of open tabs.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let tabs = await I.grabNumberOfOpenTabs();

--- a/docs/webapi/grabNumberOfVisibleElements.mustache
+++ b/docs/webapi/grabNumberOfVisibleElements.mustache
@@ -1,4 +1,5 @@
 Grab number of visible elements by locator.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let numOfElements = await I.grabNumberOfVisibleElements('p');

--- a/docs/webapi/grabSource.mustache
+++ b/docs/webapi/grabSource.mustache
@@ -1,5 +1,5 @@
 Retrieves page source and returns it to test.
-Resumes test execution, so should be used inside an async function.
+Resumes test execution, so **should be used inside async function with `await`** operator.
 
 ```js
 let pageSource = await I.grabSource();


### PR DESCRIPTION
## Motivation/Description of the PR
Add missing `async` descriptions for `grab*` methods.

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
