### PR TITLE
Promise based helper methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ package-lock.json
 yarn.lock
 /.vs
 typings/types.d.ts
+typings/promiseBasedTypes.d.ts

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -138,3 +138,15 @@ declare namespace CodeceptJS {
   }
 }
 ```
+
+## Full promise-based methods <Badge text="Since 3.3.6" type="warning"/>
+
+All CodeceptJS methods return a promise; however, some of its are not typed as accordingly.
+This feature, which is enabled by [configuration](https://codecept.io/configuration/), refers to alternative typescript definitions transforming all methods to asynchronous actions.
+
+How to enable it?
+- Add required configuration
+```ts
+  fullPromiseBased: true;
+```
+- Refresh internal TypeScript definitions by running following command: `npx codeceptjs def`

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -138,7 +138,8 @@ module.exports = function (genPath, options) {
       helperPaths[name] = require;
       helperNames.push(name);
     } else {
-      helperNames.push(name);
+      const fullBasedPromised = codecept.config.fullPromiseBased;
+      helperNames.push(fullBasedPromised === true ? `${name}Ts` : name);
     }
 
     if (!actingHelpers.includes(name)) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint-fix": "eslint bin/ examples/ lib/ test/ translations/ runok.js --fix",
     "docs": "./runok.js docs",
     "test:unit": "mocha test/unit --recursive",
-    "test:runner": "mocha test/runner --recursive",
+    "test:runner": "mocha test/runner --recursive --timeout 5000",
     "test": "npm run test:unit && npm run test:runner",
     "test:appium-quick": "mocha test/helper/Appium_test.js --grep 'quick'",
     "test:appium-other": "mocha test/helper/Appium_test.js --grep 'second'",

--- a/runok.js
+++ b/runok.js
@@ -33,6 +33,8 @@ module.exports = {
   async defTypings() {
     console.log('Generate TypeScript definition');
     await npx('jsdoc -c typings/jsdoc.conf.js');
+    await npx('jsdoc -c typings/jsdocPromiseBased.conf.js');
+    fs.renameSync('types.d.ts', 'typings/promiseBasedTypes.d.ts');
   },
 
   async docsPlugins() {

--- a/runok.js
+++ b/runok.js
@@ -32,9 +32,11 @@ module.exports = {
 
   async defTypings() {
     console.log('Generate TypeScript definition');
-    await npx('jsdoc -c typings/jsdoc.conf.js');
+    // Generate definitions for promised-based helper methods
     await npx('jsdoc -c typings/jsdocPromiseBased.conf.js');
-    fs.renameSync('types.d.ts', 'typings/promiseBasedTypes.d.ts');
+    fs.renameSync('typings/types.d.ts', 'typings/promiseBasedTypes.d.ts');
+    // Generate all other regular definitions
+    await npx('jsdoc -c typings/jsdoc.conf.js');
   },
 
   async docsPlugins() {

--- a/test/data/sandbox/configs/definitions/codecept.promise.based.js
+++ b/test/data/sandbox/configs/definitions/codecept.promise.based.js
@@ -1,0 +1,13 @@
+exports.config = {
+  tests: './*_test.js',
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    FileSystem: {},
+  },
+  include: {},
+  bootstrap: false,
+  mocha: {},
+  name: 'sandbox',
+  fullPromiseBased: true,
+};

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -193,7 +193,7 @@ describe('BDD Gherkin', () => {
   });
 
   it('should show all available steps', (done) => {
-    exec(`${runner} gherkin:steps --config ${codecept_dir}/codecept.bdd.json`, (err, stdout, stderr) => { //eslint-disable-line
+    exec(`${runner} gherkin:steps --config ${codecept_dir}/codecept.bdd.js`, (err, stdout, stderr) => { //eslint-disable-line
       stdout.should.include('Gherkin');
       stdout.should.include('/I have product with \\$(\\d+) price/');
       stdout.should.include('step_definitions/my_steps.js:3:1');
@@ -206,7 +206,7 @@ describe('BDD Gherkin', () => {
   });
 
   it('should generate snippets for missing steps', (done) => {
-    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.dummy.bdd.json`, (err, stdout, stderr) => { //eslint-disable-line
+    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.dummy.bdd.js`, (err, stdout, stderr) => { //eslint-disable-line
       stdout.should.include(`Given('I open a browser on a site', () => {
   // From "support/dummy.feature" {"line":4,"column":5}
   throw new Error('Not implemented yet');
@@ -277,7 +277,7 @@ When(/^I define a step with a \\( paren and a "(.*?)" string$/, () => {
   });
 
   it('should not generate duplicated steps', (done) => {
-    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.duplicate.bdd.json`, (err, stdout, stderr) => { //eslint-disable-line
+    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.duplicate.bdd.js`, (err, stdout, stderr) => { //eslint-disable-line
       assert.equal(stdout.match(/I open a browser on a site/g).length, 1);
       assert(!err);
       done();

--- a/test/runner/before_failure_test.js
+++ b/test/runner/before_failure_test.js
@@ -3,7 +3,7 @@ const exec = require('child_process').exec;
 
 const runner = path.join(__dirname, '/../../bin/codecept.js');
 const codecept_dir = path.join(__dirname, '/../data/sandbox');
-const codecept_run = `${runner} run --config ${codecept_dir}/codecept.beforetest.failure.json `;
+const codecept_run = `${runner} run --config ${codecept_dir}/codecept.beforetest.failure.js `;
 
 describe('Failure in before', function () {
   this.timeout(5000);

--- a/test/runner/definitions_test.js
+++ b/test/runner/definitions_test.js
@@ -34,7 +34,7 @@ describe('Definitions', function () {
 
   describe('Static files', () => {
     it('should have internal object that is available as variable codeceptjs', (done) => {
-      exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, () => {
+      exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
         const types = typesFrom(`${codecept_dir}/steps.d.ts`);
         types.should.be.valid;
 
@@ -79,7 +79,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file with correct page def', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, (err, stdout) => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, (err, stdout) => {
       stdout.should.include('Definitions were generated in steps.d.ts');
       const types = typesFrom(`${codecept_dir}/steps.d.ts`);
       types.should.be.valid;
@@ -94,7 +94,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file given a config file', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/../../codecept.ddt.json`, (err, stdout) => {
+    exec(`${runner} def --config ${codecept_dir}/../../codecept.ddt.js`, (err, stdout) => {
       stdout.should.include('Definitions were generated in steps.d.ts');
       const types = typesFrom(`${codecept_dir}/../../steps.d.ts`);
       types.should.be.valid;
@@ -104,7 +104,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file with support object', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, () => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`);
       types.should.be.valid;
 
@@ -128,7 +128,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file with inject which contains support objects', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, () => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`);
       types.should.be.valid;
 
@@ -145,7 +145,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file with inject which contains I object', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, (err) => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, (err) => {
       assert(!err);
       const types = typesFrom(`${codecept_dir}/steps.d.ts`);
       types.should.be.valid;
@@ -165,7 +165,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file with inject which contains I object from helpers', (done) => {
-    exec(`${runner} def --config ${codecept_dir}//codecept.inject.powi.json`, () => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.powi.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`);
       types.should.be.valid;
 
@@ -179,7 +179,7 @@ describe('Definitions', function () {
   });
 
   it('def should create definition file with callback params', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.json`, () => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`);
       types.should.be.valid;
 
@@ -190,6 +190,30 @@ describe('Definitions', function () {
         { name: 'MyPage', type: 'MyPage' },
         { name: 'SecondPage', type: 'SecondPage' },
       ]);
+      done();
+    });
+  });
+
+  it('def should create definition file with promise-based feature', (done) => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.promise.based.js`, (err, stdout) => {
+      stdout.should.include('Definitions were generated in steps.d.ts');
+      const types = typesFrom(`${codecept_dir}/steps.d.ts`);
+      types.should.be.valid;
+
+      const definitionFile = types.getSourceFileOrThrow(`${codecept_dir}/steps.d.ts`);
+      const extend = getExtends(definitionFile.getNamespaceOrThrow('CodeceptJS').getInterfaceOrThrow('I'));
+      extend.should.containSubset([{
+        methods: [{
+          name: 'amInPath',
+          returnType: 'Promise<any>',
+          parameters: [{ name: 'openPath', type: 'string' }],
+        }, {
+          name: 'seeFile',
+          returnType: 'Promise<any>',
+          parameters: [{ name: 'name', type: 'string' }],
+        }],
+      }]);
+      assert(!err);
       done();
     });
   });

--- a/test/runner/init_test.js
+++ b/test/runner/init_test.js
@@ -35,13 +35,13 @@ describe('Init Command', function () {
   });
 
   it('init - Where should logs, screenshots, and reports to be stored? (./output)', async () => {
-    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER]);
+    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, ENTER]);
     result.should.include('? What helpers do you want to use? REST');
     result.should.include('Where should logs, screenshots, and reports to be stored? (./output)');
   });
 
   it('init - Do you want localization for tests? (See https://codecept.io/translation/)', async () => {
-    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, ENTER]);
+    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, ENTER, ENTER]);
     result.should.include('? Do you want localization for tests? (See https://codecept.io/translation/)');
     result.should.include('❯ English (no localization)');
     for (const item of ['de-DE', 'it-IT', 'fr-FR', 'ja-JP', 'pl-PL', 'pt-BR']) {
@@ -51,7 +51,7 @@ describe('Init Command', function () {
   });
 
   it('init - [REST] Endpoint of API you are going to test (http://localhost:3000/api)', async () => {
-    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, ENTER, ENTER]);
+    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, ENTER, ENTER, ENTER]);
     result.should.include('Do you want localization for tests? (See https://codecept.io/translation/) Eng');
     result.should.include('Configure helpers...');
     result.should.include('? [REST] Endpoint of API you are going to test (http://localhost:3000/api)');

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -5,7 +5,7 @@ const exec = require('child_process').exec;
 
 const runner = path.join(__dirname, '/../../bin/codecept.js');
 const codecept_dir = path.join(__dirname, '/../data/sandbox');
-const codecept_run = `${runner} run-multiple --config ${codecept_dir}/codecept.multiple.json `;
+const codecept_run = `${runner} run-multiple --config ${codecept_dir}/codecept.multiple.js `;
 
 describe('CodeceptJS Multiple Runner', function () {
   this.timeout(40000);
@@ -175,7 +175,7 @@ describe('CodeceptJS Multiple Runner', function () {
 
   it('should exit with non-zero code for failures during init process', (done) => {
     process.chdir(codecept_dir);
-    exec(`${runner} run-multiple --config codecept.multiple.initFailure.json default --all`, (err, stdout) => {
+    exec(`${runner} run-multiple --config codecept.multiple.initFailure.js default --all`, (err, stdout) => {
       expect(err).not.toBeFalsy();
       expect(err.code).toBe(1);
       expect(stdout).toContain('Failed on FailureHelper');
@@ -235,7 +235,7 @@ describe('CodeceptJS Multiple Runner', function () {
 
     it('should be executed with several module when described', (done) => {
       process.chdir(codecept_dir);
-      exec(`${runner} ${_codecept_run}/codecept.require.multiple.several.json default`, (err, stdout) => {
+      exec(`${runner} ${_codecept_run}/codecept.require.multiple.several.js default`, (err, stdout) => {
         stdout.should.include(moduleOutput);
         stdout.should.include(moduleOutput2);
         (stdout.match(new RegExp(moduleOutput, 'g')) || []).should.have.lengthOf(2);

--- a/test/runner/timeout_test.js
+++ b/test/runner/timeout_test.js
@@ -6,7 +6,7 @@ const debug_this_test = false;
 
 const config_run_config = (config, grep, verbose = false) => `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/timeouts/${config} ${grep ? `--grep "${grep}"` : ''}`;
 
-describe.only('CodeceptJS Timeouts', function () {
+describe('CodeceptJS Timeouts', function () {
   this.timeout(10000);
 
   it('should stop test when timeout exceeded', (done) => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,6 @@
 // Project: https://github.com/codeception/codeceptjs/
 /// <reference path="./types.d.ts" />
+/// <reference path="./promiseBasedTypes.d.ts" />
 /// <reference types="webdriverio" />
 /// <reference path="./Mocha.d.ts" />
 /// <reference types="joi" />

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -261,6 +261,13 @@ declare namespace CodeceptJS {
       steps: Array<string>
     };
 
+    /**
+     * Enable full promise-based helper methods for [TypeScript](https://codecept.io/typescript/) project.
+     * If true, all helper methods are typed as asynchronous;
+     * Otherwise, it remains as it works in versions prior to 3.3.6
+     */
+    fullPromiseBased?: boolean;
+
     [key: string]: any;
   };
 

--- a/typings/jsdoc.promiseBased.js
+++ b/typings/jsdoc.promiseBased.js
@@ -1,4 +1,6 @@
-// Helps tsd-jsdoc to exports all helpers methods as Promise,
+// Helps tsd-jsdoc to exports all helpers methods as Promise
+// - Before parsing JS file, change class name and remove configuration already exported
+// - For each method set by default 'Promise<any>' if there is no returns tag or if the returns tag doesn't handle a promise
 
 const isHelper = (path) => path.includes('docs/build');
 const isDocumentedMethod = (doclet) => doclet.undocumented !== true
@@ -6,8 +8,7 @@ const isDocumentedMethod = (doclet) => doclet.undocumented !== true
   && doclet.scope === 'instance';
 const shouldOverrideReturns = (doclet) => !doclet.returns
   || !doclet.returns[0].type
-  || !doclet.returns[0].type.names[0].includes('Promise')
-  || doclet.returns[0].type.names[0].includes('object');
+  || !doclet.returns[0].type.names[0].includes('Promise');
 
 module.exports = {
   handlers: {
@@ -18,7 +19,7 @@ module.exports = {
           .replace(/class (.*) extends/, 'class $1Ts extends')
           // rename parent class to fix the inheritance
           .replace(/(@augments \w+)/, '$1Ts')
-          // avoid to export twice the configuration of the helper
+          // do not export twice the configuration of the helpers
           .replace(/\/\*\*(.+?(?=config))config = \{\};/s, '');
       }
     },

--- a/typings/jsdoc.promiseBased.js
+++ b/typings/jsdoc.promiseBased.js
@@ -1,0 +1,32 @@
+// Helps tsd-jsdoc to exports all helpers methods as Promise,
+
+const isHelper = (path) => path.includes('docs/build');
+const isDocumentedMethod = (doclet) => doclet.undocumented !== true
+  && doclet.kind === 'function'
+  && doclet.scope === 'instance';
+const shouldOverrideReturns = (doclet) => !doclet.returns
+  || !doclet.returns[0].type
+  || !doclet.returns[0].type.names[0].includes('Promise')
+  || doclet.returns[0].type.names[0].includes('object');
+
+module.exports = {
+  handlers: {
+    beforeParse(e) {
+      if (isHelper(e.filename)) {
+        e.source = e.source
+          // add 'Ts' suffix to generate promise-based helpers definition
+          .replace(/class (.*) extends/, 'class $1Ts extends')
+          // rename parent class to fix the inheritance
+          .replace(/(@augments \w+)/, '$1Ts');
+      }
+    },
+    newDoclet: ({ doclet }) => {
+      if (isHelper(doclet.meta.path)
+        && isDocumentedMethod(doclet)
+        && shouldOverrideReturns(doclet)) {
+        doclet.returns = [];
+        doclet.addTag('returns', '{Promise<any>}');
+      }
+    },
+  },
+};

--- a/typings/jsdoc.promiseBased.js
+++ b/typings/jsdoc.promiseBased.js
@@ -17,7 +17,9 @@ module.exports = {
           // add 'Ts' suffix to generate promise-based helpers definition
           .replace(/class (.*) extends/, 'class $1Ts extends')
           // rename parent class to fix the inheritance
-          .replace(/(@augments \w+)/, '$1Ts');
+          .replace(/(@augments \w+)/, '$1Ts')
+          // avoid to export twice the configuration of the helper
+          .replace(/\/\*\*(.+?(?=config))config = \{\};/s, '');
       }
     },
     newDoclet: ({ doclet }) => {

--- a/typings/jsdocPromiseBased.conf.js
+++ b/typings/jsdocPromiseBased.conf.js
@@ -7,7 +7,7 @@ module.exports = {
   opts: {
     template: 'node_modules/tsd-jsdoc/dist',
     recurse: true,
-    destination: './',
+    destination: './typings/',
   },
   plugins: ['jsdoc.promiseBased.js', 'jsdoc.namespace.js', 'jsdoc-typeof-plugin'],
 };

--- a/typings/jsdocPromiseBased.conf.js
+++ b/typings/jsdocPromiseBased.conf.js
@@ -1,0 +1,13 @@
+module.exports = {
+  source: {
+    include: [
+      './docs/build',
+    ],
+  },
+  opts: {
+    template: 'node_modules/tsd-jsdoc/dist',
+    recurse: true,
+    destination: './',
+  },
+  plugins: ['jsdoc.promiseBased.js', 'jsdoc.namespace.js', 'jsdoc-typeof-plugin'],
+};

--- a/typings/tests/helpers/AppiumTs.types.ts
+++ b/typings/tests/helpers/AppiumTs.types.ts
@@ -1,6 +1,6 @@
 export {}; // mark the file as external module to redeclare variables in the same block
 
-const appium = new CodeceptJS.Appium();
+const appium = new CodeceptJS.AppiumTs();
 
 const str = "text";
 const num = 1;
@@ -8,38 +8,38 @@ const appPackage = "com.example.android.apis";
 
 appium.touchPerform(); // $ExpectError
 appium.touchPerform("press"); // $ExpectError
-appium.touchPerform([{ action: "press" }]); // $ExpectType void
-appium.touchPerform([{ action: "press" }, { action: "release" }]); // $ExpectType void
+appium.touchPerform([{ action: "press" }]); // $ExpectType Promise<any>
+appium.touchPerform([{ action: "press" }, { action: "release" }]); // $ExpectType Promise<any>
 appium.touchPerform([{ action: "press" }], [{ action: "release" }]); // $ExpectError
 
-appium.hideDeviceKeyboard(); // $ExpectType void
-appium.hideDeviceKeyboard("tapOutside"); // $ExpectType void
-appium.hideDeviceKeyboard("pressKey", "Done"); // $ExpectType void
+appium.hideDeviceKeyboard(); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard("tapOutside"); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard("pressKey", "Done"); // $ExpectType Promise<any>
 appium.hideDeviceKeyboard("pressKey", "Done", "Done"); // $ExpectError
 
 appium.removeApp(); // $ExpectError
-appium.removeApp("appName"); // $ExpectType void
-appium.removeApp("appName", appPackage); // $ExpectType void
+appium.removeApp("appName"); // $ExpectType Promise<any>
+appium.removeApp("appName", appPackage); // $ExpectType Promise<any>
 appium.removeApp("appName", appPackage, "remove"); // $ExpectError
 
-appium.runOnIOS(str, () => {}); // $ExpectType void
-appium.runOnAndroid(str, () => {}); // $ExpectType void
+appium.runOnIOS(str, () => {}); // $ExpectType Promise<any>
+appium.runOnAndroid(str, () => {}); // $ExpectType Promise<any>
 appium.seeAppIsInstalled(str); // $ExpectType Promise<void>
 appium.seeAppIsNotInstalled(str); // $ExpectType Promise<void>
 appium.installApp(str); // $ExpectType Promise<void>
-appium.removeApp(str); // $ExpectType void
+appium.removeApp(str); // $ExpectType Promise<any>
 appium.seeCurrentActivityIs(str); // $ExpectType Promise<void>
 appium.seeDeviceIsLocked(); // $ExpectType Promise<void>
 appium.seeDeviceIsUnlocked(); // $ExpectType Promise<void>
 appium.seeOrientationIs("LANDSCAPE"); // $ExpectType Promise<void>
-appium.setOrientation("LANDSCAPE"); // $ExpectType void
+appium.setOrientation("LANDSCAPE"); // $ExpectType Promise<any>
 appium.grabAllContexts(); // $ExpectType Promise<string[]>
 appium.grabContext(); // $ExpectType Promise<string | null>
 appium.grabCurrentActivity(); // $ExpectType Promise<string>
 appium.grabNetworkConnection(); // $ExpectType Promise<{}>
 appium.grabOrientation(); // $ExpectType Promise<string>
 appium.grabSettings(); // $ExpectType Promise<string>
-appium._switchToContext(str); // $ExpectType void
+appium._switchToContext(str); // $ExpectType Promise<any>
 appium.switchToWeb(); // $ExpectType Promise<void>
 appium.switchToNative(); // $ExpectType Promise<void>
 appium.switchToNative(str); // $ExpectType Promise<void>
@@ -47,33 +47,33 @@ appium.startActivity(); // $ExpectError
 appium.startActivity(appPackage); // $ExpectError
 appium.startActivity(appPackage, '.RegisterUserActivity'); // $ExpectType Promise<void>
 appium.setNetworkConnection(); // $ExpectType Promise<{}>
-appium.setSettings(str); // $ExpectType void
-appium.hideDeviceKeyboard(); // $ExpectType void
+appium.setSettings(str); // $ExpectType Promise<any>
+appium.hideDeviceKeyboard(); // $ExpectType Promise<any>
 appium.sendDeviceKeyEvent(num); // $ExpectType Promise<void>
 appium.openNotifications(); // $ExpectType Promise<void>
 appium.makeTouchAction(); // $ExpectType Promise<void>
 appium.tap(str); // $ExpectType Promise<void>
-appium.performSwipe(str, str); // $ExpectType void
+appium.performSwipe(str, str); // $ExpectType Promise<any>
 appium.swipeDown(str); // $ExpectType Promise<void>
 appium.swipeLeft(str); // $ExpectType Promise<void>
 appium.swipeRight(str); // $ExpectType Promise<void>
 appium.swipeUp(str); // $ExpectType Promise<void>
 appium.swipeTo(str, str, str, num, num, num); // $ExpectType Promise<void>
-appium.touchPerform([]); // $ExpectType void
+appium.touchPerform([]); // $ExpectType Promise<any>
 appium.pullFile(str, str); // $ExpectType Promise<string>
 appium.shakeDevice(); // $ExpectType Promise<void>
 appium.rotate(); // $ExpectType Promise<void>
 appium.setImmediateValue(); // $ExpectType Promise<void>
 appium.simulateTouchId(); // $ExpectType Promise<void>
 appium.closeApp(); // $ExpectType Promise<void>
-appium.appendField(str, str); // $ExpectType void
-appium.checkOption(str); // $ExpectType void
-appium.click(str); // $ExpectType void
-appium.dontSeeCheckboxIsChecked(str); // $ExpectType void
-appium.dontSeeElement(str); // $ExpectType void
-appium.dontSeeInField(str, str); // $ExpectType void
-appium.dontSee(str); // $ExpectType void
-appium.fillField(str, str); // $ExpectType void
+appium.appendField(str, str); // $ExpectType Promise<any>
+appium.checkOption(str); // $ExpectType Promise<any>
+appium.click(str); // $ExpectType Promise<any>
+appium.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<any>
+appium.dontSeeElement(str); // $ExpectType Promise<any>
+appium.dontSeeInField(str, str); // $ExpectType Promise<any>
+appium.dontSee(str); // $ExpectType Promise<any>
+appium.fillField(str, str); // $ExpectType Promise<any>
 appium.grabTextFromAll(str); // $ExpectType Promise<string[]>
 appium.grabTextFrom(str); // $ExpectType Promise<string>
 appium.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
@@ -82,13 +82,13 @@ appium.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
 appium.grabValueFromAll(str); // $ExpectType Promise<string[]>
 appium.grabValueFrom(str); // $ExpectType Promise<string>
 appium.saveScreenshot(str); // $ExpectType Promise<void>
-appium.scrollIntoView(str, {}); // $ExpectType void
-appium.seeCheckboxIsChecked(str); // $ExpectType void
-appium.seeElement(str); // $ExpectType void
-appium.seeInField(str, str); // $ExpectType void
-appium.see(str); // $ExpectType void
-appium.selectOption(str, str); // $ExpectType void
-appium.waitForElement(str); // $ExpectType void
-appium.waitForVisible(str); // $ExpectType void
-appium.waitForInvisible(str); // $ExpectType void
-appium.waitForText(str); // $ExpectType void
+appium.scrollIntoView(str, {}); // $ExpectType Promise<any>
+appium.seeCheckboxIsChecked(str); // $ExpectType Promise<any>
+appium.seeElement(str); // $ExpectType Promise<any>
+appium.seeInField(str, str); // $ExpectType Promise<any>
+appium.see(str); // $ExpectType Promise<any>
+appium.selectOption(str, str); // $ExpectType Promise<any>
+appium.waitForElement(str); // $ExpectType Promise<any>
+appium.waitForVisible(str); // $ExpectType Promise<any>
+appium.waitForInvisible(str); // $ExpectType Promise<any>
+appium.waitForText(str); // $ExpectType Promise<any>

--- a/typings/tests/helpers/Playwright.types.ts
+++ b/typings/tests/helpers/Playwright.types.ts
@@ -1,36 +1,38 @@
+export {}; // mark the file as external module to redeclare variables in the same block
+
 const playwright = new CodeceptJS.Playwright();
 
-const str_pl = 'text';
-const num_pl = 1;
+const str = 'text';
+const num = 1;
 const position = { x: 100, y: 200 };
 const sourcePosition = { x: 10, y: 20 };
 const targetPosition = { x: 20, y: 30 };
 
-playwright.usePlaywrightTo(str_pl, () => {}); // $ExpectType void
+playwright.usePlaywrightTo(str, () => {}); // $ExpectType void
 playwright.amAcceptingPopups(); // $ExpectType void
 playwright.acceptPopup(); // $ExpectType void
 playwright.amCancellingPopups(); // $ExpectType void
 playwright.cancelPopup(); // $ExpectType void
-playwright.seeInPopup(str_pl); // $ExpectType void
-playwright._setPage(str_pl); // $ExpectType void
+playwright.seeInPopup(str); // $ExpectType void
+playwright._setPage(str); // $ExpectType void
 playwright._addPopupListener(); // $ExpectType void
 playwright._getPageUrl(); // $ExpectType void
 playwright.grabPopupText(); // $ExpectType Promise<string | null>
-playwright.amOnPage(str_pl); // $ExpectType void
-playwright.resizeWindow(num_pl, num_pl); // $ExpectType void
-playwright.haveRequestHeaders(str_pl); // $ExpectType void
-playwright.moveCursorTo(str_pl, num_pl, num_pl); // $ExpectType void
-playwright.dragAndDrop(str_pl); // $ExpectError
-playwright.dragAndDrop(str_pl, str_pl); // $ExpectType void
-playwright.dragAndDrop(str_pl, str_pl, { sourcePosition, targetPosition }); // $ExpectType void
+playwright.amOnPage(str); // $ExpectType void
+playwright.resizeWindow(num, num); // $ExpectType void
+playwright.haveRequestHeaders(str); // $ExpectType void
+playwright.moveCursorTo(str, num, num); // $ExpectType void
+playwright.dragAndDrop(str); // $ExpectError
+playwright.dragAndDrop(str, str); // $ExpectType void
+playwright.dragAndDrop(str, str, { sourcePosition, targetPosition }); // $ExpectType void
 playwright.refreshPage(); // $ExpectType void
 playwright.scrollPageToTop(); // $ExpectType void
 playwright.scrollPageToBottom(); // $ExpectType void
-playwright.scrollTo(str_pl, num_pl, num_pl); // $ExpectType void
-playwright.seeInTitle(str_pl); // $ExpectType void
+playwright.scrollTo(str, num, num); // $ExpectType void
+playwright.seeInTitle(str); // $ExpectType void
 playwright.grabPageScrollPosition(); // $ExpectType Promise<PageScrollPosition>
-playwright.seeTitleEquals(str_pl); // $ExpectType void
-playwright.dontSeeInTitle(str_pl); // $ExpectType void
+playwright.seeTitleEquals(str); // $ExpectType void
+playwright.dontSeeInTitle(str); // $ExpectType void
 playwright.grabTitle(); // $ExpectType Promise<string>
 playwright._locate(); // $ExpectType void
 playwright._locateCheckable(); // $ExpectType void
@@ -42,89 +44,89 @@ playwright.closeCurrentTab(); // $ExpectType void
 playwright.closeOtherTabs(); // $ExpectType void
 playwright.openNewTab(); // $ExpectType void
 playwright.grabNumberOfOpenTabs(); // $ExpectType Promise<number>
-playwright.seeElement(str_pl); // $ExpectType void
-playwright.dontSeeElement(str_pl); // $ExpectType void
-playwright.seeElementInDOM(str_pl); // $ExpectType void
-playwright.dontSeeElementInDOM(str_pl); // $ExpectType void
+playwright.seeElement(str); // $ExpectType void
+playwright.dontSeeElement(str); // $ExpectType void
+playwright.seeElementInDOM(str); // $ExpectType void
+playwright.dontSeeElementInDOM(str); // $ExpectType void
 playwright.handleDownloads(); // $ExpectType Promise<void>
-playwright.click(str_pl); // $ExpectType void
-playwright.click(str_pl, str_pl); // $ExpectType void
-playwright.click(str_pl, null, { position }); // $ExpectType void
+playwright.click(str); // $ExpectType void
+playwright.click(str, str); // $ExpectType void
+playwright.click(str, null, { position }); // $ExpectType void
 playwright.clickLink(); // $ExpectType void
-playwright.forceClick(str_pl); // $ExpectType void
-playwright.doubleClick(str_pl); // $ExpectType void
-playwright.rightClick(str_pl); // $ExpectType void
-playwright.checkOption(str_pl); // $ExpectType void
-playwright.uncheckOption(str_pl); // $ExpectType void
-playwright.seeCheckboxIsChecked(str_pl); // $ExpectType void
-playwright.dontSeeCheckboxIsChecked(str_pl); // $ExpectType void
-playwright.pressKeyDown(str_pl); // $ExpectType void
-playwright.pressKeyUp(str_pl); // $ExpectType void
-playwright.pressKey(str_pl); // $ExpectType void
-playwright.type(str_pl); // $ExpectType void
-playwright.fillField(str_pl, str_pl); // $ExpectType void
-playwright.clearField(str_pl); // $ExpectType void
-playwright.appendField(str_pl, str_pl); // $ExpectType void
-playwright.seeInField(str_pl, str_pl); // $ExpectType void
-playwright.dontSeeInField(str_pl, str_pl); // $ExpectType void
-playwright.attachFile(str_pl, str_pl); // $ExpectType void
-playwright.selectOption(str_pl, str_pl); // $ExpectType void
-playwright.grabNumberOfVisibleElements(str_pl); // $ExpectType Promise<number>
-playwright.seeInCurrentUrl(str_pl); // $ExpectType void
-playwright.dontSeeInCurrentUrl(str_pl); // $ExpectType void
-playwright.seeCurrentUrlEquals(str_pl); // $ExpectType void
-playwright.dontSeeCurrentUrlEquals(str_pl); // $ExpectType void
-playwright.see(str_pl); // $ExpectType void
-playwright.seeTextEquals(str_pl); // $ExpectType void
-playwright.dontSee(str_pl); // $ExpectType void
+playwright.forceClick(str); // $ExpectType void
+playwright.doubleClick(str); // $ExpectType void
+playwright.rightClick(str); // $ExpectType void
+playwright.checkOption(str); // $ExpectType void
+playwright.uncheckOption(str); // $ExpectType void
+playwright.seeCheckboxIsChecked(str); // $ExpectType void
+playwright.dontSeeCheckboxIsChecked(str); // $ExpectType void
+playwright.pressKeyDown(str); // $ExpectType void
+playwright.pressKeyUp(str); // $ExpectType void
+playwright.pressKey(str); // $ExpectType void
+playwright.type(str); // $ExpectType void
+playwright.fillField(str, str); // $ExpectType void
+playwright.clearField(str); // $ExpectType void
+playwright.appendField(str, str); // $ExpectType void
+playwright.seeInField(str, str); // $ExpectType void
+playwright.dontSeeInField(str, str); // $ExpectType void
+playwright.attachFile(str, str); // $ExpectType void
+playwright.selectOption(str, str); // $ExpectType void
+playwright.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
+playwright.seeInCurrentUrl(str); // $ExpectType void
+playwright.dontSeeInCurrentUrl(str); // $ExpectType void
+playwright.seeCurrentUrlEquals(str); // $ExpectType void
+playwright.dontSeeCurrentUrlEquals(str); // $ExpectType void
+playwright.see(str); // $ExpectType void
+playwright.seeTextEquals(str); // $ExpectType void
+playwright.dontSee(str); // $ExpectType void
 playwright.grabSource(); // $ExpectType Promise<string>
 playwright.grabBrowserLogs(); // $ExpectType Promise<any[]>
 playwright.grabCurrentUrl(); // $ExpectType Promise<string>
-playwright.seeInSource(str_pl); // $ExpectType void
-playwright.dontSeeInSource(str_pl); // $ExpectType void
-playwright.seeNumberOfElements(str_pl, num_pl); // $ExpectType void
-playwright.seeNumberOfVisibleElements(str_pl, num_pl); // $ExpectType void
-playwright.setCookie({ name: str_pl, value: str_pl}); // $ExpectType void
-playwright.seeCookie(str_pl); // $ExpectType void
-playwright.dontSeeCookie(str_pl); // $ExpectType void
+playwright.seeInSource(str); // $ExpectType void
+playwright.dontSeeInSource(str); // $ExpectType void
+playwright.seeNumberOfElements(str, num); // $ExpectType void
+playwright.seeNumberOfVisibleElements(str, num); // $ExpectType void
+playwright.setCookie({ name: str, value: str}); // $ExpectType void
+playwright.seeCookie(str); // $ExpectType void
+playwright.dontSeeCookie(str); // $ExpectType void
 playwright.grabCookie(); // $ExpectType Promise<string[]> | Promise<string>
 playwright.clearCookie(); // $ExpectType void
 playwright.executeScript(() => {}); // $ExpectType Promise<any>
-playwright.grabTextFrom(str_pl); // $ExpectType Promise<string>
-playwright.grabTextFromAll(str_pl); // $ExpectType Promise<string[]>
-playwright.grabValueFrom(str_pl); // $ExpectType Promise<string>
-playwright.grabValueFromAll(str_pl); // $ExpectType Promise<string[]>
-playwright.grabHTMLFrom(str_pl); // $ExpectType Promise<string>
-playwright.grabHTMLFromAll(str_pl); // $ExpectType Promise<string[]>
-playwright.grabCssPropertyFrom(str_pl, str_pl); // $ExpectType Promise<string>
-playwright.grabCssPropertyFromAll(str_pl, str_pl); // $ExpectType Promise<string[]>
-playwright.seeCssPropertiesOnElements(str_pl, str_pl); // $ExpectType void
-playwright.seeAttributesOnElements(str_pl, str_pl); // $ExpectType void
-playwright.dragSlider(str_pl, num_pl); // $ExpectType void
-playwright.grabAttributeFrom(str_pl, str_pl); // $ExpectType Promise<string>
-playwright.grabAttributeFromAll(str_pl, str_pl); // $ExpectType Promise<string[]>
-playwright.saveElementScreenshot(str_pl, str_pl); // $ExpectType void
-playwright.saveScreenshot(str_pl); // $ExpectType void
-playwright.makeApiRequest(str_pl, str_pl, str_pl); // $ExpectType Promise<object>
-playwright.wait(num_pl); // $ExpectType void
-playwright.waitForEnabled(str_pl); // $ExpectType void
-playwright.waitForValue(str_pl, str_pl); // $ExpectType void
-playwright.waitNumberOfVisibleElements(str_pl, num_pl); // $ExpectType void
-playwright.waitForClickable(str_pl); // $ExpectType void
-playwright.waitForElement(str_pl); // $ExpectType void
-playwright.waitForVisible(str_pl); // $ExpectType void
-playwright.waitForInvisible(str_pl); // $ExpectType void
-playwright.waitToHide(str_pl); // $ExpectType void
-playwright.waitInUrl(str_pl); // $ExpectType void
-playwright.waitUrlEquals(str_pl); // $ExpectType void
-playwright.waitForText(str_pl); // $ExpectType void
-playwright.waitForRequest(str_pl); // $ExpectType void
-playwright.waitForResponse(str_pl); // $ExpectType void
+playwright.grabTextFrom(str); // $ExpectType Promise<string>
+playwright.grabTextFromAll(str); // $ExpectType Promise<string[]>
+playwright.grabValueFrom(str); // $ExpectType Promise<string>
+playwright.grabValueFromAll(str); // $ExpectType Promise<string[]>
+playwright.grabHTMLFrom(str); // $ExpectType Promise<string>
+playwright.grabHTMLFromAll(str); // $ExpectType Promise<string[]>
+playwright.grabCssPropertyFrom(str, str); // $ExpectType Promise<string>
+playwright.grabCssPropertyFromAll(str, str); // $ExpectType Promise<string[]>
+playwright.seeCssPropertiesOnElements(str, str); // $ExpectType void
+playwright.seeAttributesOnElements(str, str); // $ExpectType void
+playwright.dragSlider(str, num); // $ExpectType void
+playwright.grabAttributeFrom(str, str); // $ExpectType Promise<string>
+playwright.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
+playwright.saveElementScreenshot(str, str); // $ExpectType void
+playwright.saveScreenshot(str); // $ExpectType void
+playwright.makeApiRequest(str, str, str); // $ExpectType Promise<object>
+playwright.wait(num); // $ExpectType void
+playwright.waitForEnabled(str); // $ExpectType void
+playwright.waitForValue(str, str); // $ExpectType void
+playwright.waitNumberOfVisibleElements(str, num); // $ExpectType void
+playwright.waitForClickable(str); // $ExpectType void
+playwright.waitForElement(str); // $ExpectType void
+playwright.waitForVisible(str); // $ExpectType void
+playwright.waitForInvisible(str); // $ExpectType void
+playwright.waitToHide(str); // $ExpectType void
+playwright.waitInUrl(str); // $ExpectType void
+playwright.waitUrlEquals(str); // $ExpectType void
+playwright.waitForText(str); // $ExpectType void
+playwright.waitForRequest(str); // $ExpectType void
+playwright.waitForResponse(str); // $ExpectType void
 playwright.switchTo(); // $ExpectType void
 playwright.waitForFunction(() => { }); // $ExpectType void
-playwright.waitForNavigation(str_pl); // $ExpectType void
-playwright.waitForDetached(str_pl); // $ExpectType void
+playwright.waitForNavigation(str); // $ExpectType void
+playwright.waitForDetached(str); // $ExpectType void
 playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<any>
-playwright.grabElementBoundingRect(str_pl); // $ExpectType Promise<number> | Promise<DOMRect>
-playwright.mockRoute(str_pl); // $ExpectType void
-playwright.stopMockingRoute(str_pl); // $ExpectType void
+playwright.grabElementBoundingRect(str); // $ExpectType Promise<number> | Promise<DOMRect>
+playwright.mockRoute(str); // $ExpectType void
+playwright.stopMockingRoute(str); // $ExpectType void

--- a/typings/tests/helpers/PlaywrightTs.types.ts
+++ b/typings/tests/helpers/PlaywrightTs.types.ts
@@ -107,7 +107,7 @@ playwright.grabAttributeFrom(str, str); // $ExpectType Promise<string>
 playwright.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
 playwright.saveElementScreenshot(str, str); // $ExpectType Promise<any>
 playwright.saveScreenshot(str); // $ExpectType Promise<any>
-playwright.makeApiRequest(str, str, str); // $ExpectType Promise<any>
+playwright.makeApiRequest(str, str, str); // $ExpectType Promise<object>
 playwright.wait(num); // $ExpectType Promise<any>
 playwright.waitForEnabled(str); // $ExpectType Promise<any>
 playwright.waitForValue(str, str); // $ExpectType Promise<any>

--- a/typings/tests/helpers/PlaywrightTs.types.ts
+++ b/typings/tests/helpers/PlaywrightTs.types.ts
@@ -1,0 +1,132 @@
+export {}; // mark the file as external module to redeclare variables in the same block
+
+const playwright = new CodeceptJS.PlaywrightTs();
+
+const str = 'text';
+const num = 1;
+const position = { x: 100, y: 200 };
+const sourcePosition = { x: 10, y: 20 };
+const targetPosition = { x: 20, y: 30 };
+
+playwright.usePlaywrightTo(str, () => {}); // $ExpectType Promise<any>
+playwright.amAcceptingPopups(); // $ExpectType Promise<any>
+playwright.acceptPopup(); // $ExpectType Promise<any>
+playwright.amCancellingPopups(); // $ExpectType Promise<any>
+playwright.cancelPopup(); // $ExpectType Promise<any>
+playwright.seeInPopup(str); // $ExpectType Promise<any>
+playwright._setPage(str); // $ExpectType Promise<any>
+playwright._addPopupListener(); // $ExpectType Promise<any>
+playwright._getPageUrl(); // $ExpectType Promise<any>
+playwright.grabPopupText(); // $ExpectType Promise<string | null>
+playwright.amOnPage(str); // $ExpectType Promise<any>
+playwright.resizeWindow(num, num); // $ExpectType Promise<any>
+playwright.haveRequestHeaders(str); // $ExpectType Promise<any>
+playwright.moveCursorTo(str, num, num); // $ExpectType Promise<any>
+playwright.dragAndDrop(str); // $ExpectError
+playwright.dragAndDrop(str, str); // $ExpectType Promise<any>
+playwright.dragAndDrop(str, str, { sourcePosition, targetPosition }); // $ExpectType Promise<any>
+playwright.refreshPage(); // $ExpectType Promise<any>
+playwright.scrollPageToTop(); // $ExpectType Promise<any>
+playwright.scrollPageToBottom(); // $ExpectType Promise<any>
+playwright.scrollTo(str, num, num); // $ExpectType Promise<any>
+playwright.seeInTitle(str); // $ExpectType Promise<any>
+playwright.grabPageScrollPosition(); // $ExpectType Promise<PageScrollPosition>
+playwright.seeTitleEquals(str); // $ExpectType Promise<any>
+playwright.dontSeeInTitle(str); // $ExpectType Promise<any>
+playwright.grabTitle(); // $ExpectType Promise<string>
+playwright._locate(); // $ExpectType Promise<any>
+playwright._locateCheckable(); // $ExpectType Promise<any>
+playwright._locateClickable(); // $ExpectType Promise<any>
+playwright._locateFields(); // $ExpectType Promise<any>
+playwright.switchToNextTab(); // $ExpectType Promise<any>
+playwright.switchToPreviousTab(); // $ExpectType Promise<any>
+playwright.closeCurrentTab(); // $ExpectType Promise<any>
+playwright.closeOtherTabs(); // $ExpectType Promise<any>
+playwright.openNewTab(); // $ExpectType Promise<any>
+playwright.grabNumberOfOpenTabs(); // $ExpectType Promise<number>
+playwright.seeElement(str); // $ExpectType Promise<any>
+playwright.dontSeeElement(str); // $ExpectType Promise<any>
+playwright.seeElementInDOM(str); // $ExpectType Promise<any>
+playwright.dontSeeElementInDOM(str); // $ExpectType Promise<any>
+playwright.handleDownloads(); // $ExpectType Promise<void>
+playwright.click(str); // $ExpectType Promise<any>
+playwright.click(str, str); // $ExpectType Promise<any>
+playwright.click(str, null, { position }); // $ExpectType Promise<any>
+playwright.clickLink(); // $ExpectType Promise<any>
+playwright.forceClick(str); // $ExpectType Promise<any>
+playwright.doubleClick(str); // $ExpectType Promise<any>
+playwright.rightClick(str); // $ExpectType Promise<any>
+playwright.checkOption(str); // $ExpectType Promise<any>
+playwright.uncheckOption(str); // $ExpectType Promise<any>
+playwright.seeCheckboxIsChecked(str); // $ExpectType Promise<any>
+playwright.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<any>
+playwright.pressKeyDown(str); // $ExpectType Promise<any>
+playwright.pressKeyUp(str); // $ExpectType Promise<any>
+playwright.pressKey(str); // $ExpectType Promise<any>
+playwright.type(str); // $ExpectType Promise<any>
+playwright.fillField(str, str); // $ExpectType Promise<any>
+playwright.clearField(str); // $ExpectType Promise<any>
+playwright.appendField(str, str); // $ExpectType Promise<any>
+playwright.seeInField(str, str); // $ExpectType Promise<any>
+playwright.dontSeeInField(str, str); // $ExpectType Promise<any>
+playwright.attachFile(str, str); // $ExpectType Promise<any>
+playwright.selectOption(str, str); // $ExpectType Promise<any>
+playwright.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
+playwright.seeInCurrentUrl(str); // $ExpectType Promise<any>
+playwright.dontSeeInCurrentUrl(str); // $ExpectType Promise<any>
+playwright.seeCurrentUrlEquals(str); // $ExpectType Promise<any>
+playwright.dontSeeCurrentUrlEquals(str); // $ExpectType Promise<any>
+playwright.see(str); // $ExpectType Promise<any>
+playwright.seeTextEquals(str); // $ExpectType Promise<any>
+playwright.dontSee(str); // $ExpectType Promise<any>
+playwright.grabSource(); // $ExpectType Promise<string>
+playwright.grabBrowserLogs(); // $ExpectType Promise<any[]>
+playwright.grabCurrentUrl(); // $ExpectType Promise<string>
+playwright.seeInSource(str); // $ExpectType Promise<any>
+playwright.dontSeeInSource(str); // $ExpectType Promise<any>
+playwright.seeNumberOfElements(str, num); // $ExpectType Promise<any>
+playwright.seeNumberOfVisibleElements(str, num); // $ExpectType Promise<any>
+playwright.setCookie({ name: str, value: str}); // $ExpectType Promise<any>
+playwright.seeCookie(str); // $ExpectType Promise<any>
+playwright.dontSeeCookie(str); // $ExpectType Promise<any>
+playwright.grabCookie(); // $ExpectType Promise<string[]> | Promise<string>
+playwright.clearCookie(); // $ExpectType Promise<any>
+playwright.executeScript(() => {}); // $ExpectType Promise<any>
+playwright.grabTextFrom(str); // $ExpectType Promise<string>
+playwright.grabTextFromAll(str); // $ExpectType Promise<string[]>
+playwright.grabValueFrom(str); // $ExpectType Promise<string>
+playwright.grabValueFromAll(str); // $ExpectType Promise<string[]>
+playwright.grabHTMLFrom(str); // $ExpectType Promise<string>
+playwright.grabHTMLFromAll(str); // $ExpectType Promise<string[]>
+playwright.grabCssPropertyFrom(str, str); // $ExpectType Promise<string>
+playwright.grabCssPropertyFromAll(str, str); // $ExpectType Promise<string[]>
+playwright.seeCssPropertiesOnElements(str, str); // $ExpectType Promise<any>
+playwright.seeAttributesOnElements(str, str); // $ExpectType Promise<any>
+playwright.dragSlider(str, num); // $ExpectType Promise<any>
+playwright.grabAttributeFrom(str, str); // $ExpectType Promise<string>
+playwright.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
+playwright.saveElementScreenshot(str, str); // $ExpectType Promise<any>
+playwright.saveScreenshot(str); // $ExpectType Promise<any>
+playwright.makeApiRequest(str, str, str); // $ExpectType Promise<any>
+playwright.wait(num); // $ExpectType Promise<any>
+playwright.waitForEnabled(str); // $ExpectType Promise<any>
+playwright.waitForValue(str, str); // $ExpectType Promise<any>
+playwright.waitNumberOfVisibleElements(str, num); // $ExpectType Promise<any>
+playwright.waitForClickable(str); // $ExpectType Promise<any>
+playwright.waitForElement(str); // $ExpectType Promise<any>
+playwright.waitForVisible(str); // $ExpectType Promise<any>
+playwright.waitForInvisible(str); // $ExpectType Promise<any>
+playwright.waitToHide(str); // $ExpectType Promise<any>
+playwright.waitInUrl(str); // $ExpectType Promise<any>
+playwright.waitUrlEquals(str); // $ExpectType Promise<any>
+playwright.waitForText(str); // $ExpectType Promise<any>
+playwright.waitForRequest(str); // $ExpectType Promise<any>
+playwright.waitForResponse(str); // $ExpectType Promise<any>
+playwright.switchTo(); // $ExpectType Promise<any>
+playwright.waitForFunction(() => { }); // $ExpectType Promise<any>
+playwright.waitForNavigation(str); // $ExpectType Promise<any>
+playwright.waitForDetached(str); // $ExpectType Promise<any>
+playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<any>
+playwright.grabElementBoundingRect(str); // $ExpectType Promise<number> | Promise<DOMRect>
+playwright.mockRoute(str); // $ExpectType Promise<any>
+playwright.stopMockingRoute(str); // $ExpectType Promise<any>

--- a/typings/tests/helpers/WebDriverIO.types.ts
+++ b/typings/tests/helpers/WebDriverIO.types.ts
@@ -1,7 +1,9 @@
+export {}; // mark the file as external module to redeclare variables in the same block
+
 const wd = new CodeceptJS.WebDriver();
 
-const str_wd = 'text';
-const num_wd = 1;
+const str = 'text';
+const num = 1;
 
 wd.amOnPage(); // $ExpectError
 wd.amOnPage(''); // $ExpectType void
@@ -80,25 +82,25 @@ wd.rightClick('div', { ios: '//div' });
 
 wd.fillField(); // $ExpectError
 wd.fillField('div'); // $ExpectError
-wd.fillField('div', str_wd); // $ExpectType void
-wd.fillField({ css: 'div' }, str_wd);
-wd.fillField({ xpath: '//div' }, str_wd);
-wd.fillField({ name: 'div' }, str_wd);
-wd.fillField({ id: 'div' }, str_wd);
-wd.fillField({ android: 'div' }, str_wd);
-wd.fillField({ ios: 'div' }, str_wd);
-wd.fillField(locate('div'), str_wd);
+wd.fillField('div', str); // $ExpectType void
+wd.fillField({ css: 'div' }, str);
+wd.fillField({ xpath: '//div' }, str);
+wd.fillField({ name: 'div' }, str);
+wd.fillField({ id: 'div' }, str);
+wd.fillField({ android: 'div' }, str);
+wd.fillField({ ios: 'div' }, str);
+wd.fillField(locate('div'), str);
 
 wd.appendField(); // $ExpectError
 wd.appendField('div'); // $ExpectError
-wd.appendField('div', str_wd); // $ExpectType void
-wd.appendField({ css: 'div' }, str_wd);
-wd.appendField({ xpath: '//div' }, str_wd);
-wd.appendField({ name: 'div' }, str_wd);
-wd.appendField({ id: 'div' }, str_wd);
-wd.appendField({ android: 'div' }, str_wd);
-wd.appendField({ ios: 'div' }, str_wd);
-wd.appendField(locate('div'), str_wd);
+wd.appendField('div', str); // $ExpectType void
+wd.appendField({ css: 'div' }, str);
+wd.appendField({ xpath: '//div' }, str);
+wd.appendField({ name: 'div' }, str);
+wd.appendField({ id: 'div' }, str);
+wd.appendField({ android: 'div' }, str);
+wd.appendField({ ios: 'div' }, str);
+wd.appendField(locate('div'), str);
 
 wd.clearField(); // $ExpectError
 wd.clearField('div');
@@ -111,11 +113,11 @@ wd.clearField({ ios: 'div' });
 
 wd.selectOption(); // $ExpectError
 wd.selectOption('div'); // $ExpectError
-wd.selectOption('div', str_wd); // $ExpectType void
+wd.selectOption('div', str); // $ExpectType void
 
 wd.attachFile(); // $ExpectError
 wd.attachFile('div'); // $ExpectError
-wd.attachFile('div', str_wd); // $ExpectType void
+wd.attachFile('div', str); // $ExpectType void
 
 wd.checkOption(); // $ExpectError
 wd.checkOption('div'); // $ExpectType void
@@ -124,33 +126,33 @@ wd.uncheckOption(); // $ExpectError
 wd.uncheckOption('div'); // $ExpectType void
 
 wd.seeInTitle(); // $ExpectError
-wd.seeInTitle(str_wd); // $ExpectType void
+wd.seeInTitle(str); // $ExpectType void
 
 wd.seeTitleEquals(); // $ExpectError
-wd.seeTitleEquals(str_wd); // $ExpectType void
+wd.seeTitleEquals(str); // $ExpectType void
 
 wd.dontSeeInTitle(); // $ExpectError
-wd.dontSeeInTitle(str_wd); // $ExpectType void
+wd.dontSeeInTitle(str); // $ExpectType void
 
 wd.see(); // $ExpectError
-wd.see(str_wd); // $ExpectType void
-wd.see(str_wd, 'div'); // $ExpectType void
+wd.see(str); // $ExpectType void
+wd.see(str, 'div'); // $ExpectType void
 
 wd.dontSee(); // $ExpectError
-wd.dontSee(str_wd); // $ExpectType void
-wd.dontSee(str_wd, 'div'); // $ExpectType void
+wd.dontSee(str); // $ExpectType void
+wd.dontSee(str, 'div'); // $ExpectType void
 
 wd.seeTextEquals(); // $ExpectError
-wd.seeTextEquals(str_wd); // $ExpectType void
-wd.seeTextEquals(str_wd, 'div'); // $ExpectType void
+wd.seeTextEquals(str); // $ExpectType void
+wd.seeTextEquals(str, 'div'); // $ExpectType void
 
 wd.seeInField(); // $ExpectError
 wd.seeInField('div'); // $ExpectError
-wd.seeInField('div', str_wd); // $ExpectType void
+wd.seeInField('div', str); // $ExpectType void
 
 wd.dontSeeInField(); // $ExpectError
 wd.dontSeeInField('div'); // $ExpectError
-wd.dontSeeInField('div', str_wd); // $ExpectType void
+wd.dontSeeInField('div', str); // $ExpectType void
 
 wd.seeCheckboxIsChecked(); // $ExpectError
 wd.seeCheckboxIsChecked('div'); // $ExpectType void
@@ -171,46 +173,46 @@ wd.dontSeeElementInDOM(); // $ExpectError
 wd.dontSeeElementInDOM('div'); // $ExpectType void
 
 wd.seeInSource(); // $ExpectError
-wd.seeInSource(str_wd); // $ExpectType void
+wd.seeInSource(str); // $ExpectType void
 
 wd.dontSeeInSource(); // $ExpectError
-wd.dontSeeInSource(str_wd); // $ExpectType void
+wd.dontSeeInSource(str); // $ExpectType void
 
 wd.seeNumberOfElements(); // $ExpectError
 wd.seeNumberOfElements('div'); // $ExpectError
-wd.seeNumberOfElements('div', num_wd); // $ExpectType void
+wd.seeNumberOfElements('div', num); // $ExpectType void
 
 wd.seeNumberOfVisibleElements(); // $ExpectError
 wd.seeNumberOfVisibleElements('div'); // $ExpectError
-wd.seeNumberOfVisibleElements('div', num_wd); // $ExpectType void
+wd.seeNumberOfVisibleElements('div', num); // $ExpectType void
 
 wd.seeCssPropertiesOnElements(); // $ExpectError
 wd.seeCssPropertiesOnElements('div'); // $ExpectError
-wd.seeCssPropertiesOnElements('div', str_wd); // $ExpectType void
+wd.seeCssPropertiesOnElements('div', str); // $ExpectType void
 
 wd.seeAttributesOnElements(); // $ExpectError
 wd.seeAttributesOnElements('div'); // $ExpectError
-wd.seeAttributesOnElements('div', str_wd); // $ExpectType void
+wd.seeAttributesOnElements('div', str); // $ExpectType void
 
 wd.seeInCurrentUrl(); // $ExpectError
-wd.seeInCurrentUrl(str_wd); // $ExpectType void
+wd.seeInCurrentUrl(str); // $ExpectType void
 
 wd.seeCurrentUrlEquals(); // $ExpectError
-wd.seeCurrentUrlEquals(str_wd); // $ExpectType void
+wd.seeCurrentUrlEquals(str); // $ExpectType void
 
 wd.dontSeeInCurrentUrl(); // $ExpectError
-wd.dontSeeInCurrentUrl(str_wd); // $ExpectType void
+wd.dontSeeInCurrentUrl(str); // $ExpectType void
 
 wd.dontSeeCurrentUrlEquals(); // $ExpectError
-wd.dontSeeCurrentUrlEquals(str_wd); // $ExpectType void
+wd.dontSeeCurrentUrlEquals(str); // $ExpectType void
 
 wd.executeScript(); // $ExpectError
-wd.executeScript(str_wd); // $ExpectType void
+wd.executeScript(str); // $ExpectType void
 wd.executeScript(() => {}); // $ExpectType void
 wd.executeScript(() => {}, {}); // $ExpectType void
 
 wd.executeAsyncScript(); // $ExpectError
-wd.executeAsyncScript(str_wd); // $ExpectType void
+wd.executeAsyncScript(str); // $ExpectType void
 wd.executeAsyncScript(() => {}); // $ExpectType void
 wd.executeAsyncScript(() => {}, {}); // $ExpectType void
 
@@ -220,126 +222,126 @@ wd.scrollIntoView('div', { behavior: 'auto', block: 'center', inline: 'center' }
 
 wd.scrollTo(); // $ExpectError
 wd.scrollTo('div'); // $ExpectType void
-wd.scrollTo('div', num_wd, num_wd); // $ExpectType void
+wd.scrollTo('div', num, num); // $ExpectType void
 
 wd.moveCursorTo(); // $ExpectError
 wd.moveCursorTo('div'); // $ExpectType void
-wd.moveCursorTo('div', num_wd, num_wd); // $ExpectType void
+wd.moveCursorTo('div', num, num); // $ExpectType void
 
 wd.saveScreenshot(); // $ExpectError
-wd.saveScreenshot(str_wd); // $ExpectType void
-wd.saveScreenshot(str_wd, true); // $ExpectType void
+wd.saveScreenshot(str); // $ExpectType void
+wd.saveScreenshot(str, true); // $ExpectType void
 
 wd.setCookie(); // $ExpectError
-wd.setCookie({ name: str_wd, value: str_wd }); // $ExpectType void
-wd.setCookie([{ name: str_wd, value: str_wd }]); // $ExpectType void
+wd.setCookie({ name: str, value: str }); // $ExpectType void
+wd.setCookie([{ name: str, value: str }]); // $ExpectType void
 
 wd.clearCookie(); // $ExpectType void
-wd.clearCookie(str_wd); // $ExpectType void
+wd.clearCookie(str); // $ExpectType void
 
 wd.seeCookie(); // $ExpectError
-wd.seeCookie(str_wd); // $ExpectType void
+wd.seeCookie(str); // $ExpectType void
 
 wd.acceptPopup(); // $ExpectType void
 
 wd.cancelPopup(); // $ExpectType void
 
 wd.seeInPopup(); // $ExpectError
-wd.seeInPopup(str_wd); // $ExpectType void
+wd.seeInPopup(str); // $ExpectType void
 
 wd.pressKeyDown(); // $ExpectError
-wd.pressKeyDown(str_wd); // $ExpectType void
+wd.pressKeyDown(str); // $ExpectType void
 
 wd.pressKeyUp(); // $ExpectError
-wd.pressKeyUp(str_wd); // $ExpectType void
+wd.pressKeyUp(str); // $ExpectType void
 
 wd.pressKey(); // $ExpectError
-wd.pressKey(str_wd); // $ExpectType void
+wd.pressKey(str); // $ExpectType void
 
 wd.type(); // $ExpectError
-wd.type(str_wd); // $ExpectType void
+wd.type(str); // $ExpectType void
 
 wd.resizeWindow(); // $ExpectError
-wd.resizeWindow(num_wd); // $ExpectError
-wd.resizeWindow(num_wd, num_wd); // $ExpectType void
+wd.resizeWindow(num); // $ExpectError
+wd.resizeWindow(num, num); // $ExpectType void
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('div'); // $ExpectError
 wd.dragAndDrop('div', 'div'); // $ExpectType void
 
 wd.dragSlider(); // $ExpectError
-wd.dragSlider('div', num_wd); // $ExpectType void
+wd.dragSlider('div', num); // $ExpectType void
 
 wd.switchToWindow(); // $ExpectError
-wd.switchToWindow(str_wd); // $ExpectType void
+wd.switchToWindow(str); // $ExpectType void
 
 wd.closeOtherTabs(); // $ExpectType void
 
 wd.wait(); // $ExpectError
-wd.wait(num_wd); // $ExpectType void
+wd.wait(num); // $ExpectType void
 
 wd.waitForEnabled(); // $ExpectError
 wd.waitForEnabled('div'); // $ExpectType void
-wd.waitForEnabled('div', num_wd); // $ExpectType void
+wd.waitForEnabled('div', num); // $ExpectType void
 
 wd.waitForElement(); // $ExpectError
 wd.waitForElement('div'); // $ExpectType void
-wd.waitForElement('div', num_wd); // $ExpectType void
+wd.waitForElement('div', num); // $ExpectType void
 
 wd.waitForClickable(); // $ExpectError
 wd.waitForClickable('div'); // $ExpectType void
-wd.waitForClickable('div', num_wd); // $ExpectType void
+wd.waitForClickable('div', num); // $ExpectType void
 
 wd.waitForVisible(); // $ExpectError
 wd.waitForVisible('div'); // $ExpectType void
-wd.waitForVisible('div', num_wd); // $ExpectType void
+wd.waitForVisible('div', num); // $ExpectType void
 
 wd.waitForInvisible(); // $ExpectError
 wd.waitForInvisible('div'); // $ExpectType void
-wd.waitForInvisible('div', num_wd); // $ExpectType void
+wd.waitForInvisible('div', num); // $ExpectType void
 
 wd.waitToHide(); // $ExpectError
 wd.waitToHide('div'); // $ExpectType void
-wd.waitToHide('div', num_wd); // $ExpectType void
+wd.waitToHide('div', num); // $ExpectType void
 
 wd.waitForDetached(); // $ExpectError
 wd.waitForDetached('div'); // $ExpectType void
-wd.waitForDetached('div', num_wd); // $ExpectType void
+wd.waitForDetached('div', num); // $ExpectType void
 
 wd.waitForFunction(); // $ExpectError
 wd.waitForFunction('div'); // $ExpectType void
 wd.waitForFunction(() => {}); // $ExpectType void
-wd.waitForFunction(() => {}, [num_wd], num_wd); // $ExpectType void
-wd.waitForFunction(() => {}, [str_wd], num_wd); // $ExpectType void
+wd.waitForFunction(() => {}, [num], num); // $ExpectType void
+wd.waitForFunction(() => {}, [str], num); // $ExpectType void
 
 wd.waitInUrl(); // $ExpectError
-wd.waitInUrl(str_wd); // $ExpectType void
-wd.waitInUrl(str_wd, num_wd); // $ExpectType void
+wd.waitInUrl(str); // $ExpectType void
+wd.waitInUrl(str, num); // $ExpectType void
 
 wd.waitForText(); // $ExpectError
-wd.waitForText(str_wd); // $ExpectType void
-wd.waitForText(str_wd, num_wd, str_wd); // $ExpectType void
+wd.waitForText(str); // $ExpectType void
+wd.waitForText(str, num, str); // $ExpectType void
 
 wd.waitForValue(); // $ExpectError
-wd.waitForValue(str_wd); // $ExpectError
-wd.waitForValue(str_wd, str_wd); // $ExpectType void
-wd.waitForValue(str_wd, str_wd, num_wd); // $ExpectType void
+wd.waitForValue(str); // $ExpectError
+wd.waitForValue(str, str); // $ExpectType void
+wd.waitForValue(str, str, num); // $ExpectType void
 
 wd.waitNumberOfVisibleElements(); // $ExpectError
 wd.waitNumberOfVisibleElements('div'); // $ExpectError
-wd.waitNumberOfVisibleElements(str_wd, num_wd); // $ExpectType void
-wd.waitNumberOfVisibleElements(str_wd, num_wd, num_wd); // $ExpectType void
+wd.waitNumberOfVisibleElements(str, num); // $ExpectType void
+wd.waitNumberOfVisibleElements(str, num, num); // $ExpectType void
 
 wd.waitUrlEquals(); // $ExpectError
-wd.waitUrlEquals(str_wd); // $ExpectType void
-wd.waitUrlEquals(str_wd, num_wd); // $ExpectType void
+wd.waitUrlEquals(str); // $ExpectType void
+wd.waitUrlEquals(str, num); // $ExpectType void
 
 wd.switchTo(); // $ExpectType void
 wd.switchTo('div'); // $ExpectType void
 
-wd.switchToNextTab(num_wd, num_wd); // $ExpectType void
+wd.switchToNextTab(num, num); // $ExpectType void
 
-wd.switchToPreviousTab(num_wd, num_wd); // $ExpectType void
+wd.switchToPreviousTab(num, num); // $ExpectType void
 
 wd.closeCurrentTab(); // $ExpectType void
 
@@ -352,12 +354,12 @@ wd.scrollPageToTop(); // $ExpectType void
 wd.scrollPageToBottom(); // $ExpectType void
 
 wd.setGeoLocation(); // $ExpectError
-wd.setGeoLocation(num_wd); // $ExpectError
-wd.setGeoLocation(num_wd, num_wd); // $ExpectType void
-wd.setGeoLocation(num_wd, num_wd, num_wd); // $ExpectType void
+wd.setGeoLocation(num); // $ExpectError
+wd.setGeoLocation(num, num); // $ExpectType void
+wd.setGeoLocation(num, num, num); // $ExpectType void
 
 wd.dontSeeCookie(); // $ExpectError
-wd.dontSeeCookie(str_wd); // $ExpectType void
+wd.dontSeeCookie(str); // $ExpectType void
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('#dragHandle'); // $ExpectError


### PR DESCRIPTION
## Motivation/Description of the PR
- Provide TypeScript definitions for all helper methods with promise,
- Add new configuration `fullPromiseBased` to refer the promise-based definition.
- Fix runner-related tests and add typing tests

Applicable helpers:

- [X] WebDriver
- [X] Puppeteer
- [X] Nightmare
- [X] REST
- [X] FileHelper
- [X] Appium
- [X] Protractor
- [X] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [X] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
