### PR TITLE
Upgrade playwright to 1.0.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,3 +44,5 @@ jobs:
       run: "BROWSER=firefox node ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug"
     - name: run webkit tests
       run: "BROWSER=webkit node ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug"
+    - name: run unit tests
+      run: mocha test/helper/Playwright_test.js

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,4 +45,4 @@ jobs:
     - name: run webkit tests
       run: "BROWSER=webkit node ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug"
     - name: run unit tests
-      run: mocha test/helper/Playwright_test.js
+      run: ./node_modules/.bin/mocha test/helper/Playwright_test.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
   apt:
     packages:
     - php5-cli
+    # This is required to run chromium
+    - libgbm1
 services:
 - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,36 +13,20 @@ env:
   - HELPER=ProtractorWeb
   - HELPER=WebDriver
   - HELPER=TestCafe
-  - HELPER=Playwright
 addons:
   apt:
     packages:
-    # this is needed for running headful tests
-    - xvfb
-    # This is required to run new chrome on old trusty
-    - libnss3
     - php5-cli
-    # This is required to run chromium
-    - libgbm1
 services:
 - docker
-install:
-- npm install
-cache:
-  directories:
-  - node_modules
 before_install:
 - docker pull selenium/standalone-chrome:3.141.59-oxygen
 before_script:
-# Enable user namespace cloning
-- "sysctl kernel.unprivileged_userns_clone=1"
 - docker run -d --net=host --shm-size=2g selenium/standalone-chrome:3.141.59-oxygen
 - export DBUS_SESSION_BUS_ADDRESS=/dev/null
-# Launch XVFB
-- "sh -e /etc/init.d/xvfb start"
 - export DISPLAY=:99.0
 - sleep 3
 - chmod -R 777 test/data
 - php -S 127.0.0.1:8000 -t test/data/app >/dev/null 2>&1 &
 script:
-- export DEBUG=pw:browser* && mocha test/helper/${HELPER}_test.js
+- mocha test/helper/${HELPER}_test.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ before_script:
 - chmod -R 777 test/data
 - php -S 127.0.0.1:8000 -t test/data/app >/dev/null 2>&1 &
 script:
-- mocha test/helper/${HELPER}_test.js
+- export DEBUG=pw:browser* && mocha test/helper/${HELPER}_test.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
 addons:
   apt:
     packages:
+    # this is needed for running headful tests
+    - xvfb
+    # This is required to run new chrome on old trusty
+    - libnss3
     - php5-cli
     # This is required to run chromium
     - libgbm1
@@ -25,8 +29,12 @@ services:
 before_install:
 - docker pull selenium/standalone-chrome:3.141.59-oxygen
 before_script:
+# Enable user namespace cloning
+- "sysctl kernel.unprivileged_userns_clone=1"
 - docker run -d --net=host --shm-size=2g selenium/standalone-chrome:3.141.59-oxygen
 - export DBUS_SESSION_BUS_ADDRESS=/dev/null
+# Launch XVFB
+- "sh -e /etc/init.d/xvfb start"
 - export DISPLAY=:99.0
 - sleep 3
 - chmod -R 777 test/data

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 services:
 - docker
 install:
-- npm ci
+- npm install
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ addons:
     - libgbm1
 services:
 - docker
+install:
+- npm ci
+cache:
+  directories:
+  - node_modules
 before_install:
 - docker pull selenium/standalone-chrome:3.141.59-oxygen
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
     && apt-get update \
     && apt-get install -y google-chrome-unstable \
       --no-install-recommends \
+    && apt-get install -y libgbm1 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge --auto-remove -y curl \
     && rm -rf /src/*.deb

--- a/docs/custom-helpers.md
+++ b/docs/custom-helpers.md
@@ -209,7 +209,7 @@ async clickOnEveryElement(locator) {
 }
 ```
 
-In this case `el` will be an instance of [ElementHandle](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#class-elementhandle) which is similar for Playwright & [Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-class-elementhandle).
+In this case `el` will be an instance of [ElementHandle](https://playwright.dev/#version=master&path=docs%2Fapi.md&q=class-elementhandle) which is similar for Playwright & [Puppeteer](https://pptr.dev/#?product=Puppeteer&version=master&show=api-class-elementhandle).
 
 > ℹ There are more `_locate*` methods in each helper. Take a look on documentation of a helper you use to see which exact method it exposes.
 

--- a/docs/custom-helpers.md
+++ b/docs/custom-helpers.md
@@ -209,7 +209,7 @@ async clickOnEveryElement(locator) {
 }
 ```
 
-In this case `el` will be an instance of [ElementHandle](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md#class-elementhandle) which is similar for Playwright & [Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-class-elementhandle).
+In this case `el` will be an instance of [ElementHandle](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#class-elementhandle) which is similar for Playwright & [Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-class-elementhandle).
 
 > ℹ There are more `_locate*` methods in each helper. Take a look on documentation of a helper you use to see which exact method it exposes.
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -19,9 +19,9 @@ Uses [Playwright][1] library to run tests inside:
 
 This helper works with a browser out of the box with no additional tools required to install.
 
-Requires `playwright` package version ^1.0.1 to be installed:
+Requires `playwright` package to be installed:
 
-    npm i playwright@^1.0.1 --save
+    npm i playwright@^1 --save
 
 ## Configuration
 
@@ -1755,7 +1755,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [11]: https://codecept.io/helpers/FileSystem
 
-[12]: https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#browsernewpageoptions
+[12]: https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewpageoptions
 
 [13]: #fillfield
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -38,7 +38,7 @@ This helper should be configured in codecept.json or codecept.conf.js
 -   `keepBrowserState`:  - keep browser state between tests when `restart` is set to false.
 -   `keepCookies`:  - keep cookies between tests when `restart` is set to false.
 -   `waitForAction`: (optional) how long to wait after click, doubleClick or PressKey actions in ms. Default: 100.
--   `waitForNavigation`: . When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. Choose one of those options is possible. See [Playwright API][2].
+-   `waitForNavigation`: . When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle`. Choose one of those options is possible. See [Playwright API][2].
 -   `pressKeyDelay`: . Delay between key presses in ms. Used when calling Playwrights page.type(...) in fillField/appendField
 -   `getPageTimeout`  config option to set maximum navigation time in milliseconds.
 -   `waitForTimeout`: (optional) default wait* timeout in ms. Default: 1000.

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -19,9 +19,9 @@ Uses [Playwright][1] library to run tests inside:
 
 This helper works with a browser out of the box with no additional tools required to install.
 
-Requires `playwright` package version ^0.12.1 to be installed:
+Requires `playwright` package version ^1.0.1 to be installed:
 
-    npm i playwright@^0.12.1 --save
+    npm i playwright@^1.0.1 --save
 
 ## Configuration
 
@@ -1755,7 +1755,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [11]: https://codecept.io/helpers/FileSystem
 
-[12]: https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md#browsernewpageoptions
+[12]: https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#browsernewpageoptions
 
 [13]: #fillfield
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -28,7 +28,7 @@ It's readable and simple and working using Playwright API!
 To start you need CodeceptJS with Playwright packages installed
 
 ```bash
-npm install codeceptjs playwright@^1.0.1 --save
+npm install codeceptjs playwright@^1 --save
 ```
 
 Or see [alternative installation options](http://codecept.io/installation/)
@@ -235,7 +235,7 @@ helpers: {
   }
 }
 ```
-To adjust browser settings you can pass [custom options](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#browsernewcontextoptions)
+To adjust browser settings you can pass [custom options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewcontextoptions)
 
 ```js
 helpers: {
@@ -262,7 +262,7 @@ Scenario('website looks nice on iPhone', () => {
 
 ## Extending
 
-Playwright has a very [rich and flexible API](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md). Sure, you can extend your test suites to use the methods listed there. CodeceptJS already prepares some objects for you and you can use them from your you helpers.
+Playwright has a very [rich and flexible API](https://github.com/microsoft/playwright/blob/master/docs/api.md). Sure, you can extend your test suites to use the methods listed there. CodeceptJS already prepares some objects for you and you can use them from your you helpers.
 
 Start with creating an `MyPlaywright` helper using `generate:helper` or `gh` command:
 
@@ -299,7 +299,6 @@ async setPermissions() {
 }
 ```
 
-> [▶ Learn more about BrowserContext](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#class-browsercontext)
+> [▶ Learn more about BrowserContext](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-browsercontext)
 
 > [▶ Learn more about Helpers](http://codecept.io/helpers/)
-

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -28,7 +28,7 @@ It's readable and simple and working using Playwright API!
 To start you need CodeceptJS with Playwright packages installed
 
 ```bash
-npm install codeceptjs playwright@^0.12.1 --save
+npm install codeceptjs playwright@^1.0.1 --save
 ```
 
 Or see [alternative installation options](http://codecept.io/installation/)
@@ -236,7 +236,7 @@ helpers: {
   }
 }
 ```
-To adjust browser settings you can pass [custom options](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md#browsernewcontextoptions)
+To adjust browser settings you can pass [custom options](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#browsernewcontextoptions)
 
 ```js
 helpers: {
@@ -263,7 +263,7 @@ Scenario('website looks nice on iPhone', () => {
 
 ## Extending
 
-Playwright has a very [rich and flexible API](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md). Sure, you can extend your test suites to use the methods listed there. CodeceptJS already prepares some objects for you and you can use them from your you helpers.
+Playwright has a very [rich and flexible API](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md). Sure, you can extend your test suites to use the methods listed there. CodeceptJS already prepares some objects for you and you can use them from your you helpers.
 
 Start with creating an `MyPlaywright` helper using `generate:helper` or `gh` command:
 
@@ -300,7 +300,7 @@ async setPermissions() {
 }
 ```
 
-> [▶ Learn more about BrowserContext](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md#class-browsercontext)
+> [▶ Learn more about BrowserContext](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#class-browsercontext)
 
 > [▶ Learn more about Helpers](http://codecept.io/helpers/)
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -68,8 +68,7 @@ Playwright uses different strategies to detect if a page is loaded. In configura
 When to consider navigation succeeded, defaults to `load`. Given an array of event strings, navigation is considered to be successful after all events have been fired. Events can be either:
 - `load` - consider navigation to be finished when the load event is fired.
 - `domcontentloaded` - consider navigation to be finished when the DOMContentLoaded event is fired.
-- `networkidle0` - consider navigation to be finished when there are no more than 0 network connections for at least 500 ms.
-- `networkidle2` - consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.
+- `networkidle` - consider navigation to be finished when there are no network connections for at least 500 ms.
 
 ```js
   helpers: {

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1766,7 +1766,7 @@ class Playwright extends Helper {
     locator = new Locator(locator, 'css');
 
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout });
+    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, state: 'attached' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${err.message}`);
     });

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -71,7 +71,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * * `keepBrowserState`: (optional, default: false) - keep browser state between tests when `restart` is set to false.
  * * `keepCookies`: (optional, default: false) - keep cookies between tests when `restart` is set to false.
  * * `waitForAction`: (optional) how long to wait after click, doubleClick or PressKey actions in ms. Default: 100.
- * * `waitForNavigation`: (optional, default: 'load'). When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. Choose one of those options is possible. See [Playwright API](https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitfornavigationoptions).
+ * * `waitForNavigation`: (optional, default: 'load'). When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle`. Choose one of those options is possible. See [Playwright API](https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitfornavigationoptions).
  * * `pressKeyDelay`: (optional, default: '10'). Delay between key presses in ms. Used when calling Playwrights page.type(...) in fillField/appendField
  * * `getPageTimeout` (optional, default: '0') config option to set maximum navigation time in milliseconds.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 1000.

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -50,10 +50,10 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *
  * This helper works with a browser out of the box with no additional tools required to install.
  *
- * Requires `playwright` package version ^1.0.1 to be installed:
+ * Requires `playwright` package version ^1 to be installed:
  *
  * ```
- * npm i playwright@^1.0.1 --save
+ * npm i playwright@^1 --save
  * ```
  *
  * ## Configuration
@@ -277,7 +277,7 @@ class Playwright extends Helper {
     try {
       requireg('playwright');
     } catch (e) {
-      return ['playwright@^1.0.1'];
+      return ['playwright@^1'];
     }
   }
 
@@ -939,7 +939,7 @@ class Playwright extends Helper {
    * I.openNewTab();
    * ```
    *
-   * You can pass in [page options](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#browsernewpageoptions) to emulate device on this page
+   * You can pass in [page options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewpageoptions) to emulate device on this page
    *
    * ```js
    * // enable mobile

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -50,10 +50,10 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *
  * This helper works with a browser out of the box with no additional tools required to install.
  *
- * Requires `playwright` package version ^0.12.1 to be installed:
+ * Requires `playwright` package version ^1.0.1 to be installed:
  *
  * ```
- * npm i playwright@^0.12.1 --save
+ * npm i playwright@^1.0.1 --save
  * ```
  *
  * ## Configuration
@@ -277,7 +277,7 @@ class Playwright extends Helper {
     try {
       requireg('playwright');
     } catch (e) {
-      return ['playwright@^0.12.1'];
+      return ['playwright@^1.0.1'];
     }
   }
 
@@ -939,7 +939,7 @@ class Playwright extends Helper {
    * I.openNewTab();
    * ```
    *
-   * You can pass in [page options](https://github.com/microsoft/playwright/blob/v0.12.1/docs/api.md#browsernewpageoptions) to emulate device on this page
+   * You can pass in [page options](https://github.com/microsoft/playwright/blob/v1.0.1/docs/api.md#browsernewpageoptions) to emulate device on this page
    *
    * ```js
    * // enable mobile
@@ -1704,7 +1704,7 @@ class Playwright extends Helper {
     const context = await this._getContext();
     if (!locator.isXPath()) {
       // uses a custom selector engine for finding value properties on elements
-      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> __value=${value}`, { timeout: waitTimeout, waitFor: 'visible' });
+      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> __value=${value}`, { timeout: waitTimeout, state: 'visible' });
     } else {
       const valueFn = function ([locator, $XPath, value]) {
         eval($XPath); // eslint-disable-line no-eval
@@ -1781,7 +1781,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'visible' });
+    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, state: 'visible' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1794,7 +1794,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'hidden' });
+    const waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, state: 'hidden' });
     return waiter.catch((err) => {
       throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${err.message}`);
     });
@@ -1807,7 +1807,7 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     const context = await this._getContext();
-    return context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'hidden' }).catch((err) => {
+    return context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, state: 'hidden' }).catch((err) => {
       throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`);
     });
   }
@@ -1874,7 +1874,7 @@ class Playwright extends Helper {
     if (context) {
       const locator = new Locator(context, 'css');
       if (!locator.isXPath()) {
-        waiter = contextObject.waitFor(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> text=${text}`, { timeout: waitTimeout, waitFor: 'visible' });
+        waiter = contextObject.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> text=${text}`, { timeout: waitTimeout, state: 'visible' });
       }
 
       if (locator.isXPath()) {
@@ -2023,7 +2023,7 @@ class Playwright extends Helper {
     let waiter;
     const context = await this._getContext();
     if (!locator.isXPath()) {
-      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, waitFor: 'detached' });
+      waiter = context.waitForSelector(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`, { timeout: waitTimeout, state: 'detached' });
     } else {
       const visibleFn = function ([locator, $XPath]) {
         eval($XPath); // eslint-disable-line no-eval

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "mocha-parallel-tests": "^2.2.2",
     "nightmare": "^3.0.2",
     "nodemon": "^1.19.4",
-    "playwright": "^0.14.0",
+    "playwright": "^1.0.1",
     "protractor": "^5.4.1",
     "puppeteer": "^3.0.0",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
## Motivation/Description of the PR
- Upgrade playwright to their first Major release.
- 2 breaking changes: waitFor method gone, and waitFor attribute of waitForSelector ranamed to state
- networkidle2 removed, networkidle0 === networkidle

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [x] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
