### PR TITLE
bump version of @faker-js/faker used by plugin fakerTransform to latest version

### DIFF
--- a/lib/plugin/fakerTransform.js
+++ b/lib/plugin/fakerTransform.js
@@ -1,4 +1,4 @@
-const faker = require('@faker-js/faker');
+const { faker } = require('@faker-js/faker');
 const transform = require('../transform');
 
 /**
@@ -44,7 +44,7 @@ const transform = require('../transform');
 module.exports = function (config) {
   transform.addTransformerBeforeAll('gherkin.examples', (value) => {
     if (typeof value === 'string' && value.length > 0) {
-      return faker.fake(value);
+      return faker.helpers.fake(value);
     }
     return value;
   });

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "devDependencies": {
     "@codeceptjs/detox-helper": "^1.0.2",
     "@codeceptjs/mock-request": "^0.3.1",
-    "@faker-js/faker": "^5.5.3",
+    "@faker-js/faker": "^7.6.0",
     "@pollyjs/adapter-puppeteer": "^5.1.0",
     "@pollyjs/core": "^5.1.0",
     "@types/inquirer": "^0.0.35",


### PR DESCRIPTION
## Motivation/Description of the PR
Bumping the version of [@faker-js/faker](https://www.npmjs.com/package/@faker-js/faker) used by plugin `fakerTransform` to the latest version `7.6.0`.  Staying current gives us access to expanded capabilities and access to nice api [documentation](https://fakerjs.dev/api/).

**NOTE** 
I did not perform an exhaustive comparison of the 7.6.0 and 5.5.3 API.  It is likely this will be a breaking change for folks using `fakerTransform` plugin

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles
- [x] fakerTransform

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ x] Lint checking (Run `npm run lint`)
- [ x] Local tests are passed (Run `npm test`)
