### PR TITLE
fix(3384): scenario outline parameter substitution

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -356,6 +356,18 @@ In case scenarios represent the same logic but differ on data, we can use *Scena
       | 50    | 45    |
 ```
 
+It might be the case that the same column value needs to be utilized multiple times in the same step, that also can be possible with scenario outline.
+
+```gherkin
+  Scenario Outline: check parameter substitution
+    Given I have a defined step
+    When I see "<text>" text and "<text>" is not "xyz"
+    Examples:
+      | text   |
+      | Google |
+
+```
+
 ### Long Strings
 
 Text values inside a scenarios can be set inside a `"""` block:

--- a/examples/features/basic.feature
+++ b/examples/features/basic.feature
@@ -6,3 +6,10 @@ Feature: Business rules
   Scenario: do something
     Given I have a defined step
     When I open GitHub
+
+  Scenario Outline: check parameter substitution
+    Given I have a defined step
+    When I see "<text>" text and "<text>" is not "xyz"
+    Examples:
+      | text   |
+      | Google |

--- a/examples/step_definitions/steps.js
+++ b/examples/step_definitions/steps.js
@@ -26,3 +26,8 @@ Then('check link', async () => {
   assert(response.statusCode === 200);
   I.see('Google');
 });
+
+When(/^I see "(.*)" text and "(.*)" is not "(.*)"$/, async (text, text2, text3) => {
+  I.see(text);
+  assert(text2 !== text3)
+});

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -91,7 +91,7 @@ module.exports = (text, file) => {
             current[placeholder] = value;
             exampleSteps = exampleSteps.map((step) => {
               step = { ...step };
-              step.text = step.text.replace(`<${placeholder}>`, value);
+              step.text = step.text.split("<"+placeholder+">").join(value)
               return step;
             });
           }


### PR DESCRIPTION
## Motivation/Description of the PR
- Now the same column can be used multiple times in the same step in scenario outline 
- Resolves #3384.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
