### PR TITLE
REST: Fixed override of headers/token in haveRequestHeaders() and amBearerAuthenticated()

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -87,7 +87,7 @@ class REST extends Helper {
    * @param {object} headers headers list
    */
   haveRequestHeaders(headers) {
-    this.headers = { ...headers, ...this.headers };
+    this.headers = { ...this.headers, ...headers };
   }
 
   /**
@@ -113,7 +113,7 @@ class REST extends Helper {
    */
   async _executeRequest(request) {
     // Add custom headers. They can be set by amBearerAuthenticated() or haveRequestHeaders()
-    request.headers = { ...request.headers, ...this.headers };
+    request.headers = { ...this.headers, ...request.headers };
 
     const _debugRequest = { ...request };
     this.axios.defaults.timeout = request.timeout || this.options.timeout;

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -206,12 +206,66 @@ describe('REST', () => {
       }
     });
 
+    it('should set headers for all requests multiple times', async () => {
+      I.haveRequestHeaders({ 'XY1-Test': 'xy1-first' });
+      I.haveRequestHeaders({ 'XY1-Test': 'xy1-second' });
+      I.haveRequestHeaders({ 'XY2-Test': 'xy2' });
+      {
+        const response = await I.sendGetRequest('/user');
+
+        response.config.headers.should.have.property('XY1-Test');
+        response.config.headers['XY1-Test'].should.eql('xy1-second');
+
+        response.config.headers.should.have.property('XY2-Test');
+        response.config.headers['XY2-Test'].should.eql('xy2');
+
+        response.config.headers.should.have.property('X-Test');
+        response.config.headers['X-Test'].should.eql('test');
+      }
+    });
+
+    it('should override the header set for all requests', async () => {
+      I.haveRequestHeaders({ 'XY-Test': 'first' });
+      {
+        const response = await I.sendGetRequest('/user', { 'XY-Test': 'value_custom' });
+
+        response.config.headers.should.have.property('XY-Test');
+        response.config.headers['XY-Test'].should.eql('value_custom');
+
+        response.config.headers.should.have.property('X-Test');
+        response.config.headers['X-Test'].should.eql('test');
+      }
+    });
+
     it('should set Bearer authorization', async () => {
       I.amBearerAuthenticated('token');
       const response = await I.sendGetRequest('/user');
 
       response.config.headers.should.have.property('Authorization');
       response.config.headers.Authorization.should.eql('Bearer token');
+
+      response.config.headers.should.have.property('X-Test');
+      response.config.headers['X-Test'].should.eql('test');
+    });
+
+    it('should set Bearer authorization multiple times', async () => {
+      I.amBearerAuthenticated('token1');
+      I.amBearerAuthenticated('token2');
+      const response = await I.sendGetRequest('/user');
+
+      response.config.headers.should.have.property('Authorization');
+      response.config.headers.Authorization.should.eql('Bearer token2');
+
+      response.config.headers.should.have.property('X-Test');
+      response.config.headers['X-Test'].should.eql('test');
+    });
+
+    it('should override Bearer authorization', async () => {
+      I.amBearerAuthenticated('token');
+      const response = await I.sendGetRequest('/user', { Authorization: 'Bearer token_custom' });
+
+      response.config.headers.should.have.property('Authorization');
+      response.config.headers.Authorization.should.eql('Bearer token_custom');
 
       response.config.headers.should.have.property('X-Test');
       response.config.headers['X-Test'].should.eql('test');


### PR DESCRIPTION
## Motivation/Description of the PR
In CodeceptJS 3.3.1, if you call `I.amBearerAuthenticated()` several times with various tokens, only the token passed for the 1st time is used in all calls.
Also `I.haveRequestHeaders()` is affected

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
