### PR TITLE
fix: TS complains when initializing codeceptjs

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -181,7 +181,7 @@ module.exports = function (initPath) {
       if (isTypeScript) {
         configSource = beautify(`export const config : CodeceptJS.MainConfig = ${inspect(config, false, 4, false)}`);
 
-        if (hasConfigure) configSource = importCodeceptConfigure + configHeader + configSource;
+        if (hasConfigure) configSource = requireCodeceptConfigure + configHeader + configSource;
 
         fs.writeFileSync(typeScriptconfigFile, configSource, 'utf-8');
         print(`Config created at ${typeScriptconfigFile}`);


### PR DESCRIPTION
## Motivation/Description of the PR
- This PR solves this error


```
TSError: ⨯ Unable to compile TypeScript:
codecept.conf.ts:1:51 - error TS7016: Could not find a declaration file for module '@codeceptjs/configure'. '/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/@codeceptjs/configure/index.js' implicitly has an 'any' type.
  Try `npm install @types/codeceptjs__configure` if it exists or add a new declaration (.d.ts) file containing `declare module '@codeceptjs/configure';`

1 import { setHeadlessWhen, setCommonPlugins } from '@codeceptjs/configure';
                                                    ~~~~~~~~~~~~~~~~~~~~~~~

    at createTSError (/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/ts-node/src/index.ts:434:12)
    at reportTSError (/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/ts-node/src/index.ts:438:19)
    at getOutput (/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/ts-node/src/index.ts:578:36)
    at Object.compile (/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/ts-node/src/index.ts:775:32)
    at Module.m._compile (/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/ts-node/src/index.ts:858:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/tamara-thanh/Desktop/codeceptjs-rest-demo/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)

```

## Type of change
- [x] :bug: Bug fix


