### PR TITLE
Consider I Object Translation in Type Definitions

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -152,7 +152,7 @@ module.exports = function (genPath, options) {
   }
 
   const supportObject = new Map();
-  supportObject.set('I', 'I');
+  supportObject.set(translations.I, translations.I);
   supportObject.set('current', 'any');
 
   if (autoLogin) {


### PR DESCRIPTION
## Motivation/Description of the PR
Running codecptjs with translated `I` object in typescript resulting in a type error because the translated object is not available in the type definition file. 
This PR solves this by considering the translations for the `I` object.

As I could not get detox run on my mac I did not add tests. Detox seems to be required for testing the def command.

This may be related to #3007. I could find no other issues than this typing bug.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
