### PR TITLE
FIX(test-react-app): change link to self-hosted calculator app

### DIFF
--- a/examples/react_test.js
+++ b/examples/react_test.js
@@ -1,7 +1,7 @@
 Feature('React Apps');
 
 Data([{ a: 1, toString: () => 'a' }, { b: 2, toString: () => 'b' }]).Scenario('try react app', ({ I }) => {
-  I.amOnPage('https://ahfarmer.github.io/calculator/');
+  I.amOnPage('https://codecept.io/test-react-calculator/');
   I.click('7');
   I.seeElement({ react: 't', props: { name: '5' } });
   I.click('button', { react: 't', props: { name: '2' } });

--- a/test/acceptance/react_test.js
+++ b/test/acceptance/react_test.js
@@ -1,7 +1,7 @@
 Feature('React Selectors');
 
 Scenario('props @WebDriver @Puppeteer @Playwright', ({ I }) => {
-  I.amOnPage('https://ahfarmer.github.io/calculator/');
+  I.amOnPage('https://codecept.io/test-react-calculator/');
   I.click('7');
   I.seeElement({ react: 't', props: { name: '5' } });
   I.click('button', { react: 't', props: { name: '2' } });


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves

The react tests were linked to third party hosted app [ahfarmer.github.io/calculator/](https://ahfarmer.github.io/calculator/)
But the owner changed github name from `ahfarmer` to [greatbunny](https://github.com/greatbunny). 
So I decided to move from ahfarmer GH page to codeceptjs hosted one: https://codecept.io/test-react-calculator/


## Type of change

- [X] :bug: Bug fix
