### PR TITLE
fix(gpo): codeceptjs config is contaminated when having includes()

### DIFF
--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -128,7 +128,9 @@ module.exports.pageObject = function (genPath, opts) {
     const name = lcfirst(result.name) + ucfirst(kind);
     let data = readConfig(configFile);
     config.include[name] = result.filename;
-    data = data.replace(/include:[\s\S][^\}]*/i, `include: ${JSON.stringify(config.include).slice(0, -1)}`);
+    const currentInclude = `${data.match(/include:[\s\S][^\}]*/i)[0]}\n ${name}:${JSON.stringify(config.include[name])}`;
+
+    data = data.replace(/include:[\s\S][^\}]*/i, `${currentInclude}`);
 
     fs.writeFileSync(configFile, beautify(data), 'utf-8');
 

--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -128,7 +128,7 @@ module.exports.pageObject = function (genPath, opts) {
     const name = lcfirst(result.name) + ucfirst(kind);
     let data = readConfig(configFile);
     config.include[name] = result.filename;
-    data = data.replace(/include[\s\S][^\}]*/i, `include: ${JSON.stringify(config.include).slice(0, -1)}`);
+    data = data.replace(/include:[\s\S][^\}]*/i, `include: ${JSON.stringify(config.include).slice(0, -1)}`);
 
     fs.writeFileSync(configFile, beautify(data), 'utf-8');
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3530 
<img width="837" alt="Screen Shot 2022-12-13 at 11 23 21 AM" src="https://user-images.githubusercontent.com/7845001/207292456-d22cc7f7-f361-41cd-ad26-a94f481fba97.png">

- Resolves #3532 
<img width="874" alt="Screen Shot 2022-12-13 at 4 11 13 PM" src="https://user-images.githubusercontent.com/7845001/207370776-b1ebb803-ce72-48e8-933c-eb4ed663a0c1.png">

## Type of change
- [x] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
