### PR TITLE
Fix MetaStep Run Issue

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -268,13 +268,13 @@ class MetaStep extends Step {
       step.metaStep = this;
     };
     event.dispatcher.prependListener(event.step.before, registerStep);
-    let rethrownError = null;
+    // Handle async and sync methods.
     if (fn.constructor.name === 'AsyncFunction') {
       result = fn.apply(this.context, this.args).then((result) => {
         return result;
-      }).catch(function (error) {
+      }).catch((error) => {
         this.setStatus('failed');
-        rethrownError = error;
+        throw error;
       }).finally(() => {
         this.endTime = Date.now();
         event.dispatcher.removeListener(event.step.before, registerStep);
@@ -285,13 +285,13 @@ class MetaStep extends Step {
         result = fn.apply(this.context, this.args);
       } catch (error) {
         this.setStatus('failed');
-        rethrownError = error;
+        throw error;
       } finally {
         this.endTime = Date.now();
         event.dispatcher.removeListener(event.step.before, registerStep);
       }
     }
-    if (rethrownError) { throw rethrownError; }
+
     return result;
   }
 }


### PR DESCRIPTION
## Motivation/Description of the PR
With the release 3.3.5 a bug was introduced. In some cases test were marked es passed although they are failed. This PR fixes it.

Resolves #3462 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
