### PR TITLE
fix for expected type of "bootstrap", "teardown", "bootstrapAll" and "teardownAll"

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,8 +11,8 @@ After running `codeceptjs init` it should be saved in test root.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `bootstrap?` | () => `Promise`<`void`\> \| `boolean` \| `string` | [Execute code before](https://codecept.io/bootstrap/) tests are run.  Can be either JS module file or async function:  ```bootstrap: async () => server.launch(), ``` or ```bootstrap: 'bootstrap.js', ``` |
-| `bootstrapAll?` | () => `Promise`<`void`\> \| `boolean` \| `string` | [Execute code before launching tests in parallel mode](https://codecept.io/bootstrap/#bootstrapall-teardownall) |
+| `bootstrap?` | (() => `Promise`<`void`\>) \| `boolean` \| `string` | [Execute code before](https://codecept.io/bootstrap/) tests are run.  Can be either JS module file or async function:  ```bootstrap: async () => server.launch(), ``` or ```bootstrap: 'bootstrap.js', ``` |
+| `bootstrapAll?` | (() => `Promise`<`void`\>) \| `boolean` \| `string` | [Execute code before launching tests in parallel mode](https://codecept.io/bootstrap/#bootstrapall-teardownall) |
 | `gherkin?` | { `features`: `string` \| `string`[] ; `steps`: `string`[]  } | Enable [BDD features](https://codecept.io/bdd/#configuration).   Sample configuration: ```gherkin: {   features: "./features/*.feature",   steps: ["./step_definitions/steps.js"] } ``` |
 | `gherkin.features` | `string` \| `string`[] | load feature files by pattern. Multiple patterns can be specified as array |
 | `gherkin.steps` | `string`[] | load step definitions from JS files |
@@ -24,8 +24,8 @@ After running `codeceptjs init` it should be saved in test root.
 | `output` | `string` | Where to store failure screenshots, artifacts, etc   ```output: './output' ``` |
 | `plugins?` | `any` | Enable CodeceptJS plugins. Example:  ```plugins: {   autoDelay: {     enabled: true   }  } ``` |
 | `require?` | `string`[] | [Require additional JS modules](https://codecept.io/configuration/#require)  Example: ``` require: ["should"] ``` |
-| `teardown?` | () => `Promise`<`void`\> \| `boolean` \| `string` | [Execute code after tests](https://codecept.io/bootstrap/) finished.   Can be either JS module file or async function:  ```teardown: async () => server.stop(), ``` or ```teardown: 'teardown.js', ``` |
-| `teardownAll?` | () => `Promise`<`void`\> \| `boolean` \| `string` | [Execute JS code after finishing tests in parallel mode](https://codecept.io/bootstrap/#bootstrapall-teardownall) |
+| `teardown?` | (() => `Promise`<`void`\>) \| `boolean` \| `string` | [Execute code after tests](https://codecept.io/bootstrap/) finished.   Can be either JS module file or async function:  ```teardown: async () => server.stop(), ``` or ```teardown: 'teardown.js', ``` |
+| `teardownAll?` | (() => `Promise`<`void`\>) \| `boolean` \| `string` | [Execute JS code after finishing tests in parallel mode](https://codecept.io/bootstrap/#bootstrapall-teardownall) |
 | `tests` | `string` | Pattern to locate CodeceptJS tests. Allows to enter glob pattern or an Array<string> of patterns to match tests / test file names.  For tests in JavaScript:  ```tests: 'tests/**.test.js' ``` For tests in TypeScript:  ```tests: 'tests/**.test.ts' ``` |
 | `timeout?` | `number` | Set default tests timeout in seconds. Tests will be killed on no response after timeout.  ```timeout: 20, ``` |
 | `translation?` | `string` | Enable [localized test commands](https://codecept.io/translation/) |

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -206,7 +206,7 @@ declare namespace CodeceptJS {
      * bootstrap: 'bootstrap.js',
      * ```
     */
-    bootstrap?: () => Promise<void> | boolean | string;
+    bootstrap?: (() => Promise<void>) | boolean | string;
     /**
      * [Execute code after tests](https://codecept.io/bootstrap/) finished.
      *
@@ -220,16 +220,16 @@ declare namespace CodeceptJS {
      * teardown: 'teardown.js',
      * ```
     */
-    teardown?: () => Promise<void> | boolean | string;
+    teardown?: (() => Promise<void>) | boolean | string;
     /**
      * [Execute code before launching tests in parallel mode](https://codecept.io/bootstrap/#bootstrapall-teardownall)
      *
      */
-    bootstrapAll?: () => Promise<void> | boolean | string;
+    bootstrapAll?: (() => Promise<void>) | boolean | string;
     /**
      * [Execute JS code after finishing tests in parallel mode](https://codecept.io/bootstrap/#bootstrapall-teardownall)
     */
-    teardownAll?: () => Promise<void> | boolean | string;
+    teardownAll?: (() => Promise<void>) | boolean | string;
     /** Enable [localized test commands](https://codecept.io/translation/) */
     translation?: string;
     /**


### PR DESCRIPTION
…"teardownAll"

## Motivation/Description of the PR
- Fixes Typescript type of "bootstrap", "teardown", "bootstrapAll" and "teardownAll"
- Resolves issue reported in Slack: https://codeceptjs.slack.com/archives/C94G8JXJB/p1664174040678089

> Souvik Dutta
> Hi All, I am trying to configure bootstrap with TS and it gives me following error, any idea why this is happening


## Type of change

- [ x ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ x ] Documentation has been added (Run `npm run docs`)
- [ x ] Lint checking (Run `npm run lint`)
- [ x ] Local tests are passed (Run `npm test`)
