### PR TITLE
Docs: Fixed property name for plugin "retryFailedStep"

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -682,7 +682,7 @@ Run tests with plugin enabled:
 plugins: {
     retryFailedStep: {
         enabled: true,
-        ignoreSteps: [
+        ignoredSteps: [
           'scroll*', // ignore all scroll steps
           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
         ]

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -60,7 +60,7 @@ const defaultConfig = {
  * plugins: {
  *     retryFailedStep: {
  *         enabled: true,
- *         ignoreSteps: [
+ *         ignoredSteps: [
  *           'scroll*', // ignore all scroll steps
  *           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
  *         ]


### PR DESCRIPTION
## Motivation/Description of the PR
I wondered why the copy&pasted config from [CodeceptJS](https://codecept.io/plugins/#retryfailedstep) didn't work for me and then noticed a typo in property name.
Therefore I fixed it.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [x] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
