### PR TITLE
fix: handle importing custom helper nicely

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -165,7 +165,11 @@ function createHelpers(config) {
       } else {
         moduleName = `./helper/${helperName}`; // built-in helper
       }
-      const HelperClass = require(moduleName);
+
+      // @ts-ignore
+      // this handles the loading of custom helper. Either old syntax `export = HelperName` or new syntax `export default HelperName`
+      const HelperClass = moduleName.startsWith('./helper/') ? require(moduleName) : require(moduleName).default || require(moduleName);
+
       if (HelperClass._checkRequirements) {
         const requirements = HelperClass._checkRequirements();
         if (requirements) {
@@ -351,8 +355,8 @@ function loadSupportObject(modulePath, supportObjectName) {
       }
     }
     if (typeof obj !== 'function'
-        && Object.getPrototypeOf(obj) !== Object.prototype
-        && !Array.isArray(obj)
+      && Object.getPrototypeOf(obj) !== Object.prototype
+      && !Array.isArray(obj)
     ) {
       const methods = getObjectMethods(obj);
       Object.keys(methods)

--- a/lib/container.js
+++ b/lib/container.js
@@ -167,8 +167,13 @@ function createHelpers(config) {
       }
 
       // @ts-ignore
-      // this handles the loading of custom helper. Either old syntax `export = HelperName` or new syntax `export default HelperName`
-      const HelperClass = moduleName.startsWith('./helper/') ? require(moduleName) : require(moduleName).default || require(moduleName);
+      let HelperClass;
+      // check if the helper is the built-in, use the require() syntax. 
+      if (moduleName.startsWith('./helper/')) {
+         HelperClass = require(moduleName); }
+        else {
+          // check if the new syntax export default HelperName is used and loads the Helper, otherwise loads the module that used old syntax export = HelperName. 
+          HelperClass =  require(moduleName).default || require(moduleName); }
 
       if (HelperClass._checkRequirements) {
         const requirements = HelperClass._checkRequirements();


### PR DESCRIPTION
## Motivation/Description of the PR
- This PR aims to handle the importing helpers nicely.

````
// new export syntax

class CustomHelper {}

export default CustomHelper;


// old export syntax

class CustomHelper {}

export = CustomHelper;

// js class
class TestHelper extends Helper {

}

module.exports = TestHelper;

````

## Type of change
- [x] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
