### PR TITLE
check if browser is W3C instead of Android

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -916,7 +916,7 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async click(locator, context = null) {
-    const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findClickable.call(this, locator, locateFn);
@@ -1126,7 +1126,7 @@ class WebDriver extends Helper {
    * Appium: not tested
    */
   async checkOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findCheckable.call(this, field, locateFn);
@@ -1145,7 +1145,7 @@ class WebDriver extends Helper {
    * Appium: not tested
    */
   async uncheckOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick';
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
     const locateFn = prepareLocateFn.call(this, context);
 
     const res = await findCheckable.call(this, field, locateFn);
@@ -1632,7 +1632,7 @@ class WebDriver extends Helper {
       assertElementExists(res);
       const elem = usingFirstElement(res);
       const elementId = getElementId(elem);
-      if (this.browser.isMobile && this.browser.capabilities.platformName !== 'android') return this.browser.touchScroll(offsetX, offsetY, elementId);
+      if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(offsetX, offsetY, elementId);
       const location = await elem.getLocation();
       assertElementExists(location, 'Failed to receive', 'location');
       /* eslint-disable prefer-arrow-callback */
@@ -1640,7 +1640,7 @@ class WebDriver extends Helper {
       /* eslint-enable */
     }
 
-    if (this.browser.isMobile && this.browser.capabilities.platformName !== 'android') return this.browser.touchScroll(locator, offsetX, offsetY);
+    if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(locator, offsetX, offsetY);
 
     /* eslint-disable prefer-arrow-callback, comma-dangle */
     return this.browser.execute(function (x, y) { return window.scrollTo(x, y); }, offsetX, offsetY);


### PR DESCRIPTION
## Motivation/Description of the PR
My first implementation to this was stupid, this is way better one
- Resolves #3317

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
