### PR TITLE
fix for type of "webdriver.port"

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -44,7 +44,7 @@ let version;
  * @prop {string} browser browser in which to perform testing.
  * @prop {string} [basicAuth] - (optional) the basic authentication to pass to base url. Example: {username: 'username', password: 'password'}
  * @prop {string} [host=localhost] - WebDriver host to connect.
- * @prop {string} [port=4444] - WebDriver port to connect.
+ * @prop {number} [port=4444] - WebDriver port to connect.
  * @prop {string} [protocol=http] - protocol for WebDriver server.
  * @prop {string} [path=/wd/hub] - path to WebDriver server,
  * @prop {boolean} [restart=true] - restart browser between tests.


### PR DESCRIPTION
## Motivation/Description of the PR
- It will resolve problem that defined type "string" of "WebDriver.port" does not match with expected type "number" from WebDriverIO
- Resolves issue #3420 

Applicable helpers:

- [ x ] WebDriver

## Type of change

- [ x ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
