### PR TITLE
Fixed typo in a message when starting interactive shell

### DIFF
--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -21,7 +21,7 @@ module.exports = async function (path, options) {
 
     if (options.verbose) output.level(3);
 
-    output.print('String interactive shell for current suite...');
+    output.print('Starting interactive shell for current suite...');
     recorder.start();
     event.emit(event.suite.before, {
       fullTitle: () => 'Interactive Shell',


### PR DESCRIPTION
## Motivation/Description of the PR
![image](https://user-images.githubusercontent.com/12584138/166671334-542d2cee-b1f4-4642-976f-643ea7e66b2c.png)

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
