### PR TITLE
(docs): update playwright docs for how to use the waitForNavigation

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -69,7 +69,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * * `keepBrowserState`: (optional, default: false) - keep browser state between tests when `restart` is set to false.
  * * `keepCookies`: (optional, default: false) - keep cookies between tests when `restart` is set to false.
  * * `waitForAction`: (optional) how long to wait after click, doubleClick or PressKey actions in ms. Default: 100.
- * * `waitForNavigation`: (optional, default: 'load'). When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. See [Playwright API](https://github.com/GoogleChrome/Playwright/blob/master/docs/api.md#pagewaitfornavigationoptions). Array values are accepted as well.
+ * * `waitForNavigation`: (optional, default: 'load'). When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. Choose one of those options is possible. See [Playwright API](https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitfornavigationoptions).
  * * `pressKeyDelay`: (optional, default: '10'). Delay between key presses in ms. Used when calling Playwrights page.type(...) in fillField/appendField
  * * `getPageTimeout` (optional, default: '0') config option to set maximum navigation time in milliseconds.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 1000.
@@ -94,7 +94,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * }
  * ```
  *
- * #### Example #2: Wait for DOMContentLoaded event and 0 network connections
+ * #### Example #2: Wait for DOMContentLoaded event
  *
  * ```js
  * {
@@ -102,7 +102,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *      Playwright : {
  *        url: "http://localhost",
  *        restart: false,
- *        waitForNavigation: [ "domcontentloaded", "networkidle0" ],
+ *        waitForNavigation: "domcontentloaded",
  *        waitForAction: 500
  *      }
  *    }


### PR DESCRIPTION
## Motivation/Description of the PR
- https://github.com/microsoft/playwright/blob/master/docs/api.md#pagesetcontenthtml-options. According to the doc, only use either one of those values 

```
"load"|"domcontentloaded"|"networkidle0"|"networkidle2"
```

- Resolve #2328, #2305

Applicable helpers:

- [x] Playwright

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
