### PR TITLE
added examples in docblocks of new network test steps in Playwright helper

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2667,7 +2667,7 @@ class Playwright extends Helper {
    * This also resets recorded network requests.
    *
    * ```js
-   * await I.startRecordingTraffic();
+   * I.startRecordingTraffic();
    * ```
    *
    * @return {Promise<void>}
@@ -2712,10 +2712,10 @@ class Playwright extends Helper {
    * Examples:
    *
    * ```js
-   * await I.blockTraffic('http://example.com/css/style.css');
-   * await I.blockTraffic('http://example.com/css/*.css');
-   * await I.blockTraffic('http://example.com/**');
-   * await I.blockTraffic(/\.css$/);
+   * I.blockTraffic('http://example.com/css/style.css');
+   * I.blockTraffic('http://example.com/css/*.css');
+   * I.blockTraffic('http://example.com/**');
+   * I.blockTraffic(/\.css$/);
    * ```
    *
    * @param url URL to block . URL can contain * for wildcards. Example: https://www.example.com** to block all traffic for that domain. Regexp are also supported.
@@ -2737,9 +2737,9 @@ class Playwright extends Helper {
    * Examples:
    *
    * ```js
-   * await I.mockTraffic('/api/users/1', '{ id: 1, name: 'John Doe' }');
-   * await I.mockTraffic('/api/users/*', JSON.stringify({ id: 1, name: 'John Doe' }));
-   * await I.mockTraffic([/^https://api.example.com/v1/, 'https://api.example.com/v2/**'], 'Internal Server Error', 'text/html');
+   * I.mockTraffic('/api/users/1', '{ id: 1, name: 'John Doe' }');
+   * I.mockTraffic('/api/users/*', JSON.stringify({ id: 1, name: 'John Doe' }));
+   * I.mockTraffic([/^https://api.example.com/v1/, 'https://api.example.com/v2/**'], 'Internal Server Error', 'text/html');
    * ```
    *
    * @param urls string|Array These are the URL(s) to mock, e.g. "/fooapi/*" or "['/fooapi_1/*', '/barapi_2/*']". Regular expressions are also supported.
@@ -2782,7 +2782,7 @@ class Playwright extends Helper {
    * Stops recording of network traffic. Recorded traffic is not flashed.
    *
    * ```js
-   * await I.stopRecordingTraffic();
+   * I.stopRecordingTraffic();
    * ```
    */
   async stopRecordingTraffic() {
@@ -2795,7 +2795,7 @@ class Playwright extends Helper {
    * ```js
    * // checking the request url contains certain query strings
    * I.amOnPage('https://openai.com/blog/chatgpt');
-   * await I.startRecordingTraffic();
+   * I.startRecordingTraffic();
    * await I.seeTraffic({
    *    name: 'sentry event',
    *    url: 'https://images.openai.com/blob/cf717bdb-0c8c-428a-b82b-3c3add87a600',
@@ -2809,7 +2809,7 @@ class Playwright extends Helper {
    * ```js
    * // checking the request url contains certain post data
    * I.amOnPage('https://openai.com/blog/chatgpt');
-   * await I.startRecordingTraffic();
+   * I.startRecordingTraffic();
    * await I.seeTraffic({
    *    name: 'event',
    *    url: 'https://cloudflareinsights.com/cdn-cgi/rum',
@@ -2869,8 +2869,8 @@ class Playwright extends Helper {
    * Examples:
    *
    * ```js
-   * await I.getTrafficUrl('https://api.example.com/session');
-   * await I.getTrafficUrl(/session.*start/);
+   * I.getTrafficUrl('https://api.example.com/session');
+   * I.getTrafficUrl(/session.*start/);
    * ```
    *
    * @param urlMatch String Regular expression string the wanted URL must match

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2666,6 +2666,10 @@ class Playwright extends Helper {
    * Starts recording of network traffic.
    * This also resets recorded network requests.
    *
+   * ```js
+   * await I.startRecordingTraffic();
+   * ```
+   *
    * @return {Promise<void>}
    */
   async startRecordingTraffic() {
@@ -2705,7 +2709,16 @@ class Playwright extends Helper {
   /**
    * Blocks traffic for URL.
    *
-   * @param url URL to block . URL can contain * for wildcards. Example: https://www.example.com* to block all traffic for that domain.
+   * Examples:
+   *
+   * ```js
+   * await I.blockTraffic('http://example.com/css/style.css');
+   * await I.blockTraffic('http://example.com/css/*.css');
+   * await I.blockTraffic('http://example.com/**');
+   * await I.blockTraffic(/\.css$/);
+   * ```
+   *
+   * @param url URL to block . URL can contain * for wildcards. Example: https://www.example.com** to block all traffic for that domain. Regexp are also supported.
    */
   async blockTraffic(url) {
     this.page.route(url, (route) => {
@@ -2719,11 +2732,19 @@ class Playwright extends Helper {
 
   /**
    * Mocks traffic for URL(s).
-   * This is a powerful feature to manipulate network traffic. Can be used e.g. to stabilize your tests.
+   * This is a powerful feature to manipulate network traffic. Can be used e.g. to stabilize your tests, speed up your tests or as a last resort to make some test scenarios even possible.
    *
-   * @param urls string|Array These are the URL(s) to mock, e.g. "/fooapi/*" or "['/fooapi_1/*', '/barapi_2/*']"
-   * @param responseString string The string to return in fake response.
-   * @param contentType Content type of response. If not specified default value 'application/json' is used.
+   * Examples:
+   *
+   * ```js
+   * await I.mockTraffic('/api/users/1', '{ id: 1, name: 'John Doe' }');
+   * await I.mockTraffic('/api/users/*', JSON.stringify({ id: 1, name: 'John Doe' }));
+   * await I.mockTraffic([/^https://api.example.com/v1/, 'https://api.example.com/v2/**'], 'Internal Server Error', 'text/html');
+   * ```
+   *
+   * @param urls string|Array These are the URL(s) to mock, e.g. "/fooapi/*" or "['/fooapi_1/*', '/barapi_2/*']". Regular expressions are also supported.
+   * @param responseString string The string to return in fake response's body.
+   * @param contentType Content type of fake response. If not specified default value 'application/json' is used.
    */
   async mockTraffic(urls, responseString, contentType = 'application/json') {
     // Required to mock cross-domain requests
@@ -2759,6 +2780,10 @@ class Playwright extends Helper {
 
   /**
    * Stops recording of network traffic. Recorded traffic is not flashed.
+   *
+   * ```js
+   * await I.stopRecordingTraffic();
+   * ```
    */
   async stopRecordingTraffic() {
     this.page.removeAllListeners('request');
@@ -2840,10 +2865,22 @@ class Playwright extends Helper {
 
   /**
    * Returns full URL of request matching parameter "urlMatch".
+   *
+   * Examples:
+   *
+   * ```js
+   * await I.getTrafficUrl('https://api.example.com/session');
+   * await I.getTrafficUrl(/session.*start/);
+   * ```
+   *
    * @param urlMatch String Regular expression string the wanted URL must match
    * @return {Promise<*>}
    */
   async getTrafficUrl(urlMatch) {
+    if (!this.recordedAtLeastOnce) {
+      throw new Error('Failure in test automation. You use "I.getTrafficUrl", but "I.startRecordingTraffic" was never called before.');
+    }
+
     for (const i in this.requests) {
       // eslint-disable-next-line no-prototype-builtins
       if (this.requests.hasOwnProperty(i)) {
@@ -2860,10 +2897,17 @@ class Playwright extends Helper {
 
   /**
    * Verifies that a certain request is not part of network traffic.
+   *
+   * Examples:
+   *
+   * ```js
+   * I.dontSeeTraffic('Unexpected API Call', 'https://api.example.com');
+   * I.dontSeeTraffic('Unexpected API Call of "user" endpoint', /api.example.com.*user/);
+   * ```
    * @param {string} name A name of that request. Can be any value. Only relevant to have a more meaningful error message in case of fail.
-   * @param {string} url Expected URL of request in network traffic
+   * @param {string} url Expected URL of request in network traffic. Can be a string or a regular expression.
    */
-  async dontSeeTraffic(name, url) {
+  dontSeeTraffic(name, url) {
     if (!this.recordedAtLeastOnce) {
       throw new Error('Failure in test automation. You use "I.dontSeeTraffic", but "I.startRecordingTraffic" was never called before.');
     }


### PR DESCRIPTION
## Motivation/Description of the PR
- I created examples in docblock of the new steps in Playwright helper for network testing.
- Minor Functional adjustments/improvements:
   - I removed `async` from  `dontSeeTraffic`, because there is no need for it. The evaluating code inside runs synchronously.
    - I make `getTrafficUrl` fail hard when recording of traffic has not yet started. I think this is helpful for the test automation engineer. I cannot imagine there is usecase where this new behavior is unwanted.
- Resolves request for support from @DavertMik at https://github.com/codeceptjs/CodeceptJS/pull/3748#issuecomment-1629711741

Applicable helpers:

- [ x ] Protractor


## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ x ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ x ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
