### PR TITLE
Fix Wrong Order with async MetaSteps

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -269,15 +269,27 @@ class MetaStep extends Step {
     };
     event.dispatcher.prependListener(event.step.before, registerStep);
     let rethrownError = null;
-    try {
-      this.startTime = Date.now();
-      result = fn.apply(this.context, this.args);
-    } catch (error) {
-      this.setStatus('failed');
-      rethrownError = error;
-    } finally {
-      this.endTime = Date.now();
-      event.dispatcher.removeListener(event.step.before, registerStep);
+    if (fn.constructor.name === 'AsyncFunction') {
+      result = fn.apply(this.context, this.args).then((result) => {
+        return result;
+      }).catch(function (error) {
+        this.setStatus('failed');
+        rethrownError = error;
+      }).finally(() => {
+        this.endTime = Date.now();
+        event.dispatcher.removeListener(event.step.before, registerStep);
+      });
+    } else {
+      try {
+        this.startTime = Date.now();
+        result = fn.apply(this.context, this.args);
+      } catch (error) {
+        this.setStatus('failed');
+        rethrownError = error;
+      } finally {
+        this.endTime = Date.now();
+        event.dispatcher.removeListener(event.step.before, registerStep);
+      }
     }
     if (rethrownError) { throw rethrownError; }
     return result;

--- a/test/data/sandbox/configs/pageObjects/first_test.js
+++ b/test/data/sandbox/configs/pageObjects/first_test.js
@@ -5,7 +5,7 @@ Scenario('@ClassPageObject', async ({ classpage }) => {
   await classpage.purgeDomains();
 });
 
-Scenario('@NestedClassPageObject', ({ classnestedpage }) => {
-  classnestedpage.type('Nested Class Page Type');
+Scenario('@NestedClassPageObject', async ({ classnestedpage, I }) => {
+  await classnestedpage.type('Nested Class Page Type');
   classnestedpage.purgeDomains();
 });


### PR DESCRIPTION
The reporters loose track of the meta step information which results in a wrong order of the steps in the report.

### Root Cause
When a meta step gets executed it prepends a before listener to add the meta step information to a step. This works well with sync functions because it is finished after all steps inside the meta step are executed. And after that the prepended listener gets removed.
With an async function a promise gets returned before the all steps are executed inside the meta step. Now the prepended listener gets removed before the steps were executed and the steps do not getting its meta step information properly.

### Proposed Solution
I implemented a differentiation between async und sync functions. Async functions are handled with `then()` and `catch()` to make sure all steps were executed before the listener gets removed. 
Sync functions are handled like before.

### Additional changes
Fixed a bug in the runners pageobject test as it was failing with my changes.

Resolves #3131 
Resolves #3132

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
