### PR TITLE
Fully promise-based helpers

### DIFF
--- a/docs/webapi/amOnPage.mustache
+++ b/docs/webapi/amOnPage.mustache
@@ -8,3 +8,4 @@ I.amOnPage('/login'); // opens a login page
 ```
 
 @param {string} url url path or global url.
+@return {Promise<any>}

--- a/docs/webapi/appendField.mustache
+++ b/docs/webapi/appendField.mustache
@@ -6,3 +6,4 @@ I.appendField('#myTextField', 'appended');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator
 @param {string} value text value to append.
+@return {Promise<any>}

--- a/docs/webapi/attachFile.mustache
+++ b/docs/webapi/attachFile.mustache
@@ -9,3 +9,4 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 @param {CodeceptJS.LocatorOrString} locator field located by label|name|CSS|XPath|strict locator.
 @param {string} pathToFile local file path relative to codecept.json config file.
+@return {Promise<any>}

--- a/docs/webapi/checkOption.mustache
+++ b/docs/webapi/checkOption.mustache
@@ -10,3 +10,4 @@ I.checkOption('agree', '//form');
 ```
 @param {CodeceptJS.LocatorOrString} field checkbox located by label | name | CSS | XPath | strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS | XPath | strict locator.
+@return {Promise<any>}

--- a/docs/webapi/clearCookie.mustache
+++ b/docs/webapi/clearCookie.mustache
@@ -7,3 +7,4 @@ I.clearCookie('test');
 ```
 
 @param {?string} [cookie=null] (optional, `null` by default) cookie name
+@return {Promise<any>}

--- a/docs/webapi/clearField.mustache
+++ b/docs/webapi/clearField.mustache
@@ -6,3 +6,4 @@ I.clearField('user[email]');
 I.clearField('#email');
 ```
 @param {LocatorOrString} editable field located by label|name|CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/click.mustache
+++ b/docs/webapi/click.mustache
@@ -22,3 +22,4 @@ I.click({css: 'nav a.login'});
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+@return {Promise<any>}

--- a/docs/webapi/clickLink.mustache
+++ b/docs/webapi/clickLink.mustache
@@ -5,3 +5,4 @@ I.clickLink('Logout', '#nav');
 ```
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator
+@return {Promise<any>}

--- a/docs/webapi/closeCurrentTab.mustache
+++ b/docs/webapi/closeCurrentTab.mustache
@@ -1,5 +1,7 @@
- Close current tab.
+Close current tab.
 
- ```js
- I.closeCurrentTab();
- ```
+```js
+I.closeCurrentTab();
+```
+
+@return {Promise<any>}

--- a/docs/webapi/closeOtherTabs.mustache
+++ b/docs/webapi/closeOtherTabs.mustache
@@ -1,6 +1,8 @@
- Close all tabs except for the current one.
+Close all tabs except for the current one.
 
 
- ```js
- I.closeOtherTabs();
- ```
+```js
+I.closeOtherTabs();
+```
+
+@return {Promise<any>}

--- a/docs/webapi/dontSee.mustache
+++ b/docs/webapi/dontSee.mustache
@@ -8,3 +8,4 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 @param {string} text which is not present.
 @param {CodeceptJS.LocatorOrString} [context] (optional) element located by CSS|XPath|strict locator in which to perfrom search.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeCheckboxIsChecked.mustache
+++ b/docs/webapi/dontSeeCheckboxIsChecked.mustache
@@ -7,3 +7,4 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeCookie.mustache
+++ b/docs/webapi/dontSeeCookie.mustache
@@ -5,3 +5,4 @@ I.dontSeeCookie('auth'); // no auth cookie
 ```
 
 @param {string} name cookie name.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeCurrentUrlEquals.mustache
+++ b/docs/webapi/dontSeeCurrentUrlEquals.mustache
@@ -7,3 +7,4 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 ```
 
 @param {string} url value to check.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeElement.mustache
+++ b/docs/webapi/dontSeeElement.mustache
@@ -5,3 +5,4 @@ I.dontSeeElement('.modal'); // modal is not shown
 ```
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|Strict locator.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeElementInDOM.mustache
+++ b/docs/webapi/dontSeeElementInDOM.mustache
@@ -5,3 +5,4 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 ```
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|Strict locator.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeInCurrentUrl.mustache
+++ b/docs/webapi/dontSeeInCurrentUrl.mustache
@@ -1,3 +1,4 @@
 Checks that current url does not contain a provided fragment.
 
 @param {string} url value to check.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeInField.mustache
+++ b/docs/webapi/dontSeeInField.mustache
@@ -8,3 +8,4 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
 @param {string} value value to check.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeInSource.mustache
+++ b/docs/webapi/dontSeeInSource.mustache
@@ -5,3 +5,4 @@ I.dontSeeInSource('<!--'); // no comments in source
 ```
 
 @param {string} value to check.
+@return {Promise<any>}

--- a/docs/webapi/dontSeeInTitle.mustache
+++ b/docs/webapi/dontSeeInTitle.mustache
@@ -5,3 +5,4 @@ I.dontSeeInTitle('Error');
 ```
 
 @param {string} text value to check.
+@return {Promise<any>}

--- a/docs/webapi/doubleClick.mustache
+++ b/docs/webapi/doubleClick.mustache
@@ -10,3 +10,4 @@ I.doubleClick('.btn.edit');
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+@return {Promise<any>}

--- a/docs/webapi/downloadFile.mustache
+++ b/docs/webapi/downloadFile.mustache
@@ -9,3 +9,4 @@ I.downloadFile('td[class="text-right file-link"] a', 'thisIsCustomName');
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by CSS|XPath locator.
 @param {string} file custom file name.
+@return {Promise<any>}

--- a/docs/webapi/dragAndDrop.mustache
+++ b/docs/webapi/dragAndDrop.mustache
@@ -6,3 +6,4 @@ I.dragAndDrop('#dragHandle', '#container');
 
 @param {LocatorOrString} srcElement located by CSS|XPath|strict locator.
 @param {LocatorOrString} destElement located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/dragSlider.mustache
+++ b/docs/webapi/dragSlider.mustache
@@ -8,3 +8,4 @@ I.dragSlider('#slider', -70);
 
 @param {CodeceptJS.LocatorOrString} locator located by label|name|CSS|XPath|strict locator.
 @param {number} offsetX position to drag.
+@return {Promise<any>}

--- a/docs/webapi/fillField.mustache
+++ b/docs/webapi/fillField.mustache
@@ -13,3 +13,4 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
 @param {CodeceptJS.StringOrSecret} value text value to fill.
+@return {Promise<any>}

--- a/docs/webapi/forceClick.mustache
+++ b/docs/webapi/forceClick.mustache
@@ -25,3 +25,4 @@ I.forceClick({css: 'nav a.login'});
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+@return {Promise<any>}

--- a/docs/webapi/forceRightClick.mustache
+++ b/docs/webapi/forceRightClick.mustache
@@ -15,3 +15,4 @@ I.forceRightClick('Menu');
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+@return {Promise<any>}

--- a/docs/webapi/grabDataFromPerformanceTiming.mustache
+++ b/docs/webapi/grabDataFromPerformanceTiming.mustache
@@ -17,3 +17,4 @@ let data = await I.grabDataFromPerformanceTiming();
   loadEventEnd: 241
 }
 ```
+@return {Promise<any>}

--- a/docs/webapi/moveCursorTo.mustache
+++ b/docs/webapi/moveCursorTo.mustache
@@ -9,3 +9,4 @@ I.moveCursorTo('#submit', 5,5);
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {number} [offsetX=0] (optional, `0` by default) X-axis offset.
 @param {number} [offsetY=0] (optional, `0` by default) Y-axis offset.
+@return {Promise<any>}

--- a/docs/webapi/openNewTab.mustache
+++ b/docs/webapi/openNewTab.mustache
@@ -1,5 +1,7 @@
- Open new tab and switch to it.
+Open new tab and switch to it.
 
- ```js
- I.openNewTab();
- ```
+```js
+I.openNewTab();
+```
+
+@return {Promise<any>}

--- a/docs/webapi/pressKey.mustache
+++ b/docs/webapi/pressKey.mustache
@@ -9,3 +9,4 @@ I.pressKey(['Control','a']);
 ```
 
 @param {string|string[]} key key or array of keys to press.
+@return {Promise<any>}

--- a/docs/webapi/pressKeyDown.mustache
+++ b/docs/webapi/pressKeyDown.mustache
@@ -9,3 +9,4 @@ I.pressKeyUp('Control');
 ```
 
 @param {string} key name of key to press down.
+@return {Promise<any>}

--- a/docs/webapi/pressKeyUp.mustache
+++ b/docs/webapi/pressKeyUp.mustache
@@ -9,3 +9,4 @@ I.pressKeyUp('Control');
 ```
 
 @param {string} key name of key to release.
+@return {Promise<any>}

--- a/docs/webapi/pressKeyWithKeyNormalization.mustache
+++ b/docs/webapi/pressKeyWithKeyNormalization.mustache
@@ -57,3 +57,4 @@ Some of the supported key names are:
 - `'Tab'`
 
 @param {string|string[]} key key or array of keys to press.
+@return {Promise<any>}

--- a/docs/webapi/refreshPage.mustache
+++ b/docs/webapi/refreshPage.mustache
@@ -3,3 +3,4 @@ Reload the current page.
 ```js
 I.refreshPage();
 ```
+@return {Promise<any>}

--- a/docs/webapi/resizeWindow.mustache
+++ b/docs/webapi/resizeWindow.mustache
@@ -3,3 +3,4 @@ First parameter can be set to `maximize`.
 
 @param {number} width width in pixels or `maximize`.
 @param {number} height height in pixels.
+@return {Promise<any>}

--- a/docs/webapi/rightClick.mustache
+++ b/docs/webapi/rightClick.mustache
@@ -11,3 +11,4 @@ I.rightClick('Click me', '.context');
 
 @param {CodeceptJS.LocatorOrString} locator clickable element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/saveElementScreenshot.mustache
+++ b/docs/webapi/saveElementScreenshot.mustache
@@ -7,3 +7,4 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {string} fileName file name to save.
+@return {Promise<any>}

--- a/docs/webapi/saveScreenshot.mustache
+++ b/docs/webapi/saveScreenshot.mustache
@@ -9,3 +9,4 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 
 @param {string} fileName file name to save.
 @param {boolean} [fullPage=false] (optional, `false` by default) flag to enable fullscreen screenshot mode.
+@return {Promise<any>}

--- a/docs/webapi/say.mustache
+++ b/docs/webapi/say.mustache
@@ -7,3 +7,4 @@ I.say('This is by default'); //cyan is used
 ```
 @param {string} text expected on console log.
 @param {string} [color='cyan'] color you want to use.
+@return {Promise<any>}

--- a/docs/webapi/scrollIntoView.mustache
+++ b/docs/webapi/scrollIntoView.mustache
@@ -8,3 +8,4 @@ I.scrollIntoView('#submit', { behavior: "smooth", block: "center", inline: "cent
 
 @param {LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {ScrollIntoViewOptions} scrollIntoViewOptions see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView.
+@return {Promise<any>}

--- a/docs/webapi/scrollPageToBottom.mustache
+++ b/docs/webapi/scrollPageToBottom.mustache
@@ -3,3 +3,4 @@ Scroll page to the bottom.
 ```js
 I.scrollPageToBottom();
 ```
+@return {Promise<any>}

--- a/docs/webapi/scrollPageToTop.mustache
+++ b/docs/webapi/scrollPageToTop.mustache
@@ -3,3 +3,4 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
+@return {Promise<any>}

--- a/docs/webapi/scrollTo.mustache
+++ b/docs/webapi/scrollTo.mustache
@@ -9,3 +9,4 @@ I.scrollTo('#submit', 5, 5);
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {number} [offsetX=0] (optional, `0` by default) X-axis offset.
 @param {number} [offsetY=0] (optional, `0` by default) Y-axis offset.
+@return {Promise<any>}

--- a/docs/webapi/see.mustache
+++ b/docs/webapi/see.mustache
@@ -8,3 +8,4 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 ```
 @param {string} text expected on page.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text.
+@return {Promise<any>}

--- a/docs/webapi/seeAttributesOnElements.mustache
+++ b/docs/webapi/seeAttributesOnElements.mustache
@@ -6,3 +6,4 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {object} attributes attributes and their values to check.
+@return {Promise<any>}

--- a/docs/webapi/seeCheckboxIsChecked.mustache
+++ b/docs/webapi/seeCheckboxIsChecked.mustache
@@ -7,3 +7,4 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 ```
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/seeCookie.mustache
+++ b/docs/webapi/seeCookie.mustache
@@ -5,3 +5,4 @@ I.seeCookie('Auth');
 ```
 
 @param {string} name cookie name.
+@return {Promise<any>}

--- a/docs/webapi/seeCssPropertiesOnElements.mustache
+++ b/docs/webapi/seeCssPropertiesOnElements.mustache
@@ -6,3 +6,4 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {object} cssProperties object with CSS properties and their values to check.
+@return {Promise<any>}

--- a/docs/webapi/seeCurrentUrlEquals.mustache
+++ b/docs/webapi/seeCurrentUrlEquals.mustache
@@ -8,3 +8,4 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 ```
 
 @param {string} url value to check.
+@return {Promise<any>}

--- a/docs/webapi/seeElement.mustache
+++ b/docs/webapi/seeElement.mustache
@@ -5,3 +5,4 @@ Element is located by CSS or XPath.
 I.seeElement('#modal');
 ```
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/seeElementInDOM.mustache
+++ b/docs/webapi/seeElementInDOM.mustache
@@ -5,3 +5,4 @@ Element is located by CSS or XPath.
 I.seeElementInDOM('#modal');
 ```
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/seeInCurrentUrl.mustache
+++ b/docs/webapi/seeInCurrentUrl.mustache
@@ -5,3 +5,4 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 ```
 
 @param {string} url a fragment to check
+@return {Promise<any>}

--- a/docs/webapi/seeInField.mustache
+++ b/docs/webapi/seeInField.mustache
@@ -9,3 +9,4 @@ I.seeInField('#searchform input','Search');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
 @param {string} value value to check.
+@return {Promise<any>}

--- a/docs/webapi/seeInPopup.mustache
+++ b/docs/webapi/seeInPopup.mustache
@@ -5,3 +5,4 @@ given string.
 I.seeInPopup('Popup text');
 ```
 @param {string} text value to check.
+@return {Promise<any>}

--- a/docs/webapi/seeInSource.mustache
+++ b/docs/webapi/seeInSource.mustache
@@ -4,3 +4,4 @@ Checks that the current page contains the given string in its raw source code.
 I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 ```
 @param {string} text value to check.
+@return {Promise<any>}

--- a/docs/webapi/seeInTitle.mustache
+++ b/docs/webapi/seeInTitle.mustache
@@ -5,3 +5,4 @@ I.seeInTitle('Home Page');
 ```
 
 @param {string} text text value to check.
+@return {Promise<any>}

--- a/docs/webapi/seeNumberOfElements.mustache
+++ b/docs/webapi/seeNumberOfElements.mustache
@@ -8,3 +8,4 @@ I.seeNumberOfElements('#submitBtn', 1);
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} num number of elements.
+@return {Promise<any>}

--- a/docs/webapi/seeNumberOfVisibleElements.mustache
+++ b/docs/webapi/seeNumberOfVisibleElements.mustache
@@ -7,3 +7,4 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} num number of elements.
+@return {Promise<any>}

--- a/docs/webapi/seeTextEquals.mustache
+++ b/docs/webapi/seeTextEquals.mustache
@@ -6,3 +6,4 @@ I.seeTextEquals('text', 'h1');
 
 @param {string} text element value to check.
 @param {CodeceptJS.LocatorOrString?} [context=null]  element located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/seeTitleEquals.mustache
+++ b/docs/webapi/seeTitleEquals.mustache
@@ -1,7 +1,8 @@
- Checks that title is equal to provided one.
+Checks that title is equal to provided one.
 
- ```js
- I.seeTitleEquals('Test title.');
- ```
+```js
+I.seeTitleEquals('Test title.');
+```
 
- @param {string} text value to check.
+@param {string} text value to check.
+@return {Promise<any>}

--- a/docs/webapi/selectOption.mustache
+++ b/docs/webapi/selectOption.mustache
@@ -18,3 +18,4 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 ```
 @param {LocatorOrString} select field located by label|name|CSS|XPath|strict locator.
 @param {string|Array<*>} option visible text or value of option.
+@return {Promise<any>}

--- a/docs/webapi/setCookie.mustache
+++ b/docs/webapi/setCookie.mustache
@@ -13,3 +13,4 @@ I.setCookie([
 ```
 
 @param {Cookie|Array<Cookie>} cookie a cookie object or array of cookie objects.
+@return {Promise<any>}

--- a/docs/webapi/setGeoLocation.mustache
+++ b/docs/webapi/setGeoLocation.mustache
@@ -9,3 +9,4 @@ I.setGeoLocation(121.21, 11.56, 10);
 @param {number} latitude to set.
 @param {number} longitude to set
 @param {number=} altitude (optional, null by default) to set
+@return {Promise<any>}

--- a/docs/webapi/switchTo.mustache
+++ b/docs/webapi/switchTo.mustache
@@ -6,3 +6,4 @@ I.switchTo(); // switch back to main page
 ```
 
 @param {?CodeceptJS.LocatorOrString} [locator=null] (optional, `null` by default) element located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/switchToNextTab.mustache
+++ b/docs/webapi/switchToNextTab.mustache
@@ -1,9 +1,10 @@
- Switch focus to a particular tab by its number. It waits tabs loading and then switch tab.
+Switch focus to a particular tab by its number. It waits tabs loading and then switch tab.
 
- ```js
- I.switchToNextTab();
- I.switchToNextTab(2);
- ```
+```js
+I.switchToNextTab();
+I.switchToNextTab(2);
+```
 
- @param {number} [num] (optional) number of tabs to switch forward, default: 1.
- @param {number | null} [sec] (optional) time in seconds to wait.
+@param {number} [num] (optional) number of tabs to switch forward, default: 1.
+@param {number | null} [sec] (optional) time in seconds to wait.
+@return {Promise<any>}

--- a/docs/webapi/switchToPreviousTab.mustache
+++ b/docs/webapi/switchToPreviousTab.mustache
@@ -1,9 +1,10 @@
- Switch focus to a particular tab by its number. It waits tabs loading and then switch tab.
+Switch focus to a particular tab by its number. It waits tabs loading and then switch tab.
 
- ```js
- I.switchToPreviousTab();
- I.switchToPreviousTab(2);
- ```
+```js
+I.switchToPreviousTab();
+I.switchToPreviousTab(2);
+```
 
- @param {number} [num] (optional) number of tabs to switch backward, default: 1.
- @param {number?} [sec] (optional) time in seconds to wait.
+@param {number} [num] (optional) number of tabs to switch backward, default: 1.
+@param {number?} [sec] (optional) time in seconds to wait.
+@return {Promise<any>}

--- a/docs/webapi/type.mustache
+++ b/docs/webapi/type.mustache
@@ -15,3 +15,4 @@ I.type(['T', 'E', 'X', 'T']);
 
 @param {string|string[]} key or array of keys to type.
 @param {?number} [delay=null] (optional) delay in ms between key presses
+@return {Promise<any>}

--- a/docs/webapi/uncheckOption.mustache
+++ b/docs/webapi/uncheckOption.mustache
@@ -10,3 +10,4 @@ I.uncheckOption('agree', '//form');
 ```
 @param {CodeceptJS.LocatorOrString} field checkbox located by label | name | CSS | XPath | strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS | XPath | strict locator.
+@return {Promise<any>}

--- a/docs/webapi/wait.mustache
+++ b/docs/webapi/wait.mustache
@@ -5,3 +5,4 @@ I.wait(2); // wait 2 secs
 ```
 
 @param {number} sec number of second to wait.
+@return {Promise<any>}

--- a/docs/webapi/waitForClickable.mustache
+++ b/docs/webapi/waitForClickable.mustache
@@ -8,3 +8,4 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitForDetached.mustache
+++ b/docs/webapi/waitForDetached.mustache
@@ -7,3 +7,4 @@ I.waitForDetached('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitForElement.mustache
+++ b/docs/webapi/waitForElement.mustache
@@ -8,3 +8,4 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitForEnabled.mustache
+++ b/docs/webapi/waitForEnabled.mustache
@@ -3,3 +3,4 @@ Element can be located by CSS or XPath.
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional) time in seconds to wait, 1 by default.
+@return {Promise<any>}

--- a/docs/webapi/waitForFunction.mustache
+++ b/docs/webapi/waitForFunction.mustache
@@ -14,3 +14,4 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 @param {string|function} fn to be executed in browser context.
 @param {any[]|number} [argsOrSec] (optional, `1` by default) arguments for function or seconds.
 @param {number} [sec] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitForInvisible.mustache
+++ b/docs/webapi/waitForInvisible.mustache
@@ -7,3 +7,4 @@ I.waitForInvisible('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitForText.mustache
+++ b/docs/webapi/waitForText.mustache
@@ -10,3 +10,4 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 @param {string }text to wait for.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
 @param {CodeceptJS.LocatorOrString} [context] (optional) element located by CSS|XPath|strict locator.
+@return {Promise<any>}

--- a/docs/webapi/waitForValue.mustache
+++ b/docs/webapi/waitForValue.mustache
@@ -7,3 +7,4 @@ I.waitForValue('//input', "GoodValue");
 @param {LocatorOrString} field input field.
 @param {string }value expected value.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitForVisible.mustache
+++ b/docs/webapi/waitForVisible.mustache
@@ -7,3 +7,4 @@ I.waitForVisible('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitInUrl.mustache
+++ b/docs/webapi/waitInUrl.mustache
@@ -6,3 +6,4 @@ I.waitInUrl('/info', 2);
 
 @param {string} urlPart value to check.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitNumberOfVisibleElements.mustache
+++ b/docs/webapi/waitNumberOfVisibleElements.mustache
@@ -7,3 +7,4 @@ I.waitNumberOfVisibleElements('a', 3);
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} num number of elements.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitToHide.mustache
+++ b/docs/webapi/waitToHide.mustache
@@ -7,3 +7,4 @@ I.waitToHide('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/docs/webapi/waitUrlEquals.mustache
+++ b/docs/webapi/waitUrlEquals.mustache
@@ -7,3 +7,4 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 @param {string} urlPart value to check.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
+@return {Promise<any>}

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -492,6 +492,7 @@ class Appium extends Webdriver {
    *
    * @param {string} appId
    * @param {string} [bundleId] ID of bundle
+   * @return {Promise<any>}
    */
   async removeApp(appId, bundleId) {
     onlyForApps.call(this, 'Android');
@@ -728,7 +729,7 @@ class Appium extends Webdriver {
    * Switch to the specified context.
    *
    * @param {*} context the context to switch to
-
+   * @return {Promise<any>}
    */
   async _switchToContext(context) {
     return this.browser.switchContext(context);
@@ -859,6 +860,7 @@ class Appium extends Webdriver {
    *
    * @param {'tapOutside' | 'pressKey'} [strategy] Desired strategy to close keyboard (‘tapOutside’ or ‘pressKey’)
    * @param {string} [key] Optional key
+   * @return {Promise<any>}
    */
   async hideDeviceKeyboard(strategy, key) {
     onlyForApps.call(this);
@@ -981,6 +983,7 @@ class Appium extends Webdriver {
    *
    * @param {object} from
    * @param {object} to
+   * @return {Promise<any>}
    *
    * Appium: support Android and iOS
    */
@@ -1213,6 +1216,7 @@ class Appium extends Webdriver {
    * Appium: support Android and iOS
    *
    * @param {Array} actions Array of touch actions
+   * @return {Promise<any>}
    */
   async touchPerform(actions) {
     onlyForApps.call(this);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -539,6 +539,7 @@ class Playwright extends Helper {
   *
   * @param {string} description used to show in logs.
   * @param {function} fn async function that executed with Playwright helper as argument
+  * @return {Promise<any>}
   */
   usePlaywrightTo(description, fn) {
     return this._useTo(...arguments);
@@ -553,6 +554,7 @@ class Playwright extends Helper {
    * I.click('#triggerPopup');
    * I.acceptPopup();
    * ```
+   * @return {Promise<any>}
    */
   amAcceptingPopups() {
     popupStore.actionType = 'accept';
@@ -562,6 +564,7 @@ class Playwright extends Helper {
    * Accepts the active JavaScript native popup window, as created by window.alert|window.confirm|window.prompt.
    * Don't confuse popups with modal windows, as created by [various
    * libraries](http://jster.net/category/windows-modals-popups).
+   * @return {Promise<any>}
    */
   acceptPopup() {
     popupStore.assertPopupActionType('accept');
@@ -576,6 +579,7 @@ class Playwright extends Helper {
    * I.click('#triggerPopup');
    * I.cancelPopup();
    * ```
+   * @return {Promise<any>}
    */
   amCancellingPopups() {
     popupStore.actionType = 'cancel';
@@ -583,6 +587,7 @@ class Playwright extends Helper {
 
   /**
    * Dismisses the active JavaScript popup, as created by window.alert|window.confirm|window.prompt.
+   * @return {Promise<any>}
    */
   cancelPopup() {
     popupStore.assertPopupActionType('cancel');
@@ -600,6 +605,7 @@ class Playwright extends Helper {
   /**
    * Set current page
    * @param {object} page page to set
+   * @return {Promise<any>}
    */
   async _setPage(page) {
     page = await page;
@@ -624,6 +630,7 @@ class Playwright extends Helper {
   /**
    * Add the 'dialog' event listener to a page
    * @page {playwright.Page}
+   * @return {Promise<any>}
    *
    * The popup listener handles the dialog with the predefined action when it appears on the page.
    * It also saves a reference to the object which is used in seeInPopup.
@@ -654,6 +661,7 @@ class Playwright extends Helper {
 
   /**
    * Gets page URL including hash.
+   * @return {Promise<any>}
    */
   async _getPageUrl() {
     return this.executeScript(() => window.location.href);
@@ -826,6 +834,7 @@ class Playwright extends Helper {
    * ```
    *
    * @param {object} customHeaders headers to set
+   * @return {Promise<any>}
    */
   async haveRequestHeaders(customHeaders) {
     if (!customHeaders) {
@@ -886,7 +895,7 @@ class Playwright extends Helper {
   /**
    * {{> scrollPageToBottom }}
    */
-  scrollPageToBottom() {
+  async scrollPageToBottom() {
     return this.executeScript(() => {
       const body = document.body;
       const html = document.documentElement;
@@ -972,8 +981,7 @@ class Playwright extends Helper {
    * ```js
    * const elements = await this.helpers['Playwright']._locate({name: 'password'});
    * ```
-   *
-   *
+   * @return {Promise<any>}
    */
   async _locate(locator) {
     const context = await this.context || await this._getContext();
@@ -987,6 +995,7 @@ class Playwright extends Helper {
    * ```js
    * this.helpers['Playwright']._locateCheckable('I agree with terms and conditions').then // ...
    * ```
+   * @return {Promise<any>}
    */
   async _locateCheckable(locator, providedContext = null) {
     const context = providedContext || await this._getContext();
@@ -1001,6 +1010,7 @@ class Playwright extends Helper {
    * ```js
    * this.helpers['Playwright']._locateClickable('Next page').then // ...
    * ```
+   * @return {Promise<any>}
    */
   async _locateClickable(locator) {
     const context = await this._getContext();
@@ -1013,6 +1023,7 @@ class Playwright extends Helper {
    * ```js
    * this.helpers['Playwright']._locateFields('Your email').then // ...
    * ```
+   * @return {Promise<any>}
    */
   async _locateFields(locator) {
     return findFields.call(this, locator);
@@ -1027,6 +1038,7 @@ class Playwright extends Helper {
    * ```
    *
    * @param {number} [num=1]
+   * @return {Promise<any>}
    */
   async switchToNextTab(num = 1) {
     if (this.isElectron) {
@@ -1053,6 +1065,7 @@ class Playwright extends Helper {
    * I.switchToPreviousTab(2);
    * ```
    * @param {number} [num=1]
+   * @return {Promise<any>}
    */
   async switchToPreviousTab(num = 1) {
     if (this.isElectron) {
@@ -1077,6 +1090,7 @@ class Playwright extends Helper {
    * ```js
    * I.closeCurrentTab();
    * ```
+   * @return {Promise<any>}
    */
   async closeCurrentTab() {
     if (this.isElectron) {
@@ -1094,6 +1108,7 @@ class Playwright extends Helper {
    * ```js
    * I.closeOtherTabs();
    * ```
+   * @return {Promise<any>}
    */
   async closeOtherTabs() {
     const pages = await this.browserContext.pages();
@@ -1118,6 +1133,7 @@ class Playwright extends Helper {
    * // enable mobile
    * I.openNewTab({ isMobile: true });
    * ```
+   * @return {Promise<any>}
    */
   async openNewTab(options) {
     if (this.isElectron) {
@@ -1186,6 +1202,7 @@ class Playwright extends Helper {
    * ```
    *
    * @param {string} [fileName] set filename for downloaded file
+   * @return {Promise<void>}
    */
   async handleDownloads(fileName = 'downloads') {
     this.page.waitForEvent('download').then(async (download) => {
@@ -1223,6 +1240,7 @@ class Playwright extends Helper {
 
   /**
    * Clicks link and waits for navigation (deprecated)
+   * @return {Promise<any>}
    */
   async clickLink(locator, context = null) {
     console.log('clickLink deprecated: Playwright automatically waits for navigation to happen.');
@@ -2270,6 +2288,7 @@ class Playwright extends Helper {
    *
    * @param {string|function} urlOrPredicate
    * @param {?number} [sec=null] seconds to wait
+   * @return {Promise<any>}
    */
   async waitForRequest(urlOrPredicate, sec = null) {
     const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
@@ -2286,6 +2305,7 @@ class Playwright extends Helper {
    *
    * @param {string|function} urlOrPredicate
    * @param {?number} [sec=null] number of seconds to wait
+   * @return {Promise<any>}
    */
   async waitForResponse(urlOrPredicate, sec = null) {
     const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
@@ -2357,6 +2377,7 @@ class Playwright extends Helper {
    * See [Playwright's reference](https://playwright.dev/docs/api/class-page?_highlight=waitfornavi#pagewaitfornavigationoptions)
    *
    * @param {*} opts
+   * @return {Promise<any>}
    */
   async waitForNavigation(opts = {}) {
     opts = {
@@ -2429,7 +2450,7 @@ class Playwright extends Helper {
   *
   * @param {string} [url] URL, regex or pattern for to match URL
   * @param {function} [handler] a function to process request
-  *
+  * @return {Promise<any>}
   */
   async mockRoute(url, handler) {
     return this.browserContext.route(...arguments);
@@ -2446,7 +2467,7 @@ class Playwright extends Helper {
   *
   * @param {string} [url] URL, regex or pattern for to match URL
   * @param {function} [handler] a function to process request
-  *
+  * @return {Promise<any>}
   */
   async stopMockingRoute(url, handler) {
     return this.browserContext.unroute(...arguments);

--- a/typings/tests/helpers/Appium.types.ts
+++ b/typings/tests/helpers/Appium.types.ts
@@ -1,17 +1,88 @@
 const appium = new CodeceptJS.Appium();
 
-appium.touchPerform(); // $ExpectError
-appium.touchPerform('press'); // $ExpectError
-appium.touchPerform([{ action: 'press' }]); // $ExpectType void
-appium.touchPerform([{ action: 'press' }, { action: 'release' }]); // $ExpectType void
-appium.touchPerform([{ action: 'press' }], [{ action: 'release' }]); // $ExpectError
+const str_ap = "text";
+const num_ap = 1;
 
-appium.hideDeviceKeyboard(); // $ExpectType void
-appium.hideDeviceKeyboard('tapOutside'); // $ExpectType void
-appium.hideDeviceKeyboard('pressKey', 'Done'); // $ExpectType void
-appium.hideDeviceKeyboard('pressKey', 'Done', 'Done'); // $ExpectError
+appium.touchPerform(); // $ExpectError
+appium.touchPerform("press"); // $ExpectError
+appium.touchPerform([{ action: "press" }]); // $ExpectType Promise<any>
+appium.touchPerform([{ action: "press" }, { action: "release" }]); // $ExpectType Promise<any>
+appium.touchPerform([{ action: "press" }], [{ action: "release" }]); // $ExpectError
+
+appium.hideDeviceKeyboard(); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard("tapOutside"); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard("pressKey", "Done"); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard("pressKey", "Done", "Done"); // $ExpectError
 
 appium.removeApp(); // $ExpectError
-appium.removeApp('appName'); // $ExpectType void
-appium.removeApp('appName', 'com.example.android.apis'); // $ExpectType void
-appium.removeApp('appName', 'com.example.android.apis', 'remove'); // $ExpectError
+appium.removeApp("appName"); // $ExpectType Promise<any>
+appium.removeApp("appName", "com.example.android.apis"); // $ExpectType Promise<any>
+appium.removeApp("appName", "com.example.android.apis", "remove"); // $ExpectError
+
+appium.runOnIOS(str_ap, () => {}); // $ExpectType Promise<any>
+appium.runOnAndroid(str_ap, () => {}); // $ExpectType Promise<any>
+appium.seeAppIsInstalled(str_ap); // $ExpectType Promise<void>
+appium.seeAppIsNotInstalled(str_ap); // $ExpectType Promise<void>
+appium.installApp(str_ap); // $ExpectType Promise<void>
+appium.removeApp(str_ap); // $ExpectType Promise<any>
+appium.seeCurrentActivityIs(str_ap); // $ExpectType Promise<void>
+appium.seeDeviceIsLocked(); // $ExpectType Promise<void>
+appium.seeDeviceIsUnlocked(); // $ExpectType Promise<void>
+appium.seeOrientationIs("LANDSCAPE"); // $ExpectType Promise<void>
+appium.setOrientation("LANDSCAPE"); // $ExpectType Promise<any>
+appium.grabAllContexts(); // $ExpectType Promise<string[]>
+appium.grabContext(); // $ExpectType Promise<string | null>
+appium.grabCurrentActivity(); // $ExpectType Promise<string>
+appium.grabNetworkConnection(); // $ExpectType Promise<{}>
+appium.grabOrientation(); // $ExpectType Promise<string>
+appium.grabSettings(); // $ExpectType Promise<string>
+appium._switchToContext(str_ap); // $ExpectType Promise<any>
+appium.switchToWeb(); // $ExpectType Promise<void>
+appium.switchToNative(str_ap); // $ExpectType Promise<void>
+appium.startActivity(); // $ExpectType Promise<void>
+appium.setNetworkConnection(); // $ExpectType Promise<{}>
+appium.setSettings(str_ap); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard(); // $ExpectType Promise<any>
+appium.sendDeviceKeyEvent(num_ap); // $ExpectType Promise<void>
+appium.openNotifications(); // $ExpectType Promise<void>
+appium.makeTouchAction(); // $ExpectType Promise<void>
+appium.tap(str_ap); // $ExpectType Promise<void>
+appium.performSwipe(str_ap, str_ap); // $ExpectType Promise<any>
+appium.swipeDown(str_ap); // $ExpectType Promise<void>
+appium.swipeLeft(str_ap); // $ExpectType Promise<void>
+appium.swipeRight(str_ap); // $ExpectType Promise<void>
+appium.swipeUp(str_ap); // $ExpectType Promise<void>
+appium.swipeTo(str_ap, str_ap, str_ap, num_ap, num_ap, num_ap); // $ExpectType Promise<void>
+appium.touchPerform([]); // $ExpectType Promise<any>
+appium.pullFile(str_ap, str_ap); // $ExpectType Promise<string>
+appium.shakeDevice(); // $ExpectType Promise<void>
+appium.rotate(); // $ExpectType Promise<void>
+appium.setImmediateValue(); // $ExpectType Promise<void>
+appium.simulateTouchId(); // $ExpectType Promise<void>
+appium.closeApp(); // $ExpectType Promise<void>
+appium.appendField(str_ap, str_ap); // $ExpectType Promise<any>
+appium.checkOption(str_ap); // $ExpectType Promise<any>
+appium.click(str_ap); // $ExpectType Promise<any>
+appium.dontSeeCheckboxIsChecked(str_ap); // $ExpectType Promise<any>
+appium.dontSeeElement(str_ap); // $ExpectType Promise<any>
+appium.dontSeeInField(str_ap, str_ap); // $ExpectType Promise<any>
+appium.dontSee(str_ap); // $ExpectType Promise<any>
+appium.fillField(str_ap, str_ap); // $ExpectType Promise<any>
+appium.grabTextFromAll(str_ap); // $ExpectType Promise<string[]>
+appium.grabTextFrom(str_ap); // $ExpectType Promise<string>
+appium.grabNumberOfVisibleElements(str_ap); // $ExpectType Promise<number>
+appium.grabAttributeFrom(str_ap, str_ap); // $ExpectType Promise<string>
+appium.grabAttributeFromAll(str_ap, str_ap); // $ExpectType Promise<string[]>
+appium.grabValueFromAll(str_ap); // $ExpectType Promise<string[]>
+appium.grabValueFrom(str_ap); // $ExpectType Promise<string>
+appium.saveScreenshot(str_ap); // $ExpectType Promise<void>
+appium.scrollIntoView(str_ap, {}); // $ExpectType Promise<any>
+appium.seeCheckboxIsChecked(str_ap); // $ExpectType Promise<any>
+appium.seeElement(str_ap); // $ExpectType Promise<any>
+appium.seeInField(str_ap, str_ap); // $ExpectType Promise<any>
+appium.see(str_ap); // $ExpectType Promise<any>
+appium.selectOption(str_ap, str_ap); // $ExpectType Promise<any>
+appium.waitForElement(str_ap); // $ExpectType Promise<any>
+appium.waitForVisible(str_ap); // $ExpectType Promise<any>
+appium.waitForInvisible(str_ap); // $ExpectType Promise<any>
+appium.waitForText(str_ap); // $ExpectType Promise<any>

--- a/typings/tests/helpers/Playwright.types.ts
+++ b/typings/tests/helpers/Playwright.types.ts
@@ -1,0 +1,123 @@
+const playwright = new CodeceptJS.Playwright();
+
+const str_pl = 'text';
+const num_pl = 1;
+
+playwright.usePlaywrightTo(str_pl, () => {}); // $ExpectType Promise<any>
+playwright.amAcceptingPopups(); // $ExpectType Promise<any>
+playwright.acceptPopup(); // $ExpectType Promise<any>
+playwright.amCancellingPopups(); // $ExpectType Promise<any>
+playwright.cancelPopup(); // $ExpectType Promise<any>
+playwright.seeInPopup(str_pl); // $ExpectType Promise<any>
+playwright._setPage(str_pl); // $ExpectType Promise<any>
+playwright._addPopupListener(); // $ExpectType Promise<any>
+playwright._getPageUrl(); // $ExpectType Promise<any>
+playwright.grabPopupText(); // $ExpectType Promise<string | null>
+playwright.amOnPage(str_pl); // $ExpectType Promise<any>
+playwright.resizeWindow(num_pl, num_pl); // $ExpectType Promise<any>
+playwright.haveRequestHeaders(str_pl); // $ExpectType Promise<any>
+playwright.moveCursorTo(str_pl, num_pl, num_pl); // $ExpectType Promise<any>
+playwright.dragAndDrop(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.refreshPage(); // $ExpectType Promise<any>
+playwright.scrollPageToTop(); // $ExpectType Promise<any>
+playwright.scrollPageToBottom(); // $ExpectType Promise<any>
+playwright.scrollTo(str_pl, num_pl, num_pl); // $ExpectType Promise<any>
+playwright.seeInTitle(str_pl); // $ExpectType Promise<any>
+playwright.grabPageScrollPosition(); // $ExpectType Promise<PageScrollPosition>
+playwright.seeTitleEquals(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeInTitle(str_pl); // $ExpectType Promise<any>
+playwright.grabTitle(); // $ExpectType Promise<string>
+playwright._locate(); // $ExpectType Promise<any>
+playwright._locateCheckable(); // $ExpectType Promise<any>
+playwright._locateClickable(); // $ExpectType Promise<any>
+playwright._locateFields(); // $ExpectType Promise<any>
+playwright.switchToNextTab(); // $ExpectType Promise<any>
+playwright.switchToPreviousTab(); // $ExpectType Promise<any>
+playwright.closeCurrentTab(); // $ExpectType Promise<any>
+playwright.closeOtherTabs(); // $ExpectType Promise<any>
+playwright.openNewTab(); // $ExpectType Promise<any>
+playwright.grabNumberOfOpenTabs(); // $ExpectType Promise<number>
+playwright.seeElement(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeElement(str_pl); // $ExpectType Promise<any>
+playwright.seeElementInDOM(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeElementInDOM(str_pl); // $ExpectType Promise<any>
+playwright.handleDownloads(); // $ExpectType Promise<void>
+playwright.click(str_pl); // $ExpectType Promise<any>
+playwright.clickLink(); // $ExpectType Promise<any>
+playwright.forceClick(str_pl); // $ExpectType Promise<any>
+playwright.doubleClick(str_pl); // $ExpectType Promise<any>
+playwright.rightClick(str_pl); // $ExpectType Promise<any>
+playwright.checkOption(str_pl); // $ExpectType Promise<any>
+playwright.uncheckOption(str_pl); // $ExpectType Promise<any>
+playwright.seeCheckboxIsChecked(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeCheckboxIsChecked(str_pl); // $ExpectType Promise<any>
+playwright.pressKeyDown(str_pl); // $ExpectType Promise<any>
+playwright.pressKeyUp(str_pl); // $ExpectType Promise<any>
+playwright.pressKey(str_pl); // $ExpectType Promise<any>
+playwright.type(str_pl); // $ExpectType Promise<any>
+playwright.fillField(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.clearField(str_pl); // $ExpectType Promise<any>
+playwright.appendField(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.seeInField(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.dontSeeInField(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.attachFile(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.selectOption(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.grabNumberOfVisibleElements(str_pl); // $ExpectType Promise<number>
+playwright.seeInCurrentUrl(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeInCurrentUrl(str_pl); // $ExpectType Promise<any>
+playwright.seeCurrentUrlEquals(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeCurrentUrlEquals(str_pl); // $ExpectType Promise<any>
+playwright.see(str_pl); // $ExpectType Promise<any>
+playwright.seeTextEquals(str_pl); // $ExpectType Promise<any>
+playwright.dontSee(str_pl); // $ExpectType Promise<any>
+playwright.grabSource(); // $ExpectType Promise<string>
+playwright.grabBrowserLogs(); // $ExpectType Promise<any[]>
+playwright.grabCurrentUrl(); // $ExpectType Promise<string>
+playwright.seeInSource(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeInSource(str_pl); // $ExpectType Promise<any>
+playwright.seeNumberOfElements(str_pl, num_pl); // $ExpectType Promise<any>
+playwright.seeNumberOfVisibleElements(str_pl, num_pl); // $ExpectType Promise<any>
+playwright.setCookie({ name: str_pl, value: str_pl}); // $ExpectType Promise<any>
+playwright.seeCookie(str_pl); // $ExpectType Promise<any>
+playwright.dontSeeCookie(str_pl); // $ExpectType Promise<any>
+playwright.grabCookie(); // $ExpectType Promise<string[]> | Promise<string>
+playwright.clearCookie(); // $ExpectType Promise<any>
+playwright.executeScript(() => {}); // $ExpectType Promise<any>
+playwright.grabTextFrom(str_pl); // $ExpectType Promise<string>
+playwright.grabTextFromAll(str_pl); // $ExpectType Promise<string[]>
+playwright.grabValueFrom(str_pl); // $ExpectType Promise<string>
+playwright.grabValueFromAll(str_pl); // $ExpectType Promise<string[]>
+playwright.grabHTMLFrom(str_pl); // $ExpectType Promise<string>
+playwright.grabHTMLFromAll(str_pl); // $ExpectType Promise<string[]>
+playwright.grabCssPropertyFrom(str_pl, str_pl); // $ExpectType Promise<string>
+playwright.grabCssPropertyFromAll(str_pl, str_pl); // $ExpectType Promise<string[]>
+playwright.seeCssPropertiesOnElements(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.seeAttributesOnElements(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.dragSlider(str_pl, num_pl); // $ExpectType Promise<any>
+playwright.grabAttributeFrom(str_pl, str_pl); // $ExpectType Promise<string>
+playwright.grabAttributeFromAll(str_pl, str_pl); // $ExpectType Promise<string[]>
+playwright.saveElementScreenshot(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.saveScreenshot(str_pl); // $ExpectType Promise<any>
+playwright.makeApiRequest(str_pl, str_pl, str_pl); // $ExpectType Promise<object>
+playwright.wait(num_pl); // $ExpectType Promise<any>
+playwright.waitForEnabled(str_pl); // $ExpectType Promise<any>
+playwright.waitForValue(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.waitNumberOfVisibleElements(str_pl, num_pl); // $ExpectType Promise<any>
+playwright.waitForClickable(str_pl); // $ExpectType Promise<any>
+playwright.waitForElement(str_pl); // $ExpectType Promise<any>
+playwright.waitForVisible(str_pl); // $ExpectType Promise<any>
+playwright.waitForInvisible(str_pl); // $ExpectType Promise<any>
+playwright.waitToHide(str_pl); // $ExpectType Promise<any>
+playwright.waitInUrl(str_pl); // $ExpectType Promise<any>
+playwright.waitUrlEquals(str_pl); // $ExpectType Promise<any>
+playwright.waitForText(str_pl); // $ExpectType Promise<any>
+playwright.waitForRequest(str_pl); // $ExpectType Promise<any>
+playwright.waitForResponse(str_pl); // $ExpectType Promise<any>
+playwright.switchTo(); // $ExpectType Promise<any>
+playwright.waitForFunction(() => { }); // $ExpectType Promise<any>
+playwright.waitForNavigation(str_pl); // $ExpectType Promise<any>
+playwright.waitForDetached(str_pl); // $ExpectType Promise<any>
+playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<any>
+playwright.grabElementBoundingRect(str_pl); // $ExpectType Promise<number> | Promise<DOMRect>
+playwright.mockRoute(str_pl); // $ExpectType Promise<any>
+playwright.stopMockingRoute(str_pl); // $ExpectType Promise<any>

--- a/typings/tests/helpers/WebDriverIO.types.ts
+++ b/typings/tests/helpers/WebDriverIO.types.ts
@@ -1,13 +1,13 @@
 const wd = new CodeceptJS.WebDriver();
 
-const str = 'text';
-const num = 1;
+const str_wd = 'text';
+const num_wd = 1;
 
 wd.amOnPage(); // $ExpectError
-wd.amOnPage(''); // $ExpectType void
+wd.amOnPage(''); // $ExpectType Promise<any>
 
 wd.click(); // $ExpectError
-wd.click('div'); // $ExpectType void
+wd.click('div'); // $ExpectType Promise<any>
 wd.click({ css: 'div' });
 wd.click({ xpath: '//div' });
 wd.click({ name: 'div' });
@@ -25,7 +25,7 @@ wd.click('div', { android: '//div' });
 wd.click('div', { ios: '//div' });
 
 wd.forceClick(); // $ExpectError
-wd.forceClick('div'); // $ExpectType void
+wd.forceClick('div'); // $ExpectType Promise<any>
 wd.forceClick({ css: 'div' });
 wd.forceClick({ xpath: '//div' });
 wd.forceClick({ name: 'div' });
@@ -43,7 +43,7 @@ wd.forceClick('div', { android: '//div' });
 wd.forceClick('div', { ios: '//div' });
 
 wd.doubleClick(); // $ExpectError
-wd.doubleClick('div'); // $ExpectType void
+wd.doubleClick('div'); // $ExpectType Promise<any>
 wd.doubleClick({ css: 'div' });
 wd.doubleClick({ xpath: '//div' });
 wd.doubleClick({ name: 'div' });
@@ -61,7 +61,7 @@ wd.doubleClick('div', { android: '//div' });
 wd.doubleClick('div', { ios: '//div' });
 
 wd.rightClick(); // $ExpectError
-wd.rightClick('div'); // $ExpectType void
+wd.rightClick('div'); // $ExpectType Promise<any>
 wd.rightClick({ css: 'div' });
 wd.rightClick({ xpath: '//div' });
 wd.rightClick({ name: 'div' });
@@ -80,25 +80,25 @@ wd.rightClick('div', { ios: '//div' });
 
 wd.fillField(); // $ExpectError
 wd.fillField('div'); // $ExpectError
-wd.fillField('div', str); // $ExpectType void
-wd.fillField({ css: 'div' }, str);
-wd.fillField({ xpath: '//div' }, str);
-wd.fillField({ name: 'div' }, str);
-wd.fillField({ id: 'div' }, str);
-wd.fillField({ android: 'div' }, str);
-wd.fillField({ ios: 'div' }, str);
-wd.fillField(locate('div'), str);
+wd.fillField('div', str_wd); // $ExpectType Promise<any>
+wd.fillField({ css: 'div' }, str_wd);
+wd.fillField({ xpath: '//div' }, str_wd);
+wd.fillField({ name: 'div' }, str_wd);
+wd.fillField({ id: 'div' }, str_wd);
+wd.fillField({ android: 'div' }, str_wd);
+wd.fillField({ ios: 'div' }, str_wd);
+wd.fillField(locate('div'), str_wd);
 
 wd.appendField(); // $ExpectError
 wd.appendField('div'); // $ExpectError
-wd.appendField('div', str); // $ExpectType void
-wd.appendField({ css: 'div' }, str);
-wd.appendField({ xpath: '//div' }, str);
-wd.appendField({ name: 'div' }, str);
-wd.appendField({ id: 'div' }, str);
-wd.appendField({ android: 'div' }, str);
-wd.appendField({ ios: 'div' }, str);
-wd.appendField(locate('div'), str);
+wd.appendField('div', str_wd); // $ExpectType Promise<any>
+wd.appendField({ css: 'div' }, str_wd);
+wd.appendField({ xpath: '//div' }, str_wd);
+wd.appendField({ name: 'div' }, str_wd);
+wd.appendField({ id: 'div' }, str_wd);
+wd.appendField({ android: 'div' }, str_wd);
+wd.appendField({ ios: 'div' }, str_wd);
+wd.appendField(locate('div'), str_wd);
 
 wd.clearField(); // $ExpectError
 wd.clearField('div');
@@ -111,106 +111,106 @@ wd.clearField({ ios: 'div' });
 
 wd.selectOption(); // $ExpectError
 wd.selectOption('div'); // $ExpectError
-wd.selectOption('div', str); // $ExpectType void
+wd.selectOption('div', str_wd); // $ExpectType Promise<any>
 
 wd.attachFile(); // $ExpectError
 wd.attachFile('div'); // $ExpectError
-wd.attachFile('div', str); // $ExpectType void
+wd.attachFile('div', str_wd); // $ExpectType Promise<any>
 
 wd.checkOption(); // $ExpectError
-wd.checkOption('div'); // $ExpectType void
+wd.checkOption('div'); // $ExpectType Promise<any>
 
 wd.uncheckOption(); // $ExpectError
-wd.uncheckOption('div'); // $ExpectType void
+wd.uncheckOption('div'); // $ExpectType Promise<any>
 
 wd.seeInTitle(); // $ExpectError
-wd.seeInTitle(str); // $ExpectType void
+wd.seeInTitle(str_wd); // $ExpectType Promise<any>
 
 wd.seeTitleEquals(); // $ExpectError
-wd.seeTitleEquals(str); // $ExpectType void
+wd.seeTitleEquals(str_wd); // $ExpectType Promise<any>
 
 wd.dontSeeInTitle(); // $ExpectError
-wd.dontSeeInTitle(str); // $ExpectType void
+wd.dontSeeInTitle(str_wd); // $ExpectType Promise<any>
 
 wd.see(); // $ExpectError
-wd.see(str); // $ExpectType void
-wd.see(str, 'div'); // $ExpectType void
+wd.see(str_wd); // $ExpectType Promise<any>
+wd.see(str_wd, 'div'); // $ExpectType Promise<any>
 
 wd.dontSee(); // $ExpectError
-wd.dontSee(str); // $ExpectType void
-wd.dontSee(str, 'div'); // $ExpectType void
+wd.dontSee(str_wd); // $ExpectType Promise<any>
+wd.dontSee(str_wd, 'div'); // $ExpectType Promise<any>
 
 wd.seeTextEquals(); // $ExpectError
-wd.seeTextEquals(str); // $ExpectType void
-wd.seeTextEquals(str, 'div'); // $ExpectType void
+wd.seeTextEquals(str_wd); // $ExpectType Promise<any>
+wd.seeTextEquals(str_wd, 'div'); // $ExpectType Promise<any>
 
 wd.seeInField(); // $ExpectError
 wd.seeInField('div'); // $ExpectError
-wd.seeInField('div', str); // $ExpectType void
+wd.seeInField('div', str_wd); // $ExpectType Promise<any>
 
 wd.dontSeeInField(); // $ExpectError
 wd.dontSeeInField('div'); // $ExpectError
-wd.dontSeeInField('div', str); // $ExpectType void
+wd.dontSeeInField('div', str_wd); // $ExpectType Promise<any>
 
 wd.seeCheckboxIsChecked(); // $ExpectError
-wd.seeCheckboxIsChecked('div'); // $ExpectType void
+wd.seeCheckboxIsChecked('div'); // $ExpectType Promise<any>
 
 wd.dontSeeCheckboxIsChecked(); // $ExpectError
-wd.dontSeeCheckboxIsChecked('div'); // $ExpectType void
+wd.dontSeeCheckboxIsChecked('div'); // $ExpectType Promise<any>
 
 wd.seeElement(); // $ExpectError
-wd.seeElement('div'); // $ExpectType void
+wd.seeElement('div'); // $ExpectType Promise<any>
 
 wd.dontSeeElement(); // $ExpectError
-wd.dontSeeElement('div'); // $ExpectType void
+wd.dontSeeElement('div'); // $ExpectType Promise<any>
 
 wd.seeElementInDOM(); // $ExpectError
-wd.seeElementInDOM('div'); // $ExpectType void
+wd.seeElementInDOM('div'); // $ExpectType Promise<any>
 
 wd.dontSeeElementInDOM(); // $ExpectError
-wd.dontSeeElementInDOM('div'); // $ExpectType void
+wd.dontSeeElementInDOM('div'); // $ExpectType Promise<any>
 
 wd.seeInSource(); // $ExpectError
-wd.seeInSource(str); // $ExpectType void
+wd.seeInSource(str_wd); // $ExpectType Promise<any>
 
 wd.dontSeeInSource(); // $ExpectError
-wd.dontSeeInSource(str); // $ExpectType void
+wd.dontSeeInSource(str_wd); // $ExpectType Promise<any>
 
 wd.seeNumberOfElements(); // $ExpectError
 wd.seeNumberOfElements('div'); // $ExpectError
-wd.seeNumberOfElements('div', num); // $ExpectType void
+wd.seeNumberOfElements('div', num_wd); // $ExpectType Promise<any>
 
 wd.seeNumberOfVisibleElements(); // $ExpectError
 wd.seeNumberOfVisibleElements('div'); // $ExpectError
-wd.seeNumberOfVisibleElements('div', num); // $ExpectType void
+wd.seeNumberOfVisibleElements('div', num_wd); // $ExpectType Promise<any>
 
 wd.seeCssPropertiesOnElements(); // $ExpectError
 wd.seeCssPropertiesOnElements('div'); // $ExpectError
-wd.seeCssPropertiesOnElements('div', str); // $ExpectType void
+wd.seeCssPropertiesOnElements('div', str_wd); // $ExpectType Promise<any>
 
 wd.seeAttributesOnElements(); // $ExpectError
 wd.seeAttributesOnElements('div'); // $ExpectError
-wd.seeAttributesOnElements('div', str); // $ExpectType void
+wd.seeAttributesOnElements('div', str_wd); // $ExpectType Promise<any>
 
 wd.seeInCurrentUrl(); // $ExpectError
-wd.seeInCurrentUrl(str); // $ExpectType void
+wd.seeInCurrentUrl(str_wd); // $ExpectType Promise<any>
 
 wd.seeCurrentUrlEquals(); // $ExpectError
-wd.seeCurrentUrlEquals(str); // $ExpectType void
+wd.seeCurrentUrlEquals(str_wd); // $ExpectType Promise<any>
 
 wd.dontSeeInCurrentUrl(); // $ExpectError
-wd.dontSeeInCurrentUrl(str); // $ExpectType void
+wd.dontSeeInCurrentUrl(str_wd); // $ExpectType Promise<any>
 
 wd.dontSeeCurrentUrlEquals(); // $ExpectError
-wd.dontSeeCurrentUrlEquals(str); // $ExpectType void
+wd.dontSeeCurrentUrlEquals(str_wd); // $ExpectType Promise<any>
 
 wd.executeScript(); // $ExpectError
-wd.executeScript(str); // $ExpectType Promise<any>
+wd.executeScript(str_wd); // $ExpectType Promise<any>
 wd.executeScript(() => {}); // $ExpectType Promise<any>
 wd.executeScript(() => {}, {}); // $ExpectType Promise<any>
 
 wd.executeAsyncScript(); // $ExpectError
-wd.executeAsyncScript(str); // $ExpectType Promise<any>
+wd.executeAsyncScript(str_wd); // $ExpectType Promise<any>
 wd.executeAsyncScript(() => {}); // $ExpectType Promise<any>
 wd.executeAsyncScript(() => {}, {}); // $ExpectType Promise<any>
 
@@ -219,145 +219,145 @@ wd.scrollIntoView('div'); // $ExpectError
 wd.scrollIntoView('div', { behavior: 'auto', block: 'center', inline: 'center' });
 
 wd.scrollTo(); // $ExpectError
-wd.scrollTo('div'); // $ExpectType void
-wd.scrollTo('div', num, num); // $ExpectType void
+wd.scrollTo('div'); // $ExpectType Promise<any>
+wd.scrollTo('div', num_wd, num_wd); // $ExpectType Promise<any>
 
 wd.moveCursorTo(); // $ExpectError
-wd.moveCursorTo('div'); // $ExpectType void
-wd.moveCursorTo('div', num, num); // $ExpectType void
+wd.moveCursorTo('div'); // $ExpectType Promise<any>
+wd.moveCursorTo('div', num_wd, num_wd); // $ExpectType Promise<any>
 
 wd.saveScreenshot(); // $ExpectError
-wd.saveScreenshot(str); // $ExpectType void
-wd.saveScreenshot(str, true); // $ExpectType void
+wd.saveScreenshot(str_wd); // $ExpectType Promise<any>
+wd.saveScreenshot(str_wd, true); // $ExpectType Promise<any>
 
 wd.setCookie(); // $ExpectError
-wd.setCookie({ name: str, value: str }); // $ExpectType void
-wd.setCookie([{ name: str, value: str }]); // $ExpectType void
+wd.setCookie({ name: str_wd, value: str_wd }); // $ExpectType Promise<any>
+wd.setCookie([{ name: str_wd, value: str_wd }]); // $ExpectType Promise<any>
 
-wd.clearCookie(); // $ExpectType void
-wd.clearCookie(str); // $ExpectType void
+wd.clearCookie(); // $ExpectType Promise<any>
+wd.clearCookie(str_wd); // $ExpectType Promise<any>
 
 wd.seeCookie(); // $ExpectError
-wd.seeCookie(str); // $ExpectType void
+wd.seeCookie(str_wd); // $ExpectType Promise<any>
 
 wd.acceptPopup(); // $ExpectType void
 
 wd.cancelPopup(); // $ExpectType void
 
 wd.seeInPopup(); // $ExpectError
-wd.seeInPopup(str); // $ExpectType void
+wd.seeInPopup(str_wd); // $ExpectType void
 
 wd.pressKeyDown(); // $ExpectError
-wd.pressKeyDown(str); // $ExpectType void
+wd.pressKeyDown(str_wd); // $ExpectType Promise<any>
 
 wd.pressKeyUp(); // $ExpectError
-wd.pressKeyUp(str); // $ExpectType void
+wd.pressKeyUp(str_wd); // $ExpectType Promise<any>
 
 wd.pressKey(); // $ExpectError
-wd.pressKey(str); // $ExpectType void
+wd.pressKey(str_wd); // $ExpectType Promise<any>
 
 wd.type(); // $ExpectError
-wd.type(str); // $ExpectType void
+wd.type(str_wd); // $ExpectType Promise<any>
 
 wd.resizeWindow(); // $ExpectError
-wd.resizeWindow(num); // $ExpectError
-wd.resizeWindow(num, num); // $ExpectType void
+wd.resizeWindow(num_wd); // $ExpectError
+wd.resizeWindow(num_wd, num_wd); // $ExpectType Promise<any>
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('div'); // $ExpectError
-wd.dragAndDrop('div', 'div'); // $ExpectType void
+wd.dragAndDrop('div', 'div'); // $ExpectType Promise<any>
 
 wd.dragSlider(); // $ExpectError
-wd.dragSlider('div', num); // $ExpectType void
+wd.dragSlider('div', num_wd); // $ExpectType Promise<any>
 
 wd.switchToWindow(); // $ExpectError
-wd.switchToWindow(str); // $ExpectType void
+wd.switchToWindow(str_wd); // $ExpectType void
 
-wd.closeOtherTabs(); // $ExpectType void
+wd.closeOtherTabs(); // $ExpectType Promise<any>
 
 wd.wait(); // $ExpectError
-wd.wait(num); // $ExpectType void
+wd.wait(num_wd); // $ExpectType Promise<any>
 
 wd.waitForEnabled(); // $ExpectError
-wd.waitForEnabled('div'); // $ExpectType void
-wd.waitForEnabled('div', num); // $ExpectType void
+wd.waitForEnabled('div'); // $ExpectType Promise<any>
+wd.waitForEnabled('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitForElement(); // $ExpectError
-wd.waitForElement('div'); // $ExpectType void
-wd.waitForElement('div', num); // $ExpectType void
+wd.waitForElement('div'); // $ExpectType Promise<any>
+wd.waitForElement('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitForClickable(); // $ExpectError
-wd.waitForClickable('div'); // $ExpectType void
-wd.waitForClickable('div', num); // $ExpectType void
+wd.waitForClickable('div'); // $ExpectType Promise<any>
+wd.waitForClickable('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitForVisible(); // $ExpectError
-wd.waitForVisible('div'); // $ExpectType void
-wd.waitForVisible('div', num); // $ExpectType void
+wd.waitForVisible('div'); // $ExpectType Promise<any>
+wd.waitForVisible('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitForInvisible(); // $ExpectError
-wd.waitForInvisible('div'); // $ExpectType void
-wd.waitForInvisible('div', num); // $ExpectType void
+wd.waitForInvisible('div'); // $ExpectType Promise<any>
+wd.waitForInvisible('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitToHide(); // $ExpectError
-wd.waitToHide('div'); // $ExpectType void
-wd.waitToHide('div', num); // $ExpectType void
+wd.waitToHide('div'); // $ExpectType Promise<any>
+wd.waitToHide('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitForDetached(); // $ExpectError
-wd.waitForDetached('div'); // $ExpectType void
-wd.waitForDetached('div', num); // $ExpectType void
+wd.waitForDetached('div'); // $ExpectType Promise<any>
+wd.waitForDetached('div', num_wd); // $ExpectType Promise<any>
 
 wd.waitForFunction(); // $ExpectError
-wd.waitForFunction('div'); // $ExpectType void
-wd.waitForFunction(() => {}); // $ExpectType void
-wd.waitForFunction(() => {}, [num], num); // $ExpectType void
-wd.waitForFunction(() => {}, [str], num); // $ExpectType void
+wd.waitForFunction('div'); // $ExpectType Promise<any>
+wd.waitForFunction(() => {}); // $ExpectType Promise<any>
+wd.waitForFunction(() => {}, [num_wd], num_wd); // $ExpectType Promise<any>
+wd.waitForFunction(() => {}, [str_wd], num_wd); // $ExpectType Promise<any>
 
 wd.waitInUrl(); // $ExpectError
-wd.waitInUrl(str); // $ExpectType void
-wd.waitInUrl(str, num); // $ExpectType void
+wd.waitInUrl(str_wd); // $ExpectType Promise<any>
+wd.waitInUrl(str_wd, num_wd); // $ExpectType Promise<any>
 
 wd.waitForText(); // $ExpectError
-wd.waitForText(str); // $ExpectType void
-wd.waitForText(str, num, str); // $ExpectType void
+wd.waitForText(str_wd); // $ExpectType Promise<any>
+wd.waitForText(str_wd, num_wd, str_wd); // $ExpectType Promise<any>
 
 wd.waitForValue(); // $ExpectError
-wd.waitForValue(str); // $ExpectError
-wd.waitForValue(str, str); // $ExpectType void
-wd.waitForValue(str, str, num); // $ExpectType void
+wd.waitForValue(str_wd); // $ExpectError
+wd.waitForValue(str_wd, str_wd); // $ExpectType Promise<any>
+wd.waitForValue(str_wd, str_wd, num_wd); // $ExpectType Promise<any>
 
 wd.waitNumberOfVisibleElements(); // $ExpectError
 wd.waitNumberOfVisibleElements('div'); // $ExpectError
-wd.waitNumberOfVisibleElements(str, num); // $ExpectType void
-wd.waitNumberOfVisibleElements(str, num, num); // $ExpectType void
+wd.waitNumberOfVisibleElements(str_wd, num_wd); // $ExpectType Promise<any>
+wd.waitNumberOfVisibleElements(str_wd, num_wd, num_wd); // $ExpectType Promise<any>
 
 wd.waitUrlEquals(); // $ExpectError
-wd.waitUrlEquals(str); // $ExpectType void
-wd.waitUrlEquals(str, num); // $ExpectType void
+wd.waitUrlEquals(str_wd); // $ExpectType Promise<any>
+wd.waitUrlEquals(str_wd, num_wd); // $ExpectType Promise<any>
 
-wd.switchTo(); // $ExpectType void
-wd.switchTo('div'); // $ExpectType void
+wd.switchTo(); // $ExpectType Promise<any>
+wd.switchTo('div'); // $ExpectType Promise<any>
 
-wd.switchToNextTab(num, num); // $ExpectType void
+wd.switchToNextTab(num_wd, num_wd); // $ExpectType Promise<any>
 
-wd.switchToPreviousTab(num, num); // $ExpectType void
+wd.switchToPreviousTab(num_wd, num_wd); // $ExpectType Promise<any>
 
-wd.closeCurrentTab(); // $ExpectType void
+wd.closeCurrentTab(); // $ExpectType Promise<any>
 
-wd.openNewTab(); // $ExpectType void
+wd.openNewTab(); // $ExpectType Promise<any>
 
-wd.refreshPage(); // $ExpectType void
+wd.refreshPage(); // $ExpectType Promise<any>
 
-wd.scrollPageToTop(); // $ExpectType void
+wd.scrollPageToTop(); // $ExpectType Promise<any>
 
-wd.scrollPageToBottom(); // $ExpectType void
+wd.scrollPageToBottom(); // $ExpectType Promise<any>
 
 wd.setGeoLocation(); // $ExpectError
-wd.setGeoLocation(num); // $ExpectError
-wd.setGeoLocation(num, num); // $ExpectType void
-wd.setGeoLocation(num, num, num); // $ExpectType void
+wd.setGeoLocation(num_wd); // $ExpectError
+wd.setGeoLocation(num_wd, num_wd); // $ExpectType Promise<any>
+wd.setGeoLocation(num_wd, num_wd, num_wd); // $ExpectType Promise<any>
 
 wd.dontSeeCookie(); // $ExpectError
-wd.dontSeeCookie(str); // $ExpectType void
+wd.dontSeeCookie(str_wd); // $ExpectType Promise<any>
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('#dragHandle'); // $ExpectError


### PR DESCRIPTION
## Motivation/Description of the PR
Implementing test within TypeScript can be confusing for following reasons:
- some methods are wrongly typed (exemple: `I.click` from Playwright). Regarding to the file `types.d.ts`, it's a `void` function, whereas it's `promise<any>` looking into the helper `Playwright.ts` (https://github.com/codeceptjs/CodeceptJS/blob/3.x/lib/helper/Playwright.js#L1220)
- adding `await` keyword on methods considered as synchronous causes troubles with static code analysis tool such as ESLint,
- debugging such code (for manual investigation) is terrible in term of user experience: this is potentially desynchronisation between actions on the UI and the step-by-step debugging

Having fully promise-based helpers should solve previous points and allow to TS users better experience.
For JS users, it should have no impact.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [X] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Note: _all common methods in these helpers have been updated - however, specific implemented methods for other helpers than Appium and Playwright may not be fully in promise-based._

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [X] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
