### PR TITLE
Fix a broken link

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -290,7 +290,6 @@ I.waitForElement('#agree_button', 30); // secs
 // clicks a button only when it is visible
 I.click('#agree_button');
 ```
-> ℹ See [helpers reference](/helpers) for a complete list of all available commands for the helper you use.
 
 ## How It Works
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -290,7 +290,7 @@ I.waitForElement('#agree_button', 30); // secs
 // clicks a button only when it is visible
 I.click('#agree_button');
 ```
-> ℹ See [helpers reference](/reference) for a complete list of all available commands for the helper you use.
+> ℹ See [helpers reference](/helpers) for a complete list of all available commands for the helper you use.
 
 ## How It Works
 


### PR DESCRIPTION
## Motivation/Description of the PR

"helpers reference" is available in `/helpers`,  and `/reference` leads to 404.
