### PR TITLE
Playwright: Fixed docs related to fixed properties types "waitForNavigation" and "firefox"

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -55,7 +55,7 @@ Type: [object][5]
 -   `keepBrowserState` **[boolean][25]?** keep browser state between tests when `restart` is set to 'session'.
 -   `keepCookies` **[boolean][25]?** keep cookies between tests when `restart` is set to 'session'.
 -   `waitForAction` **[number][11]?** how long to wait after click, doubleClick or PressKey actions in ms. Default: 100.
--   `waitForNavigation` **[number][11]?** When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle`. Choose one of those options is possible. See [Playwright API][35].
+-   `waitForNavigation` **[string][7]?** When to consider navigation succeeded. Possible options: `load`, `domcontentloaded`, `networkidle`. Choose one of those options is possible. See [Playwright API][35].
 -   `pressKeyDelay` **[number][11]?** Delay between key presses in ms. Used when calling Playwrights page.type(...) in fillField/appendField
 -   `getPageTimeout` **[number][11]?** config option to set maximum navigation time in milliseconds.
 -   `waitForTimeout` **[number][11]?** default wait* timeout in ms. Default: 1000.
@@ -66,6 +66,7 @@ Type: [object][5]
 -   `locale` **[string][7]?** locale string. Example: 'en-GB', 'de-DE', 'fr-FR', ...
 -   `manualStart` **[boolean][25]?** do not start browser before a test, start it manually inside a helper with `this.helpers["Playwright"]._startBrowser()`.
 -   `chromium` **[object][5]?** pass additional chromium options
+-   `firefox` **[object][5]?** pass additional firefox options
 -   `electron` **[object][5]?** (pass additional electron options
 -   `channel` **any?** (While Playwright can operate against the stock Google Chrome and Microsoft Edge browsers available on the machine. In particular, current Playwright version will support Stable and Beta channels of these browsers. See [Google Chrome & Microsoft Edge][36].
 
@@ -2166,6 +2167,6 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [34]: https://playwright.dev/docs/trace-viewer
 
-[35]: https://github.com/microsoft/playwright/blob/main/docs/api.md#pagewaitfornavigationoptions
+[35]: https://playwright.dev/docs/api/class-page#page-wait-for-navigation
 
 [36]: https://playwright.dev/docs/browsers/#google-chrome--microsoft-edge


### PR DESCRIPTION
## Motivation/Description of the PR
It's a fix of docs which I forgot to commit to https://github.com/codeceptjs/CodeceptJS/pull/3401

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
