### PR TITLE
fix: FormData is built in now

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "eslint-plugin-mocha": "^6.3.0",
     "expect": "^26.6.2",
     "express": "^4.17.2",
-    "form-data": "^3.0.1",
     "graphql": "^14.6.0",
     "husky": "^8.0.1",
     "inquirer-test": "^2.0.1",

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const expect = require('expect');
 const fs = require('fs');
-const FormData = require('form-data');
 
 const TestHelper = require('../support/TestHelper');
 const REST = require('../../lib/helper/REST');
@@ -325,7 +324,7 @@ describe('REST - Form upload', () => {
       form.append('file', fs.createReadStream(testFile));
 
       try {
-        await I.sendPostRequest('upload', form, { ...form.getHeaders() });
+        await I.sendPostRequest('upload', form);
       } catch (error) {
         error.message.should.eql('Request body larger than maxBodyLength limit');
       }
@@ -336,7 +335,7 @@ describe('REST - Form upload', () => {
       form.append('file', fs.createReadStream(testFile));
 
       try {
-        const response = await I.sendPostRequest('upload', form, { ...form.getHeaders() });
+        const response = await I.sendPostRequest('upload', form);
         response.data.should.include('File Uploaded!');
       } catch (error) {
         console.log(error.message);


### PR DESCRIPTION
## Motivation/Description of the PR
- FormData is shipped natively in all ever green browser and backends now.
- https://github.com/form-data/form-data/issues/537

Applicable helpers:
- [ ] REST

## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
