### PR TITLE
Test fails with plugin stepByStepReport applied on step in function BeforeSuite

### DIFF
--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -131,6 +131,9 @@ module.exports = function (config) {
   async function persistStep(step) {
     if (isStepIgnored(step)) return;
     if (savedStep === step) return; // already saved
+    // Ignore steps from BeforeSuite function
+    if (step.metaStep && step.metaStep.name === 'BeforeSuite') return;
+
     const fileName = `${pad.substring(0, pad.length - stepNum.toString().length) + stepNum.toString()}.png`;
     try {
       stepNum++;


### PR DESCRIPTION
Fixed. Steps from BeforeSuite are skipped now when running `stepByStepReport` plugin.

## Motivation/Description of the PR
- Fixes failed test if a helper method is used in `BeforeSuite`
- Resolves #2337 (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [x] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
