### PR TITLE
Fix backtick inside Playwright.md

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -416,7 +416,7 @@ Calls [blur][9] on the element.
 -   `locator` **([string][8] | [object][5])** field located by label|name|CSS|XPath|strict locator.
 -   `options` **any?** [Additional options][9] for available options object as 2nd argument.Examples:```js
     I.blur('.text-area')
-    ``````js
+    ```js
     //element `#product-tile` is focused
     I.see('#add-to-cart-btn');
     I.blur('#product-tile')
@@ -474,7 +474,7 @@ Clear the <input>, <textarea> or [contenteditable] .
 -   `locator` **([string][8] | [object][5])** field located by label|name|CSS|XPath|strict locator.
 -   `options` **any?** [Additional options][11] for available options object as 2nd argument.Examples:```js
     I.clearField('.text-area')
-    ``````js
+    ```js
     I.clearField('#submit', { force: true }) // force to bypass the [actionability](https://playwright.dev/docs/actionability) checks.
     ``` 
 


### PR DESCRIPTION
That lead to truncate doc on website

![image](https://github.com/codeceptjs/CodeceptJS/assets/15615569/a37f8a8c-8af8-4af9-a3e3-608284ee1d3f)

## Motivation/Description of the PR
- Playwright helper docs page was truncate due to wrong number of backtick

## Type of change

- [x] :clipboard: Documentation changes/updates
- [x] :hammer: Markdown files fix - not related to source code

