### PR TITLE
fix: test unit webapi command

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:unit:webbapi:playwright": "mocha test/helper/Playwright_test.js",
     "test:unit:webbapi:puppeteer": "mocha test/helper/Puppeteer_test.js",
     "test:unit:webbapi:webDriver": "mocha test/helper/WebDriver_test.js",
-    "test:unit:webbapi:testCafet": "xvfb-run --server-args=\"-screen 0 1280x720x24\" mocha test/helper/TestCafe_test.js",
+    "test:unit:webbapi:testCafe": "mocha test/helper/TestCafe_test.js",
     "def": "./runok.js def",
     "dev:graphql": "nodemon test/data/graphql/index.js",
     "publish:site": "./runok.js publish:site",


### PR DESCRIPTION
## Motivation/Description of the PR
- fix typo and error when calling the command

````
➜  CodeceptJS git:(fix-test-unit-webapi-command) npm run test:unit:webbapi:testCafet         

> codeceptjs@3.4.1 test:unit:webbapi:testCafet
> xvfb-run --server-args="-screen 0 1280x720x24" mocha test/helper/TestCafe_test.js

sh: xvfb-run: command not found

````

## Type of change
- [ ] :bug: Bug fix
