### PR TITLE
test: add the dslint script to pre-commit checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
+npm run lint && npm run dtslint


### PR DESCRIPTION
## Motivation/Description of the PR
Typing verification has been added previously but it is very inconvenient to find these problems already within the framework of running tests on ci/cd. This is an extra waste of resources on the run. Because the check is very easy and fast, it is better to add it to the pre-commit too.

## Type of change

- [X] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
