### PR TITLE
REST: Changed "endpoint" to optional

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -22,7 +22,7 @@ Type: [object][4]
 
 ### Properties
 
--   `endpoint` **[string][3]** API base URL
+-   `endpoint` **[string][3]?** API base URL
 -   `prettyPrintJson` **[boolean][6]?** pretty print json for response/request on console logs
 -   `timeout` **[number][5]?** timeout for requests in milliseconds. 10000ms by default
 -   `defaultHeaders` **[object][4]?** a list of default headers

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -9,7 +9,7 @@ const { beautify } = require('../utils');
  *
  * @typedef RESTConfig
  * @type {object}
- * @prop {string} endpoint - API base URL
+ * @prop {string} [endpoint] - API base URL
  * @prop {boolean} [prettyPrintJson=false] - pretty print json for response/request on console logs
  * @prop {number} [timeout=1000] - timeout for requests in milliseconds. 10000ms by default
  * @prop {object} [defaultHeaders] - a list of default headers


### PR DESCRIPTION
## Motivation/Description of the PR
When I switched to TypeScript config in CodeceptJS 3.3.5, CodeceptJS forced me to specify `endpoint: ""` though I don't use this property at all.
Every REST API call in my tests is performed to absolute URL `http(s)://` (because test switches between several servers), so I don't need `endpoint`
Moreover I noticed that default value of `endpoint` in REST helper is already an empty string, so I think that it's not needed to specify it from test's config:
https://github.com/codeceptjs/CodeceptJS/blob/3.x/lib/helper/REST.js#L62

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
