### PR TITLE
Typo fix for waitForTimeout in Webdriver config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ exports.config = {
       key: process.env.CLOUDSERVICE_KEY,
 
       coloredLogs: true,
-      waitForTimeout: 10000
+      waitforTimeout: 10000
     }
   },
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -41,7 +41,7 @@ Type: [object][16]
 -   `keepBrowserState` **[boolean][29]?** keep browser state between tests when `restart` is set to false.
 -   `keepCookies` **[boolean][29]?** keep cookies between tests when `restart` set to false.
 -   `windowSize` **[string][17]?** default window size. Set to `maximize` or a dimension in the format `640x480`.
--   `waitForTimeout` **[number][20]?** sets default wait time in _ms_ for all `wait*` functions.
+-   `waitforTimeout` **[number][20]?** sets default wait time in _ms_ for all `wait*` functions.
 -   `desiredCapabilities` **[object][16]?** Selenium's [desired capabilities][6].
 -   `manualStart` **[boolean][29]?** do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriver"]._startBrowser()`.
 -   `timeouts` **[object][16]?** [WebDriver timeouts][34] defined as hash.

--- a/docs/webdriver.md
+++ b/docs/webdriver.md
@@ -375,7 +375,7 @@ exports.config = {
     WebDriver: {
       // WebDriver config goes here
       // wait for 5 seconds
-      waitForTimeout: 5000
+      waitforTimeout: 5000
     }
   }
 }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -55,7 +55,7 @@ let version;
  * @prop {boolean} [keepBrowserState=false] - keep browser state between tests when `restart` is set to false.
  * @prop {boolean} [keepCookies=false] - keep cookies between tests when `restart` set to false.
  * @prop {string} [windowSize=window] default window size. Set to `maximize` or a dimension in the format `640x480`.
- * @prop {number} [waitForTimeout=1000] sets default wait time in *ms* for all `wait*` functions.
+ * @prop {number} [waitforTimeout=1000] sets default wait time in *ms* for all `wait*` functions.
  * @prop {object} [desiredCapabilities] Selenium's [desired capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities).
  * @prop {boolean} [manualStart=false] - do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriver"]._startBrowser()`.
  * @prop {object} [timeouts] [WebDriver timeouts](http://webdriver.io/docs/timeouts.html) defined as hash.
@@ -425,7 +425,7 @@ class WebDriver extends Helper {
       // codeceptjs
       remoteFileUpload: true,
       smartWait: 0,
-      waitForTimeout: 1000, // ms
+      waitforTimeout: 1000, // ms
       capabilities: {},
       restart: true,
       uniqueScreenshotNames: false,
@@ -463,7 +463,7 @@ class WebDriver extends Helper {
       delete config.capabilities.selenoidOptions;
     }
 
-    config.waitForTimeout /= 1000; // convert to seconds
+    config.waitforTimeout /= 1000; // convert to seconds
 
     if (!config.capabilities.platformName && (!config.url || !config.browser)) {
       throw new Error(`
@@ -2042,7 +2042,7 @@ class WebDriver extends Helper {
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2076,7 +2076,7 @@ class WebDriver extends Helper {
    * {{> waitForElement }}
    */
   async waitForElement(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2093,7 +2093,7 @@ class WebDriver extends Helper {
    * {{> waitForClickable }}
    */
   async waitForClickable(locator, waitTimeout) {
-    waitTimeout = waitTimeout || this.options.waitForTimeout;
+    waitTimeout = waitTimeout || this.options.waitforTimeout;
     let res = await this._locate(locator);
     res = usingFirstElement(res);
     assertElementExists(res, locator);
@@ -2109,7 +2109,7 @@ class WebDriver extends Helper {
    */
   async waitInUrl(urlPart, sec = null) {
     const client = this.browser;
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     let currUrl = '';
     if (isWebDriver5()) {
       return client
@@ -2143,7 +2143,7 @@ class WebDriver extends Helper {
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     const baseUrl = this.options.url;
     if (urlPart.indexOf('http') < 0) {
       urlPart = baseUrl + urlPart;
@@ -2167,7 +2167,7 @@ class WebDriver extends Helper {
    *
    */
   async waitForText(text, sec = null, context = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     const _context = context || this.root;
     if (isWebDriver5()) {
       return this.browser.waitUntil(
@@ -2205,7 +2205,7 @@ class WebDriver extends Helper {
    */
   async waitForValue(field, value, sec = null) {
     const client = this.browser;
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return client.waitUntil(
         async () => {
@@ -2241,7 +2241,7 @@ class WebDriver extends Helper {
    *
    */
   async waitForVisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2268,7 +2268,7 @@ class WebDriver extends Helper {
    * {{> waitNumberOfVisibleElements }}
    */
   async waitNumberOfVisibleElements(locator, num, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2295,7 +2295,7 @@ class WebDriver extends Helper {
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2323,7 +2323,7 @@ class WebDriver extends Helper {
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this._res(locator);
@@ -2355,7 +2355,7 @@ class WebDriver extends Helper {
       }
     }
 
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => this.browser.execute(fn, ...args), aSec * 1000, '');
     }
@@ -2384,7 +2384,7 @@ class WebDriver extends Helper {
    * {{> switchToNextTab }}
    */
   async switchToNextTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     let target;
     const current = await this.browser.getWindowHandle();
 
@@ -2415,7 +2415,7 @@ class WebDriver extends Helper {
    * {{> switchToPreviousTab }}
    */
   async switchToPreviousTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitforTimeout;
     const current = await this.browser.getWindowHandle();
     let target;
 

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -32,7 +32,7 @@ describe('WebDriver', function () {
       smartWait: 0, // just to try
       host: TestHelper.seleniumHost(),
       port: TestHelper.seleniumPort(),
-      waitForTimeout: 5000,
+      waitforTimeout: 5000,
       capabilities: {
         chromeOptions: {
           args: ['--headless', '--disable-gpu', '--window-size=1280,1024'],
@@ -1221,7 +1221,7 @@ describe('WebDriver - Basic Authentication', () => {
       smartWait: 0, // just to try
       host: TestHelper.seleniumHost(),
       port: TestHelper.seleniumPort(),
-      waitForTimeout: 5000,
+      waitforTimeout: 5000,
       capabilities: {
         chromeOptions: {
           args: ['--headless', '--disable-gpu', '--window-size=1280,1024'],


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently there is a typo in regards to Webdriver configuration where `waitforTimeout` is quoted as `waitForTimeout` with caps `F`. However as per [Webdriver documentation](https://webdriver.io/docs/timeouts/#waitfor-timeout) it should be small `f`.
> WebdriverIO provides multiple commands to wait on elements to reach a certain state (e.g. enabled, visible, existing). These commands take a selector argument and a timeout number, which determines how long the instance should wait for that element to reach the state. The `waitforTimeout` option allows you to set the global timeout for all `waitFor*` commands, so you don't need to set the same timeout over and over again. (**Note the lowercase f!**)



Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
