### PR TITLE
Fix a borken link to webdriver

### DIFF
--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -14,7 +14,7 @@ title: WebDriver
 WebDriver helper which wraps [webdriverio][1] library to
 manipulate browser using Selenium WebDriver or PhantomJS.
 
-WebDriver requires [Selenium Server and ChromeDriver/GeckoDriver to be installed][2].
+WebDriver requires Selenium Server and ChromeDriver/GeckoDriver to be installed. Those tools can be easily installed via NPM. Please check [Testing with WebDriver][2] for more details.
 
 ### Configuration
 
@@ -2031,7 +2031,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [1]: http://webdriver.io/
 
-[2]: http://codecept.io/quickstart/#prepare-selenium-server
+[2]: https://codecept.io/webdriver/#testing-with-webdriver
 
 [3]: http://codecept.io/acceptance/#smartwait
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -37,7 +37,7 @@ let version;
  * WebDriver helper which wraps [webdriverio](http://webdriver.io/) library to
  * manipulate browser using Selenium WebDriver or PhantomJS.
  *
- * WebDriver requires [Selenium Server and ChromeDriver/GeckoDriver to be installed](http://codecept.io/quickstart/#prepare-selenium-server).
+ * WebDriver requires Selenium Server and ChromeDriver/GeckoDriver to be installed. Those tools can be easily installed via NPM. Please check [Testing with WebDriver](https://codecept.io/webdriver/#testing-with-webdriver) for more details.
  *
  * ### Configuration
  *


### PR DESCRIPTION
The [`/quickstart/#prepare-selenium-server`](https://codecept.io/quickstart/#prepare-selenium-server) path cannot found.

Fix link to [`/webdriver#what-is-selenium-webdriver`](https://codecept.io/webdriver/#testing-with-webdriver)

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
