### PR TITLE
REST: Fixed haveRequestHeaders() and amBearerAuthenticated()

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -112,6 +112,9 @@ class REST extends Helper {
    * @returns {Promise<*>} response
    */
   async _executeRequest(request) {
+    // Add custom headers. They can be set by amBearerAuthenticated() or haveRequestHeaders()
+    request.headers = { ...request.headers, ...this.headers };
+
     const _debugRequest = { ...request };
     this.axios.defaults.timeout = request.timeout || this.options.timeout;
 

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -178,6 +178,44 @@ describe('REST', () => {
       response.config.headers.should.have.property('Content-Type');
       response.config.headers['Content-Type'].should.eql('application/json');
     });
+
+    it('should set headers for all requests', async () => {
+      I.haveRequestHeaders({ 'XY1-Test': 'xy1test' });
+      // 1st request
+      {
+        const response = await I.sendGetRequest('/user');
+
+        response.config.headers.should.have.property('XY1-Test');
+        response.config.headers['XY1-Test'].should.eql('xy1test');
+
+        response.config.headers.should.have.property('X-Test');
+        response.config.headers['X-Test'].should.eql('test');
+      }
+      // 2nd request
+      {
+        const response = await I.sendPostRequest('/user', { name: 'john' }, { 'XY2-Test': 'xy2test' });
+
+        response.config.headers.should.have.property('XY1-Test');
+        response.config.headers['XY1-Test'].should.eql('xy1test');
+
+        response.config.headers.should.have.property('XY2-Test');
+        response.config.headers['XY2-Test'].should.include('xy2test');
+
+        response.config.headers.should.have.property('X-Test');
+        response.config.headers['X-Test'].should.eql('test');
+      }
+    });
+
+    it('should set Bearer authorization', async () => {
+      I.amBearerAuthenticated('token');
+      const response = await I.sendGetRequest('/user');
+
+      response.config.headers.should.have.property('Authorization');
+      response.config.headers.Authorization.should.eql('Bearer token');
+
+      response.config.headers.should.have.property('X-Test');
+      response.config.headers['X-Test'].should.eql('test');
+    });
   });
 
   describe('_url autocompletion', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- It solves non functional `haveRequestHeaders()` and `amBearerAuthenticated()`
- Resolves #3254

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
- [x] REST tests are passed (Run `npx mocha test/rest/REST_test.js`)
