### PR TITLE
fix: tests are loaded from node_modules folder

### DIFF
--- a/.github/workflows/webdriver.yml
+++ b/.github/workflows/webdriver.yml
@@ -16,11 +16,11 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - run: docker run -d --net=host --shm-size=2g selenium/standalone-chrome:3.141.59-oxygen

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -158,6 +158,7 @@ class Codecept {
 
     for (pattern of patterns) {
       glob.sync(pattern, options).forEach((file) => {
+        if (file.includes('node_modules')) return;
         if (!fsPath.isAbsolute(file)) {
           file = fsPath.join(global.codecept_dir, file);
         }


### PR DESCRIPTION
## Motivation/Description of the PR
- fix the case where tests are loaded from `node_modules` folder

we have this glob in configuration: `tests: './**/*.test.ts',`, when tests run, CodeceptJS will load tests in every folder, even the `node_modules` folder with test.ts files.

## Type of change
- [x] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
