### PR TITLE
Fixed issue of after all event getting called after complete execution

### DIFF
--- a/lib/rerun.js
+++ b/lib/rerun.js
@@ -20,14 +20,19 @@ class CodeceptRerunner extends BaseCodecept {
         }
         mocha.files = mocha.files.filter(t => fsPath.basename(t, '.js') === test || t === test);
       }
+      const done = (failures) => {
+        event.emit(event.all.result, this);
+        event.emit(event.all.after, this);
+        if (failures === 0) {
+          // @ts-ignore
+          resolve();
+        } else {
+          reject(new Error(`${failures} tests fail`));
+        }
+      };
       try {
-        mocha.run((failures) => {
-          if (failures === 0) {
-            resolve();
-          } else {
-            reject(new Error(`${failures} tests fail`));
-          }
-        });
+        event.emit(event.all.before, this);
+        mocha.run((failures) => done(failures));
       } catch (e) {
         reject(e);
       }
@@ -62,17 +67,12 @@ class CodeceptRerunner extends BaseCodecept {
   }
 
   run(test) {
-    const done = () => {
-      event.emit(event.all.result, this);
-      event.emit(event.all.after, this);
-    };
-    event.emit(event.all.before, this);
     return this.runTests(test)
       .then(() => {
-        this.teardown(done);
+        this.teardown();
       })
       .catch((e) => {
-        this.teardown(done);
+        this.teardown();
         throw e;
       });
   }

--- a/lib/rerun.js
+++ b/lib/rerun.js
@@ -20,19 +20,14 @@ class CodeceptRerunner extends BaseCodecept {
         }
         mocha.files = mocha.files.filter(t => fsPath.basename(t, '.js') === test || t === test);
       }
-      const done = (failures) => {
-        event.emit(event.all.result, this);
-        event.emit(event.all.after, this);
-        if (failures === 0) {
-          // @ts-ignore
-          resolve();
-        } else {
-          reject(new Error(`${failures} tests fail`));
-        }
-      };
       try {
-        event.emit(event.all.before, this);
-        mocha.run((failures) => done(failures));
+        mocha.run((failures) => {
+          if (failures === 0) {
+            resolve();
+          } else {
+            reject(new Error(`${failures} tests fail`));
+          }
+        });
       } catch (e) {
         reject(e);
       }
@@ -66,15 +61,16 @@ class CodeceptRerunner extends BaseCodecept {
     }
   }
 
-  run(test) {
-    return this.runTests(test)
-      .then(() => {
-        this.teardown();
-      })
-      .catch((e) => {
-        this.teardown();
-        throw e;
-      });
+  async run(test) {
+    event.emit(event.all.before, this);
+    try {
+      await this.runTests(test);
+    } catch (e) {
+      output.error(e.stack);
+    } finally {
+      event.emit(event.all.result, this);
+      event.emit(event.all.after, this);
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation/Description of the PR
- With the recent fixes in run-rerun plugin events `event.all.*` started getting triggered after the completion of `minSuccess` or `maxReruns` . This makes plugins listening to `event.all.*` behave weirdly. With this PR, an attempt is to restore the original behavior to emit these events after the execution of each test run. 
-
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
