### PR TITLE
Playwright: connect over cdp option

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -131,7 +131,8 @@ Traces will be saved to `output/trace`
      Playwright: {
        url: "http://localhost",
        chromium: {
-         browserWSEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a'
+         browserWSEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a',
+         cdpConnection: false // default is false
        }
      }
    }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -168,7 +168,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *        url: "http://localhost",
  *        chromium: {
  *          browserWSEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a',
-            cdpConnection: false // default is false
+ *          cdpConnection: false // default is false
  *        }
  *      }
  *    }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -272,6 +272,7 @@ class Playwright extends Helper {
     this.sessionPages = {};
     this.activeSessionName = '';
     this.isElectron = false;
+    this.isCDPConnection = false;
     this.electronSessions = [];
     this.storageState = null;
 
@@ -347,6 +348,7 @@ class Playwright extends Helper {
     this.isRemoteBrowser = !!this.playwrightOptions.browserWSEndpoint;
     this.isElectron = this.options.browser === 'electron';
     this.userDataDir = this.playwrightOptions.userDataDir;
+    this.isCDPConnection = this.playwrightOptions.cdpConnection;
     popupStore.defaultAction = this.options.defaultPopupAction;
   }
 
@@ -692,6 +694,15 @@ class Playwright extends Helper {
   async _startBrowser() {
     if (this.isElectron) {
       this.browser = await playwright._electron.launch(this.playwrightOptions);
+    } else if (this.isRemoteBrowser && this.isCDPConnection) {
+      try {
+        this.browser = await playwright[this.options.browser].connectOverCDP(this.playwrightOptions);
+      } catch (err) {
+        if (err.toString().indexOf('ECONNREFUSED')) {
+          throw new RemoteBrowserConnectionRefused(err);
+        }
+        throw err;
+      }
     } else if (this.isRemoteBrowser) {
       try {
         this.browser = await playwright[this.options.browser].connect(this.playwrightOptions);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -167,7 +167,8 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *      Playwright: {
  *        url: "http://localhost",
  *        chromium: {
- *          browserWSEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a'
+ *          browserWSEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a',
+            cdpConnection: false // default is false
  *        }
  *      }
  *    }


### PR DESCRIPTION
## Motivation/Description of the PR
I want to use playwright helper with Browserless remote browser service, but it's didn't work for me.
When I change the connection type to connectOverCDP, it works fine.
https://docs.browserless.io/docs/playwright.html#playwrightchromiumconnectovercdpwsendpoint-string

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
