### PR TITLE
Appium: Fix TS definition of switchToNative()

### DIFF
--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -429,7 +429,7 @@ I.switchToNative('SOME_OTHER_CONTEXT');
 
 #### Parameters
 
--   `context` **any**  (optional, default `null`)
+-   `context` **any?**  (optional, default `null`)
 
 Returns **[Promise][4]&lt;void>** 
 

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -775,7 +775,7 @@ class Appium extends Webdriver {
    * // or set context explicitly
    * I.switchToNative('SOME_OTHER_CONTEXT');
    * ```
-   * @param {*} context
+   * @param {*} [context]
    * @return {Promise<void>}
    */
   async switchToNative(context = null) {

--- a/typings/tests/helpers/Appium.types.ts
+++ b/typings/tests/helpers/Appium.types.ts
@@ -38,6 +38,7 @@ appium.grabOrientation(); // $ExpectType Promise<string>
 appium.grabSettings(); // $ExpectType Promise<string>
 appium._switchToContext(str_ap); // $ExpectType Promise<any>
 appium.switchToWeb(); // $ExpectType Promise<void>
+appium.switchToNative(); // $ExpectType Promise<void>
 appium.switchToNative(str_ap); // $ExpectType Promise<void>
 appium.startActivity(); // $ExpectType Promise<void>
 appium.setNetworkConnection(); // $ExpectType Promise<{}>


### PR DESCRIPTION
## Motivation/Description of the PR
I was not able to call `switchToNative()` without context (to get a default context) and must always pass it: `I.switchToNative("NATIVE_APP")` which is redundant.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
