### PR TITLE
re-implement run-rerun command

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -192,6 +192,43 @@ program.command('dry-run [test]')
   .option('--debug', 'output additional information')
   .action(errorHandler(require('../lib/command/dryRun')));
 
+program.command('run-rerun [test]')
+  .description('Executes tests in more than one test suite run')
+
+  // codecept-only options
+  .option('--steps', 'show step-by-step execution')
+  .option('--debug', 'output additional information')
+  .option('--verbose', 'output internal logging information')
+  .option('-o, --override [value]', 'override current config options')
+  .option('--profile [value]', 'configuration profile to be used')
+  .option('-c, --config [file]', 'configuration file to be used')
+  .option('--features', 'run only *.feature files and skip tests')
+  .option('--tests', 'run only JS test files and skip features')
+  .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
+
+  // mocha options
+  .option('--colors', 'force enabling of colors')
+  .option('--no-colors', 'force disabling of colors')
+  .option('-G, --growl', 'enable growl notification support')
+  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
+  .option('-R, --reporter <name>', 'specify the reporter to use')
+  .option('-S, --sort', 'sort test files')
+  .option('-b, --bail', 'bail after first test failure')
+  .option('-d, --debug', "enable node's debugger, synonym for node --debug")
+  .option('-g, --grep <pattern>', 'only run tests matching <pattern>')
+  .option('-f, --fgrep <string>', 'only run tests containing <string>')
+  .option('-i, --invert', 'inverts --grep and --fgrep matches')
+  .option('--full-trace', 'display the full stack trace')
+  .option('--compilers <ext>:<module>,...', 'use the given module(s) to compile files')
+  .option('--debug-brk', "enable node's debugger breaking on the first line")
+  .option('--inline-diffs', 'display actual/expected differences inline within each string')
+  .option('--no-exit', 'require a clean shutdown of the event loop: mocha will not call process.exit')
+  .option('--recursive', 'include sub directories')
+  .option('--trace', 'trace function calls')
+  .option('--child <string>', 'option for child processes')
+
+  .action(require('../lib/command/run-rerun'));
+
 program.on('command:*', (cmd) => {
   console.log(`\nUnknown command ${cmd}\n`);
   program.outputHelp();

--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -1,0 +1,38 @@
+const { getConfig, getTestRoot } = require('./utils');
+const { printError, createOutputDir } = require('./utils');
+const Config = require('../config');
+const Codecept = require('../rerun');
+
+module.exports = async function (test, options) {
+  // registering options globally to use in config
+  // Backward compatibility for --profile
+  process.profile = options.profile;
+  process.env.profile = options.profile;
+  const configFile = options.config;
+
+  let config = getConfig(configFile);
+  if (options.override) {
+    config = Config.append(JSON.parse(options.override));
+  }
+  const testRoot = getTestRoot(configFile);
+  createOutputDir(config, testRoot);
+
+  function processError(err) {
+    printError(err);
+    process.exit(1);
+  }
+  const codecept = new Codecept(config, options);
+
+  try {
+    codecept.init(testRoot);
+
+    await codecept.bootstrap();
+    codecept.loadTests(test);
+    await codecept.run();
+  } catch (err) {
+    printError(err);
+    process.exitCode = 1;
+  } finally {
+    await codecept.teardown();
+  }
+};

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -1,0 +1,92 @@
+const expect = require('expect');
+const { describe } = require('mocha');
+const path = require('path');
+const exec = require('child_process').exec;
+const semver = require('semver');
+
+const runner = path.join(__dirname, '/../../bin/codecept.js');
+const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/run-rerun/');
+const codecept_run = `${runner} run-rerun`;
+const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} --grep "${grep || ''}"`;
+
+describe('run-rerun command', () => {
+  before(() => {
+    process.chdir(codecept_dir);
+  });
+
+  it('should display count of attemps', (done) => {
+    exec(`${codecept_run_config('codecept.conf.js')} --debug`, (err, stdout) => {
+      const runs = stdout.split('Run Rerun - Command --');
+
+      // check first run
+      expect(runs[1]).toContain('OK  | 1 passed');
+      expect(runs[1]).toContain('✔ OK');
+
+      // check second run
+      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('✔ OK');
+
+      // check third run
+      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('✔ OK');
+
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/3');
+      expect(stdout).toContain('Process run 2 of max 3, success runs 2/3');
+      expect(stdout).toContain('Process run 3 of max 3, success runs 3/3');
+      expect(stdout).toContain('OK  | 1 passed');
+      expect(err).toBeNull();
+      done();
+    });
+  });
+
+  it('should display 2 success count of attemps', (done) => {
+    exec(`${codecept_run_config('codecept.conf.min_less_max.js')} --debug`, (err, stdout) => {
+      const runs = stdout.split('Run Rerun - Command --');
+
+      // check first run
+      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('✔ OK');
+
+      // check second run
+      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('✔ OK');
+
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/2');
+      expect(stdout).toContain('Process run 2 of max 3, success runs 2/2');
+      expect(stdout).not.toContain('Process run 3 of max 3');
+      expect(stdout).toContain('OK  | 1 passed');
+      expect(err).toBeNull();
+      done();
+    });
+  });
+
+  it('should display error if minSuccess more than maxReruns', (done) => {
+    exec(`${codecept_run_config('codecept.conf.min_more_max.js')} --debug`, (err, stdout) => {
+      expect(stdout).toContain('minSuccess must be less than maxReruns');
+      expect(err.code).toBe(1);
+      done();
+    });
+  });
+
+  it('should display errors if test is fail always', (done) => {
+    exec(`${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - Fail all attempt')} --debug`, (err, stdout) => {
+      expect(stdout).toContain('Fail run 1 of max 3, success runs 0/2');
+      expect(stdout).toContain('Fail run 2 of max 3, success runs 0/2');
+      expect(stdout).toContain('Fail run 3 of max 3, success runs 0/2');
+      expect(stdout).toContain('Flaky tests detected!');
+      expect(err.code).toBe(1);
+      done();
+    });
+  });
+
+  it('should display success run if test was fail one time of two attepmts and 3 reruns', (done) => {
+    exec(`FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - fail second test')} --debug`, (err, stdout) => {
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/2');
+      expect(stdout).toContain('Fail run 2 of max 3, success runs 1/2');
+      expect(stdout).toContain('Process run 3 of max 3, success runs 2/2');
+      expect(stdout).not.toContain('Flaky tests detected!');
+      expect(err).toBeNull();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Motivation/Description of the PR
This PR migrates the run-rerun command to codeceptjs 3

Resolves #2670
Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
