### PR TITLE
fix(init): step_file is not created and resolves custom steps are not showing

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -168,12 +168,11 @@ module.exports = function (initPath) {
 
     const finish = async () => {
       // create steps file by default
-      if (!isTypeScript) { // no extra step file for typescript (as it doesn't match TS conventions)
-        const stepFile = `./steps_file.${extension}`;
-        fs.writeFileSync(path.join(testsPath, stepFile), defaultActor);
-        config.include.I = stepFile;
-        print(`Steps file created at ${stepFile}`);
-      }
+      // no extra step file for typescript (as it doesn't match TS conventions)
+      const stepFile = `./steps_file.${extension}`;
+      fs.writeFileSync(path.join(testsPath, stepFile), defaultActor);
+      config.include.I = isTypeScript === true ? './steps_file' : stepFile;
+      print(`Steps file created at ${stepFile}`);
 
       let configSource;
       const hasConfigure = isLocal && !initPath;


### PR DESCRIPTION
## Motivation/Description of the PR
- A false condition is used to create step_file, hence this file is not created when TS is chosen.
- Fixing the custom steps are not showing.

## Type of change
- [x] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
