### PR TITLE
fix for type of "webdriver.smartWait"

### DIFF
--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -30,11 +30,11 @@ Type: [object][16]
 -   `browser` **[string][17]** browser in which to perform testing.
 -   `basicAuth` **[string][17]?** (optional) the basic authentication to pass to base url. Example: {username: 'username', password: 'password'}
 -   `host` **[string][17]?** WebDriver host to connect.
--   `port` **[string][17]?** WebDriver port to connect.
+-   `port` **[number][20]?** WebDriver port to connect.
 -   `protocol` **[string][17]?** protocol for WebDriver server.
 -   `path` **[string][17]?** path to WebDriver server,
 -   `restart` **[boolean][29]?** restart browser between tests.
--   `smartWait` **[boolean][29]?** **enables [SmartWait][33]**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000.
+-   `smartWait` **([boolean][29] | [number][20])?** **enables [SmartWait][33]**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000.
 -   `disableScreenshots` **[boolean][29]?** don't save screenshots on failure.
 -   `fullPageScreenshots` **[boolean][29]?** (optional - make full page screenshots on failure.
 -   `uniqueScreenshotNames` **[boolean][29]?** option to prevent screenshot override if you have scenarios with the same name in different suites.

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -48,7 +48,7 @@ let version;
  * @prop {string} [protocol=http] - protocol for WebDriver server.
  * @prop {string} [path=/wd/hub] - path to WebDriver server,
  * @prop {boolean} [restart=true] - restart browser between tests.
- * @prop {boolean} [smartWait=false] - **enables [SmartWait](http://codecept.io/acceptance/#smartwait)**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000.
+ * @prop {boolean|number} [smartWait=false] - **enables [SmartWait](http://codecept.io/acceptance/#smartwait)**; wait for additional milliseconds for element to appear. Enable for 5 secs: "smartWait": 5000.
  * @prop {boolean} [disableScreenshots=false] - don't save screenshots on failure.
  * @prop {boolean} [fullPageScreenshots=false] (optional - make full page screenshots on failure.
  * @prop {boolean} [uniqueScreenshotNames=false] - option to prevent screenshot override if you have scenarios with the same name in different suites.


### PR DESCRIPTION
## Motivation/Description of the PR
-It will resolve problem that defined type "boolean | undefined" of "WebDriver.smartWait" does not match with expected type "number" from WebDriverIO
- includes also missing docs from #3420 
- Resolves #3425 

Applicable helpers:

- [X] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [X] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
