### PR TITLE
Playwright: Fixed TypeScript definition of click() and dragAndDrop()

### DIFF
--- a/docs/webapi/click.mustache
+++ b/docs/webapi/click.mustache
@@ -21,5 +21,5 @@ I.click({css: 'nav a.login'});
 ```
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
-@param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
+@param {?CodeceptJS.LocatorOrString | null} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
 @return {Promise<any>}

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -860,7 +860,7 @@ class Playwright extends Helper {
   /**
    * {{> dragAndDrop }}
    *
-   * [Additional options](https://playwright.dev/docs/api/class-page#page-drag-and-drop) can be passed as 3rd argument.
+   * @param {any} [options] [Additional options](https://playwright.dev/docs/api/class-page#page-drag-and-drop) can be passed as 3rd argument.
    *
    * ```js
    * // specify coordinates for source position
@@ -1221,7 +1221,7 @@ class Playwright extends Helper {
   /**
    * {{> click }}
    *
-   * [Additional options](https://playwright.dev/docs/api/class-page#page-click) for click available as 3rd argument.
+   * @param {any} [opts] [Additional options](https://playwright.dev/docs/api/class-page#page-click) for click available as 3rd argument.
    *
    * Examples:
    *

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -410,14 +410,14 @@ describe('WebDriver', function () {
     });
 
     it('should check text is not equal to empty string of element text', async () => {
-      await wd.amOnPage('https://codecept.discourse.group/');
+      await wd.amOnPage('https://codecept.io');
 
       try {
-        await wd.seeTextEquals('', '[id="site-logo"]');
-        await wd.seeTextEquals('This is not empty', '[id="site-logo"]');
+        await wd.seeTextEquals('', '.logo');
+        await wd.seeTextEquals('This is not empty', '.logo');
       } catch (e) {
         e.should.be.instanceOf(Error);
-        e.message.should.be.equal('expected element [id="site-logo"] "This is not empty" to equal ""');
+        e.message.should.be.equal('expected element .logo "This is not empty" to equal ""');
       }
     });
   });

--- a/typings/tests/helpers/Playwright.types.ts
+++ b/typings/tests/helpers/Playwright.types.ts
@@ -2,6 +2,9 @@ const playwright = new CodeceptJS.Playwright();
 
 const str_pl = 'text';
 const num_pl = 1;
+const position = { x: 100, y: 200 };
+const sourcePosition = { x: 10, y: 20 };
+const targetPosition = { x: 20, y: 30 };
 
 playwright.usePlaywrightTo(str_pl, () => {}); // $ExpectType Promise<any>
 playwright.amAcceptingPopups(); // $ExpectType Promise<any>
@@ -17,7 +20,9 @@ playwright.amOnPage(str_pl); // $ExpectType Promise<any>
 playwright.resizeWindow(num_pl, num_pl); // $ExpectType Promise<any>
 playwright.haveRequestHeaders(str_pl); // $ExpectType Promise<any>
 playwright.moveCursorTo(str_pl, num_pl, num_pl); // $ExpectType Promise<any>
+playwright.dragAndDrop(str_pl); // $ExpectError
 playwright.dragAndDrop(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.dragAndDrop(str_pl, str_pl, { sourcePosition, targetPosition }); // $ExpectType Promise<any>
 playwright.refreshPage(); // $ExpectType Promise<any>
 playwright.scrollPageToTop(); // $ExpectType Promise<any>
 playwright.scrollPageToBottom(); // $ExpectType Promise<any>
@@ -43,6 +48,8 @@ playwright.seeElementInDOM(str_pl); // $ExpectType Promise<any>
 playwright.dontSeeElementInDOM(str_pl); // $ExpectType Promise<any>
 playwright.handleDownloads(); // $ExpectType Promise<void>
 playwright.click(str_pl); // $ExpectType Promise<any>
+playwright.click(str_pl, str_pl); // $ExpectType Promise<any>
+playwright.click(str_pl, null, { position }); // $ExpectType Promise<any>
 playwright.clickLink(); // $ExpectType Promise<any>
 playwright.forceClick(str_pl); // $ExpectType Promise<any>
 playwright.doubleClick(str_pl); // $ExpectType Promise<any>


### PR DESCRIPTION
## Motivation/Description of the PR
- [3.3.0](https://codecept.io/changelog/#_3-3-0) introduced optional parameters in methods `click()` and `dragAndDrop()`. This fix allows using them in TS tests.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
- [x] TS tests passed (`npm run dtslint`)
