### PR TITLE
fix: typo in ui_test.js

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -20,7 +20,7 @@ if [[ -d "/tests/" ]]; then
 		if [ ! "$NO_OF_WORKERS" ]; then
 			codeceptjs run $CODECEPT_ARGS
 		else
-		    codeceptjs run-workers $NO_OF_WORKERS $CODECEPT_ARGS
+			codeceptjs run-workers $NO_OF_WORKERS $CODECEPT_ARGS
 		fi
 	fi
 else

--- a/test/unit/data/ui_test.js
+++ b/test/unit/data/ui_test.js
@@ -39,7 +39,7 @@ describe('ui', () => {
       });
     });
 
-    it('can add a timout to all scenarios', () => {
+    it('can add a timeout to all scenarios', () => {
       const dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {});
 
       dataScenarioConfig.timeout(3);


### PR DESCRIPTION
## Motivation/Description of the PR
I found a typo and would like to correct it.

`can add a timout to all scenarios`
↓
`can add a timeout to all scenarios`

I don't think it has anything to do with the operation.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
