### PR TITLE
Add option to avoid duplicate gherkin step definitions

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -399,6 +399,7 @@ Tag should be placed before *Scenario:* or before *Feature:* keyword. In the las
 * `gherkin`
   * `features` - path to feature files, or an array of feature file paths
   * `steps` - array of files with step definitions
+  * `avoidDuplicateSteps` - attempts to avoid duplicate step definitions by shallow compare
 
 ```js
 "gherkin": {

--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -264,6 +264,8 @@ Appium: support only Android
 -   `appId` **[string][5]** 
 -   `bundleId` **[string][5]?** ID of bundle
 
+Returns **[Promise][4]&lt;any>** 
+
 ### seeCurrentActivityIs
 
 Check current activity on an Android device.
@@ -396,6 +398,8 @@ Switch to the specified context.
 
 -   `context` **any** the context to switch to
 
+Returns **[Promise][4]&lt;any>** 
+
 ### switchToWeb
 
 Switches to web context.
@@ -506,6 +510,8 @@ Appium: support Android and iOS
 -   `strategy` **(`"tapOutside"` \| `"pressKey"`)?** Desired strategy to close keyboard (‘tapOutside’ or ‘pressKey’)
 -   `key` **[string][5]?** Optional key
 
+Returns **[Promise][4]&lt;any>** 
+
 ### sendDeviceKeyEvent
 
 Send a key event to the device.
@@ -597,7 +603,9 @@ I.performSwipe({ x: 300, y: 100 }, { x: 200, y: 100 });
 #### Parameters
 
 -   `from` **[object][8]** 
--   `to` **[object][8]** Appium: support Android and iOS
+-   `to` **[object][8]** 
+
+Returns **[Promise][4]&lt;any>** Appium: support Android and iOS
 
 ### swipeDown
 
@@ -731,6 +739,8 @@ Appium: support Android and iOS
 
 -   `actions` **[Array][6]** Array of touch actions
 
+Returns **[Promise][4]&lt;any>** 
+
 ### pullFile
 
 Pulls a file from the device.
@@ -833,6 +843,8 @@ I.appendField('#myTextField', 'appended');
 -   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator
 -   `value` **[string][5]** text value to append.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### checkOption
 
 Selects a checkbox or radio button.
@@ -850,6 +862,8 @@ I.checkOption('agree', '//form');
 
 -   `field` **([string][5] \| [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
 -   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### click
 
@@ -880,6 +894,8 @@ I.click({css: 'nav a.login'});
 -   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 -   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. (optional, default `null`)
 
+Returns **[Promise][4]&lt;any>** 
+
 ### dontSeeCheckboxIsChecked
 
 Verifies that the specified checkbox is not checked.
@@ -894,6 +910,8 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 -   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### dontSeeElement
 
 Opposite to `seeElement`. Checks that element is not visible (or in DOM)
@@ -905,6 +923,8 @@ I.dontSeeElement('.modal'); // modal is not shown
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** located by CSS|XPath|Strict locator.
+
+Returns **[Promise][4]&lt;any>** 
 
 ### dontSeeInField
 
@@ -921,6 +941,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 -   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][5]** value to check.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### dontSee
 
 Opposite to `see`. Checks that a text is not present on a page.
@@ -935,6 +957,8 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 -   `text` **[string][5]** which is not present.
 -   `context` **([string][5] \| [object][8])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### fillField
 
@@ -956,6 +980,8 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 -   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 -   `value` **([string][5] \| [object][8])** text value to fill.
+
+Returns **[Promise][4]&lt;any>** 
 
 ### grabTextFromAll
 
@@ -1099,7 +1125,9 @@ I.scrollIntoView('#submit', { behavior: "smooth", block: "center", inline: "cent
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
--   `scrollIntoViewOptions` **ScrollIntoViewOptions** see [https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView][15].Supported only for web testing
+-   `scrollIntoViewOptions` **ScrollIntoViewOptions** see [https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView][15].
+
+Returns **[Promise][4]&lt;any>** Supported only for web testing
 
 ### seeCheckboxIsChecked
 
@@ -1115,6 +1143,8 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 -   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### seeElement
 
 Checks that a given Element is visible
@@ -1127,6 +1157,8 @@ I.seeElement('#modal');
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
+
+Returns **[Promise][4]&lt;any>** 
 
 ### seeInField
 
@@ -1145,6 +1177,8 @@ I.seeInField('#searchform input','Search');
 -   `field` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][5]** value to check.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### see
 
 Checks that a page contains a visible text.
@@ -1160,6 +1194,8 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 
 -   `text` **[string][5]** expected on page.
 -   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### selectOption
 
@@ -1185,7 +1221,9 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 #### Parameters
 
 -   `select` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
--   `option` **([string][5] \| [Array][6]&lt;any>)** visible text or value of option.Supported only for web testing
+-   `option` **([string][5] \| [Array][6]&lt;any>)** visible text or value of option.
+
+Returns **[Promise][4]&lt;any>** Supported only for web testing
 
 ### waitForElement
 
@@ -1202,6 +1240,8 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait (optional, default `null`)
 
+Returns **[Promise][4]&lt;any>** 
+
 ### waitForVisible
 
 Waits for an element to become visible on a page (by default waits for 1sec).
@@ -1216,6 +1256,8 @@ I.waitForVisible('#popup');
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
 
+Returns **[Promise][4]&lt;any>** 
+
 ### waitForInvisible
 
 Waits for an element to be removed or become invisible on a page (by default waits for 1sec).
@@ -1229,6 +1271,8 @@ I.waitForInvisible('#popup');
 
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### waitForText
 
@@ -1246,6 +1290,8 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 -   `text` **[string][5]** to wait for.
 -   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait (optional, default `1`)
 -   `context` **([string][5] \| [object][8])?** (optional) element located by CSS|XPath|strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### useWebDriverTo
 
@@ -1374,6 +1420,8 @@ I.amOnPage('/login'); // opens a login page
 
 -   `url` **[string][5]** url path or global url.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### forceClick
 
 Perform an emulated click on a link or a button, given by a locator.
@@ -1404,7 +1452,9 @@ I.forceClick({css: 'nav a.login'});
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** {{ react }}
 
 ### doubleClick
 
@@ -1421,7 +1471,9 @@ I.doubleClick('.btn.edit');
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** {{ react }}
 
 ### rightClick
 
@@ -1439,7 +1491,9 @@ I.rightClick('Click me', '.context');
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator.{{ react }} (optional, default `null`)
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** {{ react }}
 
 ### forceRightClick
 
@@ -1461,7 +1515,9 @@ I.forceRightClick('Menu');
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.{{ react }} (optional, default `null`)
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** {{ react }}
 
 ### clearField
 
@@ -1478,6 +1534,8 @@ I.clearField('#email');
 -   `field`  
 -   `editable` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
@@ -1493,7 +1551,8 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 -   `locator` **([string][5] \| [object][8])** field located by label|name|CSS|XPath|strict locator.
 -   `pathToFile` **[string][5]** local file path relative to codecept.json config file.
-    Appium: not tested
+
+Returns **[Promise][4]&lt;any>** Appium: not tested
 
 ### uncheckOption
 
@@ -1511,8 +1570,9 @@ I.uncheckOption('agree', '//form');
 #### Parameters
 
 -   `field` **([string][5] \| [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator.
-    Appium: not tested (optional, default `null`)
+-   `context` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** Appium: not tested
 
 ### grabHTMLFromAll
 
@@ -1560,6 +1620,8 @@ I.seeTextEquals('text', 'h1');
 -   `text` **[string][5]** element value to check.
 -   `context` **([string][5] \| [object][8])?** element located by CSS|XPath|strict locator. (optional, default `null`)
 
+Returns **[Promise][4]&lt;any>** 
+
 ### seeElementInDOM
 
 Checks that a given Element is present in the DOM
@@ -1573,6 +1635,8 @@ I.seeElementInDOM('#modal');
 
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### dontSeeElementInDOM
 
 Opposite to `seeElementInDOM`. Checks that element is not on page.
@@ -1585,6 +1649,8 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 -   `locator` **([string][5] \| [object][8])** located by CSS|XPath|Strict locator.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### seeInSource
 
 Checks that the current page contains the given string in its raw source code.
@@ -1596,6 +1662,8 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 #### Parameters
 
 -   `text` **[string][5]** value to check.
+
+Returns **[Promise][4]&lt;any>** 
 
 ### grabSource
 
@@ -1633,6 +1701,8 @@ I.dontSeeInSource('<!--'); // no comments in source
 -   `text`  
 -   `value` **[string][5]** to check.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### seeNumberOfElements
 
 Asserts that an element appears a given number of times in the DOM.
@@ -1645,7 +1715,9 @@ I.seeNumberOfElements('#submitBtn', 1);
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.{{ react }}
+-   `num` **[number][10]** number of elements.
+
+Returns **[Promise][4]&lt;any>** {{ react }}
 
 ### seeNumberOfVisibleElements
 
@@ -1659,7 +1731,9 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 #### Parameters
 
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.{{ react }}
+-   `num` **[number][10]** number of elements.
+
+Returns **[Promise][4]&lt;any>** {{ react }}
 
 ### seeAttributesOnElements
 
@@ -1673,6 +1747,8 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 -   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 -   `attributes` **[object][8]** attributes and their values to check.
+
+Returns **[Promise][4]&lt;any>** 
 
 ### scrollTo
 
@@ -1689,6 +1765,8 @@ I.scrollTo('#submit', 5, 5);
 -   `locator` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
 -   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. (optional, default `0`)
 -   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. (optional, default `0`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### moveCursorTo
 
@@ -1708,6 +1786,8 @@ I.moveCursorTo('#submit', 5,5);
 -   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. (optional, default `0`)
 -   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. (optional, default `0`)
 
+Returns **[Promise][4]&lt;any>** 
+
 ### saveElementScreenshot
 
 Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
@@ -1721,6 +1801,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 -   `locator` **([string][5] \| [object][8])** element located by CSS|XPath|strict locator.
 -   `fileName` **[string][5]** file name to save.
+
+Returns **[Promise][4]&lt;any>** 
 
 ### type
 
@@ -1745,6 +1827,8 @@ I.type(['T', 'E', 'X', 'T']);
 -   `delay` **[number][10]?** (optional) delay in ms between key presses (optional, default `null`)
 -   `key` **([string][5] \| [Array][6]&lt;[string][5]>)** or array of keys to type.
 
+Returns **[Promise][4]&lt;any>** 
+
 ### dragAndDrop
 
 Drag an item to a destination element.
@@ -1756,7 +1840,9 @@ I.dragAndDrop('#dragHandle', '#container');
 #### Parameters
 
 -   `srcElement` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
--   `destElement` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.Appium: not tested
+-   `destElement` **([string][5] \| [object][8])** located by CSS|XPath|strict locator.
+
+Returns **[Promise][4]&lt;any>** Appium: not tested
 
 ### dragSlider
 
@@ -1772,6 +1858,8 @@ I.dragSlider('#slider', -70);
 
 -   `locator` **([string][5] \| [object][8])** located by label|name|CSS|XPath|strict locator.
 -   `offsetX` **[number][10]** position to drag. (optional, default `0`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### grabAllWindowHandles
 
@@ -1821,6 +1909,8 @@ Close all tabs except for the current one.
 I.closeOtherTabs();
 ```
 
+Returns **[Promise][4]&lt;any>** 
+
 ### switchTo
 
 Switches frame or in case of null locator reverts to parent.
@@ -1833,6 +1923,8 @@ I.switchTo(); // switch back to main page
 #### Parameters
 
 -   `locator` **([string][5]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### grabNumberOfOpenTabs
 
@@ -1853,6 +1945,8 @@ Scroll page to the top.
 I.scrollPageToTop();
 ```
 
+Returns **[Promise][4]&lt;any>** 
+
 ### scrollPageToBottom
 
 Scroll page to the bottom.
@@ -1860,6 +1954,8 @@ Scroll page to the bottom.
 ```js
 I.scrollPageToBottom();
 ```
+
+Returns **[Promise][4]&lt;any>** 
 
 ### grabPageScrollPosition
 
@@ -1886,6 +1982,8 @@ I.setGeoLocation(121.21, 11.56, 10);
 -   `latitude` **[number][10]** to set.
 -   `longitude` **[number][10]** to set
 -   `altitude` **[number][10]?** (optional, null by default) to set (optional, default `null`)
+
+Returns **[Promise][4]&lt;any>** 
 
 ### grabGeoLocation
 

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -82,6 +82,8 @@ I.amOnPage('/login'); // opens a login page
 -   `url` **[string][3]** url path or global url.
 -   `headers` **[object][4]?** list of request headers can be passed 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### appendField
 
 Appends text to a input field or textarea.
@@ -95,6 +97,8 @@ I.appendField('#myTextField', 'appended');
 
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator
 -   `value` **[string][3]** text value to append.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### attachFile
 
@@ -110,7 +114,9 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 #### Parameters
 
 -   `locator` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
--   `pathToFile` **[string][3]** local file path relative to codecept.json config file.Doesn't work if the Chromium DevTools panel is open (as Chromium allows only one attachment to the debugger at a time. [See more][5])
+-   `pathToFile` **[string][3]** local file path relative to codecept.json config file.
+
+Returns **[Promise][5]&lt;any>** Doesn't work if the Chromium DevTools panel is open (as Chromium allows only one attachment to the debugger at a time. [See more][6])
 
 ### checkOption
 
@@ -130,6 +136,8 @@ I.checkOption('agree', '//form');
 -   `field` **([string][3] | [object][4])** checkbox located by label | name | CSS | XPath | strict locator.
 -   `context` **([string][3]? | [object][4])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### clearCookie
 
 Clears a cookie by name,
@@ -143,6 +151,8 @@ I.clearCookie('test');
 #### Parameters
 
 -   `cookie` **[string][3]?** (optional, `null` by default) cookie name 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### clearField
 
@@ -158,6 +168,8 @@ I.clearField('#email');
 
 -   `field`  
 -   `editable` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### click
 
@@ -188,6 +200,8 @@ I.click({css: 'nav a.login'});
 -   `locator` **([string][3] | [object][4])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 -   `context` **([string][3]? | [object][4])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSee
 
 Opposite to `see`. Checks that a text is not present on a page.
@@ -203,6 +217,8 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 -   `text` **[string][3]** which is not present.
 -   `context` **([string][3] | [object][4])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeCheckboxIsChecked
 
 Verifies that the specified checkbox is not checked.
@@ -217,6 +233,8 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeCookie
 
 Checks that cookie with given name does not exist.
@@ -228,6 +246,8 @@ I.dontSeeCookie('auth'); // no auth cookie
 #### Parameters
 
 -   `name` **[string][3]** cookie name.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeCurrentUrlEquals
 
@@ -243,6 +263,8 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 -   `url` **[string][3]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeElement
 
 Opposite to `seeElement`. Checks that element is not visible (or in DOM)
@@ -254,6 +276,8 @@ I.dontSeeElement('.modal'); // modal is not shown
 #### Parameters
 
 -   `locator` **([string][3] | [object][4])** located by CSS|XPath|Strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeElementInDOM
 
@@ -267,6 +291,8 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 -   `locator` **([string][3] | [object][4])** located by CSS|XPath|Strict locator.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeInCurrentUrl
 
 Checks that current url does not contain a provided fragment.
@@ -274,6 +300,8 @@ Checks that current url does not contain a provided fragment.
 #### Parameters
 
 -   `url` **[string][3]** value to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeInField
 
@@ -290,6 +318,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][3]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeInSource
 
 Checks that the current page does not contains the given string in its raw source code.
@@ -303,6 +333,8 @@ I.dontSeeInSource('<!--'); // no comments in source
 -   `text`  
 -   `value` **[string][3]** to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeInTitle
 
 Checks that title does not contain text.
@@ -314,6 +346,8 @@ I.dontSeeInTitle('Error');
 #### Parameters
 
 -   `text` **[string][3]** value to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### doubleClick
 
@@ -332,12 +366,14 @@ I.doubleClick('.btn.edit');
 -   `locator` **([string][3] | [object][4])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 -   `context` **([string][3]? | [object][4])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### executeAsyncScript
 
 Executes async script on page.
 Provided function should execute a passed callback (as first argument) to signal it is finished.
 
-Example: In Vue.js to make components completely rendered we are waiting for [nextTick][6].
+Example: In Vue.js to make components completely rendered we are waiting for [nextTick][7].
 
 ```js
 I.executeAsyncScript(function(done) {
@@ -358,9 +394,9 @@ let val = await I.executeAsyncScript(function(url, done) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
--   `fn` **([string][3] | [function][7])** function to be executed in browser context.
+-   `fn` **([string][3] | [function][8])** function to be executed in browser context.
 
-Returns **[Promise][8]&lt;any>** Wrapper for asynchronous [evaluate][9].
+Returns **[Promise][5]&lt;any>** Wrapper for asynchronous [evaluate][9].
 Unlike NightmareJS implementation calling `done` will return its first argument.
 
 ### executeScript
@@ -392,9 +428,9 @@ let date = await I.executeScript(function(el) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
--   `fn` **([string][3] | [function][7])** function to be executed in browser context.
+-   `fn` **([string][3] | [function][8])** function to be executed in browser context.
 
-Returns **[Promise][8]&lt;any>** Wrapper for synchronous [evaluate][9]
+Returns **[Promise][5]&lt;any>** Wrapper for synchronous [evaluate][9]
 
 ### fillField
 
@@ -417,6 +453,8 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator.
 -   `value` **([string][3] | [object][4])** text value to fill.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### grabAttributeFrom
 
 Retrieves an attribute from an element located by CSS or XPath and returns it to test.
@@ -432,7 +470,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][3]** attribute name.
 
-Returns **[Promise][8]&lt;[string][3]>** attribute value
+Returns **[Promise][5]&lt;[string][3]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -448,7 +486,7 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][3]** attribute name.
 
-Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** attribute value
+Returns **[Promise][5]&lt;[Array][10]&lt;[string][3]>>** attribute value
 
 ### grabCookie
 
@@ -465,7 +503,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][3]?** cookie name. 
 
-Returns **([Promise][8]&lt;[string][3]> | [Promise][8]&lt;[Array][10]&lt;[string][3]>>)** attribute valueCookie in JSON format. If name not passed returns all cookies for this domain.Multiple cookies can be received by passing query object `I.grabCookie({ secure: true});`. If you'd like get all cookies for all urls, use: `.grabCookie({ url: null }).`
+Returns **([Promise][5]&lt;[string][3]> | [Promise][5]&lt;[Array][10]&lt;[string][3]>>)** attribute valueCookie in JSON format. If name not passed returns all cookies for this domain.Multiple cookies can be received by passing query object `I.grabCookie({ secure: true});`. If you'd like get all cookies for all urls, use: `.grabCookie({ url: null }).`
 
 ### grabCssPropertyFrom
 
@@ -482,7 +520,7 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][3]** CSS property name.
 
-Returns **[Promise][8]&lt;[string][3]>** CSS value
+Returns **[Promise][5]&lt;[string][3]>** CSS value
 
 ### grabCurrentUrl
 
@@ -494,7 +532,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][8]&lt;[string][3]>** current URL
+Returns **[Promise][5]&lt;[string][3]>** current URL
 
 ### grabElementBoundingRect
 
@@ -522,7 +560,7 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 -   `prop`  
 -   `elementSize` **[string][3]?** x, y, width or height of the given element.
 
-Returns **([Promise][8]&lt;DOMRect> | [Promise][8]&lt;[number][11]>)** Element bounding rectangle
+Returns **([Promise][5]&lt;DOMRect> | [Promise][5]&lt;[number][11]>)** Element bounding rectangle
 
 ### grabHAR
 
@@ -548,7 +586,7 @@ let postHTML = await I.grabHTMLFrom('#post');
 -   `locator`  
 -   `element` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[string][3]>** HTML code for an element
+Returns **[Promise][5]&lt;[string][3]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -564,7 +602,7 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 -   `locator`  
 -   `element` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** HTML code for an element
+Returns **[Promise][5]&lt;[Array][10]&lt;[string][3]>>** HTML code for an element
 
 ### grabNumberOfVisibleElements
 
@@ -579,7 +617,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[number][11]>** number of visible elements
+Returns **[Promise][5]&lt;[number][11]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -590,7 +628,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][8]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][5]&lt;PageScrollPosition>** scroll position
 
 ### grabTextFrom
 
@@ -607,7 +645,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[string][3]>** attribute value
+Returns **[Promise][5]&lt;[string][3]>** attribute value
 
 ### grabTextFromAll
 
@@ -622,7 +660,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** attribute value
+Returns **[Promise][5]&lt;[Array][10]&lt;[string][3]>>** attribute value
 
 ### grabTitle
 
@@ -633,7 +671,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][8]&lt;[string][3]>** title
+Returns **[Promise][5]&lt;[string][3]>** title
 
 ### grabValueFrom
 
@@ -649,7 +687,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[string][3]>** attribute value
+Returns **[Promise][5]&lt;[string][3]>** attribute value
 
 ### grabValueFromAll
 
@@ -664,7 +702,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** attribute value
+Returns **[Promise][5]&lt;[Array][10]&lt;[string][3]>>** attribute value
 
 ### haveHeader
 
@@ -696,6 +734,8 @@ I.moveCursorTo('#submit', 5,5);
 -   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
 -   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### pressKey
 
 Sends [input event][12] on a page.
@@ -717,6 +757,8 @@ Reload the current page.
 I.refreshPage();
 ```
 
+Returns **[Promise][5]&lt;any>** 
+
 ### resizeWindow
 
 Resize the current window to provided width and height.
@@ -726,6 +768,8 @@ First parameter can be set to `maximize`.
 
 -   `width` **[number][11]** width in pixels or `maximize`.
 -   `height` **[number][11]** height in pixels.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### rightClick
 
@@ -745,6 +789,8 @@ I.rightClick('Click me', '.context');
 -   `locator` **([string][3] | [object][4])** clickable element located by CSS|XPath|strict locator.
 -   `context` **([string][3]? | [object][4])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### saveElementScreenshot
 
 Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
@@ -758,6 +804,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `fileName` **[string][3]** file name to save.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### saveScreenshot
 
@@ -775,6 +823,8 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 -   `fileName` **[string][3]** file name to save.
 -   `fullPage` **[boolean][13]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### scrollPageToBottom
 
 Scroll page to the bottom.
@@ -783,6 +833,8 @@ Scroll page to the bottom.
 I.scrollPageToBottom();
 ```
 
+Returns **[Promise][5]&lt;any>** 
+
 ### scrollPageToTop
 
 Scroll page to the top.
@@ -790,6 +842,8 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
+
+Returns **[Promise][5]&lt;any>** 
 
 ### scrollTo
 
@@ -807,6 +861,8 @@ I.scrollTo('#submit', 5, 5);
 -   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
 -   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### see
 
 Checks that a page contains a visible text.
@@ -823,6 +879,8 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 -   `text` **[string][3]** expected on page.
 -   `context` **([string][3]? | [object][4])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeCheckboxIsChecked
 
 Verifies that the specified checkbox is checked.
@@ -837,6 +895,8 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeCookie
 
 Checks that cookie with given name exists.
@@ -848,6 +908,8 @@ I.seeCookie('Auth');
 #### Parameters
 
 -   `name` **[string][3]** cookie name.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeCurrentUrlEquals
 
@@ -864,6 +926,8 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 -   `url` **[string][3]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeElement
 
 Checks that a given Element is visible
@@ -876,6 +940,8 @@ I.seeElement('#modal');
 #### Parameters
 
 -   `locator` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeElementInDOM
 
@@ -890,6 +956,8 @@ I.seeElementInDOM('#modal');
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeInCurrentUrl
 
 Checks that current url contains a provided fragment.
@@ -901,6 +969,8 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 #### Parameters
 
 -   `url` **[string][3]** a fragment to check
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeInField
 
@@ -919,6 +989,8 @@ I.seeInField('#searchform input','Search');
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][3]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeInSource
 
 Checks that the current page contains the given string in its raw source code.
@@ -931,6 +1003,8 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 -   `text` **[string][3]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeInTitle
 
 Checks that title contains text.
@@ -942,6 +1016,8 @@ I.seeInTitle('Home Page');
 #### Parameters
 
 -   `text` **[string][3]** text value to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeNumberOfElements
 
@@ -957,6 +1033,8 @@ I.seeNumberOfElements('#submitBtn', 1);
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `num` **[number][11]** number of elements.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeNumberOfVisibleElements
 
 Asserts that an element is visible a given number of times.
@@ -970,6 +1048,8 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `num` **[number][11]** number of elements.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### selectOption
 
@@ -997,6 +1077,8 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 -   `select` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 -   `option` **([string][3] | [Array][10]&lt;any>)** visible text or value of option.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### setCookie
 
 Sets cookie(s).
@@ -1015,8 +1097,10 @@ I.setCookie([
 
 #### Parameters
 
--   `cookie` **(Cookie | [Array][10]&lt;Cookie>)** a cookie object or array of cookie objects.Wrapper for `.cookies.set(cookie)`.
-    [See more][14]
+-   `cookie` **(Cookie | [Array][10]&lt;Cookie>)** a cookie object or array of cookie objects.
+
+Returns **[Promise][5]&lt;any>** Wrapper for `.cookies.set(cookie)`.
+[See more][14]
 
 ### triggerMouseEvent
 
@@ -1051,6 +1135,8 @@ I.uncheckOption('agree', '//form');
 -   `field` **([string][3] | [object][4])** checkbox located by label | name | CSS | XPath | strict locator.
 -   `context` **([string][3]? | [object][4])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### wait
 
 Pauses execution for a number of seconds.
@@ -1062,6 +1148,8 @@ I.wait(2); // wait 2 secs
 #### Parameters
 
 -   `sec` **[number][11]** number of second to wait.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForDetached
 
@@ -1077,6 +1165,8 @@ I.waitForDetached('#popup');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### waitForElement
 
 Waits for element to be present on page (by default waits for 1sec).
@@ -1091,6 +1181,8 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForFunction
 
@@ -1109,9 +1201,11 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][3] | [function][7])** to be executed in browser context.
+-   `fn` **([string][3] | [function][8])** to be executed in browser context.
 -   `argsOrSec` **([Array][10]&lt;any> | [number][11])?** (optional, `1` by default) arguments for function or seconds. 
 -   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForInvisible
 
@@ -1126,6 +1220,8 @@ I.waitForInvisible('#popup');
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForText
 
@@ -1144,6 +1240,8 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 -   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 -   `context` **([string][3] | [object][4])?** (optional) element located by CSS|XPath|strict locator. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### waitForVisible
 
 Waits for an element to become visible on a page (by default waits for 1sec).
@@ -1157,6 +1255,8 @@ I.waitForVisible('#popup');
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitToHide
 
@@ -1172,6 +1272,8 @@ I.waitToHide('#popup');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
+Returns **[Promise][5]&lt;any>** 
+
 [1]: https://github.com/segmentio/nightmare
 
 [2]: https://github.com/segmentio/nightmare#api
@@ -1180,13 +1282,13 @@ I.waitToHide('#popup');
 
 [4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[5]: https://github.com/rosshinkley/nightmare-upload#important-note-about-setting-file-upload-inputs
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[6]: https://vuejs.org/v2/api/#Vue-nextTick
+[6]: https://github.com/rosshinkley/nightmare-upload#important-note-about-setting-file-upload-inputs
 
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[7]: https://vuejs.org/v2/api/#Vue-nextTick
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [9]: https://github.com/segmentio/nightmare#evaluatefn-arg1-arg2
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -219,6 +219,9 @@ Add the 'dialog' event listener to a page
 
 -   `page`  
 
+Returns **[Promise][10]&lt;any>** The popup listener handles the dialog with the predefined action when it appears on the page.
+It also saves a reference to the object which is used in seeInPopup.
+
 ### _contextLocator
 
 Grab Locator if called within Context
@@ -230,6 +233,8 @@ Grab Locator if called within Context
 ### _getPageUrl
 
 Gets page URL including hash.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### _locate
 
@@ -243,6 +248,8 @@ const elements = await this.helpers['Playwright']._locate({name: 'password'});
 #### Parameters
 
 -   `locator`  
+
+Returns **[Promise][10]&lt;any>** 
 
 ### _locateCheckable
 
@@ -258,6 +265,8 @@ this.helpers['Playwright']._locateCheckable('I agree with terms and conditions')
 -   `locator`  
 -   `providedContext`   
 
+Returns **[Promise][10]&lt;any>** 
+
 ### _locateClickable
 
 Find a clickable element by providing human readable text:
@@ -269,6 +278,8 @@ this.helpers['Playwright']._locateClickable('Next page').then // ...
 #### Parameters
 
 -   `locator`  
+
+Returns **[Promise][10]&lt;any>** 
 
 ### _locateFields
 
@@ -282,19 +293,25 @@ this.helpers['Playwright']._locateFields('Your email').then // ...
 
 -   `locator`  
 
+Returns **[Promise][10]&lt;any>** 
+
 ### _setPage
 
 Set current page
 
 #### Parameters
 
--   `page` **[object][10]** page to set
+-   `page` **[object][11]** page to set
+
+Returns **[Promise][10]&lt;any>** 
 
 ### acceptPopup
 
 Accepts the active JavaScript native popup window, as created by window.alert|window.confirm|window.prompt.
 Don't confuse popups with modal windows, as created by [various
-libraries][11].
+libraries][12].
+
+Returns **[Promise][10]&lt;any>** 
 
 ### amAcceptingPopups
 
@@ -307,6 +324,8 @@ I.click('#triggerPopup');
 I.acceptPopup();
 ```
 
+Returns **[Promise][10]&lt;any>** 
+
 ### amCancellingPopups
 
 Set the automatic popup response to Cancel/Dismiss.
@@ -317,6 +336,8 @@ I.amCancellingPopups();
 I.click('#triggerPopup');
 I.cancelPopup();
 ```
+
+Returns **[Promise][10]&lt;any>** 
 
 ### amOnPage
 
@@ -331,7 +352,9 @@ I.amOnPage('/login'); // opens a login page
 
 #### Parameters
 
--   `url` **[string][12]** url path or global url.
+-   `url` **[string][13]** url path or global url.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### appendField
 
@@ -344,8 +367,10 @@ I.appendField('#myTextField', 'appended');
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator
--   `value` **[string][12]** text value to append.
+-   `field` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator
+-   `value` **[string][13]** text value to append.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### attachFile
 
@@ -360,12 +385,16 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** field located by label|name|CSS|XPath|strict locator.
--   `pathToFile` **[string][12]** local file path relative to codecept.json config file.
+-   `locator` **([string][13] | [object][11])** field located by label|name|CSS|XPath|strict locator.
+-   `pathToFile` **[string][13]** local file path relative to codecept.json config file.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### cancelPopup
 
 Dismisses the active JavaScript popup, as created by window.alert|window.confirm|window.prompt.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### checkOption
 
@@ -382,12 +411,14 @@ I.checkOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element located by CSS | XPath | strict locator.[Additional options][13] for check available as 3rd argument.Examples:```js
-    // click on element at position
-    I.checkOption('Agree', '.signup', { position: { x: 5, y: 5 } })
-    ```> ⚠️ To avoid flakiness, option `force: true` is set by default 
+-   `field` **([string][13] | [object][11])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 -   `options`   
+
+Returns **[Promise][10]&lt;any>** [Additional options][14] for check available as 3rd argument.Examples:```js
+// click on element at position
+I.checkOption('Agree', '.signup', { position: { x: 5, y: 5 } })
+```> ⚠️ To avoid flakiness, option `force: true` is set by default
 
 ### clearCookie
 
@@ -401,7 +432,9 @@ I.clearCookie('test');
 
 #### Parameters
 
--   `cookie` **[string][12]?** (optional, `null` by default) cookie name 
+-   `cookie` **[string][13]?** (optional, `null` by default) cookie name 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### clearField
 
@@ -416,7 +449,9 @@ I.clearField('#email');
 #### Parameters
 
 -   `field`  
--   `editable` **([string][12] | [object][10])** field located by label|name|CSS|XPath|strict locator.
+-   `editable` **([string][13] | [object][11])** field located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### click
 
@@ -444,15 +479,17 @@ I.click({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.[Additional options][14] for click available as 3rd argument.Examples:```js
-    // click on element at position
-    I.click('canvas', '.model', { position: { x: 20, y: 40 } })
-
-    // make ctrl-click
-    I.click('.edit', null, { modifiers: ['Ctrl'] } )
-    ``` 
+-   `locator` **([string][13] | [object][11])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 -   `opts`   
+
+Returns **[Promise][10]&lt;any>** [Additional options][15] for click available as 3rd argument.Examples:```js
+// click on element at position
+I.click('canvas', '.model', { position: { x: 20, y: 40 } })
+
+// make ctrl-click
+I.click('.edit', null, { modifiers: ['Ctrl'] } )
+```
 
 ### clickLink
 
@@ -463,6 +500,8 @@ Clicks link and waits for navigation (deprecated)
 -   `locator`  
 -   `context`   
 
+Returns **[Promise][10]&lt;any>** 
+
 ### closeCurrentTab
 
 Close current tab and switches to previous.
@@ -471,6 +510,8 @@ Close current tab and switches to previous.
 I.closeCurrentTab();
 ```
 
+Returns **[Promise][10]&lt;any>** 
+
 ### closeOtherTabs
 
 Close all tabs except for the current one.
@@ -478,6 +519,8 @@ Close all tabs except for the current one.
 ```js
 I.closeOtherTabs();
 ```
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSee
 
@@ -491,8 +534,10 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 #### Parameters
 
--   `text` **[string][12]** which is not present.
--   `context` **([string][12] | [object][10])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+-   `text` **[string][13]** which is not present.
+-   `context` **([string][13] | [object][11])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeCheckboxIsChecked
 
@@ -506,7 +551,9 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeCookie
 
@@ -518,7 +565,9 @@ I.dontSeeCookie('auth'); // no auth cookie
 
 #### Parameters
 
--   `name` **[string][12]** cookie name.
+-   `name` **[string][13]** cookie name.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeCurrentUrlEquals
 
@@ -532,7 +581,9 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 #### Parameters
 
--   `url` **[string][12]** value to check.
+-   `url` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeElement
 
@@ -544,7 +595,9 @@ I.dontSeeElement('.modal'); // modal is not shown
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|Strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeElementInDOM
 
@@ -556,7 +609,9 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|Strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeInCurrentUrl
 
@@ -564,7 +619,9 @@ Checks that current url does not contain a provided fragment.
 
 #### Parameters
 
--   `url` **[string][12]** value to check.
+-   `url` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeInField
 
@@ -578,8 +635,10 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][12]** value to check.
+-   `field` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeInSource
 
@@ -592,7 +651,9 @@ I.dontSeeInSource('<!--'); // no comments in source
 #### Parameters
 
 -   `text`  
--   `value` **[string][12]** to check.
+-   `value` **[string][13]** to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dontSeeInTitle
 
@@ -604,7 +665,9 @@ I.dontSeeInTitle('Error');
 
 #### Parameters
 
--   `text` **[string][12]** value to check.
+-   `text` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### doubleClick
 
@@ -620,8 +683,10 @@ I.doubleClick('.btn.edit');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][13] | [object][11])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### dragAndDrop
 
@@ -633,12 +698,14 @@ I.dragAndDrop('#dragHandle', '#container');
 
 #### Parameters
 
--   `srcElement` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
--   `destElement` **([string][12] | [object][10])** located by CSS|XPath|strict locator.[Additional options][15] can be passed as 3rd argument.```js
-    // specify coordinates for source position
-    I.dragAndDrop('img.src', 'img.dst', { sourcePosition: {x: 10, y: 10} })
-    ```> By default option `force: true` is set
+-   `srcElement` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
+-   `destElement` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
 -   `options`   
+
+Returns **[Promise][10]&lt;any>** [Additional options][16] can be passed as 3rd argument.```js
+// specify coordinates for source position
+I.dragAndDrop('img.src', 'img.dst', { sourcePosition: {x: 10, y: 10} })
+```> By default option `force: true` is set
 
 ### dragSlider
 
@@ -652,8 +719,10 @@ I.dragSlider('#slider', -70);
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator.
--   `offsetX` **[number][16]** position to drag. 
+-   `locator` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator.
+-   `offsetX` **[number][17]** position to drag. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### executeScript
 
@@ -680,10 +749,10 @@ If a function returns a Promise it will wait for its resolution.
 
 #### Parameters
 
--   `fn` **([string][12] | [function][17])** function to be executed in browser context.
+-   `fn` **([string][13] | [function][18])** function to be executed in browser context.
 -   `arg` **any?** optional argument to pass to the function
 
-Returns **[Promise][18]&lt;any>** 
+Returns **[Promise][10]&lt;any>** 
 
 ### fillField
 
@@ -703,8 +772,10 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator.
--   `value` **([string][12] | [object][10])** text value to fill.
+-   `field` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator.
+-   `value` **([string][13] | [object][11])** text value to fill.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### forceClick
 
@@ -735,8 +806,10 @@ I.forceClick({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][13] | [object][11])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### grabAttributeFrom
 
@@ -750,10 +823,10 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `attr` **[string][12]** attribute name.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][13]** attribute name.
 
-Returns **[Promise][18]&lt;[string][12]>** attribute value
+Returns **[Promise][10]&lt;[string][13]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -766,10 +839,10 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `attr` **[string][12]** attribute name.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][13]** attribute name.
 
-Returns **[Promise][18]&lt;[Array][19]&lt;[string][12]>>** attribute value
+Returns **[Promise][10]&lt;[Array][19]&lt;[string][13]>>** attribute value
 
 ### grabBrowserLogs
 
@@ -780,7 +853,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **[Promise][18]&lt;[Array][19]&lt;any>>** 
+Returns **[Promise][10]&lt;[Array][19]&lt;any>>** 
 
 ### grabCookie
 
@@ -795,9 +868,9 @@ assert(cookie.value, '123456');
 
 #### Parameters
 
--   `name` **[string][12]?** cookie name. 
+-   `name` **[string][13]?** cookie name. 
 
-Returns **([Promise][18]&lt;[string][12]> | [Promise][18]&lt;[Array][19]&lt;[string][12]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][10]&lt;[string][13]> | [Promise][10]&lt;[Array][19]&lt;[string][13]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCssPropertyFrom
 
@@ -811,10 +884,10 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `cssProperty` **[string][12]** CSS property name.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `cssProperty` **[string][13]** CSS property name.
 
-Returns **[Promise][18]&lt;[string][12]>** CSS value
+Returns **[Promise][10]&lt;[string][13]>** CSS value
 
 ### grabCssPropertyFromAll
 
@@ -827,10 +900,10 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `cssProperty` **[string][12]** CSS property name.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `cssProperty` **[string][13]** CSS property name.
 
-Returns **[Promise][18]&lt;[Array][19]&lt;[string][12]>>** CSS value
+Returns **[Promise][10]&lt;[Array][19]&lt;[string][13]>>** CSS value
 
 ### grabCurrentUrl
 
@@ -842,7 +915,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][18]&lt;[string][12]>** current URL
+Returns **[Promise][10]&lt;[string][13]>** current URL
 
 ### grabDataFromPerformanceTiming
 
@@ -867,6 +940,8 @@ let data = await I.grabDataFromPerformanceTiming();
 }
 ```
 
+Returns **[Promise][10]&lt;any>** 
+
 ### grabElementBoundingRect
 
 Grab the width, height, location of given locator.
@@ -889,11 +964,11 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
 -   `prop`  
--   `elementSize` **[string][12]?** x, y, width or height of the given element.
+-   `elementSize` **[string][13]?** x, y, width or height of the given element.
 
-Returns **([Promise][18]&lt;DOMRect> | [Promise][18]&lt;[number][16]>)** Element bounding rectangle
+Returns **([Promise][10]&lt;DOMRect> | [Promise][10]&lt;[number][17]>)** Element bounding rectangle
 
 ### grabHTMLFrom
 
@@ -908,9 +983,9 @@ let postHTML = await I.grabHTMLFrom('#post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
+-   `element` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[string][12]>** HTML code for an element
+Returns **[Promise][10]&lt;[string][13]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -924,9 +999,9 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
+-   `element` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[Array][19]&lt;[string][12]>>** HTML code for an element
+Returns **[Promise][10]&lt;[Array][19]&lt;[string][13]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -937,7 +1012,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][18]&lt;[number][16]>** number of open tabs
+Returns **[Promise][10]&lt;[number][17]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -950,9 +1025,9 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[number][16]>** number of visible elements
+Returns **[Promise][10]&lt;[number][17]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -963,7 +1038,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][18]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][10]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -973,7 +1048,7 @@ Grab the text within the popup. If no popup is visible then it will return null
 await I.grabPopupText();
 ```
 
-Returns **[Promise][18]&lt;([string][12] | null)>** 
+Returns **[Promise][10]&lt;([string][13] | null)>** 
 
 ### grabSource
 
@@ -984,7 +1059,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][18]&lt;[string][12]>** source code
+Returns **[Promise][10]&lt;[string][13]>** source code
 
 ### grabTextFrom
 
@@ -999,9 +1074,9 @@ If multiple elements found returns first element.
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[string][12]>** attribute value
+Returns **[Promise][10]&lt;[string][13]>** attribute value
 
 ### grabTextFromAll
 
@@ -1014,9 +1089,9 @@ let pins = await I.grabTextFromAll('#pin li');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[Array][19]&lt;[string][12]>>** attribute value
+Returns **[Promise][10]&lt;[Array][19]&lt;[string][13]>>** attribute value
 
 ### grabTitle
 
@@ -1027,7 +1102,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][18]&lt;[string][12]>** title
+Returns **[Promise][10]&lt;[string][13]>** title
 
 ### grabValueFrom
 
@@ -1041,9 +1116,9 @@ let email = await I.grabValueFrom('input[name=email]');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[string][12]>** attribute value
+Returns **[Promise][10]&lt;[string][13]>** attribute value
 
 ### grabValueFromAll
 
@@ -1056,9 +1131,9 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][18]&lt;[Array][19]&lt;[string][12]>>** attribute value
+Returns **[Promise][10]&lt;[Array][19]&lt;[string][13]>>** attribute value
 
 ### handleDownloads
 
@@ -1076,7 +1151,9 @@ I.waitForFile('downloads/avatar.jpg', 5);
 
 #### Parameters
 
--   `fileName` **[string][12]?** set filename for downloaded file 
+-   `fileName` **[string][13]?** set filename for downloaded file 
+
+Returns **[Promise][10]&lt;void>** 
 
 ### haveRequestHeaders
 
@@ -1090,7 +1167,9 @@ I.haveRequestHeaders({
 
 #### Parameters
 
--   `customHeaders` **[object][10]** headers to set
+-   `customHeaders` **[object][11]** headers to set
+
+Returns **[Promise][10]&lt;any>** 
 
 ### makeApiRequest
 
@@ -1107,11 +1186,11 @@ I.makeApiRequest('PATCH', )
 
 #### Parameters
 
--   `method` **[string][12]** HTTP method
--   `url` **[string][12]** endpoint
--   `options` **[object][10]** request options depending on method used
+-   `method` **[string][13]** HTTP method
+-   `url` **[string][13]** endpoint
+-   `options` **[object][11]** request options depending on method used
 
-Returns **[Promise][18]&lt;[object][10]>** response
+Returns **[Promise][10]&lt;[object][11]>** response
 
 ### mockRoute
 
@@ -1125,8 +1204,10 @@ This method allows intercepting and mocking requests & responses. [Learn more ab
 
 #### Parameters
 
--   `url` **[string][12]?** URL, regex or pattern for to match URL
--   `handler` **[function][17]?** a function to process request
+-   `url` **[string][13]?** URL, regex or pattern for to match URL
+-   `handler` **[function][18]?** a function to process request
+
+Returns **[Promise][10]&lt;any>** 
 
 ### moveCursorTo
 
@@ -1140,9 +1221,11 @@ I.moveCursorTo('#submit', 5,5);
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][16]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][16]** (optional, `0` by default) Y-axis offset. 
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][17]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][17]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### openNewTab
 
@@ -1162,6 +1245,8 @@ I.openNewTab({ isMobile: true });
 #### Parameters
 
 -   `options`  
+
+Returns **[Promise][10]&lt;any>** 
 
 ### pressKey
 
@@ -1226,7 +1311,9 @@ Some of the supported key names are:
 
 #### Parameters
 
--   `key` **([string][12] | [Array][19]&lt;[string][12]>)** key or array of keys to press._Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/Puppeteer#1313][26]).
+-   `key` **([string][13] | [Array][19]&lt;[string][13]>)** key or array of keys to press.
+
+Returns **[Promise][10]&lt;any>** _Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/Puppeteer#1313][26]).
 
 ### pressKeyDown
 
@@ -1242,7 +1329,9 @@ I.pressKeyUp('Control');
 
 #### Parameters
 
--   `key` **[string][12]** name of key to press down.
+-   `key` **[string][13]** name of key to press down.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### pressKeyUp
 
@@ -1258,7 +1347,9 @@ I.pressKeyUp('Control');
 
 #### Parameters
 
--   `key` **[string][12]** name of key to release.
+-   `key` **[string][13]** name of key to release.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### refreshPage
 
@@ -1268,6 +1359,8 @@ Reload the current page.
 I.refreshPage();
 ```
 
+Returns **[Promise][10]&lt;any>** 
+
 ### resizeWindow
 
 Resize the current window to provided width and height.
@@ -1275,14 +1368,16 @@ First parameter can be set to `maximize`.
 
 #### Parameters
 
--   `width` **[number][16]** width in pixels or `maximize`.
--   `height` **[number][16]** height in pixels.Unlike other drivers Playwright changes the size of a viewport, not the window!
-    Playwright does not control the window of a browser so it can't adjust its real size.
-    It also can't maximize a window.Update configuration to change real window size on start:```js
-    // inside codecept.conf.js
-    // @codeceptjs/configure package must be installed
-    { setWindowSize } = require('@codeceptjs/configure');
-    ```
+-   `width` **[number][17]** width in pixels or `maximize`.
+-   `height` **[number][17]** height in pixels.
+
+Returns **[Promise][10]&lt;any>** Unlike other drivers Playwright changes the size of a viewport, not the window!
+Playwright does not control the window of a browser so it can't adjust its real size.
+It also can't maximize a window.Update configuration to change real window size on start:```js
+// inside codecept.conf.js
+// @codeceptjs/configure package must be installed
+{ setWindowSize } = require('@codeceptjs/configure');
+```
 
 ### rightClick
 
@@ -1299,8 +1394,10 @@ I.rightClick('Click me', '.context');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][13] | [object][11])** clickable element located by CSS|XPath|strict locator.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### saveElementScreenshot
 
@@ -1313,8 +1410,10 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `fileName` **[string][12]** file name to save.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `fileName` **[string][13]** file name to save.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### saveScreenshot
 
@@ -1329,8 +1428,10 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 
 #### Parameters
 
--   `fileName` **[string][12]** file name to save.
+-   `fileName` **[string][13]** file name to save.
 -   `fullPage` **[boolean][28]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### scrollPageToBottom
 
@@ -1340,6 +1441,8 @@ Scroll page to the bottom.
 I.scrollPageToBottom();
 ```
 
+Returns **[Promise][10]&lt;any>** 
+
 ### scrollPageToTop
 
 Scroll page to the top.
@@ -1347,6 +1450,8 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
+
+Returns **[Promise][10]&lt;any>** 
 
 ### scrollTo
 
@@ -1360,9 +1465,11 @@ I.scrollTo('#submit', 5, 5);
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][16]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][16]** (optional, `0` by default) Y-axis offset. 
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][17]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][17]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### see
 
@@ -1377,8 +1484,10 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 
 #### Parameters
 
--   `text` **[string][12]** expected on page.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+-   `text` **[string][13]** expected on page.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeAttributesOnElements
 
@@ -1390,8 +1499,10 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
--   `attributes` **[object][10]** attributes and their values to check.
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
+-   `attributes` **[object][11]** attributes and their values to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeCheckboxIsChecked
 
@@ -1405,7 +1516,9 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeCookie
 
@@ -1417,7 +1530,9 @@ I.seeCookie('Auth');
 
 #### Parameters
 
--   `name` **[string][12]** cookie name.
+-   `name` **[string][13]** cookie name.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeCssPropertiesOnElements
 
@@ -1429,8 +1544,10 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
--   `cssProperties` **[object][10]** object with CSS properties and their values to check.
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
+-   `cssProperties` **[object][11]** object with CSS properties and their values to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeCurrentUrlEquals
 
@@ -1445,7 +1562,9 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 #### Parameters
 
--   `url` **[string][12]** value to check.
+-   `url` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeElement
 
@@ -1458,7 +1577,9 @@ I.seeElement('#modal');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** located by CSS|XPath|strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeElementInDOM
 
@@ -1471,7 +1592,9 @@ I.seeElementInDOM('#modal');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeInCurrentUrl
 
@@ -1483,7 +1606,9 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 
 #### Parameters
 
--   `url` **[string][12]** a fragment to check
+-   `url` **[string][13]** a fragment to check
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeInField
 
@@ -1499,8 +1624,10 @@ I.seeInField('#searchform input','Search');
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][12]** value to check.
+-   `field` **([string][13] | [object][11])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeInPopup
 
@@ -1513,7 +1640,9 @@ I.seeInPopup('Popup text');
 
 #### Parameters
 
--   `text` **[string][12]** value to check.
+-   `text` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeInSource
 
@@ -1525,7 +1654,9 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 #### Parameters
 
--   `text` **[string][12]** value to check.
+-   `text` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeInTitle
 
@@ -1537,7 +1668,9 @@ I.seeInTitle('Home Page');
 
 #### Parameters
 
--   `text` **[string][12]** text value to check.
+-   `text` **[string][13]** text value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeNumberOfElements
 
@@ -1550,8 +1683,10 @@ I.seeNumberOfElements('#submitBtn', 1);
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `num` **[number][16]** number of elements.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `num` **[number][17]** number of elements.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeNumberOfVisibleElements
 
@@ -1564,8 +1699,10 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `num` **[number][16]** number of elements.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `num` **[number][17]** number of elements.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeTextEquals
 
@@ -1577,8 +1714,10 @@ I.seeTextEquals('text', 'h1');
 
 #### Parameters
 
--   `text` **[string][12]** element value to check.
--   `context` **([string][12] | [object][10])?** element located by CSS|XPath|strict locator. 
+-   `text` **[string][13]** element value to check.
+-   `context` **([string][13] | [object][11])?** element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### seeTitleEquals
 
@@ -1590,7 +1729,9 @@ I.seeTitleEquals('Test title.');
 
 #### Parameters
 
--   `text` **[string][12]** value to check.
+-   `text` **[string][13]** value to check.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### selectOption
 
@@ -1615,8 +1756,10 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 
 #### Parameters
 
--   `select` **([string][12] | [object][10])** field located by label|name|CSS|XPath|strict locator.
--   `option` **([string][12] | [Array][19]&lt;any>)** visible text or value of option.
+-   `select` **([string][13] | [object][11])** field located by label|name|CSS|XPath|strict locator.
+-   `option` **([string][13] | [Array][19]&lt;any>)** visible text or value of option.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### setCookie
 
@@ -1638,6 +1781,8 @@ I.setCookie([
 
 -   `cookie` **(Cookie | [Array][19]&lt;Cookie>)** a cookie object or array of cookie objects.
 
+Returns **[Promise][10]&lt;any>** 
+
 ### stopMockingRoute
 
 Stops network mocking created by `mockRoute`.
@@ -1651,8 +1796,10 @@ If no handler is passed, all mock requests for the rote are disabled.
 
 #### Parameters
 
--   `url` **[string][12]?** URL, regex or pattern for to match URL
--   `handler` **[function][17]?** a function to process request
+-   `url` **[string][13]?** URL, regex or pattern for to match URL
+-   `handler` **[function][18]?** a function to process request
+
+Returns **[Promise][10]&lt;any>** 
 
 ### switchTo
 
@@ -1665,7 +1812,9 @@ I.switchTo(); // switch back to main page
 
 #### Parameters
 
--   `locator` **([string][12]? | [object][10])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][13]? | [object][11])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### switchToNextTab
 
@@ -1678,7 +1827,9 @@ I.switchToNextTab(2);
 
 #### Parameters
 
--   `num` **[number][16]**  
+-   `num` **[number][17]**  
+
+Returns **[Promise][10]&lt;any>** 
 
 ### switchToPreviousTab
 
@@ -1691,7 +1842,9 @@ I.switchToPreviousTab(2);
 
 #### Parameters
 
--   `num` **[number][16]**  
+-   `num` **[number][17]**  
+
+Returns **[Promise][10]&lt;any>** 
 
 ### type
 
@@ -1713,8 +1866,10 @@ I.type(['T', 'E', 'X', 'T']);
 #### Parameters
 
 -   `keys`  
--   `delay` **[number][16]?** (optional) delay in ms between key presses 
--   `key` **([string][12] | [Array][19]&lt;[string][12]>)** or array of keys to type.
+-   `delay` **[number][17]?** (optional) delay in ms between key presses 
+-   `key` **([string][13] | [Array][19]&lt;[string][13]>)** or array of keys to type.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### uncheckOption
 
@@ -1731,12 +1886,14 @@ I.uncheckOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][12]? | [object][10])** (optional, `null` by default) element located by CSS | XPath | strict locator.[Additional options][29] for uncheck available as 3rd argument.Examples:```js
-    // click on element at position
-    I.uncheckOption('Agree', '.signup', { position: { x: 5, y: 5 } })
-    ```> ⚠️ To avoid flakiness, option `force: true` is set by default 
+-   `field` **([string][13] | [object][11])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][13]? | [object][11])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 -   `options`   
+
+Returns **[Promise][10]&lt;any>** [Additional options][29] for uncheck available as 3rd argument.Examples:```js
+// click on element at position
+I.uncheckOption('Agree', '.signup', { position: { x: 5, y: 5 } })
+```> ⚠️ To avoid flakiness, option `force: true` is set by default
 
 ### usePlaywrightTo
 
@@ -1755,8 +1912,10 @@ I.usePlaywrightTo('emulate offline mode', async ({ browserContext }) => {
 
 #### Parameters
 
--   `description` **[string][12]** used to show in logs.
--   `fn` **[function][17]** async function that executed with Playwright helper as argument
+-   `description` **[string][13]** used to show in logs.
+-   `fn` **[function][18]** async function that executed with Playwright helper as argument
+
+Returns **[Promise][10]&lt;any>** 
 
 ### wait
 
@@ -1768,7 +1927,9 @@ I.wait(2); // wait 2 secs
 
 #### Parameters
 
--   `sec` **[number][16]** number of second to wait.
+-   `sec` **[number][17]** number of second to wait.
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForClickable
 
@@ -1782,9 +1943,11 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
 -   `waitTimeout`  
--   `sec` **[number][16]?** (optional, `1` by default) time in seconds to wait
+-   `sec` **[number][17]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForDetached
 
@@ -1797,8 +1960,10 @@ I.waitForDetached('#popup');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForElement
 
@@ -1812,8 +1977,10 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `sec` **[number][16]?** (optional, `1` by default) time in seconds to wait
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][17]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForEnabled
 
@@ -1822,8 +1989,10 @@ Element can be located by CSS or XPath.
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `sec` **[number][16]** (optional) time in seconds to wait, 1 by default. 
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][17]** (optional) time in seconds to wait, 1 by default. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForFunction
 
@@ -1842,9 +2011,11 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][12] | [function][17])** to be executed in browser context.
--   `argsOrSec` **([Array][19]&lt;any> | [number][16])?** (optional, `1` by default) arguments for function or seconds. 
--   `sec` **[number][16]?** (optional, `1` by default) time in seconds to wait 
+-   `fn` **([string][13] | [function][18])** to be executed in browser context.
+-   `argsOrSec` **([Array][19]&lt;any> | [number][17])?** (optional, `1` by default) arguments for function or seconds. 
+-   `sec` **[number][17]?** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForInvisible
 
@@ -1857,8 +2028,10 @@ I.waitForInvisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForNavigation
 
@@ -1869,6 +2042,8 @@ See [Playwright's reference][33]
 #### Parameters
 
 -   `opts` **any**  
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForRequest
 
@@ -1881,8 +2056,10 @@ I.waitForRequest(request => request.url() === 'http://example.com' && request.me
 
 #### Parameters
 
--   `urlOrPredicate` **([string][12] | [function][17])** 
--   `sec` **[number][16]?** seconds to wait 
+-   `urlOrPredicate` **([string][13] | [function][18])** 
+-   `sec` **[number][17]?** seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForResponse
 
@@ -1895,8 +2072,10 @@ I.waitForResponse(response => response.url() === 'https://example.com' && respon
 
 #### Parameters
 
--   `urlOrPredicate` **([string][12] | [function][17])** 
--   `sec` **[number][16]?** number of seconds to wait 
+-   `urlOrPredicate` **([string][13] | [function][18])** 
+-   `sec` **[number][17]?** number of seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForText
 
@@ -1911,9 +2090,11 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 
 #### Parameters
 
--   `text` **[string][12]** to wait for.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
--   `context` **([string][12] | [object][10])?** (optional) element located by CSS|XPath|strict locator. 
+-   `text` **[string][13]** to wait for.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+-   `context` **([string][13] | [object][11])?** (optional) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForValue
 
@@ -1925,9 +2106,11 @@ I.waitForValue('//input', "GoodValue");
 
 #### Parameters
 
--   `field` **([string][12] | [object][10])** input field.
--   `value` **[string][12]** expected value.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `field` **([string][13] | [object][11])** input field.
+-   `value` **[string][13]** expected value.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitForVisible
 
@@ -1940,8 +2123,10 @@ I.waitForVisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to waitThis method accepts [React selectors][34]. 
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** This method accepts [React selectors][34].
 
 ### waitInUrl
 
@@ -1953,8 +2138,10 @@ I.waitInUrl('/info', 2);
 
 #### Parameters
 
--   `urlPart` **[string][12]** value to check.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `urlPart` **[string][13]** value to check.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitNumberOfVisibleElements
 
@@ -1966,9 +2153,11 @@ I.waitNumberOfVisibleElements('a', 3);
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `num` **[number][16]** number of elements.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `num` **[number][17]** number of elements.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitToHide
 
@@ -1981,8 +2170,10 @@ I.waitToHide('#popup');
 
 #### Parameters
 
--   `locator` **([string][12] | [object][10])** element located by CSS|XPath|strict locator.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][13] | [object][11])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 ### waitUrlEquals
 
@@ -1995,8 +2186,10 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 #### Parameters
 
--   `urlPart` **[string][12]** value to check.
--   `sec` **[number][16]** (optional, `1` by default) time in seconds to wait 
+-   `urlPart` **[string][13]** value to check.
+-   `sec` **[number][17]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][10]&lt;any>** 
 
 [1]: https://github.com/microsoft/playwright
 
@@ -2016,23 +2209,23 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [9]: https://github.com/microsoft/playwright/blob/v0.11.0/docs/api.md#working-with-chrome-extensions
 
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[11]: http://jster.net/category/windows-modals-popups
+[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[12]: http://jster.net/category/windows-modals-popups
 
-[13]: https://playwright.dev/docs/api/class-elementhandle#element-handle-check
+[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[14]: https://playwright.dev/docs/api/class-page#page-click
+[14]: https://playwright.dev/docs/api/class-elementhandle#element-handle-check
 
-[15]: https://playwright.dev/docs/api/class-page#page-drag-and-drop
+[15]: https://playwright.dev/docs/api/class-page#page-click
 
-[16]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[16]: https://playwright.dev/docs/api/class-page#page-drag-and-drop
 
-[17]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[17]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[18]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [19]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -279,6 +279,8 @@ I.amOnPage('/login'); // opens a login page
 
 -   `url` **[string][8]** url path or global url.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### appendField
 
 Appends text to a input field or textarea.
@@ -292,6 +294,8 @@ I.appendField('#myTextField', 'appended');
 
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator
 -   `value` **[string][8]** text value to append.
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -311,7 +315,9 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** field located by label|name|CSS|XPath|strict locator.
--   `pathToFile` **[string][8]** local file path relative to codecept.json config file.> ⚠ There is an [issue with file upload in Puppeteer 2.1.0 & 2.1.1][9], downgrade to 2.0.0 if you face it.
+-   `pathToFile` **[string][8]** local file path relative to codecept.json config file.
+
+Returns **[Promise][9]&lt;any>** > ⚠ There is an [issue with file upload in Puppeteer 2.1.0 & 2.1.1][10], downgrade to 2.0.0 if you face it.
 
 ### cancelPopup
 
@@ -335,6 +341,8 @@ I.checkOption('agree', '//form');
 -   `field` **([string][8] | [object][6])** checkbox located by label | name | CSS | XPath | strict locator.
 -   `context` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
+Returns **[Promise][9]&lt;any>** 
+
 ### clearCookie
 
 Clears a cookie by name,
@@ -350,6 +358,8 @@ I.clearCookie('test');
 -   `name`  
 -   `cookie` **[string][8]?** (optional, `null` by default) cookie name 
 
+Returns **[Promise][9]&lt;any>** 
+
 ### clearField
 
 Clears a `<textarea>` or text `<input>` element's value.
@@ -364,6 +374,8 @@ I.clearField('#email');
 
 -   `field`  
 -   `editable` **([string][8] | [object][6])** field located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### click
 
@@ -392,11 +404,13 @@ I.click({css: 'nav a.login'});
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### clickLink
 
@@ -409,11 +423,13 @@ I.clickLink('Logout', '#nav');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator
--   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator
+-   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### closeCurrentTab
 
@@ -444,11 +460,13 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 #### Parameters
 
 -   `text` **[string][8]** which is not present.
--   `context` **([string][8] | [object][6])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search.
+-   `context` **([string][8] | [object][6])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### dontSeeCheckboxIsChecked
 
@@ -464,6 +482,8 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### dontSeeCookie
 
 Checks that cookie with given name does not exist.
@@ -475,6 +495,8 @@ I.dontSeeCookie('auth'); // no auth cookie
 #### Parameters
 
 -   `name` **[string][8]** cookie name.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### dontSeeCurrentUrlEquals
 
@@ -490,6 +512,8 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 -   `url` **[string][8]** value to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### dontSeeElement
 
 Opposite to `seeElement`. Checks that element is not visible (or in DOM)
@@ -501,7 +525,8 @@ I.dontSeeElement('.modal'); // modal is not shown
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|Strict locator.
-    
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -519,6 +544,8 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|Strict locator.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### dontSeeInCurrentUrl
 
 Checks that current url does not contain a provided fragment.
@@ -526,6 +553,8 @@ Checks that current url does not contain a provided fragment.
 #### Parameters
 
 -   `url` **[string][8]** value to check.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### dontSeeInField
 
@@ -542,6 +571,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][8]** value to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### dontSeeInSource
 
 Checks that the current page does not contains the given string in its raw source code.
@@ -555,6 +586,8 @@ I.dontSeeInSource('<!--'); // no comments in source
 -   `text`  
 -   `value` **[string][8]** to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### dontSeeInTitle
 
 Checks that title does not contain text.
@@ -566,6 +599,8 @@ I.dontSeeInTitle('Error');
 #### Parameters
 
 -   `text` **[string][8]** value to check.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### doubleClick
 
@@ -582,11 +617,13 @@ I.doubleClick('.btn.edit');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### downloadFile
 
@@ -612,6 +649,8 @@ I.dragAndDrop('#dragHandle', '#container');
 -   `srcElement` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 -   `destElement` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### dragSlider
 
 Drag the scrubber of a slider to a given position
@@ -625,19 +664,20 @@ I.dragSlider('#slider', -70);
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
--   `offsetX` **[number][10]** position to drag.
-    
+-   `offsetX` **[number][11]** position to drag. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### executeAsyncScript
 
 Executes async script on page.
 Provided function should execute a passed callback (as first argument) to signal it is finished.
 
-Example: In Vue.js to make components completely rendered we are waiting for [nextTick][11].
+Example: In Vue.js to make components completely rendered we are waiting for [nextTick][12].
 
 ```js
 I.executeAsyncScript(function(done) {
@@ -658,9 +698,9 @@ let val = await I.executeAsyncScript(function(url, done) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
--   `fn` **([string][8] | [function][12])** function to be executed in browser context.
+-   `fn` **([string][8] | [function][13])** function to be executed in browser context.
 
-Returns **[Promise][13]&lt;any>** Asynchronous scripts can also be executed with `executeScript` if a function returns a Promise.
+Returns **[Promise][9]&lt;any>** Asynchronous scripts can also be executed with `executeScript` if a function returns a Promise.
 
 ### executeScript
 
@@ -691,9 +731,9 @@ let date = await I.executeScript(function(el) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
--   `fn` **([string][8] | [function][12])** function to be executed in browser context.
+-   `fn` **([string][8] | [function][13])** function to be executed in browser context.
 
-Returns **[Promise][13]&lt;any>** If a function returns a Promise It will wait for it resolution.
+Returns **[Promise][9]&lt;any>** If a function returns a Promise It will wait for it resolution.
 
 ### fillField
 
@@ -715,6 +755,8 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
 -   `value` **([string][8] | [object][6])** text value to fill.
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -750,11 +792,13 @@ I.forceClick({css: 'nav a.login'});
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][8]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### grabAttributeFrom
 
@@ -771,7 +815,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][8]** attribute name.
 
-Returns **[Promise][13]&lt;[string][8]>** attribute value
+Returns **[Promise][9]&lt;[string][8]>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -791,7 +835,7 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][8]** attribute name.
 
-Returns **[Promise][13]&lt;[Array][14]&lt;[string][8]>>** attribute value
+Returns **[Promise][9]&lt;[Array][14]&lt;[string][8]>>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -806,7 +850,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **[Promise][13]&lt;[Array][14]&lt;any>>** 
+Returns **[Promise][9]&lt;[Array][14]&lt;any>>** 
 
 ### grabCookie
 
@@ -823,7 +867,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][8]?** cookie name. 
 
-Returns **([Promise][13]&lt;[string][8]> | [Promise][13]&lt;[Array][14]&lt;[string][8]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][9]&lt;[string][8]> | [Promise][9]&lt;[Array][14]&lt;[string][8]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCssPropertyFrom
 
@@ -840,7 +884,7 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][8]** CSS property name.
 
-Returns **[Promise][13]&lt;[string][8]>** CSS value
+Returns **[Promise][9]&lt;[string][8]>** CSS value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -860,7 +904,7 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][8]** CSS property name.
 
-Returns **[Promise][13]&lt;[Array][14]&lt;[string][8]>>** CSS value
+Returns **[Promise][9]&lt;[Array][14]&lt;[string][8]>>** CSS value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -876,7 +920,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][13]&lt;[string][8]>** current URL
+Returns **[Promise][9]&lt;[string][8]>** current URL
 
 ### grabDataFromPerformanceTiming
 
@@ -900,6 +944,8 @@ let data = await I.grabDataFromPerformanceTiming();
   loadEventEnd: 241
 }
 ```
+
+Returns **[Promise][9]&lt;any>** 
 
 ### grabElementBoundingRect
 
@@ -927,7 +973,7 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 -   `prop`  
 -   `elementSize` **[string][8]?** x, y, width or height of the given element.
 
-Returns **([Promise][13]&lt;DOMRect> | [Promise][13]&lt;[number][10]>)** Element bounding rectangle
+Returns **([Promise][9]&lt;DOMRect> | [Promise][9]&lt;[number][11]>)** Element bounding rectangle
 
 ### grabHTMLFrom
 
@@ -944,7 +990,7 @@ let postHTML = await I.grabHTMLFrom('#post');
 -   `locator`  
 -   `element` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[string][8]>** HTML code for an element
+Returns **[Promise][9]&lt;[string][8]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -960,7 +1006,7 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 -   `locator`  
 -   `element` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[Array][14]&lt;[string][8]>>** HTML code for an element
+Returns **[Promise][9]&lt;[Array][14]&lt;[string][8]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -971,7 +1017,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][13]&lt;[number][10]>** number of open tabs
+Returns **[Promise][9]&lt;[number][11]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -986,7 +1032,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[number][10]>** number of visible elements
+Returns **[Promise][9]&lt;[number][11]>** number of visible elements
 
 
 
@@ -1002,7 +1048,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][13]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][9]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -1012,7 +1058,7 @@ Grab the text within the popup. If no popup is visible then it will return null
 await I.grabPopupText();
 ```
 
-Returns **[Promise][13]&lt;([string][8] | null)>** 
+Returns **[Promise][9]&lt;([string][8] | null)>** 
 
 ### grabSource
 
@@ -1023,7 +1069,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][13]&lt;[string][8]>** source code
+Returns **[Promise][9]&lt;[string][8]>** source code
 
 ### grabTextFrom
 
@@ -1040,7 +1086,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[string][8]>** attribute value
+Returns **[Promise][9]&lt;[string][8]>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1059,7 +1105,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[Array][14]&lt;[string][8]>>** attribute value
+Returns **[Promise][9]&lt;[Array][14]&lt;[string][8]>>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1074,7 +1120,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][13]&lt;[string][8]>** title
+Returns **[Promise][9]&lt;[string][8]>** title
 
 ### grabValueFrom
 
@@ -1090,7 +1136,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][8] | [object][6])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[string][8]>** attribute value
+Returns **[Promise][9]&lt;[string][8]>** attribute value
 
 ### grabValueFromAll
 
@@ -1105,7 +1151,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][8] | [object][6])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][13]&lt;[Array][14]&lt;[string][8]>>** attribute value
+Returns **[Promise][9]&lt;[Array][14]&lt;[string][8]>>** attribute value
 
 ### handleDownloads
 
@@ -1153,12 +1199,14 @@ I.moveCursorTo('#submit', 5,5);
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset.
+-   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### openNewTab
 
@@ -1231,7 +1279,9 @@ Some of the supported key names are:
 
 #### Parameters
 
--   `key` **([string][8] | [Array][14]&lt;[string][8]>)** key or array of keys to press._Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/puppeteer#1313][17]).
+-   `key` **([string][8] | [Array][14]&lt;[string][8]>)** key or array of keys to press.
+
+Returns **[Promise][9]&lt;any>** _Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/puppeteer#1313][17]).
 
 ### pressKeyDown
 
@@ -1249,6 +1299,8 @@ I.pressKeyUp('Control');
 
 -   `key` **[string][8]** name of key to press down.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### pressKeyUp
 
 Releases a key in the browser which was previously set to a down state.
@@ -1265,6 +1317,8 @@ I.pressKeyUp('Control');
 
 -   `key` **[string][8]** name of key to release.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### refreshPage
 
 Reload the current page.
@@ -1273,6 +1327,8 @@ Reload the current page.
 I.refreshPage();
 ```
 
+Returns **[Promise][9]&lt;any>** 
+
 ### resizeWindow
 
 Resize the current window to provided width and height.
@@ -1280,10 +1336,12 @@ First parameter can be set to `maximize`.
 
 #### Parameters
 
--   `width` **[number][10]** width in pixels or `maximize`.
--   `height` **[number][10]** height in pixels.Unlike other drivers Puppeteer changes the size of a viewport, not the window!
-    Puppeteer does not control the window of a browser so it can't adjust its real size.
-    It also can't maximize a window.
+-   `width` **[number][11]** width in pixels or `maximize`.
+-   `height` **[number][11]** height in pixels.
+
+Returns **[Promise][9]&lt;any>** Unlike other drivers Puppeteer changes the size of a viewport, not the window!
+Puppeteer does not control the window of a browser so it can't adjust its real size.
+It also can't maximize a window.
 
 ### rightClick
 
@@ -1301,11 +1359,13 @@ I.rightClick('Click me', '.context');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator.
+-   `context` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### saveElementScreenshot
 
@@ -1320,6 +1380,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 -   `fileName` **[string][8]** file name to save.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### saveScreenshot
 
@@ -1337,6 +1399,8 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 -   `fileName` **[string][8]** file name to save.
 -   `fullPage` **[boolean][19]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
 
+Returns **[Promise][9]&lt;any>** 
+
 ### scrollPageToBottom
 
 Scroll page to the bottom.
@@ -1345,6 +1409,8 @@ Scroll page to the bottom.
 I.scrollPageToBottom();
 ```
 
+Returns **[Promise][9]&lt;any>** 
+
 ### scrollPageToTop
 
 Scroll page to the top.
@@ -1352,6 +1418,8 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
+
+Returns **[Promise][9]&lt;any>** 
 
 ### scrollTo
 
@@ -1366,8 +1434,10 @@ I.scrollTo('#submit', 5, 5);
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. 
+-   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### see
 
@@ -1383,11 +1453,13 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 #### Parameters
 
 -   `text` **[string][8]** expected on page.
--   `context` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text.
+-   `context` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### seeAttributesOnElements
 
@@ -1401,7 +1473,8 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 -   `attributes` **[object][6]** attributes and their values to check.
-    
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1421,6 +1494,8 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeCookie
 
 Checks that cookie with given name exists.
@@ -1432,6 +1507,8 @@ I.seeCookie('Auth');
 #### Parameters
 
 -   `name` **[string][8]** cookie name.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### seeCssPropertiesOnElements
 
@@ -1445,7 +1522,8 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
 -   `cssProperties` **[object][6]** object with CSS properties and their values to check.
-    
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1466,6 +1544,8 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 -   `url` **[string][8]** value to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeElement
 
 Checks that a given Element is visible
@@ -1478,7 +1558,8 @@ I.seeElement('#modal');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** located by CSS|XPath|strict locator.
-    
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1497,6 +1578,8 @@ I.seeElementInDOM('#modal');
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeInCurrentUrl
 
 Checks that current url contains a provided fragment.
@@ -1508,6 +1591,8 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 #### Parameters
 
 -   `url` **[string][8]** a fragment to check
+
+Returns **[Promise][9]&lt;any>** 
 
 ### seeInField
 
@@ -1526,6 +1611,8 @@ I.seeInField('#searchform input','Search');
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][8]** value to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeInPopup
 
 Checks that the active JavaScript popup, as created by `window.alert|window.confirm|window.prompt`, contains the
@@ -1539,6 +1626,8 @@ I.seeInPopup('Popup text');
 
 -   `text` **[string][8]** value to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeInSource
 
 Checks that the current page contains the given string in its raw source code.
@@ -1550,6 +1639,8 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 #### Parameters
 
 -   `text` **[string][8]** value to check.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### seeInTitle
 
@@ -1563,6 +1654,8 @@ I.seeInTitle('Home Page');
 
 -   `text` **[string][8]** text value to check.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeNumberOfElements
 
 Asserts that an element appears a given number of times in the DOM.
@@ -1575,7 +1668,9 @@ I.seeNumberOfElements('#submitBtn', 1);
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
+-   `num` **[number][11]** number of elements.
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1593,7 +1688,9 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
+-   `num` **[number][11]** number of elements.
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1612,6 +1709,8 @@ I.seeTextEquals('text', 'h1');
 -   `text` **[string][8]** element value to check.
 -   `context` **([string][8] | [object][6])?** element located by CSS|XPath|strict locator. 
 
+Returns **[Promise][9]&lt;any>** 
+
 ### seeTitleEquals
 
 Checks that title is equal to provided one.
@@ -1623,6 +1722,8 @@ I.seeTitleEquals('Test title.');
 #### Parameters
 
 -   `text` **[string][8]** value to check.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### selectOption
 
@@ -1650,6 +1751,8 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 -   `select` **([string][8] | [object][6])** field located by label|name|CSS|XPath|strict locator.
 -   `option` **([string][8] | [Array][14]&lt;any>)** visible text or value of option.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### setCookie
 
 Sets cookie(s).
@@ -1670,6 +1773,8 @@ I.setCookie([
 
 -   `cookie` **(Cookie | [Array][14]&lt;Cookie>)** a cookie object or array of cookie objects.
 
+Returns **[Promise][9]&lt;any>** 
+
 ### switchTo
 
 Switches frame or in case of null locator reverts to parent.
@@ -1683,6 +1788,8 @@ I.switchTo(); // switch back to main page
 
 -   `locator` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
+Returns **[Promise][9]&lt;any>** 
+
 ### switchToNextTab
 
 Switch focus to a particular tab by its number. It waits tabs loading and then switch tab
@@ -1694,7 +1801,7 @@ I.switchToNextTab(2);
 
 #### Parameters
 
--   `num` **[number][10]**  
+-   `num` **[number][11]**  
 
 ### switchToPreviousTab
 
@@ -1707,7 +1814,7 @@ I.switchToPreviousTab(2);
 
 #### Parameters
 
--   `num` **[number][10]**  
+-   `num` **[number][11]**  
 
 ### type
 
@@ -1729,8 +1836,10 @@ I.type(['T', 'E', 'X', 'T']);
 #### Parameters
 
 -   `keys`  
--   `delay` **[number][10]?** (optional) delay in ms between key presses 
+-   `delay` **[number][11]?** (optional) delay in ms between key presses 
 -   `key` **([string][8] | [Array][14]&lt;[string][8]>)** or array of keys to type.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### uncheckOption
 
@@ -1750,6 +1859,8 @@ I.uncheckOption('agree', '//form');
 -   `field` **([string][8] | [object][6])** checkbox located by label | name | CSS | XPath | strict locator.
 -   `context` **([string][8]? | [object][6])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
+Returns **[Promise][9]&lt;any>** 
+
 ### usePuppeteerTo
 
 Use Puppeteer API inside a test.
@@ -1768,7 +1879,7 @@ I.usePuppeteerTo('emulate offline mode', async ({ page }) {
 #### Parameters
 
 -   `description` **[string][8]** used to show in logs.
--   `fn` **[function][12]** async function that is executed with Puppeteer as argument
+-   `fn` **[function][13]** async function that is executed with Puppeteer as argument
 
 ### wait
 
@@ -1780,7 +1891,9 @@ I.wait(2); // wait 2 secs
 
 #### Parameters
 
--   `sec` **[number][10]** number of second to wait.
+-   `sec` **[number][11]** number of second to wait.
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForClickable
 
@@ -1796,7 +1909,9 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
 -   `waitTimeout`  
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForDetached
 
@@ -1810,7 +1925,9 @@ I.waitForDetached('#popup');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForElement
 
@@ -1825,8 +1942,9 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait
-    
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1840,7 +1958,9 @@ Element can be located by CSS or XPath.
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional) time in seconds to wait, 1 by default. 
+-   `sec` **[number][11]** (optional) time in seconds to wait, 1 by default. 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForFunction
 
@@ -1859,9 +1979,11 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][8] | [function][12])** to be executed in browser context.
--   `argsOrSec` **([Array][14]&lt;any> | [number][10])?** (optional, `1` by default) arguments for function or seconds. 
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait 
+-   `fn` **([string][8] | [function][13])** to be executed in browser context.
+-   `argsOrSec` **([Array][14]&lt;any> | [number][11])?** (optional, `1` by default) arguments for function or seconds. 
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForInvisible
 
@@ -1875,7 +1997,9 @@ I.waitForInvisible('#popup');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForNavigation
 
@@ -1898,8 +2022,8 @@ I.waitForRequest(request => request.url() === 'http://example.com' && request.me
 
 #### Parameters
 
--   `urlOrPredicate` **([string][8] | [function][12])** 
--   `sec` **[number][10]?** seconds to wait 
+-   `urlOrPredicate` **([string][8] | [function][13])** 
+-   `sec` **[number][11]?** seconds to wait 
 
 ### waitForResponse
 
@@ -1912,8 +2036,8 @@ I.waitForResponse(response => response.url() === 'http://example.com' && respons
 
 #### Parameters
 
--   `urlOrPredicate` **([string][8] | [function][12])** 
--   `sec` **[number][10]?** number of seconds to wait 
+-   `urlOrPredicate` **([string][8] | [function][13])** 
+-   `sec` **[number][11]?** number of seconds to wait 
 
 ### waitForText
 
@@ -1929,8 +2053,10 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 #### Parameters
 
 -   `text` **[string][8]** to wait for.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 -   `context` **([string][8] | [object][6])?** (optional) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForValue
 
@@ -1944,7 +2070,9 @@ I.waitForValue('//input', "GoodValue");
 
 -   `field` **([string][8] | [object][6])** input field.
 -   `value` **[string][8]** expected value.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitForVisible
 
@@ -1958,7 +2086,9 @@ I.waitForVisible('#popup');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to waitThis method accepts [React selectors][22]. 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** This method accepts [React selectors][22].
 
 ### waitInUrl
 
@@ -1971,7 +2101,9 @@ I.waitInUrl('/info', 2);
 #### Parameters
 
 -   `urlPart` **[string][8]** value to check.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitNumberOfVisibleElements
 
@@ -1984,13 +2116,14 @@ I.waitNumberOfVisibleElements('a', 3);
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait
-    
+-   `num` **[number][11]** number of elements.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### waitToHide
 
@@ -2004,7 +2137,9 @@ I.waitToHide('#popup');
 #### Parameters
 
 -   `locator` **([string][8] | [object][6])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 ### waitUrlEquals
 
@@ -2018,7 +2153,9 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 #### Parameters
 
 -   `urlPart` **[string][8]** value to check.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][9]&lt;any>** 
 
 [1]: https://github.com/GoogleChrome/puppeteer
 
@@ -2036,15 +2173,15 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[9]: https://github.com/puppeteer/puppeteer/issues/5420
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[10]: https://github.com/puppeteer/puppeteer/issues/5420
 
-[11]: https://vuejs.org/v2/api/#Vue-nextTick
+[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[12]: https://vuejs.org/v2/api/#Vue-nextTick
 
-[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -82,7 +82,7 @@ I.amBearerAuthenticated(secret('heregoestoken'))
 
 #### Parameters
 
--   `accessToken` **[string][3]** Bearer access token
+-   `accessToken` **([string][3] | CodeceptJS.Secret)** Bearer access token
 
 ### haveRequestHeaders
 

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -107,6 +107,8 @@ I.amOnPage('/login'); // opens a login page
 
 -   `url` **[string][4]** url path or global url.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### appendField
 
 Appends text to a input field or textarea.
@@ -118,8 +120,10 @@ I.appendField('#myTextField', 'appended');
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator
+-   `field` **([string][4] | [object][6])** located by label|name|CSS|XPath|strict locator
 -   `value` **[string][4]** text value to append.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### attachFile
 
@@ -136,7 +140,9 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 -   `field`  
 -   `pathToFile` **[string][4]** local file path relative to codecept.json config file.
--   `locator` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** field located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### checkOption
 
@@ -153,8 +159,10 @@ I.checkOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][4]? | [object][5])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+-   `field` **([string][4] | [object][6])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### clearCookie
 
@@ -171,6 +179,8 @@ I.clearCookie('test');
 -   `cookieName`  
 -   `cookie` **[string][4]?** (optional, `null` by default) cookie name 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### clearField
 
 Clears a `<textarea>` or text `<input>` element's value.
@@ -184,7 +194,9 @@ I.clearField('#email');
 #### Parameters
 
 -   `field`  
--   `editable` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
+-   `editable` **([string][4] | [object][6])** field located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### click
 
@@ -212,8 +224,10 @@ I.click({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][5])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][4] | [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][4]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSee
 
@@ -228,7 +242,9 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 #### Parameters
 
 -   `text` **[string][4]** which is not present.
--   `context` **([string][4] | [object][5])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+-   `context` **([string][4] | [object][6])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeCheckboxIsChecked
 
@@ -242,7 +258,9 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][4] | [object][6])** located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeCookie
 
@@ -255,6 +273,8 @@ I.dontSeeCookie('auth'); // no auth cookie
 #### Parameters
 
 -   `name` **[string][4]** cookie name.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeCurrentUrlEquals
 
@@ -270,6 +290,8 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 -   `url` **[string][4]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### dontSeeElement
 
 Opposite to `seeElement`. Checks that element is not visible (or in DOM)
@@ -280,7 +302,9 @@ I.dontSeeElement('.modal'); // modal is not shown
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][4] | [object][6])** located by CSS|XPath|Strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeElementInDOM
 
@@ -292,7 +316,9 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][4] | [object][6])** located by CSS|XPath|Strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeInCurrentUrl
 
@@ -301,6 +327,8 @@ Checks that current url does not contain a provided fragment.
 #### Parameters
 
 -   `url` **[string][4]** value to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeInField
 
@@ -314,8 +342,10 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][4] | [object][6])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][4]** value to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### dontSeeInSource
 
@@ -329,6 +359,8 @@ I.dontSeeInSource('<!--'); // no comments in source
 
 -   `text`  
 -   `value` **[string][4]** to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### doubleClick
 
@@ -344,8 +376,10 @@ I.doubleClick('.btn.edit');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][5])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][4] | [object][6])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][4]? | [object][6])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### executeScript
 
@@ -375,10 +409,10 @@ let date = await I.executeScript(function(el) {
 
 #### Parameters
 
--   `fn` **([string][4] | [function][6])** function to be executed in browser context.
+-   `fn` **([string][4] | [function][7])** function to be executed in browser context.
 -   `args` **...any** to be passed to function.
 
-Returns **[Promise][7]&lt;any>** If a function returns a Promise It will wait for it resolution.
+Returns **[Promise][5]&lt;any>** If a function returns a Promise It will wait for it resolution.
 
 ### fillField
 
@@ -398,8 +432,10 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator.
--   `value` **([string][4] | [object][5])** text value to fill.
+-   `field` **([string][4] | [object][6])** located by label|name|CSS|XPath|strict locator.
+-   `value` **([string][4] | [object][6])** text value to fill.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### grabAttributeFrom
 
@@ -413,10 +449,10 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][4]** attribute name.
 
-Returns **[Promise][7]&lt;[string][4]>** attribute value
+Returns **[Promise][5]&lt;[string][4]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -430,10 +466,10 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][4]** attribute name.
 
-Returns **[Promise][7]&lt;[string][4]>** attribute value
+Returns **[Promise][5]&lt;[string][4]>** attribute value
 
 ### grabBrowserLogs
 
@@ -459,7 +495,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][4]?** cookie name. 
 
-Returns **([Promise][7]&lt;[string][4]> | [Promise][7]&lt;[Array][8]&lt;[string][4]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][5]&lt;[string][4]> | [Promise][5]&lt;[Array][8]&lt;[string][4]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCurrentUrl
 
@@ -471,7 +507,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][7]&lt;[string][4]>** current URL
+Returns **[Promise][5]&lt;[string][4]>** current URL
 
 ### grabNumberOfVisibleElements
 
@@ -484,9 +520,9 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][7]&lt;[number][9]>** number of visible elements
+Returns **[Promise][5]&lt;[number][9]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -497,7 +533,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][7]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][5]&lt;PageScrollPosition>** scroll position
 
 ### grabSource
 
@@ -508,7 +544,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][7]&lt;[string][4]>** source code
+Returns **[Promise][5]&lt;[string][4]>** source code
 
 ### grabTextFrom
 
@@ -523,9 +559,9 @@ If multiple elements found returns first element.
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][7]&lt;[string][4]>** attribute value
+Returns **[Promise][5]&lt;[string][4]>** attribute value
 
 ### grabTextFromAll
 
@@ -538,9 +574,9 @@ let pins = await I.grabTextFromAll('#pin li');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][7]&lt;[Array][8]&lt;[string][4]>>** attribute value
+Returns **[Promise][5]&lt;[Array][8]&lt;[string][4]>>** attribute value
 
 ### grabValueFrom
 
@@ -554,9 +590,9 @@ let email = await I.grabValueFrom('input[name=email]');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][7]&lt;[string][4]>** attribute value
+Returns **[Promise][5]&lt;[string][4]>** attribute value
 
 ### grabValueFromAll
 
@@ -569,9 +605,9 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][7]&lt;[Array][8]&lt;[string][4]>>** attribute value
+Returns **[Promise][5]&lt;[Array][8]&lt;[string][4]>>** attribute value
 
 ### moveCursorTo
 
@@ -585,9 +621,11 @@ I.moveCursorTo('#submit', 5,5);
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** located by CSS|XPath|strict locator.
 -   `offsetX` **[number][9]** (optional, `0` by default) X-axis offset. 
 -   `offsetY` **[number][9]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### pressKey
 
@@ -604,6 +642,8 @@ I.pressKey(['Control','a']);
 #### Parameters
 
 -   `key` **([string][4] | [Array][8]&lt;[string][4]>)** key or array of keys to press.
+
+Returns **[Promise][5]&lt;any>** 
 
 
 [Valid key names](https://w3c.github.io/webdriver/#keyboard-actions) are:
@@ -646,6 +686,8 @@ Reload the current page.
 I.refreshPage();
 ```
 
+Returns **[Promise][5]&lt;any>** 
+
 ### resizeWindow
 
 Resize the current window to provided width and height.
@@ -655,6 +697,8 @@ First parameter can be set to `maximize`.
 
 -   `width` **[number][9]** width in pixels or `maximize`.
 -   `height` **[number][9]** height in pixels.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### rightClick
 
@@ -671,8 +715,10 @@ I.rightClick('Click me', '.context');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][4]? | [object][5])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][4] | [object][6])** clickable element located by CSS|XPath|strict locator.
+-   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### saveElementScreenshot
 
@@ -685,8 +731,10 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `fileName` **[string][4]** file name to save.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### saveScreenshot
 
@@ -704,6 +752,8 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 -   `fileName` **[string][4]** file name to save.
 -   `fullPage` **[boolean][11]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### scrollPageToBottom
 
 Scroll page to the bottom.
@@ -712,6 +762,8 @@ Scroll page to the bottom.
 I.scrollPageToBottom();
 ```
 
+Returns **[Promise][5]&lt;any>** 
+
 ### scrollPageToTop
 
 Scroll page to the top.
@@ -719,6 +771,8 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
+
+Returns **[Promise][5]&lt;any>** 
 
 ### scrollTo
 
@@ -732,9 +786,11 @@ I.scrollTo('#submit', 5, 5);
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** located by CSS|XPath|strict locator.
 -   `offsetX` **[number][9]** (optional, `0` by default) X-axis offset. 
 -   `offsetY` **[number][9]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### see
 
@@ -750,7 +806,9 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 #### Parameters
 
 -   `text` **[string][4]** expected on page.
--   `context` **([string][4]? | [object][5])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+-   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeCheckboxIsChecked
 
@@ -764,7 +822,9 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][4] | [object][6])** located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeCookie
 
@@ -777,6 +837,8 @@ I.seeCookie('Auth');
 #### Parameters
 
 -   `name` **[string][4]** cookie name.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeCurrentUrlEquals
 
@@ -793,6 +855,8 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 -   `url` **[string][4]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeElement
 
 Checks that a given Element is visible
@@ -804,7 +868,9 @@ I.seeElement('#modal');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** located by CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeElementInDOM
 
@@ -817,7 +883,9 @@ I.seeElementInDOM('#modal');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeInCurrentUrl
 
@@ -830,6 +898,8 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 #### Parameters
 
 -   `url` **[string][4]** a fragment to check
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeInField
 
@@ -845,8 +915,10 @@ I.seeInField('#searchform input','Search');
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][4] | [object][6])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][4]** value to check.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeInSource
 
@@ -860,6 +932,8 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 -   `text` **[string][4]** value to check.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### seeNumberOfVisibleElements
 
 Asserts that an element is visible a given number of times.
@@ -871,8 +945,10 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `num` **[number][9]** number of elements.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### seeTextEquals
 
@@ -910,8 +986,10 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 
 #### Parameters
 
--   `select` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
+-   `select` **([string][4] | [object][6])** field located by label|name|CSS|XPath|strict locator.
 -   `option` **([string][4] | [Array][8]&lt;any>)** visible text or value of option.
+
+Returns **[Promise][5]&lt;any>** 
 
 ### setCookie
 
@@ -933,6 +1011,8 @@ I.setCookie([
 
 -   `cookie` **(Cookie | [Array][8]&lt;Cookie>)** a cookie object or array of cookie objects.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### switchTo
 
 Switches frame or in case of null locator reverts to parent.
@@ -944,7 +1024,9 @@ I.switchTo(); // switch back to main page
 
 #### Parameters
 
--   `locator` **([string][4]? | [object][5])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### uncheckOption
 
@@ -961,8 +1043,10 @@ I.uncheckOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][4] | [object][5])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][4]? | [object][5])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+-   `field` **([string][4] | [object][6])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][4]? | [object][6])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### useTestCafeTo
 
@@ -982,7 +1066,7 @@ I.useTestCafeTo('handle browser dialog', async ({ t }) {
 #### Parameters
 
 -   `description` **[string][4]** used to show in logs.
--   `fn` **[function][6]** async functuion that executed with TestCafe helper as argument
+-   `fn` **[function][7]** async functuion that executed with TestCafe helper as argument
 
 ### wait
 
@@ -996,6 +1080,8 @@ I.wait(2); // wait 2 secs
 
 -   `sec` **[number][9]** number of second to wait.
 
+Returns **[Promise][5]&lt;any>** 
+
 ### waitForElement
 
 Waits for element to be present on page (by default waits for 1sec).
@@ -1008,8 +1094,10 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][9]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForFunction
 
@@ -1028,9 +1116,11 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][4] | [function][6])** to be executed in browser context.
+-   `fn` **([string][4] | [function][7])** to be executed in browser context.
 -   `argsOrSec` **([Array][8]&lt;any> | [number][9])?** (optional, `1` by default) arguments for function or seconds. 
 -   `sec` **[number][9]?** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForInvisible
 
@@ -1043,8 +1133,10 @@ I.waitForInvisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForText
 
@@ -1061,7 +1153,9 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 
 -   `text` **[string][4]** to wait for.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
--   `context` **([string][4] | [object][5])?** (optional) element located by CSS|XPath|strict locator. 
+-   `context` **([string][4] | [object][6])?** (optional) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitForVisible
 
@@ -1074,8 +1168,10 @@ I.waitForVisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitInUrl
 
@@ -1090,6 +1186,8 @@ I.waitInUrl('/info', 2);
 -   `urlPart` **[string][4]** value to check.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
 
+Returns **[Promise][5]&lt;any>** 
+
 ### waitNumberOfVisibleElements
 
 Waits for a specified number of elements on the page.
@@ -1100,9 +1198,11 @@ I.waitNumberOfVisibleElements('a', 3);
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `num` **[number][9]** number of elements.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitToHide
 
@@ -1115,8 +1215,10 @@ I.waitToHide('#popup');
 
 #### Parameters
 
--   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][4] | [object][6])** element located by CSS|XPath|strict locator.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ### waitUrlEquals
 
@@ -1131,6 +1233,8 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 -   `urlPart` **[string][4]** value to check.
 -   `sec` **[number][9]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][5]&lt;any>** 
 
 ## getPageUrl
 
@@ -1148,11 +1252,11 @@ Client Functions
 
 [4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[5]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[6]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -449,6 +449,8 @@ I.amOnPage('/login'); // opens a login page
 
 -   `url` **[string][19]** url path or global url.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### appendField
 
 Appends text to a input field or textarea.
@@ -462,7 +464,8 @@ I.appendField('#myTextField', 'appended');
 
 -   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator
 -   `value` **[string][19]** text value to append.
-    
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -483,7 +486,8 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 -   `locator` **([string][19] | [object][18])** field located by label|name|CSS|XPath|strict locator.
 -   `pathToFile` **[string][19]** local file path relative to codecept.json config file.
-    Appium: not tested
+
+Returns **[Promise][21]&lt;any>** Appium: not tested
 
 ### cancelPopup
 
@@ -505,8 +509,9 @@ I.checkOption('agree', '//form');
 #### Parameters
 
 -   `field` **([string][19] | [object][18])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS | XPath | strict locator.
-    Appium: not tested 
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+
+Returns **[Promise][21]&lt;any>** Appium: not tested
 
 ### clearCookie
 
@@ -522,6 +527,8 @@ I.clearCookie('test');
 
 -   `cookie` **[string][19]?** (optional, `null` by default) cookie name 
 
+Returns **[Promise][21]&lt;any>** 
+
 ### clearField
 
 Clears a `<textarea>` or text `<input>` element's value.
@@ -536,6 +543,8 @@ I.clearField('#email');
 
 -   `field`  
 -   `editable` **([string][19] | [object][18])** field located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### click
 
@@ -564,11 +573,13 @@ I.click({css: 'nav a.login'});
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### closeCurrentTab
 
@@ -578,6 +589,8 @@ Close current tab.
 I.closeCurrentTab();
 ```
 
+Returns **[Promise][21]&lt;any>** 
+
 ### closeOtherTabs
 
 Close all tabs except for the current one.
@@ -586,9 +599,11 @@ Close all tabs except for the current one.
 I.closeOtherTabs();
 ```
 
+Returns **[Promise][21]&lt;any>** 
+
 ### defineTimeout
 
-Set [WebDriver timeouts][21] in realtime.
+Set [WebDriver timeouts][22] in realtime.
 
 Timeouts are expected to be passed as object:
 
@@ -614,11 +629,13 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 #### Parameters
 
 -   `text` **[string][19]** which is not present.
--   `context` **([string][19] | [object][18])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search.
+-   `context` **([string][19] | [object][18])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### dontSeeCheckboxIsChecked
 
@@ -632,7 +649,9 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 #### Parameters
 
--   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.Appium: not tested
+-   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][21]&lt;any>** Appium: not tested
 
 ### dontSeeCookie
 
@@ -645,6 +664,8 @@ I.dontSeeCookie('auth'); // no auth cookie
 #### Parameters
 
 -   `name` **[string][19]** cookie name.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### dontSeeCurrentUrlEquals
 
@@ -660,6 +681,8 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 -   `url` **[string][19]** value to check.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### dontSeeElement
 
 Opposite to `seeElement`. Checks that element is not visible (or in DOM)
@@ -671,7 +694,8 @@ I.dontSeeElement('.modal'); // modal is not shown
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|Strict locator.
-    
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -689,6 +713,8 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|Strict locator.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### dontSeeInCurrentUrl
 
 Checks that current url does not contain a provided fragment.
@@ -696,6 +722,8 @@ Checks that current url does not contain a provided fragment.
 #### Parameters
 
 -   `url` **[string][19]** value to check.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### dontSeeInField
 
@@ -712,6 +740,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 -   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][19]** value to check.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### dontSeeInSource
 
 Checks that the current page does not contains the given string in its raw source code.
@@ -725,6 +755,8 @@ I.dontSeeInSource('<!--'); // no comments in source
 -   `text`  
 -   `value` **[string][19]** to check.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### dontSeeInTitle
 
 Checks that title does not contain text.
@@ -736,6 +768,8 @@ I.dontSeeInTitle('Error');
 #### Parameters
 
 -   `text` **[string][19]** value to check.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### doubleClick
 
@@ -752,11 +786,13 @@ I.doubleClick('.btn.edit');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### dragAndDrop
 
@@ -769,7 +805,9 @@ I.dragAndDrop('#dragHandle', '#container');
 #### Parameters
 
 -   `srcElement` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
--   `destElement` **([string][19] | [object][18])** located by CSS|XPath|strict locator.Appium: not tested
+-   `destElement` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
+
+Returns **[Promise][21]&lt;any>** Appium: not tested
 
 ### dragSlider
 
@@ -784,14 +822,16 @@ I.dragSlider('#slider', -70);
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
--   `offsetX` **[number][22]** position to drag. 
+-   `offsetX` **[number][23]** position to drag. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### executeAsyncScript
 
 Executes async script on page.
 Provided function should execute a passed callback (as first argument) to signal it is finished.
 
-Example: In Vue.js to make components completely rendered we are waiting for [nextTick][23].
+Example: In Vue.js to make components completely rendered we are waiting for [nextTick][24].
 
 ```js
 I.executeAsyncScript(function(done) {
@@ -812,9 +852,9 @@ let val = await I.executeAsyncScript(function(url, done) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
--   `fn` **([string][19] | [function][24])** function to be executed in browser context.
+-   `fn` **([string][19] | [function][25])** function to be executed in browser context.
 
-Returns **[Promise][25]&lt;any>** 
+Returns **[Promise][21]&lt;any>** 
 
 ### executeScript
 
@@ -845,9 +885,9 @@ let date = await I.executeScript(function(el) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
--   `fn` **([string][19] | [function][24])** function to be executed in browser context.
+-   `fn` **([string][19] | [function][25])** function to be executed in browser context.
 
-Returns **[Promise][25]&lt;any>** Wraps [execute][26] command.
+Returns **[Promise][21]&lt;any>** Wraps [execute][26] command.
 
 ### fillField
 
@@ -870,10 +910,12 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 -   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
 -   `value` **([string][19] | [object][18])** text value to fill.
 
+Returns **[Promise][21]&lt;any>** 
+
 
 This action supports [React locators](https://codecept.io/react#locators)
 
-    {{ custom }}
+{{ custom }}
 
 ### forceClick
 
@@ -905,11 +947,13 @@ I.forceClick({css: 'nav a.login'});
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### forceRightClick
 
@@ -931,11 +975,13 @@ I.forceRightClick('Menu');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### grabAllWindowHandles
 
@@ -946,7 +992,7 @@ Useful for referencing a specific handle when calling `I.switchToWindow(handle)`
 const windows = await I.grabAllWindowHandles();
 ```
 
-Returns **[Promise][25]&lt;[Array][27]&lt;[string][19]>>** 
+Returns **[Promise][21]&lt;[Array][27]&lt;[string][19]>>** 
 
 ### grabAttributeFrom
 
@@ -963,7 +1009,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][19]** attribute name.
 
-Returns **[Promise][25]&lt;[string][19]>** attribute value
+Returns **[Promise][21]&lt;[string][19]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -979,7 +1025,7 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][19]** attribute name.
 
-Returns **[Promise][25]&lt;[Array][27]&lt;[string][19]>>** attribute value
+Returns **[Promise][21]&lt;[Array][27]&lt;[string][19]>>** attribute value
 
 ### grabBrowserLogs
 
@@ -991,7 +1037,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **([Promise][25]&lt;[Array][27]&lt;[object][18]>> | [undefined][28])** all browser logs
+Returns **([Promise][21]&lt;[Array][27]&lt;[object][18]>> | [undefined][28])** all browser logs
 
 ### grabCookie
 
@@ -1008,7 +1054,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][19]?** cookie name. 
 
-Returns **([Promise][25]&lt;[string][19]> | [Promise][25]&lt;[Array][27]&lt;[string][19]>>)** attribute value
+Returns **([Promise][21]&lt;[string][19]> | [Promise][21]&lt;[Array][27]&lt;[string][19]>>)** attribute value
 
 ### grabCssPropertyFrom
 
@@ -1025,7 +1071,7 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][19]** CSS property name.
 
-Returns **[Promise][25]&lt;[string][19]>** CSS value
+Returns **[Promise][21]&lt;[string][19]>** CSS value
 
 ### grabCssPropertyFromAll
 
@@ -1041,7 +1087,7 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][19]** CSS property name.
 
-Returns **[Promise][25]&lt;[Array][27]&lt;[string][19]>>** CSS value
+Returns **[Promise][21]&lt;[Array][27]&lt;[string][19]>>** CSS value
 
 ### grabCurrentUrl
 
@@ -1053,7 +1099,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][25]&lt;[string][19]>** current URL
+Returns **[Promise][21]&lt;[string][19]>** current URL
 
 ### grabCurrentWindowHandle
 
@@ -1064,7 +1110,7 @@ Useful for referencing it when calling `I.switchToWindow(handle)`
 const window = await I.grabCurrentWindowHandle();
 ```
 
-Returns **[Promise][25]&lt;[string][19]>** 
+Returns **[Promise][21]&lt;[string][19]>** 
 
 ### grabElementBoundingRect
 
@@ -1092,7 +1138,7 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 -   `prop`  
 -   `elementSize` **[string][19]?** x, y, width or height of the given element.
 
-Returns **([Promise][25]&lt;DOMRect> | [Promise][25]&lt;[number][22]>)** Element bounding rectangle
+Returns **([Promise][21]&lt;DOMRect> | [Promise][21]&lt;[number][23]>)** Element bounding rectangle
 
 ### grabGeoLocation
 
@@ -1103,7 +1149,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let geoLocation = await I.grabGeoLocation();
 ```
 
-Returns **[Promise][25]&lt;{latitude: [number][22], longitude: [number][22], altitude: [number][22]}>** 
+Returns **[Promise][21]&lt;{latitude: [number][23], longitude: [number][23], altitude: [number][23]}>** 
 
 ### grabHTMLFrom
 
@@ -1120,7 +1166,7 @@ let postHTML = await I.grabHTMLFrom('#post');
 -   `locator`  
 -   `element` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[string][19]>** HTML code for an element
+Returns **[Promise][21]&lt;[string][19]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -1136,7 +1182,7 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 -   `locator`  
 -   `element` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[Array][27]&lt;[string][19]>>** HTML code for an element
+Returns **[Promise][21]&lt;[Array][27]&lt;[string][19]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -1147,7 +1193,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][25]&lt;[number][22]>** number of open tabs
+Returns **[Promise][21]&lt;[number][23]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -1162,7 +1208,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[number][22]>** number of visible elements
+Returns **[Promise][21]&lt;[number][23]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -1173,7 +1219,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][25]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][21]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -1183,7 +1229,7 @@ Grab the text within the popup. If no popup is visible then it will return null.
 await I.grabPopupText();
 ```
 
-Returns **[Promise][25]&lt;[string][19]>** 
+Returns **[Promise][21]&lt;[string][19]>** 
 
 ### grabSource
 
@@ -1194,7 +1240,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][25]&lt;[string][19]>** source code
+Returns **[Promise][21]&lt;[string][19]>** source code
 
 ### grabTextFrom
 
@@ -1211,7 +1257,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[string][19]>** attribute value
+Returns **[Promise][21]&lt;[string][19]>** attribute value
 
 ### grabTextFromAll
 
@@ -1226,7 +1272,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[Array][27]&lt;[string][19]>>** attribute value
+Returns **[Promise][21]&lt;[Array][27]&lt;[string][19]>>** attribute value
 
 ### grabTitle
 
@@ -1237,7 +1283,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][25]&lt;[string][19]>** title
+Returns **[Promise][21]&lt;[string][19]>** title
 
 ### grabValueFrom
 
@@ -1253,7 +1299,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][19] | [object][18])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[string][19]>** attribute value
+Returns **[Promise][21]&lt;[string][19]>** attribute value
 
 ### grabValueFromAll
 
@@ -1268,7 +1314,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][19] | [object][18])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][25]&lt;[Array][27]&lt;[string][19]>>** attribute value
+Returns **[Promise][21]&lt;[Array][27]&lt;[string][19]>>** attribute value
 
 ### moveCursorTo
 
@@ -1285,8 +1331,10 @@ I.moveCursorTo('#submit', 5,5);
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 -   `xOffset`  
 -   `yOffset`  
--   `offsetX` **[number][22]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][22]** (optional, `0` by default) Y-axis offset. 
+-   `offsetX` **[number][23]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][23]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### openNewTab
 
@@ -1300,6 +1348,8 @@ I.openNewTab();
 
 -   `url`   
 -   `windowName`   
+
+Returns **[Promise][21]&lt;any>** 
 
 ### pressKey
 
@@ -1364,7 +1414,9 @@ Some of the supported key names are:
 
 #### Parameters
 
--   `key` **([string][19] | [Array][27]&lt;[string][19]>)** key or array of keys to press._Note:_ In case a text field or textarea is focused be aware that some browsers do not respect active modifier when combining modifier keys with other keys.
+-   `key` **([string][19] | [Array][27]&lt;[string][19]>)** key or array of keys to press.
+
+Returns **[Promise][21]&lt;any>** _Note:_ In case a text field or textarea is focused be aware that some browsers do not respect active modifier when combining modifier keys with other keys.
 
 ### pressKeyDown
 
@@ -1382,6 +1434,8 @@ I.pressKeyUp('Control');
 
 -   `key` **[string][19]** name of key to press down.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### pressKeyUp
 
 Releases a key in the browser which was previously set to a down state.
@@ -1398,6 +1452,8 @@ I.pressKeyUp('Control');
 
 -   `key` **[string][19]** name of key to release.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### refreshPage
 
 Reload the current page.
@@ -1406,6 +1462,8 @@ Reload the current page.
 I.refreshPage();
 ```
 
+Returns **[Promise][21]&lt;any>** 
+
 ### resizeWindow
 
 Resize the current window to provided width and height.
@@ -1413,9 +1471,10 @@ First parameter can be set to `maximize`.
 
 #### Parameters
 
--   `width` **[number][22]** width in pixels or `maximize`.
--   `height` **[number][22]** height in pixels.
-    Appium: not tested in web, in apps doesn't work
+-   `width` **[number][23]** width in pixels or `maximize`.
+-   `height` **[number][23]** height in pixels.
+
+Returns **[Promise][21]&lt;any>** Appium: not tested in web, in apps doesn't work
 
 ### rightClick
 
@@ -1433,11 +1492,13 @@ I.rightClick('Click me', '.context');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS|XPath|strict locator.
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### runInWeb
 
@@ -1479,6 +1540,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 -   `fileName` **[string][19]** file name to save.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### saveScreenshot
 
 Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
@@ -1495,6 +1558,8 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 -   `fileName` **[string][19]** file name to save.
 -   `fullPage` **[boolean][31]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
 
+Returns **[Promise][21]&lt;any>** 
+
 ### scrollIntoView
 
 Scroll element into viewport.
@@ -1510,6 +1575,8 @@ I.scrollIntoView('#submit', { behavior: "smooth", block: "center", inline: "cent
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 -   `scrollIntoViewOptions` **ScrollIntoViewOptions** see [https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView][32].
 
+Returns **[Promise][21]&lt;any>** 
+
 ### scrollPageToBottom
 
 Scroll page to the bottom.
@@ -1518,6 +1585,8 @@ Scroll page to the bottom.
 I.scrollPageToBottom();
 ```
 
+Returns **[Promise][21]&lt;any>** 
+
 ### scrollPageToTop
 
 Scroll page to the top.
@@ -1525,6 +1594,8 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
+
+Returns **[Promise][21]&lt;any>** 
 
 ### scrollTo
 
@@ -1539,8 +1610,10 @@ I.scrollTo('#submit', 5, 5);
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][22]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][22]** (optional, `0` by default) Y-axis offset. 
+-   `offsetX` **[number][23]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][23]** (optional, `0` by default) Y-axis offset. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### see
 
@@ -1556,11 +1629,13 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 #### Parameters
 
 -   `text` **[string][19]** expected on page.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text.
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
- 
+
 
 ### seeAttributesOnElements
 
@@ -1575,6 +1650,8 @@ I.seeAttributesOnElements('//form', { method: "post"});
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 -   `attributes` **[object][18]** attributes and their values to check.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### seeCheckboxIsChecked
 
 Verifies that the specified checkbox is checked.
@@ -1587,7 +1664,9 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 #### Parameters
 
--   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.Appium: not tested
+-   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
+
+Returns **[Promise][21]&lt;any>** Appium: not tested
 
 ### seeCookie
 
@@ -1601,6 +1680,8 @@ I.seeCookie('Auth');
 
 -   `name` **[string][19]** cookie name.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### seeCssPropertiesOnElements
 
 Checks that all elements with given locator have given CSS properties.
@@ -1613,6 +1694,8 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
 -   `cssProperties` **[object][18]** object with CSS properties and their values to check.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### seeCurrentUrlEquals
 
@@ -1629,6 +1712,8 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 -   `url` **[string][19]** value to check.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### seeElement
 
 Checks that a given Element is visible
@@ -1641,7 +1726,8 @@ I.seeElement('#modal');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** located by CSS|XPath|strict locator.
-    
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1660,6 +1746,8 @@ I.seeElementInDOM('#modal');
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### seeInCurrentUrl
 
 Checks that current url contains a provided fragment.
@@ -1671,6 +1759,8 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 #### Parameters
 
 -   `url` **[string][19]** a fragment to check
+
+Returns **[Promise][21]&lt;any>** 
 
 ### seeInField
 
@@ -1688,6 +1778,8 @@ I.seeInField('#searchform input','Search');
 
 -   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
 -   `value` **[string][19]** value to check.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### seeInPopup
 
@@ -1710,6 +1802,8 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 -   `text` **[string][19]** value to check.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### seeInTitle
 
 Checks that title contains text.
@@ -1721,6 +1815,8 @@ I.seeInTitle('Home Page');
 #### Parameters
 
 -   `text` **[string][19]** text value to check.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### seeNumberOfElements
 
@@ -1734,7 +1830,9 @@ I.seeNumberOfElements('#submitBtn', 1);
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `num` **[number][22]** number of elements.
+-   `num` **[number][23]** number of elements.
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1752,7 +1850,9 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `num` **[number][22]** number of elements.
+-   `num` **[number][23]** number of elements.
+
+Returns **[Promise][21]&lt;any>** 
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1771,6 +1871,8 @@ I.seeTextEquals('text', 'h1');
 -   `text` **[string][19]** element value to check.
 -   `context` **([string][19] | [object][18])?** element located by CSS|XPath|strict locator. 
 
+Returns **[Promise][21]&lt;any>** 
+
 ### seeTitleEquals
 
 Checks that title is equal to provided one.
@@ -1782,6 +1884,8 @@ I.seeTitleEquals('Test title.');
 #### Parameters
 
 -   `text` **[string][19]** value to check.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### selectOption
 
@@ -1809,6 +1913,8 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 -   `select` **([string][19] | [object][18])** field located by label|name|CSS|XPath|strict locator.
 -   `option` **([string][19] | [Array][27]&lt;any>)** visible text or value of option.
 
+Returns **[Promise][21]&lt;any>** 
+
 ### setCookie
 
 Sets cookie(s).
@@ -1827,8 +1933,10 @@ I.setCookie([
 
 #### Parameters
 
--   `cookie` **(Cookie | [Array][27]&lt;Cookie>)** a cookie object or array of cookie objects.Uses Selenium's JSON [cookie
-    format][33].
+-   `cookie` **(Cookie | [Array][27]&lt;Cookie>)** a cookie object or array of cookie objects.
+
+Returns **[Promise][21]&lt;any>** Uses Selenium's JSON [cookie
+format][33].
 
 ### setGeoLocation
 
@@ -1841,9 +1949,11 @@ I.setGeoLocation(121.21, 11.56, 10);
 
 #### Parameters
 
--   `latitude` **[number][22]** to set.
--   `longitude` **[number][22]** to set
--   `altitude` **[number][22]?** (optional, null by default) to set 
+-   `latitude` **[number][23]** to set.
+-   `longitude` **[number][23]** to set
+-   `altitude` **[number][23]?** (optional, null by default) to set 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### switchTo
 
@@ -1858,6 +1968,8 @@ I.switchTo(); // switch back to main page
 
 -   `locator` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
+Returns **[Promise][21]&lt;any>** 
+
 ### switchToNextTab
 
 Switch focus to a particular tab by its number. It waits tabs loading and then switch tab.
@@ -1869,8 +1981,10 @@ I.switchToNextTab(2);
 
 #### Parameters
 
--   `num` **[number][22]?** (optional) number of tabs to switch forward, default: 1. 
--   `sec` **([number][22] | null)?** (optional) time in seconds to wait. 
+-   `num` **[number][23]?** (optional) number of tabs to switch forward, default: 1. 
+-   `sec` **([number][23] | null)?** (optional) time in seconds to wait. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### switchToPreviousTab
 
@@ -1883,8 +1997,10 @@ I.switchToPreviousTab(2);
 
 #### Parameters
 
--   `num` **[number][22]?** (optional) number of tabs to switch backward, default: 1. 
--   `sec` **[number][22]??** (optional) time in seconds to wait. 
+-   `num` **[number][23]?** (optional) number of tabs to switch backward, default: 1. 
+-   `sec` **[number][23]??** (optional) time in seconds to wait. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### switchToWindow
 
@@ -1924,8 +2040,10 @@ I.type(['T', 'E', 'X', 'T']);
 #### Parameters
 
 -   `keys`  
--   `delay` **[number][22]?** (optional) delay in ms between key presses 
+-   `delay` **[number][23]?** (optional) delay in ms between key presses 
 -   `key` **([string][19] | [Array][27]&lt;[string][19]>)** or array of keys to type.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### uncheckOption
 
@@ -1943,8 +2061,9 @@ I.uncheckOption('agree', '//form');
 #### Parameters
 
 -   `field` **([string][19] | [object][18])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS | XPath | strict locator.
-    Appium: not tested 
+-   `context` **([string][19]? | [object][18])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+
+Returns **[Promise][21]&lt;any>** Appium: not tested
 
 ### useWebDriverTo
 
@@ -1965,7 +2084,7 @@ I.useWebDriverTo('open multiple windows', async ({ browser }) {
 #### Parameters
 
 -   `description` **[string][19]** used to show in logs.
--   `fn` **[function][24]** async functuion that executed with WebDriver helper as argument
+-   `fn` **[function][25]** async functuion that executed with WebDriver helper as argument
 
 ### wait
 
@@ -1977,7 +2096,9 @@ I.wait(2); // wait 2 secs
 
 #### Parameters
 
--   `sec` **[number][22]** number of second to wait.
+-   `sec` **[number][23]** number of second to wait.
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForClickable
 
@@ -1993,7 +2114,9 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
 -   `waitTimeout`  
--   `sec` **[number][22]?** (optional, `1` by default) time in seconds to wait
+-   `sec` **[number][23]?** (optional, `1` by default) time in seconds to wait
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForDetached
 
@@ -2007,7 +2130,9 @@ I.waitForDetached('#popup');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForElement
 
@@ -2022,7 +2147,9 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `sec` **[number][22]?** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]?** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForEnabled
 
@@ -2032,7 +2159,9 @@ Element can be located by CSS or XPath.
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `sec` **[number][22]** (optional) time in seconds to wait, 1 by default. 
+-   `sec` **[number][23]** (optional) time in seconds to wait, 1 by default. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForFunction
 
@@ -2051,9 +2180,11 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][19] | [function][24])** to be executed in browser context.
--   `argsOrSec` **([Array][27]&lt;any> | [number][22])?** (optional, `1` by default) arguments for function or seconds. 
--   `sec` **[number][22]?** (optional, `1` by default) time in seconds to wait 
+-   `fn` **([string][19] | [function][25])** to be executed in browser context.
+-   `argsOrSec` **([Array][27]&lt;any> | [number][23])?** (optional, `1` by default) arguments for function or seconds. 
+-   `sec` **[number][23]?** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForInvisible
 
@@ -2067,7 +2198,9 @@ I.waitForInvisible('#popup');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForText
 
@@ -2083,8 +2216,10 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 #### Parameters
 
 -   `text` **[string][19]** to wait for.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
 -   `context` **([string][19] | [object][18])?** (optional) element located by CSS|XPath|strict locator. 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForValue
 
@@ -2098,7 +2233,9 @@ I.waitForValue('//input', "GoodValue");
 
 -   `field` **([string][19] | [object][18])** input field.
 -   `value` **[string][19]** expected value.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitForVisible
 
@@ -2112,7 +2249,9 @@ I.waitForVisible('#popup');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitInUrl
 
@@ -2125,7 +2264,9 @@ I.waitInUrl('/info', 2);
 #### Parameters
 
 -   `urlPart` **[string][19]** value to check.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitNumberOfVisibleElements
 
@@ -2138,8 +2279,10 @@ I.waitNumberOfVisibleElements('a', 3);
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `num` **[number][22]** number of elements.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `num` **[number][23]** number of elements.
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitToHide
 
@@ -2153,7 +2296,9 @@ I.waitToHide('#popup');
 #### Parameters
 
 -   `locator` **([string][19] | [object][18])** element located by CSS|XPath|strict locator.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 ### waitUrlEquals
 
@@ -2167,7 +2312,9 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 #### Parameters
 
 -   `urlPart` **[string][19]** value to check.
--   `sec` **[number][22]** (optional, `1` by default) time in seconds to wait 
+-   `sec` **[number][23]** (optional, `1` by default) time in seconds to wait 
+
+Returns **[Promise][21]&lt;any>** 
 
 [1]: http://webdriver.io/
 
@@ -2209,15 +2356,15 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [20]: http://jster.net/category/windows-modals-popups
 
-[21]: https://webdriver.io/docs/timeouts.html
+[21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[22]: https://webdriver.io/docs/timeouts.html
 
-[23]: https://vuejs.org/v2/api/#Vue-nextTick
+[23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[24]: https://vuejs.org/v2/api/#Vue-nextTick
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
 [26]: http://webdriver.io/api/protocol/execute.html
 

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,3 +1,4 @@
+const Config = require('../config');
 const { CucumberExpression, ParameterTypeRegistry } = require('cucumber-expressions');
 
 let steps = {};
@@ -9,7 +10,11 @@ const STACK_POSITION = 2;
  * @param {*} fn
  */
 const addStep = (step, fn) => {
+  const avoidDuplicateSteps = Config.get('gherkin', {}).avoidDuplicateSteps || false;
   const stack = (new Error()).stack;
+  if (avoidDuplicateSteps && steps[step]) {
+    throw new Error(`Step '${step}' is already defined`);
+  }
   steps[step] = fn;
   fn.line = stack && stack.split('\n')[STACK_POSITION];
   if (fn.line) {

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,5 +1,5 @@
-const Config = require('../config');
 const { CucumberExpression, ParameterTypeRegistry } = require('cucumber-expressions');
+const Config = require('../config');
 
 let steps = {};
 

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const { Parser } = require('gherkin');
-const Config = require('../../lib/config')
+const Config = require('../../lib/config');
 const {
   Given,
   When,
@@ -78,8 +78,8 @@ describe('BDD', () => {
   it('should fail on duplicate step definitions with option', () => {
     Config.append({
       gherkin: {
-        avoidDuplicateSteps: true
-      }
+        avoidDuplicateSteps: true,
+      },
     });
 
     let error = null;
@@ -87,11 +87,11 @@ describe('BDD', () => {
       Given('I am a bird', () => 1);
       Then('I am a bird', () => 1);
     } catch (err) {
-      error = err
+      error = err;
     } finally {
       expect(!!error).is.true;
     }
-  })
+  });
 
   it('should contain tags', async () => {
     let sum = 0;

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { Parser } = require('gherkin');
+const Config = require('../../lib/config')
 const {
   Given,
   When,
@@ -43,6 +44,7 @@ describe('BDD', () => {
     clearSteps();
     recorder.start();
     container.create({});
+    Config.reset();
   });
 
   afterEach(() => {
@@ -72,6 +74,24 @@ describe('BDD', () => {
     expect(4).is.equal(matchStep('I see ocean')());
     expect(4).is.equal(matchStep('I see world')());
   });
+
+  it('should fail on duplicate step definitions with option', () => {
+    Config.append({
+      gherkin: {
+        avoidDuplicateSteps: true
+      }
+    });
+
+    let error = null;
+    try {
+      Given('I am a bird', () => 1);
+      Then('I am a bird', () => 1);
+    } catch (err) {
+      error = err
+    } finally {
+      expect(!!error).is.true;
+    }
+  })
 
   it('should contain tags', async () => {
     let sum = 0;


### PR DESCRIPTION
## Motivation/Description of the PR
- Adds an option to gherkin to crash if it detects duplicate step definitions.
- Resolves #3184 

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
