### PR TITLE
Update Playwright.md

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -414,14 +414,14 @@ Calls [blur][9] on the element.
 #### Parameters
 
 -   `locator` **([string][8] | [object][5])** field located by label|name|CSS|XPath|strict locator.
--   `options` **any?** [Additional options][9] for available options object as 2nd argument.Examples:```js
-    I.blur('.text-area')
-    ``````js
-    //element `#product-tile` is focused
-    I.see('#add-to-cart-btn');
-    I.blur('#product-tile')
-    I.dontSee('#add-to-cart-btn');
-    ``` 
+-   `options` **any?** [Additional options][9] for available options object as 2nd argument.Examples:
+```js
+I.blur('.text-area')
+//element `#product-tile` is focused
+I.see('#add-to-cart-btn');
+I.blur('#product-tile')
+I.dontSee('#add-to-cart-btn');
+``` 
 
 ### cancelPopup
 
@@ -467,16 +467,16 @@ I.clearCookie('test');
 
 ### clearField
 
-Clear the <input>, <textarea> or [contenteditable] .
+Clear the `input`, `textarea` or [contenteditable] .
 
 #### Parameters
 
 -   `locator` **([string][8] | [object][5])** field located by label|name|CSS|XPath|strict locator.
--   `options` **any?** [Additional options][11] for available options object as 2nd argument.Examples:```js
-    I.clearField('.text-area')
-    ``````js
-    I.clearField('#submit', { force: true }) // force to bypass the [actionability](https://playwright.dev/docs/actionability) checks.
-    ``` 
+-   `options` **any?** [Additional options][11] for available options object as 2nd argument.Examples:
+```js
+I.clearField('.text-area')
+I.clearField('#submit', { force: true }) // force to bypass the [actionability](https://playwright.dev/docs/actionability) checks.
+``` 
 
 ### click
 


### PR DESCRIPTION
That lead to truncate doc on website
& with @DavertMik feedback fix html tags that broke HTML

![image](https://github.com/codeceptjs/CodeceptJS/assets/15615569/a37f8a8c-8af8-4af9-a3e3-608284ee1d3f)

## Motivation/Description of the PR
- Playwright helper docs page was truncate due to wrong number of backtick

## Type of change

- [x] :clipboard: Documentation changes/updates
- [x] :hammer: Markdown files fix - not related to source code
