### PR TITLE
Added secret support to append() and type()

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -15,6 +15,12 @@ When executed it will be printed like this:
 ```
 I fill field "password" "*****"
 ```
+**Other Examples**
+```js
+I.fillField('password', secret('123456'));
+I.append('password', secret('123456'));
+I.type('password', secret('123456'));
+```
 
 For an object, which can be a payload to POST request, specify which fields should be masked:
 

--- a/docs/webapi/appendField.mustache
+++ b/docs/webapi/appendField.mustache
@@ -3,6 +3,8 @@ Field is located by name, label, CSS or XPath
 
 ```js
 I.appendField('#myTextField', 'appended');
+// typing secret
+I.appendField('password', secret('123456'));
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator
 @param {string} value text value to append.

--- a/docs/webapi/type.mustache
+++ b/docs/webapi/type.mustache
@@ -11,6 +11,9 @@ I.type('4141555311111111', 100);
 
 // passing in an array
 I.type(['T', 'E', 'X', 'T']);
+
+// passing a secret
+I.type(secret('123456'));
 ```
 
 @param {string|string[]} key or array of keys to type.

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -694,7 +694,7 @@ class Nightmare extends Helper {
   async appendField(field, value) {
     const el = await findField.call(this, field);
     assertElementExists(el, field, 'Field');
-    return this.browser.enterText(el, value, false)
+    return this.browser.enterText(el, value.toString(), false)
       .wait(this.options.waitForAction);
   }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1438,6 +1438,7 @@ class Playwright extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
+      keys = keys.toString();
       keys = keys.split('');
     }
 
@@ -1482,7 +1483,7 @@ class Playwright extends Helper {
     const els = await findFields.call(this, field);
     assertElementExists(els, field, 'Field');
     await els[0].press('End');
-    await els[0].type(value, { delay: this.options.pressKeyDelay });
+    await els[0].type(value.toString(), { delay: this.options.pressKeyDelay });
     return this._waitForAction();
   }
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -647,7 +647,7 @@ class Protractor extends Helper {
   async appendField(field, value) {
     const els = await findFields(this.browser, field);
     assertElementExists(els, field, 'Field');
-    return els[0].sendKeys(value);
+    return els[0].sendKeys(value.toString());
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1262,6 +1262,7 @@ class Puppeteer extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
+      keys = keys.toString();
       keys = keys.split('');
     }
 
@@ -1306,7 +1307,7 @@ class Puppeteer extends Helper {
     const els = await findVisibleFields.call(this, field);
     assertElementExists(els, field, 'Field');
     await els[0].press('End');
-    await els[0].type(value, { delay: this.options.pressKeyDelay });
+    await els[0].type(value.toString(), { delay: this.options.pressKeyDelay });
     return this._waitForAction();
   }
 

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -410,7 +410,7 @@ class TestCafe extends Helper {
     const el = await els.nth(0);
 
     return this.t
-      .typeText(el, value, { replace: false })
+      .typeText(el, value.toString(), { replace: false })
       .catch(mapError);
   }
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1035,7 +1035,7 @@ class WebDriver extends Helper {
     const res = await findFields.call(this, field);
     assertElementExists(res, field, 'Field');
     const elem = usingFirstElement(res);
-    return elem.addValue(value);
+    return elem.addValue(value.toString());
   }
 
   /**
@@ -1879,6 +1879,7 @@ class WebDriver extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
+      keys = keys.toString();
       keys = keys.split('');
     }
     if (delay) {


### PR DESCRIPTION
## Motivation/Description of the PR
- Added secret to append() and type() methods.
- Resolves #3612 

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
