### PR TITLE
String type to gherkin.steps config to support file pattern string

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -257,7 +257,7 @@ declare namespace CodeceptJS {
       /** load feature files by pattern. Multiple patterns can be specified as array */
       features: string | Array<string>,
       /** load step definitions from JS files */
-      steps: Array<string>
+      steps: string | Array<string>
     };
 
     [key: string]: any;


### PR DESCRIPTION
## Motivation/Description of the PR
- Add missing type definition
- Resolves #3474

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [-] Local tests are passed (Run `npm test`)

## Comments
**Linting**
No new issue. The existing one for `typings/index.d.ts` could be fixed with an `eslint` configuration [override](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#how-do-overrides-work) in `.eslintrc.json` to use a Typescript parser for this file.

**Test**
No test failure caused by type change.

Test run on Windows 10 with failures:
- Failed in FileSystem test - probably related to CRLF issue
- Timeout test `test\runner\timeout_test.js` failed -> not sure what caused it