### PR TITLE
fix(workers): If fail scenario with same name, but diff feature - shows negative result

### DIFF
--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -101,10 +101,11 @@ module.exports = function (workers, options) {
 
       switch (message.event) {
         case event.test.failed:
-          updateFinishedTests(repackTest(message.data), maxReruns);
           output.test.failed(repackTest(message.data));
+          updateFinishedTests(repackTest(message.data), maxReruns);
           break;
-        case event.test.passed: output.test.passed(repackTest(message.data));
+        case event.test.passed:
+          output.test.passed(repackTest(message.data));
           updateFinishedTests(repackTest(message.data), maxReruns);
           break;
         case event.suite.before: output.suite.started(message.data); break;
@@ -232,11 +233,13 @@ function simplifyObject(object) {
 const updateFinishedTests = (test, maxReruns) => {
   const { id } = test;
   if (finishedTests[id]) {
-    const stats = { passes: 0, failures: -1, tests: 0 };
     if (finishedTests[id].runs <= maxReruns) {
       finishedTests[id].runs++;
     }
-    appendStats(stats);
+    if (test.retries !== -1) {
+      const stats = { passes: 0, failures: -1, tests: 0 };
+      appendStats(stats);
+    }
   } else {
     finishedTests[id] = test;
     finishedTests[id].runs = 1;

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -80,6 +80,7 @@ function initializeListeners() {
     return {
       id: test.id,
       workerIndex,
+      retries: test._retries,
       title: test.title,
       status: test.status,
       duration: test.duration || 0,

--- a/test/data/sandbox/configs/workers/codecept.workers-negative.conf.js
+++ b/test/data/sandbox/configs/workers/codecept.workers-negative.conf.js
@@ -1,0 +1,11 @@
+exports.config = {
+  tests: '../../workers/negative_results/*.js',
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    FileSystem: {},
+  },
+  include: {},
+  mocha: {},
+  name: 'sandbox',
+};

--- a/test/data/sandbox/workers/negative_results/negative1.workers.js
+++ b/test/data/sandbox/workers/negative_results/negative1.workers.js
@@ -1,0 +1,14 @@
+Feature('Workers - negative Results1');
+
+Scenario('the same name', (I) => {
+  throw new Error('The same error');
+});
+
+Scenario('the same name', (I) => {
+  throw new Error('The same error');
+});
+
+
+Scenario('the another name', (I) => {
+  console.log('asd');
+});

--- a/test/data/sandbox/workers/negative_results/negative2.workers.js
+++ b/test/data/sandbox/workers/negative_results/negative2.workers.js
@@ -1,0 +1,14 @@
+Feature('Workers - negative Results2');
+
+Scenario('the same name', (I) => {
+  throw new Error('The same error');
+});
+
+Scenario('the same name', (I) => {
+  throw new Error('The same error');
+});
+
+
+Scenario('the another name', (I) => {
+  console.log('asd');
+});

--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -32,6 +32,17 @@ describe('CodeceptJS Workers Runner', function () {
     });
   });
 
+  it('should print positive or zero failures with same name tests', function (done) {
+    if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
+    exec(`${codecept_run_glob('configs/workers/codecept.workers-negative.conf.js')} 2`, (err, stdout, stderr) => {
+      stdout.should.include('Running tests in 2 workers...');
+      stdout.should.not.include('FAIL  | 2 passed, -6 failed');
+      stdout.should.include('FAIL  | 2 passed, 8 failed');
+      assert(err);
+      done();
+    });
+  });
+
   it('should use grep', function (done) {
     if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
     exec(`${codecept_run} 2 --grep "grep"`, (err, stdout, stderr) => {


### PR DESCRIPTION
Fix this bug>

![image](https://user-images.githubusercontent.com/11293201/80068757-d2438000-8548-11ea-9b58-f97dba539fae.png)

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
