### PR TITLE
FIX-issue-3147 incorporates pollInterval into retryTo plugin as documented.

### DIFF
--- a/lib/plugin/retryTo.js
+++ b/lib/plugin/retryTo.js
@@ -101,27 +101,20 @@ module.exports = function (config) {
           err = e;
           recorder.session.restore(`retryTo ${tries}`);
           tries++;
-          // recorder.session.restore(`retryTo`);
           if (tries <= maxTries) {
             debug(`Error ${err}... Retrying`);
             err = null;
 
-            recorder.add(`retryTo ${tries}`, () => {
-              tryBlock();
-              // recorder.add(() => new Promise(done => setTimeout(done, pollInterval)));
-            });
+            recorder.add(`retryTo ${tries}`, () => setTimeout(tryBlock, pollInterval));
           } else {
-            // recorder.throw(err);
             done(null);
           }
         });
-        // return recorder.promise();
       };
 
       recorder.add('retryTo', async () => {
         store.debugMode = true;
         tryBlock();
-        // recorder.add(() => recorder.session.restore(`retryTo ${tries-1}`));
       });
     }).then(() => {
       if (err) recorder.throw(err);


### PR DESCRIPTION
## Motivation/Description of the PR
- Description: fix for issue 3147 retryTo plugin doesn't wait for pollInterval before retry.
- Resolves  https://github.com/codeceptjs/CodeceptJS/issues/3147

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles
- [x] retryTo

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added **(let me know if you think it's needed)**
- [ ] Documentation has been added (Run `npm run docs`) **(adds code to match documentation)**
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
