### PR TITLE
add locator to all calls of assertElementExists

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -880,7 +880,7 @@ class Playwright extends Helper {
    */
   async moveCursorTo(locator, offsetX = 0, offsetY = 0) {
     const els = await this._locate(locator);
-    assertElementExists(els);
+    assertElementExists(els, locator);
 
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
     const { x, y } = await clickablePoint(els[0]);
@@ -1477,7 +1477,7 @@ class Playwright extends Helper {
       throw new Error(`File at ${file} can not be found on local system`);
     }
     const els = await findFields.call(this, locator);
-    assertElementExists(els, 'Field');
+    assertElementExists(els, locator, 'Field');
     await els[0].setInputFiles(file);
     return this._waitForAction();
   }

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -722,7 +722,7 @@ class Protractor extends Helper {
    */
   async grabTextFrom(locator) {
     const texts = await this.grabTextFromAll(locator);
-    assertElementExists(texts);
+    assertElementExists(texts, locator);
     if (texts.length > 1) {
       this.debugSection('GrabText', `Using first element out of ${texts.length}`);
     }
@@ -748,7 +748,7 @@ class Protractor extends Helper {
    */
   async grabHTMLFrom(locator) {
     const html = await this.grabHTMLFromAll(locator);
-    assertElementExists(html);
+    assertElementExists(html, locator);
     if (html.length > 1) {
       this.debugSection('GrabHTMl', `Using first element out of ${html.length}`);
     }
@@ -1200,8 +1200,8 @@ class Protractor extends Helper {
   async dragAndDrop(srcElement, destElement) {
     const srcEl = await this._locate(srcElement, true);
     const destEl = await this._locate(destElement, true);
-    assertElementExists(srcEl);
-    assertElementExists(destEl);
+    assertElementExists(srcEl, srcElement);
+    assertElementExists(destEl, destElement);
     return this.browser
       .actions()
       .dragAndDrop(srcEl[0], destEl[0])

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -696,7 +696,7 @@ class Puppeteer extends Helper {
    */
   async moveCursorTo(locator, offsetX = 0, offsetY = 0) {
     const els = await this._locate(locator);
-    assertElementExists(els);
+    assertElementExists(els, locator);
 
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
     const { x, y } = await getClickablePoint(els[0]);
@@ -1336,7 +1336,7 @@ class Puppeteer extends Helper {
       throw new Error(`File at ${file} can not be found on local system`);
     }
     const els = await findFields.call(this, locator);
-    assertElementExists(els, 'Field');
+    assertElementExists(els, locator, 'Field');
     await els[0].uploadFile(file);
     return this._waitForAction();
   }

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -448,7 +448,7 @@ class TestCafe extends Helper {
    */
   async moveCursorTo(locator, offsetX = 0, offsetY = 0) {
     const els = (await findElements.call(this, this.context, locator)).filterVisible();
-    await assertElementExists(els);
+    await assertElementExists(els, locator);
 
     return this.t
       .hover(els.nth(0), { offsetX, offsetY })
@@ -485,7 +485,7 @@ class TestCafe extends Helper {
       matcher = await els.nth(0);
     }
     const els = (await findClickable.call(this, matcher, locator)).filterVisible();
-    assertElementExists(els);
+    assertElementExists(els, locator);
     return this.t
       .rightClick(els.nth(0))
       .catch(mapError);
@@ -761,7 +761,7 @@ class TestCafe extends Helper {
     const outputFile = path.join(global.output_dir, fileName);
 
     const sel = await findElements.call(this, this.context, locator);
-    assertElementExists(sel);
+    assertElementExists(sel, locator);
     const firstElement = await sel.filterVisible().nth(0);
 
     this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
@@ -818,7 +818,7 @@ class TestCafe extends Helper {
    */
   async grabTextFrom(locator) {
     const sel = await findElements.call(this, this.context, locator);
-    assertElementExists(sel);
+    assertElementExists(sel, locator);
     const texts = await this.grabTextFromAll(locator);
     if (texts.length > 1) {
       this.debugSection('GrabText', `Using first element out of ${texts.length}`);
@@ -846,7 +846,7 @@ class TestCafe extends Helper {
    */
   async grabAttributeFrom(locator, attr) {
     const sel = await findElements.call(this, this.context, locator);
-    assertElementExists(sel);
+    assertElementExists(sel, locator);
     const attrs = await this.grabAttributeFromAll(locator, attr);
     if (attrs.length > 1) {
       this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`);
@@ -874,7 +874,7 @@ class TestCafe extends Helper {
    */
   async grabValueFrom(locator) {
     const sel = await findElements.call(this, this.context, locator);
-    assertElementExists(sel);
+    assertElementExists(sel, locator);
     const values = await this.grabValueFromAll(locator);
     if (values.length > 1) {
       this.debugSection('GrabValue', `Using first element out of ${values.length}`);

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1201,7 +1201,7 @@ class WebDriver extends Helper {
    */
   async grabHTMLFrom(locator) {
     const html = await this.grabHTMLFromAll(locator);
-    assertElementExists(html);
+    assertElementExists(html, locator);
     if (html.length > 1) {
       this.debugSection('GrabHTML', `Using first element out of ${html.length}`);
     }
@@ -1611,7 +1611,7 @@ class WebDriver extends Helper {
    */
   async scrollIntoView(locator, scrollIntoViewOptions) {
     const res = await this._locate(withStrictLocator(locator), true);
-    assertElementExists(res);
+    assertElementExists(res, locator);
     const elem = usingFirstElement(res);
     return elem.scrollIntoView(scrollIntoViewOptions);
   }
@@ -1629,12 +1629,12 @@ class WebDriver extends Helper {
 
     if (locator) {
       const res = await this._locate(withStrictLocator(locator), true);
-      assertElementExists(res);
+      assertElementExists(res, locator);
       const elem = usingFirstElement(res);
       const elementId = getElementId(elem);
       if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(offsetX, offsetY, elementId);
       const location = await elem.getLocation();
-      assertElementExists(location, 'Failed to receive', 'location');
+      assertElementExists(location, locator, 'Failed to receive', 'location');
       /* eslint-disable prefer-arrow-callback */
       return this.browser.execute(function (x, y) { return window.scrollTo(x, y); }, location.x + offsetX, location.y + offsetY);
       /* eslint-enable */
@@ -1939,11 +1939,11 @@ class WebDriver extends Helper {
    */
   async dragAndDrop(srcElement, destElement) {
     let sourceEl = await this._locate(srcElement);
-    assertElementExists(sourceEl);
+    assertElementExists(sourceEl, srcElement);
     sourceEl = usingFirstElement(sourceEl);
 
     let destEl = await this._locate(destElement);
-    assertElementExists(destEl);
+    assertElementExists(destEl, destElement);
     destEl = usingFirstElement(destEl);
 
     return sourceEl.dragAndDrop(destEl);


### PR DESCRIPTION
## Motivation/Description of the PR
- Adds the Locator to every call of assertElementExist, because it is not optional and leads to `Element "{null: undefined}" was not found by text|CSS|XPath` if missing.

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
