### PR TITLE
feature(allure): Add framework and language labels to tests

### DIFF
--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -99,6 +99,9 @@ module.exports = (config) => {
   reporter.pendingCase = function (testName, timestamp, opts = {}) {
     reporter.startCase(testName, timestamp);
 
+    plugin.addLabel('language', 'javascript');
+    plugin.addLabel('framework', 'codeceptjs');
+
     if (opts.description) plugin.setDescription(opts.description);
     if (opts.severity) plugin.severity(opts.severity);
     if (opts.severity) plugin.addLabel('tag', opts.severity);

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -99,9 +99,7 @@ module.exports = (config) => {
   reporter.pendingCase = function (testName, timestamp, opts = {}) {
     reporter.startCase(testName, timestamp);
 
-    plugin.addLabel('language', 'javascript');
-    plugin.addLabel('framework', 'codeceptjs');
-
+    plugin.addCommonMetadata();
     if (opts.description) plugin.setDescription(opts.description);
     if (opts.severity) plugin.severity(opts.severity);
     if (opts.severity) plugin.addLabel('tag', opts.severity);
@@ -193,6 +191,11 @@ module.exports = (config) => {
     }
   };
 
+  plugin.addCommonMetadata = () => {
+    plugin.addLabel('language', 'javascript');
+    plugin.addLabel('framework', 'codeceptjs');
+  };
+
   event.dispatcher.on(event.suite.before, (suite) => {
     reporter.startSuite(suite.fullTitle());
   });
@@ -211,10 +214,7 @@ module.exports = (config) => {
 
   event.dispatcher.on(event.test.before, (test) => {
     reporter.startCase(test.title);
-
-    plugin.addLabel('language', 'javascript');
-    plugin.addLabel('framework', 'codeceptjs');
-
+    plugin.addCommonMetadata();
     if (config.enableScreenshotDiffPlugin) {
       const currentTest = reporter.getCurrentTest();
       currentTest.addLabel('testType', 'screenshotDiff');
@@ -242,8 +242,7 @@ module.exports = (config) => {
     } else {
       // this means before suite failed, we should report this.
       reporter.startCase(`BeforeSuite of suite ${reporter.getCurrentSuite().name} failed.`);
-      plugin.addLabel('language', 'javascript');
-      plugin.addLabel('framework', 'codeceptjs');
+      plugin.addCommonMetadata();
       reporter.endCase('failed', err);
     }
   });

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -211,6 +211,10 @@ module.exports = (config) => {
 
   event.dispatcher.on(event.test.before, (test) => {
     reporter.startCase(test.title);
+
+    plugin.addLabel('language', 'javascript');
+    plugin.addLabel('framework', 'codeceptjs');
+
     if (config.enableScreenshotDiffPlugin) {
       const currentTest = reporter.getCurrentTest();
       currentTest.addLabel('testType', 'screenshotDiff');
@@ -238,6 +242,8 @@ module.exports = (config) => {
     } else {
       // this means before suite failed, we should report this.
       reporter.startCase(`BeforeSuite of suite ${reporter.getCurrentSuite().name} failed.`);
+      plugin.addLabel('language', 'javascript');
+      plugin.addLabel('framework', 'codeceptjs');
       reporter.endCase('failed', err);
     }
   });

--- a/test/runner/allure_test.js
+++ b/test/runner/allure_test.js
@@ -45,6 +45,11 @@ describe('CodeceptJS Allure Plugin', function () {
           expect(nestedMetaStep.name[0]).toEqual('I am in path "."');
           expect(testCase.steps[0].step[0].steps.length).toEqual(1);
 
+          expect(testCase.labels[0].label).toEqual([
+            { $: { name: 'language', value: 'javascript' } },
+            { $: { name: 'framework', value: 'codeceptjs' } },
+          ]);
+
           const secondMetaStep = testCase.steps[0].step[1];
           expect(secondMetaStep.name[0]).toEqual('I see file "allure.conf.js"');
         });


### PR DESCRIPTION
## Motivation/Description of the PR

This PR add `language` and `framework` fields for allure plugin to easily filter testResults by language or frameworks

Applicable plugins:

- [x] allure

## Type of change

- [x] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)