### PR TITLE
waitForEnabled fix for webdriver 6

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1859,6 +1859,19 @@ class WebDriver extends Helper {
    */
   async waitForEnabled(locator, sec = null) {
     const aSec = sec || this.options.waitForTimeout;
+    if (isWebDriver5()) {
+      return this.browser.waitUntil(async () => {
+        const res = await this.$$(withStrictLocator(locator));
+        if (!res || res.length === 0) {
+          return false;
+        }
+        const selected = await forEachAsync(res, async el => this.browser.isElementEnabled(getElementId(el)));
+        if (Array.isArray(selected)) {
+          return selected.filter(val => val === true).length > 0;
+        }
+        return selected;
+      }, aSec * 1000, `element (${new Locator(locator)}) still not enabled after ${aSec} sec`);
+    }
     return this.browser.waitUntil(async () => {
       const res = await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) {
@@ -1869,7 +1882,10 @@ class WebDriver extends Helper {
         return selected.filter(val => val === true).length > 0;
       }
       return selected;
-    }, aSec * 1000, `element (${new Locator(locator)}) still not enabled after ${aSec} sec`);
+    }, {
+      timeout: aSec * 1000,
+      timeoutMsg: `element (${new Locator(locator)}) still not enabled after ${aSec} sec`,
+    });
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR
- Faced issues with using of waitForEnabled - it used waitUntil with default 3000 ms for timeout
- Pretty similar fix as [this one](https://github.com/Codeception/CodeceptJS/pull/2313) but for waitForEnabled method of WebDriver

Applicable helpers:

- [X] WebDriver

## Type of change

- [X] :bug: Bug fix

## Checklist:

- [X] Local tests are passed (Run `npm test`)
