### PR TITLE
fix(utils): remove . of test title to avoid confusion

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -132,6 +132,9 @@ module.exports.clearString = function (str) {
   if (!str) return '';
   /* Replace forbidden symbols in string
    */
+  if (str.endsWith('.')) {
+    str = str.slice(0, -1);
+  }
   return str
     .replace(/ /g, '_')
     .replace(/"/g, "'")
@@ -143,8 +146,7 @@ module.exports.clearString = function (str) {
     .replace(/\|/g, '_')
     .replace(/\?/g, '.')
     .replace(/\*/g, '^')
-    .replace(/'/g, '')
-    .replace(/.$/, '');
+    .replace(/'/g, '');
 };
 
 module.exports.decodeUrl = function (url) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,7 +143,8 @@ module.exports.clearString = function (str) {
     .replace(/\|/g, '_')
     .replace(/\?/g, '.')
     .replace(/\*/g, '^')
-    .replace(/'/g, '');
+    .replace(/'/g, '')
+    .replace(/.$/, '');
 };
 
 module.exports.decodeUrl = function (url) {

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -20,6 +20,14 @@ describe('screenshotOnFail', () => {
     });
   });
 
+  it('should remove the . at the end of test title', async () => {
+    screenshotOnFail({});
+    event.dispatcher.emit(event.test.failed, { title: 'test title.' });
+    await recorder.promise();
+    expect(screenshotSaved.called).is.ok;
+    expect('test_title.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
+  });
+
   it('should exclude the data driven in failed screenshot file name', async () => {
     screenshotOnFail({});
     event.dispatcher.emit(event.test.failed, { title: 'Scenario with data driven | {"login":"admin","password":"123456"}' });
@@ -53,6 +61,5 @@ describe('screenshotOnFail', () => {
     const regexpFileName = /test1_[0-9]{10}.failed.png/;
     expect(fileName.match(regexpFileName).length).is.equal(1);
   });
-
   // TODO: write more tests for different options
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- When test title comes with full stop at the end like `Test title.`, the generated screenshot would be something like `Test_title..failed.png` which is a bit confusing.

## Type of change
- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added
- [x] Local tests are passed (Run `npm test`)
