### PR TITLE
fix typo in usePuppeteerTo

### DIFF
--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1871,7 +1871,7 @@ Second argument is async function that gets this helper as parameter.
 { [`page`][20], [`browser`][21] } from Puppeteer API are available.
 
 ```js
-I.usePuppeteerTo('emulate offline mode', async ({ page }) {
+I.usePuppeteerTo('emulate offline mode', async ({ page }) => {
   await page.setOfflineMode(true);
 });
 ```


### PR DESCRIPTION
I was trying to use this in one of my tests, and realized that it did not work without the fat arrow `=>`

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
