### PR TITLE
feat: pretty print json option for REST helper

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -17,6 +17,7 @@ REST helper allows to send additional requests to the REST API during acceptance
 ## Configuration
 
 -   endpoint: API base URL
+-   prettyPrintJson: pretty print json for response/request on console logs
 -   timeout: timeout for requests in milliseconds. 10000ms by default
 -   defaultHeaders: a list of default headers
 -   onRequest: a async function which can update request object.
@@ -29,6 +30,7 @@ REST helper allows to send additional requests to the REST API during acceptance
   helpers: {
     REST: {
       endpoint: 'http://site.com/api',
+      prettyPrintJson: true,
       onRequest: (request) => {
       request.headers.auth = '123';
     }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -154,7 +154,7 @@ class REST extends Helper {
     if (this.config.onResponse) {
       await this.config.onResponse(response);
     }
-    this.options.prettyPrintJson === true ? this.debugSection('Response', beautify(JSON.stringify(response.data))) : this.debugSection('Response', JSON.stringify(response.data));
+    this.options.prettyPrintJson ? this.debugSection('Response', beautify(JSON.stringify(response.data))) : this.debugSection('Response', JSON.stringify(response.data));
     return response;
   }
 

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -2,6 +2,7 @@ const axios = require('axios').default;
 const Secret = require('../secret');
 
 const Helper = require('../helper');
+const { beautify } = require('../utils');
 
 /**
  * REST helper allows to send additional requests to the REST API during acceptance tests.
@@ -10,6 +11,7 @@ const Helper = require('../helper');
  * ## Configuration
  *
  * * endpoint: API base URL
+ * * prettyPrintJson: pretty print json for response/request on console logs
  * * timeout: timeout for requests in milliseconds. 10000ms by default
  * * defaultHeaders: a list of default headers
  * * onRequest: a async function which can update request object.
@@ -22,6 +24,7 @@ const Helper = require('../helper');
  *   helpers: {
  *     REST: {
  *       endpoint: 'http://site.com/api',
+ *       prettyPrintJson: true,
  *       onRequest: (request) => {
  *       request.headers.auth = '123';
  *     }
@@ -49,6 +52,7 @@ class REST extends Helper {
       timeout: 10000,
       defaultHeaders: {},
       endpoint: '',
+      prettyPrintJson: false,
     };
 
     if (this.options.maxContentLength) {
@@ -137,7 +141,7 @@ class REST extends Helper {
       await this.config.onRequest(request);
     }
 
-    this.debugSection('Request', JSON.stringify(_debugRequest));
+    this.options.prettyPrintJson === true ? this.debugSection('Request', JSON.stringify(_debugRequest)) : this.debugSection('Request', beautify(JSON.stringify(_debugRequest)));
 
     let response;
     try {
@@ -150,7 +154,7 @@ class REST extends Helper {
     if (this.config.onResponse) {
       await this.config.onResponse(response);
     }
-    this.debugSection('Response', JSON.stringify(response.data));
+    this.options.prettyPrintJson === true ? this.debugSection('Response', JSON.stringify(response.data)) : this.debugSection('Response', beautify(JSON.stringify(response.data)));
     return response;
   }
 

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -141,7 +141,7 @@ class REST extends Helper {
       await this.config.onRequest(request);
     }
 
-    this.options.prettyPrintJson === true ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
+    this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
 
     let response;
     try {

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -141,7 +141,7 @@ class REST extends Helper {
       await this.config.onRequest(request);
     }
 
-    this.options.prettyPrintJson === true ? this.debugSection('Request', JSON.stringify(_debugRequest)) : this.debugSection('Request', beautify(JSON.stringify(_debugRequest)));
+    this.options.prettyPrintJson === true ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
 
     let response;
     try {
@@ -154,7 +154,7 @@ class REST extends Helper {
     if (this.config.onResponse) {
       await this.config.onResponse(response);
     }
-    this.options.prettyPrintJson === true ? this.debugSection('Response', JSON.stringify(response.data)) : this.debugSection('Response', beautify(JSON.stringify(response.data)));
+    this.options.prettyPrintJson === true ? this.debugSection('Response', beautify(JSON.stringify(response.data))) : this.debugSection('Response', JSON.stringify(response.data));
     return response;
   }
 


### PR DESCRIPTION
## Motivation/Description of the PR
- As using REST helper with verbose mode, the formatted json of response/request would help a lot

Applicable helpers:
- [x] REST

## Type of change

- [x] :rocket: improvements

## Checklist:

- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
