### PR TITLE
fix: secret function

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -115,7 +115,7 @@ I.sendDeleteRequest('/api/users/1');
 #### Parameters
 
 -   `url` **any** 
--   `headers` **[object][4]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][4]** the headers object to be sent. By default, it is sent as an empty object 
 
 Returns **[Promise][2]&lt;any>** response
 
@@ -130,7 +130,7 @@ I.sendGetRequest('/api/users.json');
 #### Parameters
 
 -   `url` **any** 
--   `headers` **[object][4]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][4]** the headers object to be sent. By default, it is sent as an empty object 
 
 Returns **[Promise][2]&lt;any>** response
 
@@ -167,8 +167,8 @@ I.sendPostRequest('/api/users.json', secret({ "email": "user@user.com" }));
 #### Parameters
 
 -   `url` **any** 
--   `payload` **any** the payload to be sent. By default it is sent as an empty object 
--   `headers` **[object][4]** the headers object to be sent. By default it is sent as an empty object 
+-   `payload` **any** the payload to be sent. By default, it is sent as an empty object 
+-   `headers` **[object][4]** the headers object to be sent. By default, it is sent as an empty object 
 
 Returns **[Promise][2]&lt;any>** response
 

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -137,6 +137,15 @@ class REST extends Helper {
       request.auth = this.headers.auth;
     }
 
+    if (typeof request.data === 'object') {
+      let returnedValue = {};
+      for (const [key, value] of Object.entries(request.data)) {
+        returnedValue[key] = value;
+        if (value instanceof Secret) returnedValue[key] = value.getMasked();
+      }
+      _debugRequest.data = returnedValue;
+    }
+
     if (request.data instanceof Secret) {
       _debugRequest.data = '*****';
       request.data = (typeof request.data === 'object' && !(request.data instanceof Secret)) ? { ...request.data.toString() } : request.data.toString();
@@ -199,7 +208,7 @@ class REST extends Helper {
    * ```
    *
    * @param {*} url
-   * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   * @param {object} [headers={}] - the headers object to be sent. By default, it is sent as an empty object
    *
    * @returns {Promise<*>} response
    */
@@ -223,8 +232,8 @@ class REST extends Helper {
    * ```
    *
    * @param {*} url
-   * @param {*} [payload={}] - the payload to be sent. By default it is sent as an empty object
-   * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   * @param {*} [payload={}] - the payload to be sent. By default, it is sent as an empty object
+   * @param {object} [headers={}] - the headers object to be sent. By default, it is sent as an empty object
    *
    * @returns {Promise<*>} response
    */
@@ -318,7 +327,7 @@ class REST extends Helper {
    * ```
    *
    * @param {*} url
-   * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   * @param {object} [headers={}] - the headers object to be sent. By default, it is sent as an empty object
    *
    * @returns {Promise<*>} response
    */

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -138,7 +138,7 @@ class REST extends Helper {
     }
 
     if (typeof request.data === 'object') {
-      let returnedValue = {};
+      const returnedValue = {};
       for (const [key, value] of Object.entries(request.data)) {
         returnedValue[key] = value;
         if (value instanceof Secret) returnedValue[key] = value.getMasked();

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -31,21 +31,9 @@ class Secret {
 }
 
 function secretObject(obj, fieldsToHide = []) {
-  const handler = {
-    get(obj, prop) {
-      if (prop === 'toString') {
-        return function () {
-          const maskedObject = deepClone(obj);
-          fieldsToHide.forEach(f => maskedObject[f] = '****');
-          return JSON.stringify(maskedObject);
-        };
-      }
-
-      return obj[prop];
-    },
-  };
-
-  return new Proxy(obj, handler);
+  const maskedObject = deepClone(obj);
+  fieldsToHide.forEach(f => maskedObject[f] = new Secret(maskedObject[f]));
+  return maskedObject;
 }
 
 module.exports = Secret;

--- a/lib/secret.js
+++ b/lib/secret.js
@@ -1,6 +1,8 @@
 /* eslint-disable max-classes-per-file */
 const { deepClone } = require('./utils');
 
+const maskedString = '*****';
+
 /** @param {string} secret */
 class Secret {
   constructor(secret) {
@@ -13,7 +15,7 @@ class Secret {
   }
 
   getMasked() {
-    return '*****';
+    return maskedString;
   }
 
   /**
@@ -31,9 +33,20 @@ class Secret {
 }
 
 function secretObject(obj, fieldsToHide = []) {
-  const maskedObject = deepClone(obj);
-  fieldsToHide.forEach(f => maskedObject[f] = new Secret(maskedObject[f]));
-  return maskedObject;
+  const handler = {
+    get(obj, prop) {
+      if (prop === 'toString') {
+        return function () {
+          const maskedObject = deepClone(obj);
+          fieldsToHide.forEach(f => maskedObject[f] = maskedString);
+          return JSON.stringify(maskedObject);
+        };
+      }
+      return fieldsToHide.includes(prop) ? new Secret(obj[prop]) : obj[prop];
+    },
+  };
+
+  return new Proxy(obj, handler);
 }
 
 module.exports = Secret;

--- a/lib/step.js
+++ b/lib/step.js
@@ -172,7 +172,12 @@ class Step {
       } else if (arg.toString && arg.toString() !== '[object Object]') {
         return arg.toString();
       } else if (typeof arg === 'object') {
-        return JSON.stringify(arg);
+        let returnedArg = {};
+        for (const [key, value] of Object.entries(arg)) {
+          returnedArg[key] = value;
+          if (value instanceof Secret) returnedArg[key] = value.getMasked();
+        }
+        return JSON.stringify(returnedArg);
       }
       return arg;
     }).join(', ');

--- a/lib/step.js
+++ b/lib/step.js
@@ -172,7 +172,7 @@ class Step {
       } else if (arg.toString && arg.toString() !== '[object Object]') {
         return arg.toString();
       } else if (typeof arg === 'object') {
-        let returnedArg = {};
+        const returnedArg = {};
         for (const [key, value] of Object.entries(arg)) {
           returnedArg[key] = value;
           if (value instanceof Secret) returnedArg[key] = value.getMasked();

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -1,11 +1,12 @@
 const path = require('path');
+const expect = require('expect');
 const fs = require('fs');
 const FormData = require('form-data');
-const { secret } = require('../../lib/secret');
 
 const TestHelper = require('../support/TestHelper');
 const REST = require('../../lib/helper/REST');
 const Container = require('../../lib/container');
+const Secret = require("../../lib/secret");
 
 const api_url = TestHelper.jsonServerUrl();
 global.codeceptjs = require('../../lib');
@@ -71,15 +72,15 @@ describe('REST', () => {
     });
 
     it('should send POST requests with secret', async () => {
-      const secretData = secret({ name: 'john', password: '123456' }, 'password');
+      const secretData = Secret.secret({ name: 'john', password: '123456' }, 'password');
       const response = await I.sendPostRequest('/user', secretData);
       response.data.name.should.eql('john');
-      response.data.password.should.eql('123456');
-      secretData.toString().should.include('"password":"****"');
+      expect(response.data.password).toEqual({ _secret: '123456' });
+      expect(secretData.password.getMasked()).toEqual('*****');
     });
 
     it('should send POST requests with secret form encoded is not converted to string', async () => {
-      const secretData = secret('name=john&password=123456');
+      const secretData = Secret.secret('name=john&password=123456');
       const response = await I.sendPostRequest('/user', secretData);
       response.data.name.should.eql('john');
       response.data.password.should.eql('123456');

--- a/test/unit/secret_test.js
+++ b/test/unit/secret_test.js
@@ -1,0 +1,19 @@
+const expect = require('expect');
+const Secret = require('../../lib/secret');
+
+describe('Secret tests', () => {
+  it('should be the Secret instance', () => {
+    const string = Secret.secret('hello');
+    expect(string).toBeInstanceOf(Secret);
+  });
+
+  it('should be the Secret instance when using as object', () => {
+    const obj = Secret.secret({ password: 'world' }, 'password');
+    expect(obj.password).toBeInstanceOf(Secret);
+  });
+
+  it('should mask the field when provided', () => {
+    const obj = Secret.secret({ password: 'world' }, 'password');
+    expect(obj.password.getMasked()).toBe('*****');
+  });
+});


### PR DESCRIPTION
## Motivation/Description of the PR
fix: secret function

````
  type redactedMyObj = { password: CodeceptJS.Secret };
  const myObj: any = secret({ password: 'pass123', pwd: 'hi' }, 'password') as redactedMyObj;
  console.log(myObj.password);

>>> Secret { _secret: 'pass123' }

  type redactedMyObj = { password: CodeceptJS.Secret };
  const myObj: any = secret({ password: 'pass123', pwd: 'hi' }, 'password') as redactedMyObj;
  console.log(myObj);
>>>> { password: Secret { _secret: 'pass123' }, pwd: 'hi' }



await I.sendPostRequest('/auth', secret({ name: 'jon', password: '123456' }, 'password'));
// console log
  Verify a successful call
    I send post request "/auth", {"name":"jon","password":"*****"}
    › [Request] {"baseURL":"https://reqres.in/auth","method":"POST","data":{"name":"jon","password":"*****"},"headers":{}}


````
## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
