### PR TITLE
Add cucumber custom types

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -175,24 +175,6 @@ Then('I should see that total number of products is {int}', (num) => {
 Then('my order amount is ${int}', (sum) => { // eslint-disable-line
   I.see('Total: ' + sum);
 });
-
-// custom parameter types
-class Color {
-  constructor(name) {
-    this.name = name;
-  }
-}
-
-DefineParameterType( {
-    name: 'color',
-    regexp: /red|blue|yellow/,
-    transformer: (s) => new Color(s),
-  });
-
-Given('I see a {color} button', async (color) => {
-  const value = await I.grabCssPropertyFrom('button', 'background-color');
-  assert.equal(color.name, value)
-});
 ```
 
 Steps can be either strings or regular expressions. Parameters from string are passed as function arguments. To define parameters in a string we use [Cucumber expressions](https://docs.cucumber.io/cucumber/cucumber-expressions/)
@@ -423,6 +405,39 @@ npx codeceptjs run --grep "@important"
 ```
 
 Tag should be placed before *Scenario:* or before *Feature:* keyword. In the last case all scenarios of that feature will be added to corresponding group.
+
+### Custom types
+
+If you need parameter text in more advanced way and you like using [Cucumber expressions](https://docs.cucumber.io/cucumber/cucumber-expressions/) better that regular expressions, use `DefineParameterType` function. You can extend Cucumber Expressions so they automatically convert output parameters to your own types or transforms the match from the regexp.
+
+```js
+DefineParameterType({
+  name: 'popup_type',
+  regexp: /critical|non-critical/,
+  transformer: (match) => {
+    return match === 'critical' ? '[class$="error"]' 
+    : '[class$="warning"]';
+  },
+};);
+
+Given('I see {popup_type} popup', (popup) => {
+  I.seeElement(popup);
+});
+```
+
+```gherkin
+  Scenario: Display error message if user doesn't have permissions
+    Given I on "Main" page without permissons
+    Then I see error popup
+```
+
+#### Parameters
+
+*  `name` **[string]** The name the parameter type will be recognised by in output parameters.
+*  `regexp` **([string] | [RegExp])** A regexp that will match the parameter. May include capture groups.
+*  `transformer` **[function]** A function or method that transforms the match from the regexp.
+*  `useForSnippets` **[boolean]** Defaults to `true`. That means this parameter type will be used to generate snippets for undefined steps. 
+*  `preferForRegexpMatch` **[boolean]** Defaults to `false`. Set to true if you have step definitions that use regular expressions, and you want this parameter type to take precedence over others during a match.
 
 ## Configuration
 

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -175,6 +175,24 @@ Then('I should see that total number of products is {int}', (num) => {
 Then('my order amount is ${int}', (sum) => { // eslint-disable-line
   I.see('Total: ' + sum);
 });
+
+// custom parameter types
+class Color {
+  constructor(name) {
+    this.name = name;
+  }
+}
+
+DefineParameterType( {
+    name: 'color',
+    regexp: /red|blue|yellow/,
+    transformer: (s) => new Color(s),
+  });
+
+Given('I see a {color} button', async (color) => {
+  const value = await I.grabCssPropertyFrom('button', 'background-color');
+  assert.equal(color.name, value)
+});
 ```
 
 Steps can be either strings or regular expressions. Parameters from string are passed as function arguments. To define parameters in a string we use [Cucumber expressions](https://docs.cucumber.io/cucumber/cucumber-expressions/)

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -85,7 +85,7 @@ class Codecept {
       global.Given = stepDefinitions.Given;
       global.When = stepDefinitions.When;
       global.Then = stepDefinitions.Then;
-      global.defineParameterType = stepDefinitions.defineParameterType;
+      global.DefineParameterType = stepDefinitions.defineParameterType;
     }
   }
 

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -85,6 +85,7 @@ class Codecept {
       global.Given = stepDefinitions.Given;
       global.When = stepDefinitions.When;
       global.Then = stepDefinitions.Then;
+      global.defineParameterType = stepDefinitions.defineParameterType;
     }
   }
 

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,4 +1,4 @@
-const { CucumberExpression, ParameterTypeRegistry } = require('cucumber-expressions');
+const { CucumberExpression, ParameterTypeRegistry, ParameterType } = require('cucumber-expressions');
 const Config = require('../config');
 
 let steps = {};
@@ -58,6 +58,30 @@ const getSteps = () => {
   return steps;
 };
 
+const defineParameterType = (options) => {
+  const parameterType = buildParameterType(options);
+  parameterTypeRegistry.defineParameterType(parameterType);
+};
+
+const buildParameterType = ({
+  name,
+  regexp,
+  transformer,
+  useForSnippets,
+  preferForRegexpMatch,
+}) => {
+  if (typeof useForSnippets !== 'boolean') useForSnippets = true;
+  if (typeof preferForRegexpMatch !== 'boolean') preferForRegexpMatch = false;
+  return new ParameterType(
+    name,
+    regexp,
+    null,
+    transformer,
+    useForSnippets,
+    preferForRegexpMatch,
+  );
+};
+
 module.exports = {
   Given: addStep,
   When: addStep,
@@ -66,4 +90,5 @@ module.exports = {
   matchStep,
   getSteps,
   clearSteps,
+  defineParameterType,
 };

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const { Parser } = require('gherkin');
+const { resolve } = require('dns');
 const Config = require('../../lib/config');
 const {
   Given,
@@ -8,12 +9,19 @@ const {
   Then,
   matchStep,
   clearSteps,
+  defineParameterType,
 } = require('../../lib/interfaces/bdd');
 const run = require('../../lib/interfaces/gherkin');
 const recorder = require('../../lib/recorder');
 const container = require('../../lib/container');
 const actor = require('../../lib/actor');
 const event = require('../../lib/event');
+
+class Color {
+  constructor(name) {
+    this.name = name;
+  }
+}
 
 const text = `
   Feature: checkout process
@@ -377,5 +385,32 @@ describe('BDD', () => {
       expect(thenParsedRows.rawData).is.deep.equal(expectedParsedDataTable);
       done();
     });
+  });
+
+  it('should match step with custom parameter type', (done) => {
+    const colorType = {
+      name: 'color',
+      regexp: /red|blue|yellow/,
+      transformer: (s) => new Color(s),
+    };
+    defineParameterType(colorType);
+    Given('I have a {color} label', (color) => color);
+    const fn = matchStep('I have a red label');
+    expect('red').is.equal(fn.params[0].name);
+    done();
+  });
+
+  it('should match step with async custom parameter type transformation', async () => {
+    const colorType = {
+      name: 'async_color',
+      regexp: /red|blue|yellow/,
+      transformer: async (s) => new Color(s),
+    };
+    defineParameterType(colorType);
+    Given('I have a {async_color} label', (color) => color);
+    const fn = matchStep('I have a blue label');
+    const color = await fn.params[0];
+    expect('blue').is.equal(color.name);
+    await Promise.resolve();
   });
 });

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -1,6 +1,5 @@
 const { expect } = require('chai');
 const { Parser } = require('gherkin');
-const { resolve } = require('dns');
 const Config = require('../../lib/config');
 const {
   Given,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -430,7 +430,7 @@ declare namespace NodeJS {
     Given: typeof Given;
     When: typeof When;
     Then: typeof Then;
-    defineParameterType: typeof defineParameterType
+    DefineParameterType: typeof defineParameterType
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -348,6 +348,14 @@ declare namespace CodeceptJS {
   interface Globals {
     codeceptjs: typeof codeceptjs;
   }
+
+  interface IParameterTypeDefinition<T> {
+    name: string
+    regexp: readonly RegExp[] | readonly string[] | RegExp | string
+    transformer: (...match: string[]) => T
+    useForSnippets?: boolean
+    preferForRegexpMatch?: boolean
+  }
 }
 
 // Globals
@@ -382,6 +390,7 @@ declare const xScenario: CodeceptJS.IScenario;
 declare const xFeature: CodeceptJS.IFeature;
 declare function Data(data: any): CodeceptJS.IData;
 declare function xData(data: any): CodeceptJS.IData;
+declare function defineParameterType(options: CodeceptJS.IParameterTypeDefinition<any>): void
 
 // Hooks
 declare const BeforeSuite: CodeceptJS.IHook;
@@ -421,6 +430,7 @@ declare namespace NodeJS {
     Given: typeof Given;
     When: typeof When;
     Then: typeof Then;
+    defineParameterType: typeof defineParameterType
   }
 }
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Possibility of creating custom parameter types in cucumber expressions  
- Resolves #2981

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)