### PR TITLE
fix(pw): handle file name better

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -1124,7 +1124,7 @@ I.waitForFile('downloads/avatar.jpg', 5);
 
 #### Parameters
 
--   `fileName` **[string][7]?** set filename for downloaded file 
+-   `fileName` **[string][7]?** set filename for downloaded file
 
 Returns **[Promise][13]&lt;void>** 
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -1119,7 +1119,7 @@ Should be used with [FileSystem helper][16] to check that file were downloaded c
 I.handleDownloads('downloads/avatar.jpg');
 I.click('Download Avatar');
 I.amInPath('output/downloads');
-I.waitForFile('downloads/avatar.jpg', 5);
+I.waitForFile('avatar.jpg', 5);
 ```
 
 #### Parameters

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1216,7 +1216,7 @@ class Playwright extends Helper {
    * I.handleDownloads('downloads/avatar.jpg');
    * I.click('Download Avatar');
    * I.amInPath('output/downloads');
-   * I.waitForFile('downloads/avatar.jpg', 5);
+   * I.waitForFile('avatar.jpg', 5);
    *
    * ```
    *

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1226,7 +1226,8 @@ class Playwright extends Helper {
   async handleDownloads(fileName) {
     this.page.waitForEvent('download').then(async (download) => {
       const filePath = await download.path();
-      fileName = fileName ? 'downloads' : path.basename(filePath);
+      fileName = fileName || `downloads/${path.basename(filePath)}`;
+
       const downloadPath = path.join(global.output_dir, fileName);
       if (!fs.existsSync(path.dirname(downloadPath))) {
         fs.mkdirSync(path.dirname(downloadPath), '0777');

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1223,10 +1223,11 @@ class Playwright extends Helper {
    * @param {string} [fileName] set filename for downloaded file
    * @return {Promise<void>}
    */
-  async handleDownloads(fileName = 'downloads') {
+  async handleDownloads(fileName) {
     this.page.waitForEvent('download').then(async (download) => {
       const filePath = await download.path();
-      const downloadPath = path.join(global.output_dir, fileName || path.basename(filePath));
+      fileName = fileName ? 'downloads' : path.basename(filePath);
+      const downloadPath = path.join(global.output_dir, fileName);
       if (!fs.existsSync(path.dirname(downloadPath))) {
         fs.mkdirSync(path.dirname(downloadPath), '0777');
       }

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -772,7 +772,25 @@ describe('Playwright', function () {
     });
   });
 
-  describe('#handleDownloads', () => {
+  describe('#handleDownloads - with passed folder', () => {
+    before(() => {
+      // create download folder;
+      global.output_dir = path.join(`${__dirname}/../data/output`);
+
+      FS = new FileSystem();
+      FS._before();
+      FS.amInPath('output/downloadHere');
+    });
+
+    it('should download file', async () => {
+      await I.amOnPage('/form/download');
+      await I.handleDownloads('downloadHere/avatar.jpg');
+      await I.click('Download file');
+      await FS.waitForFile('avatar.jpg', 5);
+    });
+  });
+
+  describe('#handleDownloads - with default folder', () => {
     before(() => {
       // create download folder;
       global.output_dir = path.join(`${__dirname}/../data/output`);
@@ -782,14 +800,7 @@ describe('Playwright', function () {
       FS.amInPath('output');
     });
 
-    it('should download file - passed folder', async () => {
-      await I.amOnPage('/form/download');
-      await I.handleDownloads('downloadHere/avatar.jpg');
-      await I.click('Download file');
-      await FS.waitForFile('downloadHere/avatar.jpg', 5);
-    });
-
-    it('should download file - default folder', async () => {
+    it('should download file', async () => {
       await I.amOnPage('/form/download');
       await I.handleDownloads('avatar.jpg');
       await I.click('Download file');

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -782,11 +782,18 @@ describe('Playwright', function () {
       FS.amInPath('output');
     });
 
-    it('should dowload file', async () => {
+    it('should download file - passed folder', async () => {
       await I.amOnPage('/form/download');
-      await I.handleDownloads('downloads/avatar.jpg');
+      await I.handleDownloads('downloadHere/avatar.jpg');
       await I.click('Download file');
-      await FS.waitForFile('downloads/avatar.jpg', 5);
+      await FS.waitForFile('downloadHere/avatar.jpg', 5);
+    });
+
+    it('should download file - default folder', async () => {
+      await I.amOnPage('/form/download');
+      await I.handleDownloads('avatar.jpg');
+      await I.click('Download file');
+      await FS.waitForFile('avatar.jpg', 5);
     });
   });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- As we see from this code `async handleDownloads(fileName = 'downloads')` fileName will never be undefined hence the condition on this code `const downloadPath = path.join(global.output_dir, fileName || path.basename(filePath));` would not be correct
- Resolves #3412 
- Resolves #3409 


Applicable helpers:
- [x] Playwright

## Type of change
- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
