### PR TITLE
Allow Typescript Support Objects To Use Default Exports

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -1,7 +1,7 @@
 const glob = require('glob');
 const path = require('path');
 const { MetaStep } = require('./step');
-const { fileExists, isFunction, isAsyncFunction } = require('./utils');
+const { fileExists, isFunction, isClass, isAsyncFunction } = require('./utils');
 const Translation = require('./translation');
 const MochaFactory = require('./mochaFactory');
 const recorder = require('./recorder');
@@ -335,7 +335,18 @@ function loadSupportObject(modulePath, supportObjectName) {
     modulePath = path.join(global.codecept_dir, modulePath);
   }
   try {
-    const obj = require(modulePath);
+    let obj = require(modulePath);
+
+    // Allows projects to use ES6 `default export` so that multiple exports
+    // may be used (which is common in Typescript).
+    if (typeof obj === 'object' && obj.hasOwnProperty('default')) {
+      obj = obj.default;
+    }
+
+    // Automatically instantiate classes.
+    if (isClass(obj)) {
+      obj = new obj();
+    }
 
     if (typeof obj === 'function') {
       const fobj = obj();

--- a/lib/container.js
+++ b/lib/container.js
@@ -339,7 +339,7 @@ function loadSupportObject(modulePath, supportObjectName) {
 
     // Allows projects to use ES6 `default export` so that multiple exports
     // may be used (which is common in Typescript).
-    if (typeof obj === 'object' && obj.hasOwnProperty('default')) {
+    if (isDefaultExport(obj)) {
       obj = obj.default;
     }
 
@@ -438,4 +438,14 @@ function loadTranslation(translation) {
   }
 
   return new Translation(vocabulary);
+}
+
+/**
+ * Returns true if the given variable appears to be a default-exported
+ * support object.
+ */
+function isDefaultExport(obj) {
+  return typeof obj === 'object' &&
+    obj.hasOwnProperty('default') &&
+    typeof obj.default === 'function';
 }

--- a/lib/container.js
+++ b/lib/container.js
@@ -1,7 +1,9 @@
 const glob = require('glob');
 const path = require('path');
 const { MetaStep } = require('./step');
-const { fileExists, isFunction, isClass, isAsyncFunction } = require('./utils');
+const {
+  fileExists, isFunction, isClass, isAsyncFunction,
+} = require('./utils');
 const Translation = require('./translation');
 const MochaFactory = require('./mochaFactory');
 const recorder = require('./recorder');
@@ -345,6 +347,7 @@ function loadSupportObject(modulePath, supportObjectName) {
 
     // Automatically instantiate classes.
     if (isClass(obj)) {
+      // eslint-disable-next-line new-cap
       obj = new obj();
     }
 
@@ -445,7 +448,7 @@ function loadTranslation(translation) {
  * support object.
  */
 function isDefaultExport(obj) {
-  return typeof obj === 'object' &&
-    obj.hasOwnProperty('default') &&
-    typeof obj.default === 'function';
+  return typeof obj === 'object'
+    && Object.prototype.hasOwnProperty.call(obj, 'default')
+    && typeof isClass(obj.default);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,9 +33,9 @@ const isFunction = module.exports.isFunction = function (fn) {
  * @see https://stackoverflow.com/a/29094209/3878074
  */
 const isClass = module.exports.isClass = function (x) {
-  return typeof x === 'function' &&
-    Function.prototype.toString.call(x).startsWith('class ');
-}
+  return typeof x === 'function'
+    && Function.prototype.toString.call(x).startsWith('class ');
+};
 
 const isAsyncFunction = module.exports.isAsyncFunction = function (fn) {
   if (!fn) return false;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,16 @@ const isFunction = module.exports.isFunction = function (fn) {
   return typeof fn === 'function';
 };
 
+/**
+ * Returns true if the given variable is a class function.
+ *
+ * @see https://stackoverflow.com/a/29094209/3878074
+ */
+const isClass = module.exports.isClass = function (x) {
+  return typeof x === 'function' &&
+    Function.prototype.toString.call(x).startsWith('class ');
+}
+
 const isAsyncFunction = module.exports.isAsyncFunction = function (fn) {
   if (!fn) return false;
   return fn[Symbol.toStringTag] === 'AsyncFunction';

--- a/test/data/dummy_class_page.js
+++ b/test/data/dummy_class_page.js
@@ -1,0 +1,9 @@
+const { I } = inject();
+
+class DummyPage {
+  constructor() {
+    this.pageUrl = '/dummy-page';
+  }
+}
+
+module.exports = { default: DummyPage };

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -191,10 +191,12 @@ describe('Container', () => {
     it('should load DI and inject custom I into PO', () => {
       container.create({
         include: {
+          dummyClassPage: './data/dummy_class_page',
           dummyPage: './data/dummy_page',
           I: './data/I',
         },
       });
+      expect(container.support('dummyClassPage')).to.have.keys('pageUrl');
       expect(container.support('dummyPage')).is.ok;
       expect(container.support('I')).is.ok;
       expect(container.support('dummyPage')).to.include.keys('openDummyPage');


### PR DESCRIPTION
## Motivation/Description of the PR
This PR resolves #3378 by making it possible to use `export default class` in support objects instead of only `export =` and `module.exports`.

**!!! Breaking Change**: The current recommended solution would require that the function property `default` be removed from any existing page objects.

---

Applicable helpers:

_(This is a core change that could impacts all helpers, but shouldn't)_

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

_(This is a core change that could impacts all plugins, but shouldn't)_

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [x] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`) _(I'm not sure where/if it's worth adding anything)_
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
