### PR TITLE
fix: JsDoc: Remove promise from `Actor.say`

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -16,8 +16,9 @@ class Actor {
    * add print comment method`
    * @param {string} msg
    * @param {string} color
-   * @return {Promise<any> | undefined}
    * @inner
+   *
+   * ⚠️ returns a promise which is synchronized internally by recorder
    */
   say(msg, color = 'cyan') {
     return recorder.add(`say ${msg}`, () => {


### PR DESCRIPTION
The return type of `Actor.say` contains `Promise<any>`. In TypeScript code, with the ESLint rule "@typescript-eslint/no-floating-promises" this causes lint errors for every `I.say` in the tests stating that a promise will not be awaited. Instead, add a comment similar to many other methods (`I.see`, `I.click`, ...) and leave the return type `void`.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
