### PR TITLE
HOTFIX(git commit throw): add check if nothing to commit | doc-generation workflow

### DIFF
--- a/.github/workflows/doc-generation.yml
+++ b/.github/workflows/doc-generation.yml
@@ -34,13 +34,17 @@ jobs:
         run: |
           npm run update-contributor-faces
           git add README.md
-          git commit -m "DOC: Update contributor faces" --no-verify
+          if ! git diff --cached --quiet; then
+            git commit -m "DOC: Update contributor faces" --no-verify
+          fi
 
       - name: Generate and update documentation
         run: |
           npm run docs
           git add docs/**/*.md
-          git commit -m "DOC: Autogenerate and update documentation" --no-verify
+          if ! git diff --cached --quiet; then
+            git commit -m "DOC: Autogenerate and update documentation" --no-verify
+          fi
 
       - name: Push to the repo
         run: git push


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves

HOTFIX for the [Update documentation after merge job](https://github.com/codeceptjs/CodeceptJS/actions/runs/5191003216/jobs/9358240920) to check if nothing to commit and to not run `git commit` on no changed files and to not `throw error code` in this way.
