### PR TITLE
Fix: allure attachment fails if screenshot failed

### DIFF
--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -142,18 +142,20 @@ module.exports = function (config) {
     if (step.metaStep && step.metaStep.name === 'BeforeSuite') return;
 
     const fileName = `${pad.substring(0, pad.length - stepNum.toString().length) + stepNum.toString()}.png`;
+    if (step.status === 'failed') {
+      scenarioFailed = true;
+    }
+    stepNum++;
+    slides[fileName] = step;
     try {
-      if (step.status === 'failed') {
-        scenarioFailed = true;
-      }
-      stepNum++;
-      slides[fileName] = step;
       await helper.saveScreenshot(path.relative(reportDir, path.join(dir, fileName)), config.fullPageScreenshots);
     } catch (err) {
       output.plugin(`Can't save step screenshot: ${err}`);
       error = err;
+      return;
+    } finally {
+      savedStep = step;
     }
-    savedStep = step;
 
     if (!currentTest.artifacts.screenshots) currentTest.artifacts.screenshots = [];
     // added attachments to test


### PR DESCRIPTION
When `helper.saveScreenshot` fails, we can stop the execution of this
function.

When the screenshot is not there and the allure report is enabled, it
will throw the folling error:
```
       "after each" hook: codeceptjs.after for "...":
     Uncaught ENOENT: no such file or directory, open '/code/output/record_19bee45168cf2898aee9250e1bbb630e/0024.png'
      at Object.openSync (node:fs:585:3)
      at Object.readFileSync (node:fs:453:35)
      at EventEmitter.persistStep (node_modules/codeceptjs/lib/plugin/stepByStepReport.js:165:69)
```

So if there is an error with the screenshot, we will not add it to the
list of artifacts, and will not try to added it to the allure report.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [x] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
