### PR TITLE
Allow retries to be seen via --debug instead of the more verbose --verbose

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -180,7 +180,7 @@ module.exports = {
       }
 
       return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => {
-        if (number > 1) output.log(`${currentQueue()}Retrying... Attempt #${number}`);
+        if (number > 1) output.debug(`${currentQueue()}Retrying... Attempt #${number}`);
 
         const retryRules = this.retries.reverse();
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -1,7 +1,7 @@
 const debug = require('debug')('codeceptjs');
 const promiseRetry = require('promise-retry');
 
-const log = require('./output').log;
+const output = require('./output');
 
 let promise;
 let running = false;
@@ -86,7 +86,7 @@ module.exports = {
     queueId++;
     sessionId = null;
     asyncErr = null;
-    log(`${currentQueue()}Starting recording promises`);
+    output.log(`${currentQueue()}Starting recording promises`);
     promise = Promise.resolve();
     oldPromises = [];
     tasks = [];
@@ -116,7 +116,7 @@ module.exports = {
      * @inner
      */
     start(name) {
-      log(`${currentQueue()}Starting <${name}> session`);
+      output.log(`${currentQueue()}Starting <${name}> session`);
       tasks.push('--->');
       oldPromises.push(promise);
       this.running = true;
@@ -130,7 +130,7 @@ module.exports = {
      */
     restore(name) {
       tasks.push('<---');
-      log(`${currentQueue()}Finalize <${name}> session`);
+      output.log(`${currentQueue()}Finalize <${name}> session`);
       this.running = false;
       sessionId = null;
       this.catch(errFn);
@@ -180,7 +180,7 @@ module.exports = {
       }
 
       return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => {
-        if (number > 1) log(`${currentQueue()}Retrying... Attempt #${number}`);
+        if (number > 1) output.log(`${currentQueue()}Retrying... Attempt #${number}`);
 
         const retryRules = this.retries.reverse();
 
@@ -219,7 +219,7 @@ module.exports = {
    */
   catch(customErrFn) {
     return promise = promise.catch((err) => {
-      log(`${currentQueue()}Error | ${err}`);
+      output.log(`${currentQueue()}Error | ${err}`);
       if (!(err instanceof Error)) { // strange things may happen
         err = new Error(`[Wrapped Error] ${JSON.stringify(err)}`); // we should be prepared for them
       }
@@ -239,7 +239,7 @@ module.exports = {
    */
   catchWithoutStop(customErrFn) {
     return promise = promise.catch((err) => {
-      log(`${currentQueue()}Error | ${err}`);
+      output.log(`${currentQueue()}Error | ${err}`);
       if (!(err instanceof Error)) { // strange things may happen
         err = new Error(`[Wrapped Error] ${JSON.stringify(err)}`); // we should be prepared for them
       }
@@ -297,7 +297,7 @@ module.exports = {
    */
   stop() {
     debug(this.toString());
-    log(`${currentQueue()}Stopping recording promises`);
+    output.log(`${currentQueue()}Stopping recording promises`);
     const err = new Error();
     running = false;
   },


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves:

  Retries are a great way to allow E2E tests to be robust against flakiness caused by things like network delays, and it would be helpful to be aware that retries are being attempted when diagnosing a failure, or even knowing about the health of one's test suite.

- ~~Resolves #issueId (if applicable)~~

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
