### PR TITLE
Playwright: Changed config's "browser" property to optional

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -40,7 +40,7 @@ Type: [object][5]
 ### Properties
 
 -   `url` **[string][7]** base url of website to be tested
--   `browser` **[string][7]** a browser to test on, either: `chromium`, `firefox`, `webkit`, `electron`. Default: chromium.
+-   `browser` **[string][7]?** a browser to test on, either: `chromium`, `firefox`, `webkit`, `electron`. Default: chromium.
 -   `show` **[boolean][25]?** show browser window.
 -   `restart` **([string][7] | [boolean][25])?** restart strategy between tests. Possible values:-   'context' or **false** - restarts [browser context][32] but keeps running browser. Recommended by Playwright team to keep tests isolated.
     -   'browser' or **true** - closes browser and opens it again between tests.

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -52,7 +52,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * @typedef PlaywrightConfig
  * @type {object}
  * @prop {string} url - base url of website to be tested
- * @prop {string} browser - a browser to test on, either: `chromium`, `firefox`, `webkit`, `electron`. Default: chromium.
+ * @prop {string} [browser] - a browser to test on, either: `chromium`, `firefox`, `webkit`, `electron`. Default: chromium.
  * @prop {boolean} [show=false] - show browser window.
  * @prop {string|boolean} [restart=false] - restart strategy between tests. Possible values:
  *   * 'context' or **false** - restarts [browser context](https://playwright.dev/docs/api/class-browsercontext) but keeps running browser. Recommended by Playwright team to keep tests isolated.


### PR DESCRIPTION
## Motivation/Description of the PR
This configuration is valid (`chromium` is used as a default browser), but TypeScript complains:

![image](https://user-images.githubusercontent.com/12584138/195586500-b7b9b7a4-5458-43d0-a4a1-bb703aef43aa.png)


Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
