### PR TITLE
Playwright: Added config prop "ignoreLog"

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -69,6 +69,7 @@ Type: [object][5]
 -   `chromium` **[object][5]?** pass additional chromium options
 -   `electron` **[object][5]?** (pass additional electron options
 -   `channel` **any?** (While Playwright can operate against the stock Google Chrome and Microsoft Edge browsers available on the machine. In particular, current Playwright version will support Stable and Beta channels of these browsers. See [Google Chrome & Microsoft Edge][36].
+-   `ignoreLog` **[Array][14]&lt;[string][7]>?** An array with console message types that are not logged to debug log. Default value is `['warning', 'log']`. E.g. you can set `[]` to log all messages. See all possible [values][37].
 
 
 
@@ -2170,3 +2171,5 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 [35]: https://playwright.dev/docs/api/class-page#page-wait-for-navigation
 
 [36]: https://playwright.dev/docs/browsers/#google-chrome--microsoft-edge
+
+[37]: https://playwright.dev/docs/api/class-consolemessage#console-message-type

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -82,6 +82,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * @prop {object} [chromium] - pass additional chromium options
  * @prop {object} [electron] - (pass additional electron options
  * @prop {any} [channel] - (While Playwright can operate against the stock Google Chrome and Microsoft Edge browsers available on the machine. In particular, current Playwright version will support Stable and Beta channels of these browsers. See [Google Chrome & Microsoft Edge](https://playwright.dev/docs/browsers/#google-chrome--microsoft-edge).
+ * @prop {string[]} [ignoreLog] - An array with console message types that are not logged to debug log. Default value is `['warning', 'log']`. E.g. you can set `[]` to log all messages. See all possible [values](https://playwright.dev/docs/api/class-consolemessage#console-message-type).
  */
 const config = {};
 


### PR DESCRIPTION
## Motivation/Description of the PR
I cannot use `ignoreLog` in TypeScript config (it was possible in JavaScript config and was working):
![image](https://user-images.githubusercontent.com/12584138/195597070-c3f17187-416e-410f-a26b-3901df57c996.png)

Such property is used by CodeceptJS to log stuff from browser console to debug log
https://github.com/codeceptjs/CodeceptJS/blob/fb44d2cee146823b7c253320ac9a220d01aa95af/lib/helper/Playwright.js#L302
https://github.com/codeceptjs/CodeceptJS/blob/fb44d2cee146823b7c253320ac9a220d01aa95af/lib/helper/Playwright.js#L2800-L2805
Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
