### PR TITLE
Playwright: Fixed parameters of startActivity()

### DIFF
--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -433,12 +433,14 @@ Start an arbitrary Android activity during a session.
 I.startActivity('io.selendroid.testapp', '.RegisterUserActivity');
 ```
 
+Appium: support only Android
+
 #### Parameters
 
--   `appPackage`  
--   `appActivity`  
+-   `appPackage` **[string][4]** 
+-   `appActivity` **[string][4]** 
 
-Returns **[Promise][5]&lt;void>** Appium: support only Android
+Returns **[Promise][5]&lt;void>** 
 
 ### setNetworkConnection
 

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -788,9 +788,11 @@ class Appium extends Webdriver {
    * I.startActivity('io.selendroid.testapp', '.RegisterUserActivity');
    * ```
    *
-   * @return {Promise<void>}
-   *
    * Appium: support only Android
+   *
+   * @param {string} appPackage
+   * @param {string} appActivity
+   * @return {Promise<void>}
    */
   async startActivity(appPackage, appActivity) {
     onlyForApps.call(this, 'Android');

--- a/typings/tests/helpers/Appium.types.ts
+++ b/typings/tests/helpers/Appium.types.ts
@@ -2,6 +2,7 @@ const appium = new CodeceptJS.Appium();
 
 const str_ap = "text";
 const num_ap = 1;
+const appPackage = "com.example.android.apis";
 
 appium.touchPerform(); // $ExpectError
 appium.touchPerform("press"); // $ExpectError
@@ -16,8 +17,8 @@ appium.hideDeviceKeyboard("pressKey", "Done", "Done"); // $ExpectError
 
 appium.removeApp(); // $ExpectError
 appium.removeApp("appName"); // $ExpectType void
-appium.removeApp("appName", "com.example.android.apis"); // $ExpectType void
-appium.removeApp("appName", "com.example.android.apis", "remove"); // $ExpectError
+appium.removeApp("appName", appPackage); // $ExpectType void
+appium.removeApp("appName", appPackage, "remove"); // $ExpectError
 
 appium.runOnIOS(str_ap, () => {}); // $ExpectType void
 appium.runOnAndroid(str_ap, () => {}); // $ExpectType void
@@ -40,7 +41,9 @@ appium._switchToContext(str_ap); // $ExpectType void
 appium.switchToWeb(); // $ExpectType Promise<void>
 appium.switchToNative(); // $ExpectType Promise<void>
 appium.switchToNative(str_ap); // $ExpectType Promise<void>
-appium.startActivity(); // $ExpectType Promise<void>
+appium.startActivity(); // $ExpectError
+appium.startActivity(appPackage); // $ExpectError
+appium.startActivity(appPackage, '.RegisterUserActivity'); // $ExpectType Promise<void>
 appium.setNetworkConnection(); // $ExpectType Promise<{}>
 appium.setSettings(str_ap); // $ExpectType void
 appium.hideDeviceKeyboard(); // $ExpectType void


### PR DESCRIPTION
## Motivation/Description of the PR
Fixes this issue (TypeScript test cannot be compiled):
![image](https://user-images.githubusercontent.com/12584138/189974823-daa3f271-7f40-4a01-854b-fc7df82e26e4.png)


Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
