### PR TITLE
fix(3341): handleDownloads function is broken with Puppeteer 14.4 and onwards

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -38,7 +38,6 @@ let puppeteer;
 let perfTiming;
 const popupStore = new Popup();
 const consoleLogStore = new Console();
-let version;
 
 /**
  * Uses [Google Chrome's Puppeteer](https://github.com/GoogleChrome/puppeteer) library to run tests inside headless Chrome.
@@ -193,8 +192,6 @@ class Puppeteer extends Helper {
     super(config);
 
     puppeteer = requireWithFallback('puppeteer', 'puppeteer-core');
-    version = require('puppeteer/package.json').version;
-
     // set defaults
     this.isRemoteBrowser = false;
     this.isRunning = false;
@@ -1071,13 +1068,12 @@ class Puppeteer extends Helper {
       fs.mkdirSync(downloadPath, '0777');
     }
     fsExtra.emptyDirSync(downloadPath);
-    // Backwards compatibility with Puppeteer < 14.4.0
-    if (parseInt(version.split('.')[0], 10) >= 14) {
-      if (parseInt(version.split('.')[1], 10) >= 4) {
-        return this.page._client().send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath });
-      }
+
+    try {
+      return this.page._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath });
+    } catch (e) {
+      return this.page._client().send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath });
     }
-    return this.page._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath });
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -38,6 +38,7 @@ let puppeteer;
 let perfTiming;
 const popupStore = new Popup();
 const consoleLogStore = new Console();
+let version;
 
 /**
  * Uses [Google Chrome's Puppeteer](https://github.com/GoogleChrome/puppeteer) library to run tests inside headless Chrome.
@@ -192,6 +193,7 @@ class Puppeteer extends Helper {
     super(config);
 
     puppeteer = requireWithFallback('puppeteer', 'puppeteer-core');
+    version = require('puppeteer/package.json').version;
 
     // set defaults
     this.isRemoteBrowser = false;
@@ -372,22 +374,22 @@ class Puppeteer extends Helper {
   }
 
   /**
-  * Use Puppeteer API inside a test.
-  *
-  * First argument is a description of an action.
-  * Second argument is async function that gets this helper as parameter.
-  *
-  * { [`page`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page), [`browser`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-browser) } from Puppeteer API are available.
-  *
-  * ```js
-  * I.usePuppeteerTo('emulate offline mode', async ({ page }) {
-  *   await page.setOfflineMode(true);
-  * });
-  * ```
-  *
-  * @param {string} description used to show in logs.
-  * @param {function} fn async function that is executed with Puppeteer as argument
-  */
+   * Use Puppeteer API inside a test.
+   *
+   * First argument is a description of an action.
+   * Second argument is async function that gets this helper as parameter.
+   *
+   * { [`page`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-page), [`browser`](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-browser) } from Puppeteer API are available.
+   *
+   * ```js
+   * I.usePuppeteerTo('emulate offline mode', async ({ page }) {
+   *   await page.setOfflineMode(true);
+   * });
+   * ```
+   *
+   * @param {string} description used to show in logs.
+   * @param {function} fn async function that is executed with Puppeteer as argument
+   */
   usePuppeteerTo(description, fn) {
     return this._useTo(...arguments);
   }
@@ -1069,6 +1071,12 @@ class Puppeteer extends Helper {
       fs.mkdirSync(downloadPath, '0777');
     }
     fsExtra.emptyDirSync(downloadPath);
+    // Backwards compatibility with Puppeteer < 14.4.0
+    if (parseInt(version.split('.')[0], 10) >= 14) {
+      if (parseInt(version.split('.')[1], 10) >= 4) {
+        return this.page._client().send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath });
+      }
+    }
     return this.page._client.send('Page.setDownloadBehavior', { behavior: 'allow', downloadPath });
   }
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "ms": "^2.1.3",
     "parse-function": "^5.6.4",
     "promise-retry": "^1.1.1",
-    "read-package-json": "^5.0.1",
     "requireg": "^0.2.2",
     "resq": "^1.10.2",
     "sprintf-js": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -84,13 +84,14 @@
     "ms": "^2.1.3",
     "parse-function": "^5.6.4",
     "promise-retry": "^1.1.1",
+    "read-package-json": "^5.0.1",
     "requireg": "^0.2.2",
     "resq": "^1.10.2",
     "sprintf-js": "^1.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@codeceptjs/detox-helper": "^1.0.2",    
+    "@codeceptjs/detox-helper": "^1.0.2",
     "@codeceptjs/mock-request": "^0.3.1",
     "@faker-js/faker": "^5.5.3",
     "@pollyjs/adapter-puppeteer": "^5.1.0",


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3341 

Applicable helpers:
- [x] Puppeteer

## Type of change
- [x] :bug: Bug fix

## Checklist:
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
