### PR TITLE
P2 fix no screenshot when before hook fails

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -98,7 +98,7 @@ module.exports = function (config) {
         }
         await helper.saveScreenshot(fileName, options.fullPageScreenshots);
 
-        if (!test.artifacts) test.artifacts = {} 
+        if (!test.artifacts) test.artifacts = {}
         test.artifacts.screenshot = path.join(global.output_dir, fileName);
         if (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments) {
           test.attachments = [path.join(global.output_dir, fileName)];


### PR DESCRIPTION
Fixed screenshotOnFail Plugin to accommodate test failure in before hooks.
Currently the screenshots are not getting attached and this PR adds the fix for it

Applicable helpers: All

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [x] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
