### PR TITLE
Changing the defunct faker library

### DIFF
--- a/lib/plugin/fakerTransform.js
+++ b/lib/plugin/fakerTransform.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 const transform = require('../transform');
 
 /**


### PR DESCRIPTION
See https://github.com/codeceptjs/CodeceptJS/issues/3231

## Motivation/Description of the PR
- the faker library has been self-sabotaged by it's author. This PR is to replace it with the new stable project at https://fakerjs.dev/
- Resolves #3232 
w

Applicable plugins:

- [ x ] fakerTransform

## Type of change

- [ x ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ x ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
