### PR TITLE
Add mocha before hook issue fix

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -24,6 +24,7 @@ module.exports = {
    * @property {'test.passed'} passed
    * @property {'test.failed'} failed
    * @property {'test.finish'} finished
+   * @property {'test.skipped'} skipped
    */
   test: {
     started: 'test.start', // sync
@@ -32,6 +33,7 @@ module.exports = {
     passed: 'test.passed', // sync
     failed: 'test.failed', // sync
     finished: 'test.finish', // sync
+    skipped: 'test.skipped', // sync
   },
   /**
    * @type {object}

--- a/lib/reporter/cli.js
+++ b/lib/reporter/cli.js
@@ -3,7 +3,6 @@ const ms = require('ms');
 const event = require('../event');
 const AssertionFailedError = require('../assert/error');
 const output = require('../output');
-const container = require('../container');
 
 const cursor = Base.cursor;
 let currentMetaStep = [];
@@ -12,12 +11,11 @@ class Cli extends Base {
   constructor(runner, opts) {
     super(runner);
     let level = 0;
-    this.failedSteps = [];
+    this.failedTests = [];
     opts = opts.reporterOptions || opts;
     if (opts.steps) level = 1;
     if (opts.debug) level = 2;
     if (opts.verbose) level = 3;
-
     output.level(level);
     output.print(`CodeceptJS v${require('../codecept').version()}`);
     output.print(`Using test root "${global.codecept_dir}"`);
@@ -45,7 +43,7 @@ class Cli extends Base {
 
     runner.on('fail', (test, err) => {
       if (test.ctx.currentTest) {
-        this.failedSteps.push(test.ctx.currentTest.id);
+        this.failedTests.push(test.ctx.currentTest.id);
       }
       if (showSteps && test.steps) {
         return output.scenario.failed(test);
@@ -97,9 +95,9 @@ class Cli extends Base {
 
     runner.on('suite end', suite => {
       let skippedCount = 0;
-      const grep = require('../container').mocha().options.grep;
+      const grep = runner._grep;
       for (const test of suite.tests) {
-        if (!test.state && !this.failedSteps.includes(test.id)) {
+        if (!test.state && !this.failedTests.includes(test.id)) {
           if (matchTest(grep, test.title)) {
             test.state = 'failed';
             output.test.failed(test);

--- a/lib/reporter/cli.js
+++ b/lib/reporter/cli.js
@@ -99,14 +99,15 @@ class Cli extends Base {
       for (const test of suite.tests) {
         if (!test.state && !this.failedTests.includes(test.id)) {
           if (matchTest(grep, test.title)) {
-            test.state = 'failed';
-            output.test.failed(test);
+            event.emit(event.test.skipped, test);
+            test.state = 'skipped';
+            output.test.skipped(test);
             skippedCount += 1;
           }
         }
       }
 
-      this.stats.failures += skippedCount;
+      this.stats.pending += skippedCount;
       this.stats.tests += skippedCount;
     });
 

--- a/lib/reporter/cli.js
+++ b/lib/reporter/cli.js
@@ -3,6 +3,7 @@ const ms = require('ms');
 const event = require('../event');
 const AssertionFailedError = require('../assert/error');
 const output = require('../output');
+const container = require('../container');
 
 const cursor = Base.cursor;
 let currentMetaStep = [];
@@ -11,6 +12,7 @@ class Cli extends Base {
   constructor(runner, opts) {
     super(runner);
     let level = 0;
+    this.failedSteps = [];
     opts = opts.reporterOptions || opts;
     if (opts.steps) level = 1;
     if (opts.debug) level = 2;
@@ -42,6 +44,9 @@ class Cli extends Base {
     });
 
     runner.on('fail', (test, err) => {
+      if (test.ctx.currentTest) {
+        this.failedSteps.push(test.ctx.currentTest.id);
+      }
       if (showSteps && test.steps) {
         return output.scenario.failed(test);
       }
@@ -90,6 +95,23 @@ class Cli extends Base {
       });
     }
 
+    runner.on('suite end', suite => {
+      let skippedCount = 0;
+      const grep = require('../container').mocha().options.grep;
+      for (const test of suite.tests) {
+        if (!test.state && !this.failedSteps.includes(test.id)) {
+          if (matchTest(grep, test.title)) {
+            test.state = 'failed';
+            output.test.failed(test);
+            skippedCount += 1;
+          }
+        }
+      }
+
+      this.stats.failures += skippedCount;
+      this.stats.tests += skippedCount;
+    });
+
     runner.on('end', this.result.bind(this));
   }
 
@@ -129,6 +151,14 @@ class Cli extends Base {
     output.result(stats.passes, stats.failures, stats.pending, ms(stats.duration));
   }
 }
+
+function matchTest(grep, test) {
+  if (grep) {
+    return grep.test(test);
+  }
+  return true;
+}
+
 module.exports = function (runner, opts) {
   return new Cli(runner, opts);
 };

--- a/test/data/sandbox/before_failure_test.js
+++ b/test/data/sandbox/before_failure_test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+
+Feature('Before Test');
+
+let val = 0;
+
+Before(() => {
+  assert.equal(val, 0);
+  val++;
+});
+
+
+Scenario('First test will be passed @grep', () => {
+  assert(true);
+});
+
+Scenario('Second test will be Failed @grep', () => {
+  assert(true);
+});
+
+Scenario('Third test will be skipped @grep', () => {
+  assert(true);
+});
+
+Scenario('Fourth test will be skipped', () => {
+  assert(true);
+});

--- a/test/data/sandbox/codecept.beforetest.failure.json
+++ b/test/data/sandbox/codecept.beforetest.failure.json
@@ -1,0 +1,12 @@
+{
+  "tests": "./*before_failure_test.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "FileSystem": {}
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/runner/before_failure_test.js
+++ b/test/runner/before_failure_test.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const exec = require('child_process').exec;
+const assert = require('assert');
+const event = require('../../lib').event;
+
+const runner = path.join(__dirname, '/../../bin/codecept.js');
+const codecept_dir = path.join(__dirname, '/../data/sandbox');
+const codecept_run = `${runner} run --config ${codecept_dir}/codecept.beforetest.failure.json `;
+
+describe('Failure in before', () => {
+  it('should skip tests that are skipped because of failure in before hook', (done) => {
+    exec(`${codecept_run}`, (err, stdout) => {
+      stdout.should.include('✔ First test will be passed');
+      stdout.should.include('S Third test will be skipped @grep');
+      stdout.should.include('S Fourth test will be skipped');
+      stdout.should.include('1 passed, 1 failed, 2 skipped');
+      err.code.should.eql(1);
+      done();
+    });
+  });
+
+  it('should skip tests correctly with grep options', (done) => {
+    exec(`${codecept_run} --grep @grep`, (err, stdout) => {
+      stdout.should.include('✔ First test will be passed');
+      stdout.should.include('S Third test will be skipped @grep');
+      stdout.should.include('1 passed, 1 failed, 1 skipped');
+      err.code.should.eql(1);
+      done();
+    });
+  });
+
+  it('should trigger skipped events', (done) => {
+    exec(`${codecept_run} --verbose`, (err, stdout) => {
+      err.code.should.eql(1);
+      stdout.should.include('Emitted | test.skipped');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# Description
If a test is failed in `before` , the rest of the tests are not executed and the status of the test is also not reported.

Hereafter these tests are marked as skipped and a new event `test.skipped` will be triggered

## Before
![before](https://user-images.githubusercontent.com/24666922/80097829-9250bd00-8589-11ea-9a19-e8780b78077f.png)

## After
![after](https://user-images.githubusercontent.com/24666922/80097862-9b418e80-8589-11ea-8b50-fb136992326e.png)


Fixes #2349