### PR TITLE
fix: screenshots every session for easy debugging

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2090,23 +2090,32 @@ class Playwright extends Helper {
    */
   async saveScreenshot(fileName, fullPage) {
     const fullPageOption = fullPage || this.options.fullPageScreenshots;
-    const outputFile = screenshotOutputFolder(fileName);
+    let outputFile = screenshotOutputFolder(fileName);
 
     this.debug(`Screenshot is saving to ${outputFile}`);
 
-    if (this.activeSessionName) {
-      const activeSessionPage = this.sessionPages[this.activeSessionName];
+    await this.page.screenshot({
+      path: outputFile,
+      fullPage: fullPageOption,
+      type: 'png',
+    });
 
-      if (activeSessionPage) {
-        return activeSessionPage.screenshot({
-          path: outputFile,
-          fullPage: fullPageOption,
-          type: 'png',
-        });
+    if (this.activeSessionName) {
+      for (const sessionName in this.sessionPages) {
+        const activeSessionPage = this.sessionPages[sessionName];
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
+
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
+
+        if (activeSessionPage) {
+          await activeSessionPage.screenshot({
+            path: outputFile,
+            fullPage: fullPageOption,
+            type: 'png',
+          });
+        }
       }
     }
-
-    return this.page.screenshot({ path: outputFile, fullPage: fullPageOption, type: 'png' });
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1838,23 +1838,32 @@ class Puppeteer extends Helper {
    */
   async saveScreenshot(fileName, fullPage) {
     const fullPageOption = fullPage || this.options.fullPageScreenshots;
-    const outputFile = screenshotOutputFolder(fileName);
+    let outputFile = screenshotOutputFolder(fileName);
 
     this.debug(`Screenshot is saving to ${outputFile}`);
 
-    if (this.activeSessionName) {
-      const activeSessionPage = this.sessionPages[this.activeSessionName];
+    await this.page.screenshot({
+      path: outputFile,
+      fullPage: fullPageOption,
+      type: 'png',
+    });
 
-      if (activeSessionPage) {
-        return activeSessionPage.screenshot({
-          path: outputFile,
-          fullPage: fullPageOption,
-          type: 'png',
-        });
+    if (this.activeSessionName) {
+      for (const sessionName in this.sessionPages) {
+        const activeSessionPage = this.sessionPages[sessionName];
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
+
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
+
+        if (activeSessionPage) {
+          await activeSessionPage.screenshot({
+            path: outputFile,
+            fullPage: fullPageOption,
+            type: 'png',
+          });
+        }
       }
     }
-
-    return this.page.screenshot({ path: outputFile, fullPage: fullPageOption, type: 'png' });
   }
 
   async _failed() {

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -111,7 +111,7 @@ module.exports = function (config) {
           if (helper.activeSessionName) {
             for (const sessionName in helper.sessionPages) {
               const screenshotFileName = `${sessionName}_${fileName}`;
-              test.artifacts[`${sessionName}_screenshot`] = path.join(global.output_dir, screenshotFileName);
+              test.artifacts[`${sessionName.replace(/ /g, '_')}_screenshot`] = path.join(global.output_dir, screenshotFileName);
               allureReporter.addAttachment(`${sessionName} - Last Seen Screenshot`, fs.readFileSync(path.join(global.output_dir, screenshotFileName)), 'image/png');
             }
           }

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -106,7 +106,15 @@ module.exports = function (config) {
 
         const allureReporter = Container.plugins('allure');
         if (allureReporter) {
-          allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
+          allureReporter.addAttachment('Main session - Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
+
+          if (helper.activeSessionName) {
+            for (const sessionName in helper.sessionPages) {
+              const screenshotFileName = `${sessionName}_${fileName}`;
+              test.artifacts[`${sessionName}_screenshot`] = path.join(global.output_dir, screenshotFileName);
+              allureReporter.addAttachment(`${sessionName} - Last Seen Screenshot`, fs.readFileSync(path.join(global.output_dir, screenshotFileName)), 'image/png');
+            }
+          }
         }
 
         const cucumberReporter = Container.plugins('cucumberJsonReporter');

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -75,7 +75,8 @@ module.exports = function (config) {
   event.dispatcher.on(event.test.failed, (test) => {
     recorder.add('screenshot of failed test', async () => {
       let fileName = clearString(test.title);
-      // This prevent data driven to be included in the failed screenshot file name
+      const dataType = 'image/png';
+      // This prevents data driven to be included in the failed screenshot file name
       if (fileName.indexOf('{') !== -1) {
         fileName = fileName.substr(0, (fileName.indexOf('{') - 3)).trim();
       }
@@ -106,13 +107,13 @@ module.exports = function (config) {
 
         const allureReporter = Container.plugins('allure');
         if (allureReporter) {
-          allureReporter.addAttachment('Main session - Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
+          allureReporter.addAttachment('Main session - Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), dataType);
 
           if (helper.activeSessionName) {
             for (const sessionName in helper.sessionPages) {
               const screenshotFileName = `${sessionName}_${fileName}`;
               test.artifacts[`${sessionName.replace(/ /g, '_')}_screenshot`] = path.join(global.output_dir, screenshotFileName);
-              allureReporter.addAttachment(`${sessionName} - Last Seen Screenshot`, fs.readFileSync(path.join(global.output_dir, screenshotFileName)), 'image/png');
+              allureReporter.addAttachment(`${sessionName} - Last Seen Screenshot`, fs.readFileSync(path.join(global.output_dir, screenshotFileName)), dataType);
             }
           }
         }


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently only screenshot of the active session is saved, this PR aims to save the screenshot of every session for easy debugging


```
Feature('ShadowDom');

Scenario('Input a text in the input box and after search validate one of the book title',  async ({ I }) => {
    I.amOnPage('/')
    I.fillField('#input', 'Science')
    I.pressKey('Enter')
    I.waitForElement('h2[class="title"]')
    await I.seeElementInDOM('h2[class="title"]')

    await session('new session', () => {
        I.amOnPage('https://codecept.io');
        I.see('123');
    })

    await session('another session', () => {
        I.amOnPage('https://google.com');
        I.see('123');
    })
});
```

```
  Artifacts:
  - screenshot: /Users/thanh.nguyen/Desktop/codeceptjs-shadow-dom-fun/output/Input_a_text_in_the_input_box_and_after_search_validate_one_of_the_book_title.failed.png
  - new session_screenshot: /Users/thanh.nguyen/Desktop/codeceptjs-shadow-dom-fun/output/new session_Input_a_text_in_the_input_box_and_after_search_validate_one_of_the_book_title.failed.png
  - another session_screenshot: /Users/thanh.nguyen/Desktop/codeceptjs-shadow-dom-fun/output/another session_Input_a_text_in_the_input_box_and_after_search_validate_one_of_the_book_title.failed.png
```

![Screenshot 2023-06-27 at 07 37 02](https://github.com/codeceptjs/CodeceptJS/assets/7845001/714c075f-688b-403a-93cb-4ccb274c5774)


Applicable helpers:
- [x] Puppeteer
- [x] Playwright

Applicable plugins:
- [x] allure
- [x] screenshotOnFail


## Type of change
- [x] :bug: Bug fix


## Checklist:
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
