### PR TITLE
[Patch/Bugfix] Supporting events detection for workers

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -178,7 +178,7 @@ function initializeListeners() {
   event.dispatcher.on(event.test.started, test => sendToParentThread({ event: event.test.started, workerIndex, data: simplifyTest(test) }));
   event.dispatcher.on(event.test.skipped, test => sendToParentThread({ event: event.test.skipped, workerIndex, data: simplifyTest(test) }));
 
-  // steps
+  // steps 
   event.dispatcher.on(event.step.finished, step => sendToParentThread({ event: event.step.finished, workerIndex, data: simplifyStep(step) }));
   event.dispatcher.on(event.step.started, step => sendToParentThread({ event: event.step.started, workerIndex, data: simplifyStep(step) }));
   event.dispatcher.on(event.step.passed, step => sendToParentThread({ event: event.step.passed, workerIndex, data: simplifyStep(step) }));

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -156,7 +156,7 @@ function initializeListeners() {
       duration: step.duration || 0,
       err,
       parent,
-      test: step.test
+      test: simplifyTest(step.test)
     };
   }
   

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -115,6 +115,8 @@ function initializeListeners() {
     }
 
     return {
+      opts: test.opts || {},
+      tags: test.tags || [],
       id: test.id,
       workerIndex,
       retries: test._retries,
@@ -125,7 +127,38 @@ function initializeListeners() {
       parent,
     };
   }
+  
+  function simplifyStep(step, err = null) {
+    step = { ...step };
 
+    if (step.startTime && !step.duration) {
+      const end = new Date();
+      step.duration = end - step.startTime;
+    }
+
+    if (step.err) {
+      err = simplifyError(step.err);
+      step.status = 'failed';
+    } else if (err) {
+      err = simplifyError(err);
+      step.status = 'failed';
+    }
+
+    const parent = {};
+    if (step.metaStep) {
+      parent.title = step.metaStep.actor;
+    }
+    return {
+      opts: step.opts || {},
+      workerIndex,
+      title: step.name,
+      status: step.status,
+      duration: step.duration || 0,
+      err,
+      parent,
+    };
+  }
+  
   collectStats();
   // suite
   event.dispatcher.on(event.suite.before, suite => sendToParentThread({ event: event.suite.before, workerIndex, data: simplifyTest(suite) }));
@@ -144,6 +177,12 @@ function initializeListeners() {
   event.dispatcher.on(event.test.started, test => sendToParentThread({ event: event.test.started, workerIndex, data: simplifyTest(test) }));
   event.dispatcher.on(event.test.skipped, test => sendToParentThread({ event: event.test.skipped, workerIndex, data: simplifyTest(test) }));
 
+  // steps
+  event.dispatcher.on(event.step.finished, step => sendToParentThread({ event: event.step.finished, workerIndex, data: simplifyStep(step) }));
+  event.dispatcher.on(event.step.started, step => sendToParentThread({ event: event.step.started, workerIndex, data: simplifyStep(step) }));
+  event.dispatcher.on(event.step.passed, step => sendToParentThread({ event: event.step.passed, workerIndex, data: simplifyStep(step) }));
+  event.dispatcher.on(event.step.failed, step => sendToParentThread({ event: event.step.failed, workerIndex, data: simplifyStep(step) }));
+  
   event.dispatcher.on(event.hook.failed, (test, err) => sendToParentThread({ event: event.hook.failed, workerIndex, data: simplifyTest(test, err) }));
   event.dispatcher.on(event.hook.passed, (test, err) => sendToParentThread({ event: event.hook.passed, workerIndex, data: simplifyTest(test, err) }));
   event.dispatcher.on(event.all.failures, (data) => sendToParentThread({ event: event.all.failures, workerIndex, data }));

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -156,6 +156,7 @@ function initializeListeners() {
       duration: step.duration || 0,
       err,
       parent,
+      test: step.test
     };
   }
   

--- a/lib/listener/steps.js
+++ b/lib/listener/steps.js
@@ -69,7 +69,7 @@ module.exports = function () {
   event.dispatcher.on(event.step.started, (step) => {
     if (store.debugMode) return;
     step.startedAt = +new Date();
-    step.currentTest = currentTest;
+    step.test = currentTest;
     if (currentHook && Array.isArray(currentHook.steps)) {
       return currentHook.steps.push(step);
     }

--- a/lib/listener/steps.js
+++ b/lib/listener/steps.js
@@ -69,6 +69,7 @@ module.exports = function () {
   event.dispatcher.on(event.step.started, (step) => {
     if (store.debugMode) return;
     step.startedAt = +new Date();
+    step.currentTest = currentTest;
     if (currentHook && Array.isArray(currentHook.steps)) {
       return currentHook.steps.push(step);
     }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -358,6 +358,18 @@ class Workers extends EventEmitter {
         case event.test.after:
           this.emit(event.test.after, repackTest(message.data));
           break;
+        case event.step.finished:
+          this.emit(event.step.finished, message.data);
+          break;
+        case event.step.started:
+          this.emit(event.step.started, message.data);
+          break;
+        case event.step.passed:
+          this.emit(event.step.passed, message.data);
+          break;
+        case event.step.failed:
+          this.emit(event.step.failed, message.data);
+          break;
       }
     });
 


### PR DESCRIPTION
## Motivation/Description of the PR
Currently events from the steps are not exposed when parallel execution is done using workers. However, this is not the case for non-parallel execution where all the events are detected within a plugin.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
