### PR TITLE
Bstack local+parallel support

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -1,6 +1,8 @@
 const { fork } = require('child_process');
 const path = require('path');
 const crypto = require('crypto');
+const BStackLocal = require('browserstack-local').Local;
+const util = require('util');
 
 const runHook = require('../hooks');
 const event = require('../event');
@@ -25,6 +27,57 @@ let runId = 1;
 let subprocessCount = 0;
 let totalSubprocessCount = 0;
 let processesDone;
+
+class LocalTunnel {
+  constructor(config = {}) {
+    this.key = null;
+    this.browserstackLocal = false;
+    this.opts = {};
+    if (config.helpers && config.helpers.WebDriver && config.helpers.WebDriver.key) {
+      this.key = config.helpers.WebDriver.key;
+    }
+    if (config.plugins && config.plugins.wdio) {
+      if (config.plugins.wdio.key) {
+        this.key = config.plugins.wdio.key;
+      }
+      if (config.plugins.wdio.browserstackLocal) {
+        this.browserstackLocal = true;
+        config.plugins.wdio.browserstackLocal = false;
+      }
+      if (config.plugins.wdio.opts) {
+        this.opts = config.plugins.wdio.opts;
+      }
+    }
+    this.config = config;
+    this.local = new BStackLocal();
+  }
+
+  async start() {
+    if (this.browserstackLocal && this.key) {
+      try {
+        await util.promisify(this.local.start.bind(this.local))({ key: this.key, ...this.opts });
+        for (const key in this.config.multiple) {
+          if (this.config.multiple[key].browsers) {
+            this.config.multiple[key].browsers.forEach(browser => {
+              browser.desiredCapabilities && (browser.desiredCapabilities['bstack:options'].local = true);
+            });
+          }
+        }
+        this.localStarted = true;
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  }
+
+  async stop() {
+    try {
+      this.localStarted && await util.promisify(this.local.stop.bind(this.local))();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+}
 
 module.exports = async function (selectedRuns, options) {
   // registering options globally to use in config
@@ -63,6 +116,10 @@ module.exports = async function (selectedRuns, options) {
   }
 
   await runHook(config.bootstrapAll, 'bootstrapAll');
+
+  const localTunnel = new LocalTunnel(config);
+  // spawn local
+  await runHook(localTunnel.start.bind(localTunnel), 'LocalTunnelStart');
 
   event.emit(event.multiple.before, null);
   if (options.config) { // update paths to config path
@@ -104,6 +161,7 @@ module.exports = async function (selectedRuns, options) {
   return childProcessesPromise.then(async () => {
     // fire hook
     await runHook(config.teardownAll, 'teardownAll');
+    await runHook(localTunnel.stop.bind(localTunnel), 'LocalTunnelStop');
     event.emit(event.multiple.after, null);
   });
 };

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -1,15 +1,13 @@
 const { fork } = require('child_process');
 const path = require('path');
 const crypto = require('crypto');
-const BStackLocal = require('browserstack-local').Local;
-const util = require('util');
 
 const runHook = require('../hooks');
 const event = require('../event');
 const collection = require('./run-multiple/collection');
 const { clearString, replaceValueDeep } = require('../utils');
 const {
-  getConfig, getTestRoot, fail,
+  getConfig, getTestRoot, fail, LocalTunnel,
 } = require('./utils');
 
 const runner = path.join(__dirname, '/../../bin/codecept');
@@ -27,57 +25,6 @@ let runId = 1;
 let subprocessCount = 0;
 let totalSubprocessCount = 0;
 let processesDone;
-
-class LocalTunnel {
-  constructor(config = {}) {
-    this.key = null;
-    this.browserstackLocal = false;
-    this.opts = {};
-    if (config.helpers && config.helpers.WebDriver && config.helpers.WebDriver.key) {
-      this.key = config.helpers.WebDriver.key;
-    }
-    if (config.plugins && config.plugins.wdio) {
-      if (config.plugins.wdio.key) {
-        this.key = config.plugins.wdio.key;
-      }
-      if (config.plugins.wdio.browserstackLocal) {
-        this.browserstackLocal = true;
-        config.plugins.wdio.browserstackLocal = false;
-      }
-      if (config.plugins.wdio.opts) {
-        this.opts = config.plugins.wdio.opts;
-      }
-    }
-    this.config = config;
-    this.local = new BStackLocal();
-  }
-
-  async start() {
-    if (this.browserstackLocal && this.key) {
-      try {
-        await util.promisify(this.local.start.bind(this.local))({ key: this.key, ...this.opts });
-        for (const key in this.config.multiple) {
-          if (this.config.multiple[key].browsers) {
-            this.config.multiple[key].browsers.forEach(browser => {
-              browser.desiredCapabilities && (browser.desiredCapabilities['bstack:options'].local = true);
-            });
-          }
-        }
-        this.localStarted = true;
-      } catch (err) {
-        console.log(err);
-      }
-    }
-  }
-
-  async stop() {
-    try {
-      this.localStarted && await util.promisify(this.local.stop.bind(this.local))();
-    } catch (err) {
-      console.log(err);
-    }
-  }
-}
 
 module.exports = async function (selectedRuns, options) {
   // registering options globally to use in config

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -3,6 +3,7 @@ const path = require('path');
 const semver = require('semver');
 const util = require('util');
 const mkdirp = require('mkdirp');
+const BStackLocal = require('browserstack-local').Local;
 
 const output = require('../output');
 const { fileExists, beautify } = require('../utils');
@@ -112,5 +113,62 @@ module.exports.createOutputDir = (config, testRoot) => {
   if (!fileExists(outputDir)) {
     output.print(`creating output directory: ${outputDir}`);
     mkdirp.sync(outputDir);
+  }
+};
+
+module.exports.LocalTunnel = class LocalTunnel {
+  constructor(config = {}) {
+    this.key = null;
+    this.browserstackLocal = false;
+    this.opts = {};
+    if (config.helpers && config.helpers.WebDriver && config.helpers.WebDriver.key) {
+      this.key = config.helpers.WebDriver.key;
+    }
+    if (config.plugins && config.plugins.wdio) {
+      if (config.plugins.wdio.key) {
+        this.key = config.plugins.wdio.key;
+      }
+      if (config.plugins.wdio.browserstackLocal) {
+        this.browserstackLocal = true;
+        config.plugins.wdio.browserstackLocal = false;
+      }
+      if (config.plugins.wdio.opts) {
+        this.opts = config.plugins.wdio.opts;
+      }
+    }
+    this.config = config;
+    this.local = new BStackLocal();
+  }
+
+  async start() {
+    if (this.browserstackLocal && this.key) {
+      try {
+        await util.promisify(this.local.start.bind(this.local))({ key: this.key, ...this.opts });
+        for (const key in this.config.multiple) {
+          if (this.config.multiple[key].browsers) {
+            this.config.multiple[key].browsers.forEach(browser => {
+              if (browser.desiredCapabilities) {
+                if (browser.desiredCapabilities['bstack:options']) {
+                  browser.desiredCapabilities['bstack:options'].local = true;
+                } else {
+                  browser.desiredCapabilities['browserstack.local'] = true;
+                }
+              }
+            });
+          }
+        }
+        this.localStarted = true;
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  }
+
+  async stop() {
+    try {
+      this.localStarted && await util.promisify(this.local.stop.bind(this.local))();
+    } catch (err) {
+      console.log(err);
+    }
   }
 };

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -158,6 +158,13 @@ module.exports.LocalTunnel = class LocalTunnel {
                 } else {
                   browser.desiredCapabilities['bstack:options'].local = true;
                 }
+                if (this.opts.localIdentifier) {
+                  if (browser.desiredCapabilities['bstack:options']) {
+                    browser.desiredCapabilities['bstack:options'].localIdentifier = this.opts.localIdentifier;
+                  } else {
+                    browser.desiredCapabilities['browserstack.localIdentifier'] = this.opts.localIdentifier;
+                  }
+                }
               }
             });
           }

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -169,6 +169,14 @@ module.exports.LocalTunnel = class LocalTunnel {
             });
           }
         }
+        // Handle local stop on sigint
+        let signal = 0;
+        const handler = async () => {
+          signal++;
+          signal === 1 && await this.stop();
+        };
+        process.on('SIGINT', handler);
+        process.on('SIGTERM', handler);
         this.localStarted = true;
       } catch (err) {
         module.exports.printError(err);

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -171,7 +171,7 @@ module.exports.LocalTunnel = class LocalTunnel {
         }
         this.localStarted = true;
       } catch (err) {
-        console.log(err);
+        module.exports.printError(err);
       }
     }
   }
@@ -180,7 +180,7 @@ module.exports.LocalTunnel = class LocalTunnel {
     try {
       this.localStarted && await util.promisify(this.local.stop.bind(this.local))();
     } catch (err) {
-      console.log(err);
+      module.exports.printError(err);
     }
   }
 };

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -148,10 +148,15 @@ module.exports.LocalTunnel = class LocalTunnel {
           if (this.config.multiple[key].browsers) {
             this.config.multiple[key].browsers.forEach(browser => {
               if (browser.desiredCapabilities) {
-                if (browser.desiredCapabilities['bstack:options']) {
-                  browser.desiredCapabilities['bstack:options'].local = true;
+                if (!browser.desiredCapabilities['bstack:options']) {
+                  const extensionCaps = Object.keys(browser.desiredCapabilities).filter((cap) => cap.includes(':'));
+                  if (extensionCaps.length) {
+                    browser.desiredCapabilities['bstack:options'] = { local: true };
+                  } else {
+                    browser.desiredCapabilities['browserstack.local'] = true;
+                  }
                 } else {
-                  browser.desiredCapabilities['browserstack.local'] = true;
+                  browser.desiredCapabilities['bstack:options'].local = true;
                 }
               }
             });

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "allure-js-commons": "^1.3.2",
     "arrify": "^2.0.1",
     "axios": "^0.21.4",
+    "browserstack-local": "^1.5.1",
     "chai": "^4.3.6",
     "chai-deep-match": "^1.2.1",
     "chalk": "^4.1.2",
@@ -86,8 +87,8 @@
     "promise-retry": "^1.1.1",
     "requireg": "^0.2.2",
     "resq": "^1.10.2",
-    "sprintf-js": "^1.1.1",
     "semver": "^6.3.0",
+    "sprintf-js": "^1.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Motivation/Description of the PR
- Spawning browserstack local tunnel from wdio `browserstack-service` in multiple mode throws, 
`LocalError: Either another browserstack local client is running on your machine or some server is listening on port 45691`. As multiple wdio services trying to spawn local in parallel.
To solve above issue spawning local on main process during run-multiple with browserstack.local caps injection and removing `browserstackLocal: true` option from wdio plugin options.

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [x] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
