### PR TITLE
add default value to profile env variable

### DIFF
--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -8,7 +8,11 @@ module.exports = async function (test, options) {
   // registering options globally to use in config
   // Backward compatibility for --profile
   process.profile = options.profile;
-  process.env.profile = options.profile || '';
+
+  if (options.profile) {
+    process.env.profile = options.profile;
+  }
+
   const configFile = options.config;
 
   let config = getConfig(configFile);

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -8,7 +8,7 @@ module.exports = async function (test, options) {
   // registering options globally to use in config
   // Backward compatibility for --profile
   process.profile = options.profile;
-  process.env.profile = options.profile;
+  process.env.profile = options.profile || '';
   const configFile = options.config;
 
   let config = getConfig(configFile);


### PR DESCRIPTION
## Motivation/Description of the PR
Assignment of `undefined` profile to env variable with `process.env.profile` resulted in a string of `"undefined"`.
This results in mysterious behaviors with code like ` const profile = process.env.profile || 'chrome'`. The env variable cannot evaluate to `false` as it holds the string `undefined`. 

This PR sets as empty string as default value, so not setting any profile in the command results in an empty string of the profile env variable.

Resolves #3339

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
