### PR TITLE
feat(dryRun): count no of tests of each suite

### DIFF
--- a/lib/command/dryRun.js
+++ b/lib/command/dryRun.js
@@ -59,7 +59,7 @@ function printTests(files) {
   let numOfSuites = 0;
 
   for (const suite of mocha.suite.suites) {
-    output.print(`${colors.white.bold(suite.title)} -- ${output.styles.log(suite.file || '')}`);
+    output.print(`${colors.white.bold(suite.title)} -- ${output.styles.log(suite.file || '')} -- ${suite.tests.length} tests`);
     numOfSuites++;
 
     for (const test of suite.tests) {


### PR DESCRIPTION
## Motivation/Description of the PR
- Counting the number of tests per suite when executing `dryRun` command

