### PR TITLE
chore(docs): config name consistency

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -216,7 +216,7 @@ Scenario('slow test that should be stopped', { timeout: 20 }, ({ I }) => {
 })
 ```
 
-This timeout can be set globally in `codecept.conf.js` in seconds:
+This timeout can be set globally in `codecept.config.js` in seconds:
 
 ```js
 exports.config = {

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,12 +50,12 @@ npx codeceptjs init
 
 ## Configuration
 
-Ensure that inside `codecept.conf.js` in helpers section `REST` or `GraphQL` helpers are enabled.
+Ensure that inside `codecept.config.js` in helpers section `REST` or `GraphQL` helpers are enabled.
 
 * If you use `REST` helper add `JSONResponse` helper below with no extra config:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 // ...
   helpers: {
     REST: {
@@ -100,7 +100,7 @@ After helpers were configured and typings were generated, you can start writing 
 
 [REST](/helpers/REST/) or [GraphQL](/helpers/GraphQL/) helpers implement methods for making API requests.
 Both helpers send requests via HTTP protocol from CodeceptJS process. 
-For most cases, you will need to have authentication. It can be passed via headers, which can be added to helper's configuration in `codecept.conf.js`. 
+For most cases, you will need to have authentication. It can be passed via headers, which can be added to helper's configuration in `codecept.config.js`. 
 
 ```js
 helpers: {
@@ -181,7 +181,7 @@ Scenario('create user', ({ I }) => {
 
 GraphQL have request format different then in REST API, but the response format is the same.
 It's plain old JSON. This why `JSONResponse` helper works for both API types.
-Configure authorization headers in `codecept.conf.js` and make your first query:  
+Configure authorization headers in `codecept.config.js` and make your first query:  
 
 ```js
 Feature('Users endpoint')

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -403,7 +403,7 @@ Tests are split by scenarios, not by files. Results are aggregated and shown up 
 
 ## Configuration
 
-Configuration is set in the `codecept.conf.js` file which was created during the `init` process.
+Configuration is set in the `codecept.config.js` file which was created during the `init` process.
 Inside the config file you can enable and configure helpers and plugins, and set bootstrap and teardown scripts.
 
 ```js

--- a/docs/best.md
+++ b/docs/best.md
@@ -150,9 +150,9 @@ module.exports.DatePicker = DatePicker; // for inheritance
 ## Configuration
 
 * create multiple config files for different setups/enrionments:
-  * `codecept.conf.js` - default one
-  * `codecept.ci.conf.js` - for CI
-  * `codecept.windows.conf.js` - for Windows, etc
+  * `codecept.config.js` - default one
+  * `codecept.ci.config.js` - for CI
+  * `codecept.windows.config.js` - for Windows, etc
 * use `.env` files and dotenv package to load sensitive data
 
 ```js

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -15,7 +15,7 @@ When using the [parallel execution](/parallel) mode, there are two additional ho
 
 ### Example: Bootstrap & Teardown
 
-If you are using JavaScript-style config `codecept.conf.js`, bootstrap and teardown functions can be placed inside of it:
+If you are using JavaScript-style config `codecept.config.js`, bootstrap and teardown functions can be placed inside of it:
 
 ```js
 var server = require('./app_server');
@@ -59,7 +59,7 @@ The `bootstrap` and `teardown` hooks are used for setting up each testing browse
 
 ### Example: BootstrapAll & TeardownAll Inside Config
 
-Using JavaScript-style config `codecept.conf.js`, bootstrapAll and teardownAll functions can be placed inside of it:
+Using JavaScript-style config `codecept.config.js`, bootstrapAll and teardownAll functions can be placed inside of it:
 
 
 ```js
@@ -98,7 +98,7 @@ exports.config = {
 It is quite common that you expect that bootstrapAll and bootstrap will do the same thing. If an application server is already started in `bootstrapAll` we should not run it again inside `bootstrap` for each worker. To avoid code duplication we can run bootstrap script only when we are not inside a worker. And we will use NodeJS `isMainThread` Workers API to detect that:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 
 // detect if we are in a worker thread
 const { isMainThread } = require('worker_threads');

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1144,7 +1144,7 @@ Use it with `FileSystem` helper to test availability of a file:
     1. Refer to [axios API](https://github.com/axios/axios).
     2. If you were using `unirest` requests/responses in your tests change them to axios format.
 * **Breaking Change.** Generators support in tests removed. Use `async/await` in your tests
-* **Using `codecept.conf.js` as default configuration format**
+* **Using `codecept.config.js` as default configuration format**
 * Fixed "enametoolong" error when saving screenshots for data driven tests by **[PeterNgTr](https://github.com/PeterNgTr)**
 * Updated NodeJS to 10 in Docker image
 * **[Pupeteer]** Add support to use WSEndpoint. Allows to execute tests remotely. [See [#1350](https://github.com/codeceptjs/CodeceptJS/issues/1350)] by **[gabrielcaires](https://github.com/gabrielcaires)** (https://github.com/codeceptjs/CodeceptJS/pull/1350)
@@ -2047,15 +2047,15 @@ module.exports = function(done) {
 * **[Protractor]** Regression fixed to ^4.0.0 support
 * Translations included into package.
 * `teardown` option added to config (opposite to `bootstrap`), expects a JS file to be executed after tests stop.
-* [Configuration](http://codecept.io/configuration/) can be set via JavaScript file `codecept.conf.js` instead of `codecept.json`. It should export `config` object:
+* [Configuration](http://codecept.io/configuration/) can be set via JavaScript file `codecept.config.js` instead of `codecept.json`. It should export `config` object:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 exports.config = {
   // contents of codecept.json
 }
 ```
-* Added `--profile` option to pass its value to `codecept.conf.js` as `process.profile` for [dynamic configuration](http://codecept.io/configuration#dynamic-configuration).
+* Added `--profile` option to pass its value to `codecept.config.js` as `process.profile` for [dynamic configuration](http://codecept.io/configuration#dynamic-configuration).
 * Documentation for [StepObjects, PageFragments](http://codecept.io/pageobjects#PageFragments) updated.
 * Documentation for [Configuration](http://codecept.io/configuration/) added.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,7 +7,7 @@ title: Commands
 
 ## Run
 
-Executes tests. Requires `codecept.conf.js` config to be present in provided path.
+Executes tests. Requires `codecept.config.js` config to be present in provided path.
 
 ---
 
@@ -56,7 +56,7 @@ npx codeceptjs run github_test.js --debug
 Select config file manually (`-c` or `--config` option)
 
 ```sh
-npx codeceptjs run -c my.codecept.conf.js
+npx codeceptjs run -c my.codecept.config.js
 npx codeceptjs run --config path/to/codecept.json
 ```
 
@@ -114,7 +114,7 @@ For this command configuration is required:
 
 ```js
 {
-  // inside codecept.conf.js
+  // inside codecept.config.js
   rerun: {
     // how many times all tests should pass
     minSuccess: 2,
@@ -169,7 +169,7 @@ npx codeceptjs run-multiple smoke:chrome regression:firefox
 
 ## Init
 
-Creates `codecept.conf.js` file in current directory:
+Creates `codecept.config.js` file in current directory:
 
 ```sh
 npx codeceptjs init
@@ -183,7 +183,7 @@ npx codecept init test
 
 ## Migrate
 
-Migrate your current `codecept.json` to `codecept.conf.js`
+Migrate your current `codecept.json` to `codecept.config.js`
 
 ```sh
 npx codeceptjs migrate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ title: Configuration
 
 # Configuration
 
-CodeceptJS configuration is set in `codecept.conf.js` file.
+CodeceptJS configuration is set in `codecept.config.js` file.
 
 After running `codeceptjs init` it should be saved in test root.
 
@@ -70,7 +70,7 @@ codeceptjs run -o '{ "helpers": {"WebDriver": {"browser": "firefox"}}}'
 ```
 
  You can also switch to JS configuration format for more dynamic options.
- Create `codecept.conf.js` file and make it export `config` property.
+ Create `codecept.config.js` file and make it export `config` property.
 
  See the config example:
 

--- a/docs/custom-helpers.md
+++ b/docs/custom-helpers.md
@@ -147,7 +147,7 @@ In this case `el` will be an instance of [ElementHandle](https://playwright.dev/
 
 ## Configuration
 
-Helpers should be enabled inside `codecept.json` or `codecept.conf.js` files. Command `generate helper`
+Helpers should be enabled inside `codecept.json` or `codecept.config.js` files. Command `generate helper`
 does that for you, however you can enable them manually by placing helper to `helpers` section inside config file.
 You can also pass additional config options to your helper from a config - **(please note, this example contains comments, while JSON format doesn't support them)**:
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -323,7 +323,7 @@ npm i @codeceptjs/configure --save
 Import `setSharedCookies` function and call it inside a config:
 
 ```js
-// in codecept.conf.js
+// in codecept.config.js
 const { setSharedCookies } = require('@codeceptjs/configure');
 
 // share cookies between browser helpers and REST/GraphQL

--- a/docs/detox.md
+++ b/docs/detox.md
@@ -70,7 +70,7 @@ You need to install Detox CodeceptJS helper:
 npm i @codeceptjs/detox-helper --save-dev
 ```
 
-Then enable this helper in `codecept.conf.js`:
+Then enable this helper in `codecept.config.js`:
 
 ```js
 helpers: {
@@ -226,7 +226,7 @@ To execute it use `codeceptjs run` command
 ```
 npx codeceptjs run
 ```
-If you want to use detox configuration other than is set in `codecept.conf.js` use `--configuration` argument:
+If you want to use detox configuration other than is set in `codecept.config.js` use `--configuration` argument:
 
 ```
 npx codeceptjs run --configuration android.test.ci

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ CodeceptJS has an [official docker image](https://hub.docker.com/r/codeceptjs/co
 This image comes with the necessary dependencies and packages to execute CodeceptJS tests.
 Mount in your CodeceptJS config directory into the `/tests` directory in the docker container.
 
-Sample mount: `-v path/to/codecept.conf.js:/tests`
+Sample mount: `-v path/to/codecept.config.js:/tests`
 
 CodeceptJS runner is available inside container as `codeceptjs`.
 

--- a/docs/email.md
+++ b/docs/email.md
@@ -21,7 +21,7 @@ MailSlurp is a commercial service with a free plan available. To start, [create 
 npm i @codeceptjs/mailslurp-helper --save-dev
 ```
 
-Then enable a helper in `codecept.conf.js`:
+Then enable a helper in `codecept.config.js`:
 
 ```js
 helpers: {

--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -23,7 +23,7 @@ Launch the daemon: `appium`
 
 ## Helper configuration
 
-This helper should be configured in codecept.json or codecept.conf.js
+This helper should be configured in codecept.json or codecept.config.js
 
 -   `app`: Application path. Local path or remote URL to an .ipa or .apk file, or a .zip containing one of these. Alias to desiredCapabilities.appPackage
 -   `host`: (default: 'localhost') Appium host
@@ -1099,7 +1099,7 @@ Returns **[Promise][4]&lt;[string][5]>** attribute value
 
 ### saveScreenshot
 
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js
@@ -1539,7 +1539,7 @@ Returns **[Promise][4]&lt;any>**
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js
@@ -1790,7 +1790,7 @@ Returns **[Promise][4]&lt;any>**
 
 ### saveElementScreenshot
 
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js

--- a/docs/helpers/Detox.md
+++ b/docs/helpers/Detox.md
@@ -51,7 +51,7 @@ If you completed step 1 and step 2 you should have a configuration similar this:
 
 Besides Detox configuration, CodeceptJS should also be configured to use Detox.
 
-In `codecept.conf.js` enable Detox helper:
+In `codecept.config.js` enable Detox helper:
 
 ```js
 helpers: {

--- a/docs/helpers/JSONResponse.md
+++ b/docs/helpers/JSONResponse.md
@@ -28,7 +28,7 @@ It can check status codes, response data, response structure.
 Zero-configuration when paired with REST:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 {
   helpers: {
     REST: {
@@ -42,7 +42,7 @@ Zero-configuration when paired with REST:
 Explicitly setting request helper if you use `makeApiRequest` of Playwright to perform requests and not paired REST:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 // ...
   helpers: {
     Playwright: {

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -20,7 +20,7 @@ Requires `nightmare` package to be installed.
 
 ## Configuration
 
-This helper should be configured in codecept.json or codecept.conf.js
+This helper should be configured in codecept.json or codecept.config.js
 
 -   `url` - base url of website to be tested
 -   `restart`  - restart browser between tests.
@@ -103,7 +103,7 @@ Returns **[Promise][5]&lt;any>**
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js
@@ -793,7 +793,7 @@ Returns **[Promise][5]&lt;any>**
 
 ### saveElementScreenshot
 
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js
@@ -809,7 +809,7 @@ Returns **[Promise][5]&lt;any>**
 
 ### saveScreenshot
 
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -31,7 +31,7 @@ Using playwright-core package, will prevent the download of browser binaries and
 
 ## Configuration
 
-This helper should be configured in codecept.json or codecept.conf.js
+This helper should be configured in codecept.json or codecept.config.js
 
 -   `url`: base url of website to be tested
 -   `browser`: a browser to test on, either: `chromium`, `firefox`, `webkit`, `electron`. Default: chromium.
@@ -375,7 +375,7 @@ Returns **[Promise][10]&lt;any>**
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js
@@ -1374,7 +1374,7 @@ First parameter can be set to `maximize`.
 Returns **[Promise][10]&lt;any>** Unlike other drivers Playwright changes the size of a viewport, not the window!
 Playwright does not control the window of a browser so it can't adjust its real size.
 It also can't maximize a window.Update configuration to change real window size on start:```js
-// inside codecept.conf.js
+// inside codecept.config.js
 // @codeceptjs/configure package must be installed
 { setWindowSize } = require('@codeceptjs/configure');
 ```
@@ -1401,7 +1401,7 @@ Returns **[Promise][10]&lt;any>**
 
 ### saveElementScreenshot
 
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js
@@ -1417,7 +1417,7 @@ Returns **[Promise][10]&lt;any>**
 
 ### saveScreenshot
 
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 

--- a/docs/helpers/Puppeteer-firefox.md
+++ b/docs/helpers/Puppeteer-firefox.md
@@ -14,7 +14,7 @@ npm install puppeteer-firefox
 
 ## Configuration
 
-If you want to use puppeteer-firefox, you should add it in Puppeteer section in codecept.conf.js.
+If you want to use puppeteer-firefox, you should add it in Puppeteer section in codecept.config.js.
 
 - browser: 'chrome' OR 'firefox', 'chrome' is default value
 
@@ -38,7 +38,7 @@ helpers: {
 
 ## Run-multiple
 
-Example multiple section in codecept.conf.js:
+Example multiple section in codecept.config.js:
 
 ```js
  multiple: {
@@ -63,7 +63,7 @@ Historically, Puppeteer supported Firefox indirectly through puppeteer-firefox, 
 npm i puppeteer@v2.1.0
 ```
 
-If you want to try this expirement within CodeceptJS, you should add it in Puppeteer section in codecept.conf.js.
+If you want to try this expirement within CodeceptJS, you should add it in Puppeteer section in codecept.config.js.
 
 - browser: 'chrome' OR 'firefox', 'chrome' is default value
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -29,7 +29,7 @@ Using `puppeteer-core` package, will prevent the download of browser binaries an
 
 ## Configuration
 
-This helper should be configured in codecept.json or codecept.conf.js
+This helper should be configured in codecept.json or codecept.config.js
 
 -   `url`: base url of website to be tested
 -   `basicAuth`: (optional) the basic authentication to pass to base url. Example: {username: 'username', password: 'password'}
@@ -304,7 +304,7 @@ This action supports [React locators](https://codecept.io/react#locators)
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js
@@ -1369,7 +1369,7 @@ This action supports [React locators](https://codecept.io/react#locators)
 
 ### saveElementScreenshot
 
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js
@@ -1385,7 +1385,7 @@ Returns **[Promise][9]&lt;any>**
 
 ### saveScreenshot
 
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -20,7 +20,7 @@ Requires `testcafe` package to be installed.
 
 ## Configuration
 
-This helper should be configured in codecept.json or codecept.conf.js
+This helper should be configured in codecept.json or codecept.config.js
 
 -   `url`: base url of website to be tested
 -   `show`:  - show browser window.
@@ -128,7 +128,7 @@ Returns **[Promise][5]&lt;any>**
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js
@@ -722,7 +722,7 @@ Returns **[Promise][5]&lt;any>**
 
 ### saveElementScreenshot
 
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js
@@ -738,7 +738,7 @@ Returns **[Promise][5]&lt;any>**
 
 ### saveScreenshot
 
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -18,7 +18,7 @@ WebDriver requires Selenium Server and ChromeDriver/GeckoDriver to be installed.
 
 ### Configuration
 
-This helper should be configured in codecept.json or codecept.conf.js
+This helper should be configured in codecept.json or codecept.config.js
 
 -   `url`: base url of website to be tested.
 -   `basicAuth`: (optional) the basic authentication to pass to base url. Example: {username: 'username', password: 'password'}
@@ -474,7 +474,7 @@ This action supports [React locators](https://codecept.io/react#locators)
 ### attachFile
 
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js
@@ -1528,7 +1528,7 @@ Placeholder for ~ locator only test case write once run on both Appium and WebDr
 
 ### saveElementScreenshot
 
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js
@@ -1544,7 +1544,7 @@ Returns **[Promise][21]&lt;any>**
 
 ### saveScreenshot
 
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 

--- a/docs/locators.md
+++ b/docs/locators.md
@@ -308,7 +308,7 @@ CodeceptJS provides the option to specify custom locators that uses Custom Locat
 To use the defined Custom Locator Strategy add your custom strategy to your configuration.
 
 ```js
-// in codecept.conf.js
+// in codecept.config.js
 
 const myStrat = (selector) => {
   return document.querySelectorAll(selector)

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -89,7 +89,7 @@ You will also be asked for the platform and the application package.
 ? [Appium] Application package. Path to file or url
 ```
 
-Check the newly created `codecept.conf.js` configuration file.
+Check the newly created `codecept.config.js` configuration file.
 You may want to set some additional Appium settings via [desiredCapabilities](https://appium.io/docs/en/writing-running-appium/caps/)
 
 ```js

--- a/docs/pageobjects.md
+++ b/docs/pageobjects.md
@@ -249,7 +249,7 @@ module.exports = {
 }
 ```
 
-> PageObject and PageFragment names are declared inside `include` section of `codecept.conf.js`. See [Dependency Injection](#dependency-injection)
+> PageObject and PageFragment names are declared inside `include` section of `codecept.config.js`. See [Dependency Injection](#dependency-injection)
 
 ## StepObjects
 

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -8,7 +8,7 @@ title: Parallel Execution
 CodeceptJS has two engines for running tests in parallel:
 
 * `run-workers` - which spawns [NodeJS Worker](https://nodejs.org/api/worker_threads.html) in a thread. Tests are split by scenarios, scenarios are mixed between groups, each worker runs tests from its own group.
-* `run-multiple` - which spawns a subprocess with CodeceptJS. Tests are split by files and configured in `codecept.conf.js`.
+* `run-multiple` - which spawns a subprocess with CodeceptJS. Tests are split by files and configured in `codecept.config.js`.
 
 Workers are faster and simpler to start, while `run-multiple` requires additional configuration and can be used to run tests in different browsers at once.
 
@@ -202,7 +202,7 @@ However, you can't access uninitialized data from a container, so to start, you 
 
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 exports.config = {
   bootstrap() {
     // append empty userData to container

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -45,7 +45,7 @@ You will be asked for a Helper to use, you should select Playwright and provide 
 
 ## Configuring
 
-Make sure `Playwright` helper is enabled in `codecept.conf.js` config:
+Make sure `Playwright` helper is enabled in `codecept.config.js` config:
 
 ```js
 { // ..
@@ -254,7 +254,7 @@ function createWindow() {
 app.whenReady().then(createWindow);
 ```
 
-`codecept.conf.js` - CodeceptJS configuration file
+`codecept.config.js` - CodeceptJS configuration file
 ```js
 const path = require("path");
 
@@ -340,7 +340,7 @@ I.makeApiRequest('GET', '/users')
 It is also possible to test JSON responses by adding [`JSONResponse`](/helpers/JSONResponse) and connecting it to Playwright:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 {
   helpers: {
     Playwright: {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -476,7 +476,7 @@ This plugin will create a valid XPath locator for you.
 Using `data-test` attribute with `$` prefix:
 
 ```js
-// in codecept.conf.js
+// in codecept.config.js
 plugins: {
  customLocator: {
    enabled: true,
@@ -495,7 +495,7 @@ I.click('$sign-up'); // matches => [data-test=sign-up]
 Using `data-qa` attribute with `=` prefix:
 
 ```js
-// in codecept.conf.js
+// in codecept.config.js
 plugins: {
  customLocator: {
    enabled: true,
@@ -710,7 +710,7 @@ Scenario('scenario tite', () => {
 
 Adds global `retryTo` which retries steps a few times before failing.
 
-Enable this plugin in `codecept.conf.js` (enabled by default for new setups):
+Enable this plugin in `codecept.config.js` (enabled by default for new setups):
 
 ```js
 plugins: {
@@ -826,7 +826,7 @@ Selenoid plugin can be started in two ways:
 
 If you are new to Selenoid and you want plug and play setup use automatic mode.
 
-Add plugin configuration in `codecept.conf.js`:
+Add plugin configuration in `codecept.config.js`:
 
 ```js
 plugins: {
@@ -856,7 +856,7 @@ This is especially useful for Continous Integration server as you can configure 
 
 > Use [Selenoid Configuration Manager][16] to create and start containers semi-automatically.
 
-1.  Create `browsers.json` file in the same directory `codecept.conf.js` is located
+1.  Create `browsers.json` file in the same directory `codecept.config.js` is located
     [Refer to Selenoid documentation][18] to know more about browsers.json.
 
 _Sample browsers.json_
@@ -1030,7 +1030,7 @@ plugins: {
 
 Adds global `tryTo` function inside of which all failed steps won't fail a test but will return true/false.
 
-Enable this plugin in `codecept.conf.js` (enabled by default for new setups):
+Enable this plugin in `codecept.config.js` (enabled by default for new setups):
 
 ```js
 plugins: {

--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -47,7 +47,7 @@ You will be asked for a Helper to use, you should select Puppeteer and provide u
 
 ## Configuring
 
-Make sure `Puppeteer` helper is enabled in `codecept.conf.js` config:
+Make sure `Puppeteer` helper is enabled in `codecept.config.js` config:
 
 ```js
 { // ..

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -62,7 +62,7 @@ After CodeceptJS is installed, try running **demo tests** using this commands:
 
 ---
 
-To start a new project initialize CodeceptJS to create main config file: `codecept.conf.js`.
+To start a new project initialize CodeceptJS to create main config file: `codecept.config.js`.
 
 ```
 npx codeceptjs init

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -264,7 +264,7 @@ Install it via NPM (locally or globally, depending on CodeceptJS installation ty
 npm i mocha-junit-reporter
 ```
 
-Additional configuration should be added to `codecept.conf.js` to print xml report to `output` directory:
+Additional configuration should be added to `codecept.config.js` to print xml report to `output` directory:
 
 ```json
   "mocha": {

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -41,7 +41,7 @@ For writing tests in TypeScript you'll need to install `typescript` and `ts-node
 npm install typescript ts-node
 ```
 
-### Configure codecept.conf.js
+### Configure codecept.config.js
 
 To configure TypeScript in your project, you need to add [`ts-node/register`](https://github.com/TypeStrong/ts-node) on first line in your config. Like in the following config file:
 
@@ -84,7 +84,7 @@ We recommended the following configuration in a [tsconfig.json](https://www.type
 
 ### Set Up steps.d.ts
 
-Configuring the `tsconfig.json` and `codecept.conf.js` is not enough, you will need to configure the `steps.d.ts` file for custom steps. Just simply do this by running this command::
+Configuring the `tsconfig.json` and `codecept.config.js` is not enough, you will need to configure the `steps.d.ts` file for custom steps. Just simply do this by running this command::
 
 `npx codeceptjs def`
 
@@ -120,7 +120,7 @@ class CustomHelper extends Helper {
 export = CustomHelper
 ```
 
-Then you need to add this helper to your `codecept.conf.js` like in this [docs](https://codecept.io/helpers/#configuration).
+Then you need to add this helper to your `codecept.config.js` like in this [docs](https://codecept.io/helpers/#configuration).
 And then run the command `npx codeceptjs def`.
 
 As result our `steps.d.ts` file will be updated like this:

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -27,7 +27,7 @@ npm install codeceptjs-resemblehelper --save
 
 ### Configuring
 
-This helper should be added to `codecept.conf.js` config file.
+This helper should be added to `codecept.config.js` config file.
 
 Example:
 

--- a/docs/vue.md
+++ b/docs/vue.md
@@ -91,7 +91,7 @@ npm run test:e2e:open
 Generator has created these files:
 
 ```js
-codecept.conf.js          👈 codeceptjs config
+codecept.config.js          👈 codeceptjs config
 jsconfig.json             👈 enabling type definitons
 tests
 ├── e2e

--- a/docs/webapi/attachFile.mustache
+++ b/docs/webapi/attachFile.mustache
@@ -1,5 +1,5 @@
 Attaches a file to element located by label, name, CSS or XPath
-Path to file is relative current codecept directory (where codecept.json or codecept.conf.js is located).
+Path to file is relative current codecept directory (where codecept.json or codecept.config.js is located).
 File will be uploaded to remote system (if tests are running remotely).
 
 ```js

--- a/docs/webapi/saveElementScreenshot.mustache
+++ b/docs/webapi/saveElementScreenshot.mustache
@@ -1,4 +1,4 @@
-Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.conf.js).
+Saves screenshot of the specified locator to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 
 ```js

--- a/docs/webapi/saveScreenshot.mustache
+++ b/docs/webapi/saveScreenshot.mustache
@@ -1,4 +1,4 @@
-Saves a screenshot to ouput folder (set in codecept.json or codecept.conf.js).
+Saves a screenshot to ouput folder (set in codecept.json or codecept.config.js).
 Filename is relative to output folder.
 Optionally resize the window to the full available page `scrollHeight` and `scrollWidth` to capture the entire page by passing `true` in as the second argument.
 

--- a/docs/webdriver.md
+++ b/docs/webdriver.md
@@ -62,7 +62,7 @@ WebDriver can be configured to run browser tests in window, headlessly, on a rem
 
 > By default CodeceptJS is already configured to run WebDriver tests locally with Chrome or Firefox. If you just need to start running tests - proceed to the next chapter.
 
-Configuration for WebDriver should be provided inside `codecept.conf.js` file under `helpers: WebDriver` section:
+Configuration for WebDriver should be provided inside `codecept.config.js` file under `helpers: WebDriver` section:
 
 ```js
   helpers: {
@@ -119,7 +119,7 @@ CodeceptJS has [Selenoid plugin](/plugins#selenoid) which can automagically load
 It is recommended to use `@codeceptjs/configure` package to easily toggle headless mode for WebDriver:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 const { setHeadlessWhen, setWindowSize } = require('@codeceptjs/configure');
 
 setHeadlessWhen(process.env.HEADLESS); // enables headless mode when HEADLESS environment variable exists
@@ -369,7 +369,7 @@ Most popular "waiters" are:
 By default, they will wait for 1 second. This number can be changed in WebDriver configuration:
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 exports.config = {
   helpers: {
     WebDriver: {
@@ -389,7 +389,7 @@ SmartWait can be enabled by setting wait option in WebDriver config.
 Add `smartWait: 5000` to wait for additional 5s.
 
 ```js
-// inside codecept.conf.js
+// inside codecept.config.js
 exports.config = {
   helpers: {
     WebDriver: {


### PR DESCRIPTION
## Motivation/Description of the PR

This is a second part of config name consistency of https://github.com/codeceptjs/CodeceptJS/pull/3195

This PR changes only docs files as described in previous PR

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
