### PR TITLE
use W3C standards when interfacing with appium.

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -907,7 +907,7 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async click(locator, context = null) {
-    const clickMethod = this.browser.isMobile ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && this.browser.platformName !== 'android' ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findClickable.call(this, locator, locateFn);
@@ -1117,7 +1117,7 @@ class WebDriver extends Helper {
    * Appium: not tested
    */
   async checkOption(field, context = null) {
-    const clickMethod = this.browser.isMobile ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && this.browser.platformName !== 'android' ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findCheckable.call(this, field, locateFn);
@@ -1136,7 +1136,7 @@ class WebDriver extends Helper {
    * Appium: not tested
    */
   async uncheckOption(field, context = null) {
-    const clickMethod = this.browser.isMobile ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && this.browser.platformName !== 'android' ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findCheckable.call(this, field, locateFn);
@@ -1623,7 +1623,7 @@ class WebDriver extends Helper {
       assertElementExists(res);
       const elem = usingFirstElement(res);
       const elementId = getElementId(elem);
-      if (this.browser.isMobile) return this.browser.touchScroll(offsetX, offsetY, elementId);
+      if (this.browser.isMobile && this.browser.platformName !== 'android') return this.browser.touchScroll(offsetX, offsetY, elementId);
       const location = await elem.getLocation();
       assertElementExists(location, 'Failed to receive', 'location');
       /* eslint-disable prefer-arrow-callback */
@@ -1631,7 +1631,7 @@ class WebDriver extends Helper {
       /* eslint-enable */
     }
 
-    if (this.browser.isMobile) return this.browser.touchScroll(locator, offsetX, offsetY);
+    if (this.browser.isMobile && this.browser.platformName !== 'android') return this.browser.touchScroll(locator, offsetX, offsetY);
 
     /* eslint-disable prefer-arrow-callback, comma-dangle */
     return this.browser.execute(function (x, y) { return window.scrollTo(x, y); }, offsetX, offsetY);

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -907,7 +907,7 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async click(locator, context = null) {
-    const clickMethod = this.browser.isMobile && this.browser.platformName !== 'android' ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findClickable.call(this, locator, locateFn);
@@ -1117,7 +1117,7 @@ class WebDriver extends Helper {
    * Appium: not tested
    */
   async checkOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && this.browser.platformName !== 'android' ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findCheckable.call(this, field, locateFn);
@@ -1136,7 +1136,7 @@ class WebDriver extends Helper {
    * Appium: not tested
    */
   async uncheckOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && this.browser.platformName !== 'android' ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findCheckable.call(this, field, locateFn);
@@ -1623,7 +1623,7 @@ class WebDriver extends Helper {
       assertElementExists(res);
       const elem = usingFirstElement(res);
       const elementId = getElementId(elem);
-      if (this.browser.isMobile && this.browser.platformName !== 'android') return this.browser.touchScroll(offsetX, offsetY, elementId);
+      if (this.browser.isMobile && this.browser.capabilities.platformName !== 'android') return this.browser.touchScroll(offsetX, offsetY, elementId);
       const location = await elem.getLocation();
       assertElementExists(location, 'Failed to receive', 'location');
       /* eslint-disable prefer-arrow-callback */
@@ -1631,7 +1631,7 @@ class WebDriver extends Helper {
       /* eslint-enable */
     }
 
-    if (this.browser.isMobile && this.browser.platformName !== 'android') return this.browser.touchScroll(locator, offsetX, offsetY);
+    if (this.browser.isMobile && this.browser.capabilities.platformName !== 'android') return this.browser.touchScroll(locator, offsetX, offsetY);
 
     /* eslint-disable prefer-arrow-callback, comma-dangle */
     return this.browser.execute(function (x, y) { return window.scrollTo(x, y); }, offsetX, offsetY);


### PR DESCRIPTION
It may still be broken when interfacing Ios, because I have no idea what
IOS platform name is

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #2904 (if applicable).

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
