### PR TITLE
Appium tests

### DIFF
--- a/.github/workflows/appium.yml
+++ b/.github/workflows/appium.yml
@@ -1,0 +1,43 @@
+name: Appium Tests
+
+on: [push, pull_request]
+
+env:
+  CI: true
+  # Force terminal colors. @see https://www.npmjs.com/package/colors
+  FORCE_COLOR: 1
+
+jobs:
+  appium1:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: 'npm run test:appium-quick'
+
+
+  appium2:
+
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: 'npm run test:appium-other'

--- a/.github/workflows/appium.yml
+++ b/.github/workflows/appium.yml
@@ -1,6 +1,12 @@
 name: Appium Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 
 env:
   CI: true
@@ -23,6 +29,9 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: 'npm run test:appium-quick'
+      env: # Or as an environment variable
+        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
 
 
   appium2:
@@ -41,3 +50,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: 'npm run test:appium-other'
+      env: # Or as an environment variable
+        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,12 @@
 name: Playwright Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 
 env:
   CI: true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,12 +1,6 @@
 name: Playwright Tests
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 env:
   CI: true


### PR DESCRIPTION
@PeterNgTr I could not migrate our Semaphore Ci setup to a new version
It appeared they require to create a new account to access Semaphore 2.0 which is not useful.
So I  moved things to Github Actions, probably we should have done it in the beginning but I didn't know Semaphore is such a mess in migration :( 