### PR TITLE
Change how tests are loaded

### DIFF
--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -23,8 +23,8 @@ module.exports = async function (test, options) {
   try {
     codecept.init(testRoot);
     await codecept.bootstrap();
-    codecept.loadTests();
-    await codecept.run(test);
+    codecept.loadTests(test);
+    await codecept.run();
   } catch (err) {
     printError(err);
     process.exitCode = 1;

--- a/test/data/sandbox/test-dir/one_test.js
+++ b/test/data/sandbox/test-dir/one_test.js
@@ -1,0 +1,3 @@
+Scenario('test one', ({ I }) => {
+  I.say('hello world');
+});

--- a/test/data/sandbox/test-dir/two_test.js
+++ b/test/data/sandbox/test-dir/two_test.js
@@ -1,0 +1,3 @@
+Scenario('test two', ({ I }) => {
+  I.say('hello world');
+});

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -52,6 +52,14 @@ describe('CodeceptJS Runner', () => {
       err.code.should.eql(1);
       done();
     });
+
+    it('should except a directory glob pattern', (done) => {
+      process.chdir(codecept_dir);
+      exec(`${codecept_run} "test-dir/*"`, (err, stdout) => {
+        stdout.should.include('2 passed'); // number of tests present in directory
+        done();
+      });
+    });
   });
 
   describe('grep', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- This changes the way that codeceptjs handles when a directory is passed to it. Previously it wouldn't run all files that matched the glob pattern passed in.

- Resolves #2280.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
 - I ran this command as well and it flagged several un-related things so I didn't push that up
- [x] Lint checking (Run `npm run lint`)
 - I ran this command and locally it complained about a file that I did not touch locally so I didn't push that up
- [x] Local tests are passed (Run `npm test`)
