### PR TITLE
Add @param to jsdoc of seeFileNameMatching

### DIFF
--- a/docs/helpers/FileSystem.md
+++ b/docs/helpers/FileSystem.md
@@ -101,7 +101,7 @@ I.seeFileNameMatching('.pdf');
 
 #### Parameters
 
--   `text`  
+-   `text` **[string][1]** 
 
 ### seeInThisFile
 

--- a/lib/helper/FileSystem.js
+++ b/lib/helper/FileSystem.js
@@ -91,6 +91,7 @@ class FileSystem extends Helper {
   * I.amInPath('output/downloads');
   * I.seeFileNameMatching('.pdf');
   * ```
+  * @param {string} text
   */
   seeFileNameMatching(text) {
     assert.ok(


### PR DESCRIPTION
I wrote jsdoc of `seeFileNameMatching`.
I added `@param` for types.d.ts.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
This PR fixes type of  function `seeFileNameMatching(text)`.
Previous type is `seeFileNameMatching()`.
This causes TypeScript's error.
New type is `seeFileNameMatching(text: string)`.

- Resolves #issueId (if applicable).
There is no issue.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
