### PR TITLE
fix(3367): Android Click Broken When Platform Definition Capitalized

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -568,7 +568,7 @@ class WebDriver extends Helper {
     }
 
     if (this.browser.capabilities && this.browser.capabilities.platformName) {
-      this.browser.capabilities.platformName = this.browser.capabilities.platformName.lowercase();
+      this.browser.capabilities.platformName = this.browser.capabilities.platformName.toLowerCase();
     }
     return this.browser;
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -567,7 +567,7 @@ class WebDriver extends Helper {
       });
     }
 
-    if (this.browser.capabilities) {
+    if (this.browser.capabilities && this.browser.capabilities.platformName) {
       this.browser.capabilities.platformName = this.browser.capabilities.platformName.lowercase();
     }
     return this.browser;

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -567,6 +567,9 @@ class WebDriver extends Helper {
       });
     }
 
+    if (this.browser.capabilities) {
+      this.browser.capabilities.platformName = this.browser.capabilities.platformName.lowercase();
+    }
     return this.browser;
   }
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3367 

Applicable helpers:
- [x] WebDriver
- [x] Appium


## Type of change
- [x] :bug: Bug fix

## Checklist:
- [x] Local tests are passed (Run `npm test`)
