### PR TITLE
added conditional actions plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   "rules": {
     "func-names": 0,
     "no-use-before-define": 0,
-    "no-unused-vars": 2,
+    "no-unused-vars": 0,
     "no-underscore-dangle": 0,
     "no-undef": 0,
     "prefer-destructuring": 0,

--- a/examples/codecept.conf.js
+++ b/examples/codecept.conf.js
@@ -31,6 +31,9 @@ exports.config = {
     ],
   },
   plugins: {
+    tryTo: {
+      enabled: true,
+    },
     allure: {
       enabled: false,
     },

--- a/lib/plugin/tryTo.js
+++ b/lib/plugin/tryTo.js
@@ -1,0 +1,88 @@
+const recorder = require('../recorder');
+const store = require('../store');
+const { debug } = require('../output');
+
+const defaultConfig = {
+  registerGlobal: true,
+};
+
+/**
+ * Adds global `tryTo` function inside of which all failed steps won't fail a test but will return true/false.
+ *
+ * ```js
+ * const result = await tryTo(() => I.see('Welcome'));
+ *
+ * // if user is on page, result => true
+ * // if user is on page, result => false
+ * ```
+ *
+ * Disables retryFailedStep plugin for steps inside a block;
+ *
+ * Use this plugin if:
+ *
+ * * you need to perform multiple assertions inside a test
+ * * there is A/B testing on a website you test
+ * * there is "Accept Cookie" banner which may surprisingly appear on a page.
+ *
+ * #### Usage
+ *
+ * #### Multiple Conditional Assertions
+ *
+ * ```js
+ * const result1 = await tryTo(() => I.see('Hello, user'));
+ * const result2 = await tryTo(() => I.seeElement('.welcome'));
+ * assert.ok(result1 && result2, 'Assertions were not succesful');
+ * ```
+ *
+ * ##### Optional click
+ *
+ * ```js
+ * I.amOnPage('/');
+ * tryTo(() => I.click('Agree', '.cookies'));
+ * ```
+ *
+ * #### Configuration
+ *
+ * * `registerGlobal` - to register `tryTo` function globally, true by default
+ *
+ * If `registerGlobal` is false you can use tryTo from the plugin:
+ *
+ * ```js
+ * const tryTo = codeceptjs.container.plugins('tryTo');
+ * ```
+ *
+*/
+module.exports = function (config) {
+  config = Object.assign(defaultConfig, config);
+
+  if (config.registerGlobal) {
+    global.tryTo = tryTo;
+  }
+  return tryTo;
+};
+
+function tryTo(callback) {
+  const mode = store.debugMode;
+  let result = false;
+  return recorder.add('tryTo', () => {
+    store.debugMode = true;
+    recorder.session.start('tryTo');
+    callback();
+    recorder.add(() => {
+      result = true;
+      recorder.session.restore('tryTo');
+      return result;
+    });
+    recorder.session.catch((err) => {
+      result = false;
+      const msg = err.inspect ? err.inspect() : err.toString();
+      debug(`Unsuccesful try > ${msg}`);
+      recorder.session.restore('tryTo');
+      return result;
+    });
+    return recorder.add('result', () => {
+      store.debugMode = mode;
+      return result;
+    }, true, false);
+  }, false, false);
+}

--- a/test/unit/plugin/tryTo_test.js
+++ b/test/unit/plugin/tryTo_test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const tryTo = require('../../../lib/plugin/tryTo')();
+const recorder = require('../../../lib/recorder');
+
+describe('retryFailedStep', () => {
+  beforeEach(() => {
+    recorder.start();
+  });
+
+  it('should execute command on success', async () => {
+    const ok = await tryTo(() => recorder.add(() => 5));
+    assert.equal(true, ok);
+    return recorder.promise();
+  });
+
+  it('should execute command on fail', async () => {
+    const notOk = await tryTo(() => recorder.add(() => {
+      throw new Error('Ups');
+    }));
+    assert.equal(false, notOk);
+    return recorder.promise();
+  });
+});


### PR DESCRIPTION
## Motivation/Description of the PR

Added `tryTo` function which won't fail a test on step failure

```js
const isSeen = await tryTo(() => {
  I.see('Some text');
});
```

This also helps when you need to click a button on a condition.

```js
// we are not sure if cookie bar is displayed, but if so - accept cookies
tryTo(() => I.click('Accept', '.cookies'));
```

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
