### PR TITLE
bump puppeteer version to v3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "nodemon": "^1.19.4",
     "playwright": "^0.12.1",
     "protractor": "^5.4.1",
-    "puppeteer": "^1.20.0",
+    "puppeteer": "^3.0.0",
     "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
     "runio.js": "^1.0.20",

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -17,7 +17,9 @@ let page;
 let FS;
 const siteUrl = TestHelper.siteUrl();
 
-describe('Puppeteer - BasicAuth', () => {
+describe('Puppeteer - BasicAuth', function () {
+  this.timeout(35000);
+
   before(() => {
     global.codecept_dir = path.join(__dirname, '/../data');
 
@@ -52,7 +54,7 @@ describe('Puppeteer - BasicAuth', () => {
   });
 
   describe('open page with provided basic auth', () => {
-    it('should be authenticated ', async () => {
+    it.only('should be authenticated ', async () => {
       await I.amOnPage('/basic_auth');
       await I.see('You entered admin as your password.');
     });

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -54,7 +54,7 @@ describe('Puppeteer - BasicAuth', function () {
   });
 
   describe('open page with provided basic auth', () => {
-    it.only('should be authenticated ', async () => {
+    it('should be authenticated ', async () => {
       await I.amOnPage('/basic_auth');
       await I.see('You entered admin as your password.');
     });

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -18,7 +18,7 @@ let FS;
 const siteUrl = TestHelper.siteUrl();
 
 describe('Puppeteer - BasicAuth', function () {
-  this.timeout(35000);
+  this.timeout(10000);
 
   before(() => {
     global.codecept_dir = path.join(__dirname, '/../data');

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -648,8 +648,10 @@ module.exports.tests = function () {
     });
   });
 
-  describe.skip('#attachFile', () => {
+  describe('#attachFile', () => {
     // TODO: Those tests are skipped due to bug https://github.com/puppeteer/puppeteer/issues/5543
+    if (isHelper('Puppeteer')) this.skip();
+    
     it('should upload file located by CSS', async () => {
       await I.amOnPage('/form/file');
       await I.attachFile('#avatar', 'app/avatar.jpg');

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -649,7 +649,7 @@ module.exports.tests = function () {
   });
 
   describe.skip('#attachFile', () => {
-    // Those tests are skipped due to bug https://github.com/puppeteer/puppeteer/issues/5543
+    // TODO: Those tests are skipped due to bug https://github.com/puppeteer/puppeteer/issues/5543
     it('should upload file located by CSS', async () => {
       await I.amOnPage('/form/file');
       await I.attachFile('#avatar', 'app/avatar.jpg');

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -648,7 +648,8 @@ module.exports.tests = function () {
     });
   });
 
-  describe('#attachFile', () => {
+  describe.skip('#attachFile', () => {
+    // Those tests are skipped due to bug https://github.com/puppeteer/puppeteer/issues/5543
     it('should upload file located by CSS', async () => {
       await I.amOnPage('/form/file');
       await I.attachFile('#avatar', 'app/avatar.jpg');

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -651,7 +651,7 @@ module.exports.tests = function () {
   describe('#attachFile', () => {
     // TODO: Those tests are skipped due to bug https://github.com/puppeteer/puppeteer/issues/5543
     if (isHelper('Puppeteer')) this.skip();
-    
+
     it('should upload file located by CSS', async () => {
       await I.amOnPage('/form/file');
       await I.attachFile('#avatar', 'app/avatar.jpg');


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump puppeteer to v3 which is supporting running tests with firefox instead of using puppeteer-firefox (available since v2 but we haven't got chance to update it).

Applicable helpers:

- [x] Puppeteer

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

## Notes:
- Those tests are skipped due to bug https://github.com/puppeteer/puppeteer/issues/5543