### PR TITLE
Playwright: Fixed executeScript()'s return type

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -726,6 +726,8 @@ If a function returns a Promise it will wait for its resolution.
 -   `fn` **([string][7] | [function][12])** function to be executed in browser context.
 -   `arg` **any?** optional argument to pass to the function
 
+Returns **[Promise][13]&lt;any>** 
+
 ### fillField
 
 Fills a text field or textarea, after clearing its value, with the given string.

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1707,6 +1707,7 @@ class Playwright extends Helper {
    *
    * @param {string|function} fn function to be executed in browser context.
    * @param {any} [arg] optional argument to pass to the function
+   * @returns {Promise<any>}
    */
   async executeScript(fn, arg) {
     let context = this.page;

--- a/typings/tests/helpers/Playwright.types.ts
+++ b/typings/tests/helpers/Playwright.types.ts
@@ -89,7 +89,7 @@ playwright.seeCookie(str_pl); // $ExpectType void
 playwright.dontSeeCookie(str_pl); // $ExpectType void
 playwright.grabCookie(); // $ExpectType Promise<string[]> | Promise<string>
 playwright.clearCookie(); // $ExpectType void
-playwright.executeScript(() => {}); // $ExpectType void
+playwright.executeScript(() => {}); // $ExpectType Promise<any>
 playwright.grabTextFrom(str_pl); // $ExpectType Promise<string>
 playwright.grabTextFromAll(str_pl); // $ExpectType Promise<string[]>
 playwright.grabValueFrom(str_pl); // $ExpectType Promise<string>


### PR DESCRIPTION
## Motivation/Description of the PR
- It solves this issue

![image](https://user-images.githubusercontent.com/12584138/195580755-5081a5eb-595f-479c-a3a5-47116a2f672b.png)

- Workaround: Add the suffix `as unknown as string` (if returned type is string) when calling the method 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
