### PR TITLE
fix: openai helper doesnt work

### DIFF
--- a/lib/helper/OpenAI.js
+++ b/lib/helper/OpenAI.js
@@ -25,7 +25,9 @@ class OpenAI extends Helper {
       chunkSize: 80000,
     };
     this.options = { ...this.options, ...config };
+  }
 
+  _beforeSuite() {
     const helpers = Container.helpers();
 
     for (const helperName of standardActingHelpers) {
@@ -37,16 +39,16 @@ class OpenAI extends Helper {
   }
 
   /**
- * Asks the OpenAI GPT language model a question based on the provided prompt within the context of the current page's HTML.
- *
- * ```js
- * I.askGptOnPage('what does this page do?');
- * ```
- *
- * @async
- * @param {string} prompt - The question or prompt to ask the GPT model.
- * @returns {Promise<string>} - A Promise that resolves to the generated responses from the GPT model, joined by newlines.
- */
+   * Asks the OpenAI GPT language model a question based on the provided prompt within the context of the current page's HTML.
+   *
+   * ```js
+   * I.askGptOnPage('what does this page do?');
+   * ```
+   *
+   * @async
+   * @param {string} prompt - The question or prompt to ask the GPT model.
+   * @returns {Promise<string>} - A Promise that resolves to the generated responses from the GPT model, joined by newlines.
+   */
   async askGptOnPage(prompt) {
     const html = await this.helper.grabSource();
 
@@ -120,3 +122,5 @@ class OpenAI extends Helper {
     return response;
   }
 }
+
+module.exports = OpenAI;


### PR DESCRIPTION
## Motivation/Description of the PR
- OpenAI helper throws error due to the helper is not yet available in constructor.
![image](https://github.com/codeceptjs/CodeceptJS/assets/7845001/64cca933-6427-4b3e-867f-22b2d489a0b4)


## Type of change
- [x] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
