### PR TITLE
Move semver to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "requireg": "^0.2.2",
     "resq": "^1.10.2",
     "sprintf-js": "^1.1.1",
+    "semver": "^6.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -127,7 +128,6 @@
     "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
     "runok": "^0.9.2",
-    "semver": "^6.3.0",
     "sinon": "^9.2.4",
     "sinon-chai": "^3.7.0",
     "testcafe": "^1.18.3",


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

On a yarn 3 installation which uses PnP I was not able to use CodeceptJs because it complains that semver is trying to be used but it's not listed in dependencies, it is in devDependencies but it does seem to be used in some places outside of the tests so I think it's correct to move it to dependencies.

error:
```
/Users/timja/projects/hmcts/labs-timja-nodejs/.pnp.cjs:27151
      Error.captureStackTrace(firstError);
            ^

Error: codeceptjs tried to access semver, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: semver
Required by: codeceptjs@virtual:0fe8ae6be068d2f30e6e1c4ad9d0c715db41428fa3e9a2c42a5aa8d93fba288315271172dae737de2f4d34a9b38ebab987b8667f4cbf6aa1a2f33cbd30fb6c1b#npm:3.3.5 (via /Users/timja/projects/hmcts/labs-timja-nodejs/.yarn/__virtual__/codeceptjs-virtual-ff12dc7118/0/cache/codeceptjs-npm-3.3.5-b4e2dcc1a7-484455c175.zip/node_modules/codeceptjs/lib/command/)

Require stack:
- /Users/timja/projects/hmcts/labs-timja-nodejs/.yarn/__virtual__/codeceptjs-virtual-ff12dc7118/0/cache/codeceptjs-npm-3.3.5-b4e2dcc1a7-484455c175.zip/node_modules/codeceptjs/lib/command/utils.js
- /Users/timja/projects/hmcts/labs-timja-nodejs/.yarn/__virtual__/codeceptjs-virtual-ff12dc7118/0/cache/codeceptjs-npm-3.3.5-b4e2dcc1a7-484455c175.zip/node_modules/codeceptjs/bin/codecept.js
    at Function.require$$0.Module._resolveFilename (/Users/timja/projects/hmcts/labs-timja-nodejs/.pnp.cjs:27151:13)
    at Function.require$$0.Module._load (/Users/timja/projects/hmcts/labs-timja-nodejs/.pnp.cjs:27005:42)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/timja/projects/hmcts/labs-timja-nodejs/.yarn/__virtual__/codeceptjs-virtual-ff12dc7118/0/cache/codeceptjs-npm-3.3.5-b4e2dcc1a7-484455c175.zip/node_modules/codeceptjs/lib/command/utils.js:3:16)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.require$$0.Module._extensions..js (/Users/timja/projects/hmcts/labs-timja-nodejs/.pnp.cjs:27195:33)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.require$$0.Module._load (/Users/timja/projects/hmcts/labs-timja-nodejs/.pnp.cjs:27035:14)
```

usage location:
```
lib/command/utils.js
3:const semver = require('semver');
68:  if (!semver.satisfies(process.version, version)) {

runok.js
378:      packageInfo.version = semver.inc(packageInfo.version, releaseType);
402:    const semver = require('semver');
412:      const newVersion = semver.inc(packageFile.version, type);
```

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- ~[ ] Tests have been added~
- ~[ ] Documentation has been added (Run `npm run docs`)~
- [ ] Lint checking (Run `npm run lint`)
I wasn't able to run the git hooks or even `npm install` on my machine in this repository, looking at CI it uses node 12.8.0 which doesn't even run on my architecture (arm64).
- [ ] Local tests are passed (Run `npm test`)
again `npm install` fails
