### PR TITLE
Pass service configs with options and caps as array for browsers…

### DIFF
--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -85,6 +85,8 @@ let restartsSession;
  *
  */
 module.exports = (config) => {
+  // Keep initial configs to pass as options to wdio services
+  const wdioOptions = { ...config };
   const webDriver = container.helpers('WebDriver');
   if (webDriver) {
     config = Object.assign(webDriver.options, config);
@@ -108,7 +110,9 @@ module.exports = (config) => {
         if (version.indexOf('5') === 0) {
           launchers.push(new Launcher(config));
         } else {
-          const options = { logPath: global.output_dir, installArgs: seleniumInstallArgs, args: seleniumArgs };
+          const options = {
+            logPath: global.output_dir, installArgs: seleniumInstallArgs, args: seleniumArgs, ...wdioOptions,
+          };
           launchers.push(new Launcher(options, [config.capabilities], config));
         }
       }
@@ -215,7 +219,12 @@ module.exports = (config) => {
     if (launcher.onPrepare) {
       event.dispatcher.on(event.all.before, () => {
         recorder.add(`launcher ${name} start`, async () => {
-          await launcher.onPrepare(config, config.capabilities);
+          // browserstack-service expects capabilities as array
+          if (launcher.constructor.name === 'BrowserstackLauncherService') {
+            await launcher.onPrepare(config, [config.capabilities]);
+          } else {
+            await launcher.onPrepare(config, config.capabilities);
+          }
           output.debug(`Started ${name}`);
         });
       });


### PR DESCRIPTION
…tack launcher

## Motivation/Description of the PR
- This PR solves issues related to webdriverio browserstack-service, it expects plugin related configs as options and capabilities as array in onPrepare.
- Resolves #3359.

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [x] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
