### PR TITLE
do not change config values while validating

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -186,7 +186,7 @@ class Appium extends Webdriver {
     config.capabilities.app = config.app || config.capabilities.app;
     config.capabilities.platformName = config.platform || config.capabilities.platformName;
     config.capabilities.tunnelIdentifier = config.tunnelIdentifier || config.capabilities.tunnelIdentifier; // Adding the code to connect to sauce labs via sauce tunnel
-    config.waitForTimeout /= 1000; // convert to seconds
+    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000; // convert to seconds
 
     // [CodeceptJS compatible] transform host to hostname
     config.hostname = config.host || config.hostname;
@@ -1165,7 +1165,7 @@ class Appium extends Webdriver {
         direction = 'swipeRight';
         break;
     }
-    timeout = timeout || this.options.waitForTimeout;
+    timeout = timeout || this.options.waitForTimeoutInSeconds;
 
     const errorMsg = `element ("${searchableLocator}") still not visible after ${timeout}seconds`;
     const browser = this.browser;

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -153,7 +153,7 @@ class Protractor extends Helper {
     if (config.proxy) config.capabilities.proxy = config.proxy;
     if (config.browser) config.capabilities.browserName = config.browser;
 
-    config.waitForTimeout /= 1000; // convert to seconds
+    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000; // convert to seconds
     return config;
   }
 
@@ -1348,7 +1348,7 @@ class Protractor extends Helper {
    * {{> waitForElement }}
    */
   async waitForElement(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
     return this.browser.wait(EC.presenceOf(el), aSec * 1000);
   }
@@ -1364,7 +1364,7 @@ class Protractor extends Helper {
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
     return this.browser.wait(EC.not(EC.presenceOf(el)), aSec * 1000).catch((err) => {
       if (err.message && err.message.indexOf('Wait timed out after') > -1) {
@@ -1381,7 +1381,7 @@ class Protractor extends Helper {
    * ```
    */
   async waitForClickable(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
     return this.browser.wait(EC.elementToBeClickable(el), aSec * 1000);
   }
@@ -1390,7 +1390,7 @@ class Protractor extends Helper {
    * {{> waitForVisible }}
    */
   async waitForVisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
     return this.browser.wait(EC.visibilityOf(el), aSec * 1000);
   }
@@ -1406,7 +1406,7 @@ class Protractor extends Helper {
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
     return this.browser.wait(EC.invisibilityOf(el), aSec * 1000);
   }
@@ -1431,7 +1431,7 @@ class Protractor extends Helper {
       };
     }
 
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const guessLoc = guessLocator(locator) || global.by.css(locator);
 
     return this.browser.wait(visibilityCountOf(guessLoc, num), aSec * 1000)
@@ -1444,7 +1444,7 @@ class Protractor extends Helper {
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const el = global.element(guessLocator(locator) || global.by.css(locator));
 
     return this.browser.wait(EC.elementToBeClickable(el), aSec * 1000)
@@ -1457,7 +1457,7 @@ class Protractor extends Helper {
    * {{> waitForValue }}
    */
   async waitForValue(field, value, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     const valueToBeInElementValue = (loc) => {
       return async () => {
@@ -1490,7 +1490,7 @@ class Protractor extends Helper {
       }
     }
 
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     return this.browser.wait(() => this.browser.executeScript.call(this.browser, fn, ...args), aSec * 1000);
   }
 
@@ -1498,7 +1498,7 @@ class Protractor extends Helper {
    * {{> waitInUrl }}
    */
   async waitInUrl(urlPart, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const waitTimeout = aSec * 1000;
 
     return this.browser.wait(EC.urlContains(urlPart), waitTimeout)
@@ -1516,7 +1516,7 @@ class Protractor extends Helper {
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const waitTimeout = aSec * 1000;
     const baseUrl = this.options.url;
     if (urlPart.indexOf('http') < 0) {
@@ -1542,7 +1542,7 @@ class Protractor extends Helper {
       context = this.context;
     }
     const el = global.element(guessLocator(context) || global.by.css(context));
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     return this.browser.wait(EC.textToBePresentInElement(el, text), aSec * 1000);
   }
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -463,7 +463,7 @@ class WebDriver extends Helper {
       delete config.capabilities.selenoidOptions;
     }
 
-    config.waitForTimeout /= 1000; // convert to seconds
+    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000; // convert to seconds
 
     if (!config.capabilities.platformName && (!config.url || !config.browser)) {
       throw new Error(`
@@ -2042,7 +2042,7 @@ class WebDriver extends Helper {
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2076,7 +2076,7 @@ class WebDriver extends Helper {
    * {{> waitForElement }}
    */
   async waitForElement(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2093,7 +2093,7 @@ class WebDriver extends Helper {
    * {{> waitForClickable }}
    */
   async waitForClickable(locator, waitTimeout) {
-    waitTimeout = waitTimeout || this.options.waitForTimeout;
+    waitTimeout = waitTimeout || this.options.waitForTimeoutInSeconds;
     let res = await this._locate(locator);
     res = usingFirstElement(res);
     assertElementExists(res, locator);
@@ -2109,7 +2109,7 @@ class WebDriver extends Helper {
    */
   async waitInUrl(urlPart, sec = null) {
     const client = this.browser;
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     let currUrl = '';
     if (isWebDriver5()) {
       return client
@@ -2143,7 +2143,7 @@ class WebDriver extends Helper {
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const baseUrl = this.options.url;
     if (urlPart.indexOf('http') < 0) {
       urlPart = baseUrl + urlPart;
@@ -2167,7 +2167,7 @@ class WebDriver extends Helper {
    *
    */
   async waitForText(text, sec = null, context = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const _context = context || this.root;
     if (isWebDriver5()) {
       return this.browser.waitUntil(
@@ -2205,7 +2205,7 @@ class WebDriver extends Helper {
    */
   async waitForValue(field, value, sec = null) {
     const client = this.browser;
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return client.waitUntil(
         async () => {
@@ -2241,7 +2241,7 @@ class WebDriver extends Helper {
    *
    */
   async waitForVisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2268,7 +2268,7 @@ class WebDriver extends Helper {
    * {{> waitNumberOfVisibleElements }}
    */
   async waitNumberOfVisibleElements(locator, num, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2295,7 +2295,7 @@ class WebDriver extends Helper {
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
@@ -2323,7 +2323,7 @@ class WebDriver extends Helper {
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => {
         const res = await this._res(locator);
@@ -2355,7 +2355,7 @@ class WebDriver extends Helper {
       }
     }
 
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     if (isWebDriver5()) {
       return this.browser.waitUntil(async () => this.browser.execute(fn, ...args), aSec * 1000, '');
     }
@@ -2384,7 +2384,7 @@ class WebDriver extends Helper {
    * {{> switchToNextTab }}
    */
   async switchToNextTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     let target;
     const current = await this.browser.getWindowHandle();
 
@@ -2415,7 +2415,7 @@ class WebDriver extends Helper {
    * {{> switchToPreviousTab }}
    */
   async switchToPreviousTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeout;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
     const current = await this.browser.getWindowHandle();
     let target;
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Every time a WebDriver Config gets validated (e.g. setting / resetting Config For a Scenario or using Selenoid) `waitForTimeout` gets converted from ms to sec. Now a new config key gets created with the converted value and is used in the wait* functions where seconds are needed.
- Resolves #2589

Applicable helpers:

- [X] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [X] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
