### PR TITLE
fix: don't report files as existing when non-directory is in path

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,12 +33,7 @@ const isAsyncFunction = module.exports.isAsyncFunction = function (fn) {
 };
 
 module.exports.fileExists = function (filePath) {
-  try {
-    fs.statSync(filePath);
-  } catch (err) {
-    if (err.code === 'ENOENT') return false;
-  }
-  return true;
+  return fs.existsSync(filePath);
 };
 
 module.exports.isFile = function (filePath) {

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -7,8 +7,9 @@ const utils = require('../../lib/utils');
 
 describe('utils', () => {
   describe('#fileExists', () => {
-    it('exists', () => expect(utils.fileExists(__filename)));
-    it('not exists', () => expect(!utils.fileExists('not_utils.js')));
+    it('exists', () => expect(utils.fileExists(__filename)).to.be.true);
+    it('not exists', () => expect(utils.fileExists('not_utils.js')).to.be.false);
+    it('not exists if file used as directory', () => expect(utils.fileExists(`${__filename}/not_utils.js`)).to.be.false);
   });
   /* eslint-disable no-unused-vars */
   describe('#getParamNames', () => {


### PR DESCRIPTION
## Motivation/Description of the PR

`fileExists` would incorrectly return `true` when testing `somedir/somefile` if `somedir` existed but was a file, not a directory. This was caused by checking for `ENOENT` only, when in that case the error code returned by `statSync` is `ENOTDIR`:

```
$ touch a
$ node -p 'fs.statSync("a/b")'
node:internal/fs/utils:344
    throw err;
    ^

Error: ENOTDIR: not a directory, stat 'a/b'
…
```

Replacing the use of `fs.statSync` by a call to `fs.existsSync` avoids the problem while working correctly for all other cases.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [x] FileSystem
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

## 👀 Notes

Note that this might cause user tests using `I.seeFile` to correctly fail where they were previously incorrectly passing. We hit that particular case because we were using the Playwright helper's `handleDownloads` but (wrongly) following the Puppeteer helper's documentation for the identically-named function, which suggests :
```
I.handleDownloads();
I.click('Download Avatar');
I.amInPath('output/downloads');
I.seeFile('avatar.jpg');
```
Running the above script with the Playwright helper causes an `output/downloads` **file** to be created, regardless of the server's suggested file name. But the test passes anyway, because `I.seeFile('avatar.jpg')` succeeds because of the bug fixed by this PR (just like `I.seeFile('anything.else')` would succeed, in fact).

Note also that the existing tests for `fileExists` were missing assertions after the `expect(…)` call, causing them to always pass regardless of the behavior of `fileExists`. I added these missing assertions in this PR as well.


