### PR TITLE
Fix usage of locator in error messages

### DIFF
--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -128,7 +128,7 @@ class Nightmare extends Helper {
       this.evaluate_now((by, locator, contextEl) => {
         const res = window.codeceptjs.findAndStoreElement(by, locator, contextEl);
         if (res === null) {
-          throw new Error(`Element ${(new Locator(locator)).toString()} couldn't be located by ${by}`);
+          throw new Error(`Element ${(new Locator(locator))} couldn't be located by ${by}`);
         }
         return res;
       }, done, by, value, contextEl);
@@ -554,7 +554,7 @@ class Nightmare extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator))}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -562,7 +562,7 @@ class Nightmare extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator))}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1168,7 +1168,7 @@ class Nightmare extends Helper {
       height: Math.floor(rect.height),
     };
 
-    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator))} element has been saved to ${outputFile}`);
     // take the screenshot
     await this.browser.screenshot(outputFile, button_clip);
   }

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -128,7 +128,7 @@ class Nightmare extends Helper {
       this.evaluate_now((by, locator, contextEl) => {
         const res = window.codeceptjs.findAndStoreElement(by, locator, contextEl);
         if (res === null) {
-          throw new Error(`Element ${locator} couldn't be located by ${by}`);
+          throw new Error(`Element ${(new Locator(locator)).toString()} couldn't be located by ${by}`);
         }
         return res;
       }, done, by, value, contextEl);
@@ -554,7 +554,7 @@ class Nightmare extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${locator}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -562,7 +562,7 @@ class Nightmare extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${locator}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1168,7 +1168,7 @@ class Nightmare extends Helper {
       height: Math.floor(rect.height),
     };
 
-    this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
     // take the screenshot
     await this.browser.screenshot(outputFile, button_clip);
   }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1631,7 +1631,7 @@ class Playwright extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator))}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -1641,7 +1641,7 @@ class Playwright extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator))}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1863,7 +1863,7 @@ class Playwright extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator))}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1892,7 +1892,7 @@ class Playwright extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator))}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1956,7 +1956,7 @@ class Playwright extends Helper {
     assertElementExists(res, locator);
     if (res.length > 1) this.debug(`[Elements] Using first element out of ${res.length}`);
     const elem = res[0];
-    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator))} element has been saved to ${outputFile}`);
     return elem.screenshot({ path: outputFile, type: 'png' });
   }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1631,7 +1631,7 @@ class Playwright extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${locator}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -1641,7 +1641,7 @@ class Playwright extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${locator}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1863,7 +1863,7 @@ class Playwright extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${locator}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1892,7 +1892,7 @@ class Playwright extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${locator}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1956,7 +1956,7 @@ class Playwright extends Helper {
     assertElementExists(res, locator);
     if (res.length > 1) this.debug(`[Elements] Using first element out of ${res.length}`);
     const elem = res[0];
-    this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
     return elem.screenshot({ path: outputFile, type: 'png' });
   }
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -920,7 +920,7 @@ class Protractor extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${locator}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -928,7 +928,7 @@ class Protractor extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${locator}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -968,7 +968,7 @@ class Protractor extends Helper {
         missingAttributes.push(...missing);
       }
     }
-    return equals(`all elements (${locator}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0);
+    return equals(`all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0);
   }
 
   /**
@@ -995,7 +995,7 @@ class Protractor extends Helper {
       }
     }
 
-    return equals(`all elements (${locator}) to have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0);
+    return equals(`all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0);
   }
 
   /**
@@ -1060,7 +1060,7 @@ class Protractor extends Helper {
     assertElementExists(res, locator);
     if (res.length > 1) this.debug(`[Elements] Using first element out of ${res.length}`);
     const elem = res[0];
-    this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
     const png = await elem.takeScreenshot();
     return writeFile(png, outputFile);
   }
@@ -1436,7 +1436,7 @@ class Protractor extends Helper {
 
     return this.browser.wait(visibilityCountOf(guessLoc, num), aSec * 1000)
       .catch(() => {
-        throw Error(`The number of elements (${locator}) is not ${num} after ${aSec} sec`);
+        throw Error(`The number of elements (${(new Locator(locator)).toString()}) is not ${num} after ${aSec} sec`);
       });
   }
 
@@ -1449,7 +1449,7 @@ class Protractor extends Helper {
 
     return this.browser.wait(EC.elementToBeClickable(el), aSec * 1000)
       .catch(() => {
-        throw Error(`element (${locator}) still not enabled after ${aSec} sec`);
+        throw Error(`element (${(new Locator(locator)).toString()}) still not enabled after ${aSec} sec`);
       });
   }
 
@@ -1583,7 +1583,7 @@ class Protractor extends Helper {
     if (locator) {
       const res = await this._locate(locator, true);
       if (!res || res.length === 0) {
-        return truth(`elements of ${locator}`, 'to be seen').assert(false);
+        return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').assert(false);
       }
       const elem = res[0];
       const location = await elem.getLocation();

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -920,7 +920,7 @@ class Protractor extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator))}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -928,7 +928,7 @@ class Protractor extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator))}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -968,7 +968,7 @@ class Protractor extends Helper {
         missingAttributes.push(...missing);
       }
     }
-    return equals(`all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0);
+    return equals(`all elements (${(new Locator(locator))}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0);
   }
 
   /**
@@ -995,7 +995,7 @@ class Protractor extends Helper {
       }
     }
 
-    return equals(`all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0);
+    return equals(`all elements (${(new Locator(locator))}) to have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0);
   }
 
   /**
@@ -1060,7 +1060,7 @@ class Protractor extends Helper {
     assertElementExists(res, locator);
     if (res.length > 1) this.debug(`[Elements] Using first element out of ${res.length}`);
     const elem = res[0];
-    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator))} element has been saved to ${outputFile}`);
     const png = await elem.takeScreenshot();
     return writeFile(png, outputFile);
   }
@@ -1436,7 +1436,7 @@ class Protractor extends Helper {
 
     return this.browser.wait(visibilityCountOf(guessLoc, num), aSec * 1000)
       .catch(() => {
-        throw Error(`The number of elements (${(new Locator(locator)).toString()}) is not ${num} after ${aSec} sec`);
+        throw Error(`The number of elements (${(new Locator(locator))}) is not ${num} after ${aSec} sec`);
       });
   }
 
@@ -1449,7 +1449,7 @@ class Protractor extends Helper {
 
     return this.browser.wait(EC.elementToBeClickable(el), aSec * 1000)
       .catch(() => {
-        throw Error(`element (${(new Locator(locator)).toString()}) still not enabled after ${aSec} sec`);
+        throw Error(`element (${(new Locator(locator))}) still not enabled after ${aSec} sec`);
       });
   }
 
@@ -1583,7 +1583,7 @@ class Protractor extends Helper {
     if (locator) {
       const res = await this._locate(locator, true);
       if (!res || res.length === 0) {
-        return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').assert(false);
+        return truth(`elements of ${(new Locator(locator))}`, 'to be seen').assert(false);
       }
       const elem = res[0];
       const location = await elem.getLocation();

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1491,7 +1491,7 @@ class Puppeteer extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${locator}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -1501,7 +1501,7 @@ class Puppeteer extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${locator}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1725,7 +1725,7 @@ class Puppeteer extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${locator}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1756,7 +1756,7 @@ class Puppeteer extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${locator}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1819,7 +1819,7 @@ class Puppeteer extends Helper {
     assertElementExists(res, locator);
     if (res.length > 1) this.debug(`[Elements] Using first element out of ${res.length}`);
     const elem = res[0];
-    this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
     return elem.screenshot({ path: outputFile, type: 'png' });
   }
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1491,7 +1491,7 @@ class Puppeteer extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator);
-    return equals(`expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    return equals(`expected number of elements (${(new Locator(locator))}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -1501,7 +1501,7 @@ class Puppeteer extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`).assert(res, num);
+    return equals(`expected number of visible elements (${(new Locator(locator))}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1725,7 +1725,7 @@ class Puppeteer extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator))}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1756,7 +1756,7 @@ class Puppeteer extends Helper {
       }
       return true;
     });
-    return equals(`all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
+    return equals(`all elements (${(new Locator(locator))}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -1819,7 +1819,7 @@ class Puppeteer extends Helper {
     assertElementExists(res, locator);
     if (res.length > 1) this.debug(`[Elements] Using first element out of ${res.length}`);
     const elem = res[0];
-    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator))} element has been saved to ${outputFile}`);
     return elem.screenshot({ path: outputFile, type: 'png' });
   }
 

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -642,7 +642,7 @@ class TestCafe extends Helper {
   async seeElement(locator) {
     const exists = (await findElements.call(this, this.context, locator)).filterVisible().exists;
     return this.t
-      .expect(exists).ok(`No element "${(new Locator(locator)).toString()}" found`)
+      .expect(exists).ok(`No element "${(new Locator(locator))}" found`)
       .catch(mapError);
   }
 
@@ -652,7 +652,7 @@ class TestCafe extends Helper {
   async dontSeeElement(locator) {
     const exists = (await findElements.call(this, this.context, locator)).filterVisible().exists;
     return this.t
-      .expect(exists).notOk(`Element "${(new Locator(locator)).toString()}" is still visible`)
+      .expect(exists).notOk(`Element "${(new Locator(locator))}" is still visible`)
       .catch(mapError);
   }
 
@@ -662,7 +662,7 @@ class TestCafe extends Helper {
   async seeElementInDOM(locator) {
     const exists = (await findElements.call(this, this.context, locator)).exists;
     return this.t
-      .expect(exists).ok(`No element "${(new Locator(locator)).toString()}" found in DOM`)
+      .expect(exists).ok(`No element "${(new Locator(locator))}" found in DOM`)
       .catch(mapError);
   }
 
@@ -672,7 +672,7 @@ class TestCafe extends Helper {
   async dontSeeElementInDOM(locator) {
     const exists = (await findElements.call(this, this.context, locator)).exists;
     return this.t
-      .expect(exists).notOk(`Element "${(new Locator(locator)).toString()}" is still in DOM`)
+      .expect(exists).notOk(`Element "${(new Locator(locator))}" is still in DOM`)
       .catch(mapError);
   }
 
@@ -764,7 +764,7 @@ class TestCafe extends Helper {
     assertElementExists(sel);
     const firstElement = await sel.filterVisible().nth(0);
 
-    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator))} element has been saved to ${outputFile}`);
     return this.t.takeElementScreenshot(firstElement, fileName);
   }
 
@@ -1130,7 +1130,7 @@ class TestCafe extends Helper {
 
     return this.t
       .expect(createSelector(locator).with({ boundTestRun: this.t }).filterVisible().count)
-      .eql(num, `The number of elements (${(new Locator(locator)).toString()}) is not ${num} after ${sec} sec`, { timeout: waitTimeout })
+      .eql(num, `The number of elements (${(new Locator(locator))}) is not ${num} after ${sec} sec`, { timeout: waitTimeout })
       .catch(mapError);
   }
 

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -642,7 +642,7 @@ class TestCafe extends Helper {
   async seeElement(locator) {
     const exists = (await findElements.call(this, this.context, locator)).filterVisible().exists;
     return this.t
-      .expect(exists).ok(`No element "${locator}" found`)
+      .expect(exists).ok(`No element "${(new Locator(locator)).toString()}" found`)
       .catch(mapError);
   }
 
@@ -652,7 +652,7 @@ class TestCafe extends Helper {
   async dontSeeElement(locator) {
     const exists = (await findElements.call(this, this.context, locator)).filterVisible().exists;
     return this.t
-      .expect(exists).notOk(`Element "${locator}" is still visible`)
+      .expect(exists).notOk(`Element "${(new Locator(locator)).toString()}" is still visible`)
       .catch(mapError);
   }
 
@@ -662,7 +662,7 @@ class TestCafe extends Helper {
   async seeElementInDOM(locator) {
     const exists = (await findElements.call(this, this.context, locator)).exists;
     return this.t
-      .expect(exists).ok(`No element "${locator}" found in DOM`)
+      .expect(exists).ok(`No element "${(new Locator(locator)).toString()}" found in DOM`)
       .catch(mapError);
   }
 
@@ -672,7 +672,7 @@ class TestCafe extends Helper {
   async dontSeeElementInDOM(locator) {
     const exists = (await findElements.call(this, this.context, locator)).exists;
     return this.t
-      .expect(exists).notOk(`Element "${locator}" is still in DOM`)
+      .expect(exists).notOk(`Element "${(new Locator(locator)).toString()}" is still in DOM`)
       .catch(mapError);
   }
 
@@ -764,7 +764,7 @@ class TestCafe extends Helper {
     assertElementExists(sel);
     const firstElement = await sel.filterVisible().nth(0);
 
-    this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
     return this.t.takeElementScreenshot(firstElement, fileName);
   }
 
@@ -1130,7 +1130,7 @@ class TestCafe extends Helper {
 
     return this.t
       .expect(createSelector(locator).with({ boundTestRun: this.t }).filterVisible().count)
-      .eql(num, `The number of elements (${locator}) is not ${num} after ${sec} sec`, { timeout: waitTimeout })
+      .eql(num, `The number of elements (${(new Locator(locator)).toString()}) is not ${num} after ${sec} sec`, { timeout: waitTimeout })
       .catch(mapError);
   }
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1380,7 +1380,7 @@ class WebDriver extends Helper {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
     const selected = await forEachAsync(res, async el => el.isDisplayed());
-    return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').assert(selected);
+    return truth(`elements of ${(new Locator(locator))}`, 'to be seen').assert(selected);
   }
 
   /**
@@ -1390,10 +1390,10 @@ class WebDriver extends Helper {
   async dontSeeElement(locator) {
     const res = await this._locate(locator, false);
     if (!res || res.length === 0) {
-      return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').negate(false);
+      return truth(`elements of ${(new Locator(locator))}`, 'to be seen').negate(false);
     }
     const selected = await forEachAsync(res, async el => el.isDisplayed());
-    return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').negate(selected);
+    return truth(`elements of ${(new Locator(locator))}`, 'to be seen').negate(selected);
   }
 
   /**
@@ -1465,7 +1465,7 @@ class WebDriver extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const res = await this._locate(locator);
-    return assert.equal(res.length, num, `expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res.length}`);
+    return assert.equal(res.length, num, `expected number of elements (${(new Locator(locator))}) is ${num}, but found ${res.length}`);
   }
 
   /**
@@ -1474,7 +1474,7 @@ class WebDriver extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return assert.equal(res, num, `expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`);
+    return assert.equal(res, num, `expected number of visible elements (${(new Locator(locator))}) is ${num}, but found ${res}`);
   }
 
   /**
@@ -1508,7 +1508,7 @@ class WebDriver extends Helper {
     });
     return assert.ok(
       chunked.length === elemAmount,
-      `expected all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`,
+      `expected all elements (${(new Locator(locator))}) to have CSS property ${JSON.stringify(cssProperties)}`,
     );
   }
 
@@ -1535,7 +1535,7 @@ class WebDriver extends Helper {
     });
     return assert.ok(
       chunked.length === elemAmount,
-      `expected all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`,
+      `expected all elements (${(new Locator(locator))}) to have attributes ${JSON.stringify(attributes)}`,
     );
   }
 
@@ -1669,7 +1669,7 @@ class WebDriver extends Helper {
     assertElementExists(res, locator);
     const elem = usingFirstElement(res);
 
-    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator))} element has been saved to ${outputFile}`);
     return elem.saveScreenshot(outputFile);
   }
 
@@ -2081,12 +2081,12 @@ class WebDriver extends Helper {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
         return res && res.length;
-      }, aSec * 1000, `element (${(new Locator(locator)).toString()}) still not present on page after ${aSec} sec`);
+      }, aSec * 1000, `element (${(new Locator(locator))}) still not present on page after ${aSec} sec`);
     }
     return this.browser.waitUntil(async () => {
       const res = await this._res(locator);
       return res && res.length;
-    }, { timeout: aSec * 1000, timeoutMsg: `element (${(new Locator(locator)).toString()}) still not present on page after ${aSec} sec` });
+    }, { timeout: aSec * 1000, timeoutMsg: `element (${(new Locator(locator))}) still not present on page after ${aSec} sec` });
   }
 
   /**

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1380,7 +1380,7 @@ class WebDriver extends Helper {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
     const selected = await forEachAsync(res, async el => el.isDisplayed());
-    return truth(`elements of ${locator}`, 'to be seen').assert(selected);
+    return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').assert(selected);
   }
 
   /**
@@ -1390,10 +1390,10 @@ class WebDriver extends Helper {
   async dontSeeElement(locator) {
     const res = await this._locate(locator, false);
     if (!res || res.length === 0) {
-      return truth(`elements of ${locator}`, 'to be seen').negate(false);
+      return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').negate(false);
     }
     const selected = await forEachAsync(res, async el => el.isDisplayed());
-    return truth(`elements of ${locator}`, 'to be seen').negate(selected);
+    return truth(`elements of ${(new Locator(locator)).toString()}`, 'to be seen').negate(selected);
   }
 
   /**
@@ -1465,7 +1465,7 @@ class WebDriver extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const res = await this._locate(locator);
-    return assert.equal(res.length, num, `expected number of elements (${locator}) is ${num}, but found ${res.length}`);
+    return assert.equal(res.length, num, `expected number of elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res.length}`);
   }
 
   /**
@@ -1474,7 +1474,7 @@ class WebDriver extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator);
-    return assert.equal(res, num, `expected number of visible elements (${locator}) is ${num}, but found ${res}`);
+    return assert.equal(res, num, `expected number of visible elements (${(new Locator(locator)).toString()}) is ${num}, but found ${res}`);
   }
 
   /**
@@ -1508,7 +1508,7 @@ class WebDriver extends Helper {
     });
     return assert.ok(
       chunked.length === elemAmount,
-      `expected all elements (${locator}) to have CSS property ${JSON.stringify(cssProperties)}`,
+      `expected all elements (${(new Locator(locator)).toString()}) to have CSS property ${JSON.stringify(cssProperties)}`,
     );
   }
 
@@ -1535,7 +1535,7 @@ class WebDriver extends Helper {
     });
     return assert.ok(
       chunked.length === elemAmount,
-      `expected all elements (${locator}) to have attributes ${JSON.stringify(attributes)}`,
+      `expected all elements (${(new Locator(locator)).toString()}) to have attributes ${JSON.stringify(attributes)}`,
     );
   }
 
@@ -1669,7 +1669,7 @@ class WebDriver extends Helper {
     assertElementExists(res, locator);
     const elem = usingFirstElement(res);
 
-    this.debug(`Screenshot of ${locator} element has been saved to ${outputFile}`);
+    this.debug(`Screenshot of ${(new Locator(locator)).toString()} element has been saved to ${outputFile}`);
     return elem.saveScreenshot(outputFile);
   }
 
@@ -2081,12 +2081,12 @@ class WebDriver extends Helper {
       return this.browser.waitUntil(async () => {
         const res = await this.$$(withStrictLocator(locator));
         return res && res.length;
-      }, aSec * 1000, `element (${locator}) still not present on page after ${aSec} sec`);
+      }, aSec * 1000, `element (${(new Locator(locator)).toString()}) still not present on page after ${aSec} sec`);
     }
     return this.browser.waitUntil(async () => {
       const res = await this._res(locator);
       return res && res.length;
-    }, { timeout: aSec * 1000, timeoutMsg: `element (${locator}) still not present on page after ${aSec} sec` });
+    }, { timeout: aSec * 1000, timeoutMsg: `element (${(new Locator(locator)).toString()}) still not present on page after ${aSec} sec` });
   }
 
   /**

--- a/lib/helper/errors/ElementNotFound.js
+++ b/lib/helper/errors/ElementNotFound.js
@@ -11,7 +11,7 @@ class ElementNotFound {
     if (typeof locator === 'object') {
       locator = JSON.stringify(locator);
     }
-    throw new Error(`${prefixMessage} "${(new Locator(locator)).toString()}" ${postfixMessage}`);
+    throw new Error(`${prefixMessage} "${(new Locator(locator))}" ${postfixMessage}`);
   }
 }
 


### PR DESCRIPTION
## Motivation/Description of the PR
If a locator of type `{"type": "value"}` is used as expression in a template literal like in https://github.com/codeceptjs/CodeceptJS/blob/37d1dc47029aea8294eef161b75a7e8f2f49d4a1/lib/helper/WebDriver.js#L2089
this leads to output like `element ([object Object]) still not present on page after 20 sec`. So we create an instance of Locate which has a toString method, which is called by the template literal.

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
