### PR TITLE
feat(run-workers) : Add support of multiple for run-workers

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -130,7 +130,7 @@ program.command('run [test]')
   .option('--child <string>', 'option for child processes')
   .action(errorHandler(require('../lib/command/run')));
 
-program.command('run-workers <workers>')
+program.command('run-workers <workers> [selectedRuns...]')
   .description('Executes tests in workers')
   .option('-c, --config [file]', 'configuration file to be used')
   .option('-g, --grep <pattern>', 'only run tests matching <pattern>')

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -5,7 +5,7 @@ const output = require('../output');
 const event = require('../event');
 const Workers = require('../workers');
 
-module.exports = async function (workerCount, options) {
+module.exports = async function (workerCount, selectedRuns, options) {
   satisfyNodeVersion(
     '>=11.7.0',
     'Required minimum Node version of 11.7.0 to work with "run-workers"',
@@ -21,6 +21,7 @@ module.exports = async function (workerCount, options) {
     by,
     testConfig,
     options,
+    selectedRuns,
   };
 
   const numberOfWorkers = parseInt(workerCount, 10);

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -10,12 +10,14 @@ const MochaFactory = require('./mochaFactory');
 const Container = require('./container');
 const { getTestRoot } = require('./command/utils');
 const { isFunction, fileExists } = require('./utils');
+const { replaceValueDeep, deepClone } = require('./utils');
 const mainConfig = require('./config');
 const output = require('./output');
 const event = require('./event');
 const recorder = require('./recorder');
 const runHook = require('./hooks');
 const WorkerStorage = require('./workerStorage');
+const collection = require('./command/run-multiple/collection');
 
 const pathToWorker = path.join(__dirname, 'command', 'workers', 'runTests.js');
 
@@ -79,15 +81,39 @@ const repackTest = (test) => {
   return test;
 };
 
-const createWorkerObjects = (testGroups, config, testRoot, options) => {
-  return testGroups.map((tests, index) => {
-    const workerObj = new WorkerObject(index);
-    workerObj.addConfig(config);
-    workerObj.addTests(tests);
-    workerObj.setTestRoot(testRoot);
-    workerObj.addOptions(options);
-    return workerObj;
+const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns) => {
+  selectedRuns = options && options.all ? Object.keys(config.multiple) : selectedRuns;
+  if (selectedRuns === undefined || !selectedRuns.length) {
+    return testGroups.map((tests, index) => {
+      const workerObj = new WorkerObject(index);
+      workerObj.addConfig(config);
+      workerObj.addTests(tests);
+      workerObj.setTestRoot(testRoot);
+      workerObj.addOptions(options);
+      return workerObj;
+    });
+  }
+  const workersToExecute = [];
+  collection.createRuns(selectedRuns, config).forEach((worker) => {
+    const workerName = worker.getOriginalName() || worker.getName();
+    const workerConfig = worker.getConfig();
+    workersToExecute.push(getOverridenConfig(workerName, workerConfig, config));
   });
+  const workers = [];
+  let index = 0;
+  testGroups.forEach((tests) => {
+    const testWorkerArray = [];
+    workersToExecute.forEach((finalConfig) => {
+      const workerObj = new WorkerObject(index++);
+      workerObj.addConfig(finalConfig);
+      workerObj.addTests(tests);
+      workerObj.setTestRoot(testRoot);
+      workerObj.addOptions(options);
+      testWorkerArray.push(workerObj);
+    });
+    workers.push(...testWorkerArray);
+  });
+  return workers;
 };
 
 const indexOfSmallestElement = (groups) => {
@@ -114,6 +140,28 @@ const convertToMochaTests = (testGroup) => {
   }
 
   return group;
+};
+
+const getOverridenConfig = (workerName, workerConfig, config) => {
+  // clone config
+  const overriddenConfig = deepClone(config);
+
+  // get configuration
+  const browserConfig = workerConfig.browser;
+
+  for (const key in browserConfig) {
+    overriddenConfig.helpers = replaceValueDeep(overriddenConfig.helpers, key, browserConfig[key]);
+  }
+
+  // override tests configuration
+  if (overriddenConfig.tests) {
+    overriddenConfig.tests = workerConfig.tests;
+  }
+
+  if (overriddenConfig.gherkin && workerConfig.gherkin && workerConfig.gherkin.features) {
+    overriddenConfig.gherkin.features = workerConfig.gherkin.features;
+  }
+  return overriddenConfig;
 };
 
 class WorkerObject {
@@ -184,7 +232,7 @@ class Workers extends EventEmitter {
 
   _initWorkers(numberOfWorkers, config) {
     this.splitTestsByGroups(numberOfWorkers, config);
-    this.workers = createWorkerObjects(this.testGroups, this.codecept.config, config.testConfig, config.options);
+    this.workers = createWorkerObjects(this.testGroups, this.codecept.config, config.testConfig, config.options, config.selectedRuns);
     this.numberOfWorkers = this.workers.length;
   }
 

--- a/test/unit/worker_test.js
+++ b/test/unit/worker_test.js
@@ -253,4 +253,36 @@ describe('Workers', () => {
       done();
     });
   });
+
+  it('should run worker with multiple config', (done) => {
+    if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
+
+    const workerConfig = {
+      by: 'test',
+      testConfig: './test/data/sandbox/codecept.multiple.js',
+      options: {},
+      selectedRuns: ['mobile'],
+    };
+
+    const workers = new Workers(2, workerConfig);
+
+    for (const worker of workers.getWorkers()) {
+      worker.addConfig({
+        helpers: {
+          FileSystem: {},
+          Workers: {
+            require: './custom_worker_helper',
+          },
+        },
+      });
+    }
+
+    workers.run();
+
+    workers.on(event.all.result, (status) => {
+      expect(workers.getWorkers().length).equal(8);
+      expect(status).equal(true);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
Add Support of using multiple with run-workers to run multiple browsers out of the box with workers instead of triggering it by manually creating a custom runner. 
- Resolves #issueId (if applicable).

## Type of change

- [x] :rocket: New functionality

## Checklist:

- [x] Tests have been added
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
