### PR TITLE
Fix enable highlight element

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -74,7 +74,7 @@ Type: [object][5]
 -   `ignoreLog` **[Array][22]&lt;[string][8]>?** An array with console message types that are not logged to debug log. Default value is `['warning', 'log']`. E.g. you can set `[]` to log all messages. See all possible [values][44].
 -   `ignoreHTTPSErrors` **[boolean][32]?** Allows access to untrustworthy pages, e.g. to a page with an expired certificate. Default value is `false`
 -   `bypassCSP` **[boolean][32]?** bypass Content Security Policy or CSP
--   `highlightElement` **[boolean][32]?** highlight the interacting elements
+-   `highlightElement` **[boolean][32]?** highlight the interacting elements. Default: false
 
 
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -56,7 +56,7 @@ Type: [object][4]
 -   `manualStart` **[boolean][20]?** do not start browser before a test, start it manually inside a helper with `this.helpers["Puppeteer"]._startBrowser()`.
 -   `browser` **[string][6]?** can be changed to `firefox` when using [puppeteer-firefox][2].
 -   `chrome` **[object][4]?** pass additional [Puppeteer run options][25].
--   `highlightElement` **[boolean][20]?** highlight the interacting elements
+-   `highlightElement` **[boolean][20]?** highlight the interacting elements. Default: false
 
 
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -45,7 +45,7 @@ Type: [object][16]
 -   `desiredCapabilities` **[object][16]?** Selenium's [desired capabilities][6].
 -   `manualStart` **[boolean][32]?** do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriver"]._startBrowser()`.
 -   `timeouts` **[object][16]?** [WebDriver timeouts][37] defined as hash.
--   `highlightElement` **[boolean][32]?** highlight the interacting elements
+-   `highlightElement` **[boolean][32]?** highlight the interacting elements. Default: false
 
 
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -93,7 +93,7 @@ const pathSeparator = path.sep;
  * @prop {string[]} [ignoreLog] - An array with console message types that are not logged to debug log. Default value is `['warning', 'log']`. E.g. you can set `[]` to log all messages. See all possible [values](https://playwright.dev/docs/api/class-consolemessage#console-message-type).
  * @prop {boolean} [ignoreHTTPSErrors] - Allows access to untrustworthy pages, e.g. to a page with an expired certificate. Default value is `false`
  * @prop {boolean} [bypassCSP] - bypass Content Security Policy or CSP
- * @prop {boolean} [highlightElement] - highlight the interacting elements
+ * @prop {boolean} [highlightElement] - highlight the interacting elements. Default: false
  */
 const config = {};
 
@@ -343,7 +343,8 @@ class Playwright extends Helper {
       show: false,
       defaultPopupAction: 'accept',
       use: { actionTimeout: 0 },
-      ignoreHTTPSErrors: false, // Adding it here o that context can be set up to ignore the SSL errors
+      ignoreHTTPSErrors: false, // Adding it here o that context can be set up to ignore the SSL errors,
+      highlightElement: false
     };
 
     config = Object.assign(defaults, config);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3478,7 +3478,7 @@ async function saveTraceForContext(context, name) {
 }
 
 function highlightActiveElement(element, context) {
-  if (!this.options.enableHighlight && !store.debugMode) return;
+  if (!this.options.highlightElement && !store.debugMode) return;
 
   highlightElement(element, context);
 }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -344,7 +344,7 @@ class Playwright extends Helper {
       defaultPopupAction: 'accept',
       use: { actionTimeout: 0 },
       ignoreHTTPSErrors: false, // Adding it here o that context can be set up to ignore the SSL errors,
-      highlightElement: false
+      highlightElement: false,
     };
 
     config = Object.assign(defaults, config);

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -69,7 +69,7 @@ const consoleLogStore = new Console();
  * @prop {boolean} [manualStart=false] - do not start browser before a test, start it manually inside a helper with `this.helpers["Puppeteer"]._startBrowser()`.
  * @prop {string} [browser=chrome] - can be changed to `firefox` when using [puppeteer-firefox](https://codecept.io/helpers/Puppeteer-firefox).
  * @prop {object} [chrome] - pass additional [Puppeteer run options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
- * @prop {boolean} [highlightElement] - highlight the interacting elements
+ * @prop {boolean} [highlightElement] - highlight the interacting elements. Default: false
 */
 const config = {};
 
@@ -231,6 +231,7 @@ class Puppeteer extends Helper {
       keepBrowserState: false,
       show: false,
       defaultPopupAction: 'accept',
+      highlightElement: false
     };
 
     return Object.assign(defaults, config);

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2714,7 +2714,7 @@ function getNormalizedKey(key) {
 }
 
 function highlightActiveElement(element, context) {
-  if (!this.options.enableHighlight && !store.debugMode) return;
+  if (!this.options.highlightElement && !store.debugMode) return;
 
   highlightElement(element, context);
 }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -231,7 +231,7 @@ class Puppeteer extends Helper {
       keepBrowserState: false,
       show: false,
       defaultPopupAction: 'accept',
-      highlightElement: false
+      highlightElement: false,
     };
 
     return Object.assign(defaults, config);

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -62,7 +62,7 @@ const webRoot = 'body';
  * @prop {object} [desiredCapabilities] Selenium's [desired capabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities).
  * @prop {boolean} [manualStart=false] - do not start browser before a test, start it manually inside a helper with `this.helpers["WebDriver"]._startBrowser()`.
  * @prop {object} [timeouts] [WebDriver timeouts](http://webdriver.io/docs/timeouts.html) defined as hash.
- * @prop {boolean} [highlightElement] - highlight the interacting elements
+ * @prop {boolean} [highlightElement] - highlight the interacting elements. Default: false
  */
 const config = {};
 
@@ -429,6 +429,7 @@ class WebDriver extends Helper {
       keepCookies: false,
       keepBrowserState: false,
       deprecationWarnings: false,
+      highlightElement: false,
     };
 
     // override defaults with config
@@ -2914,7 +2915,7 @@ function isModifierKey(key) {
 }
 
 function highlightActiveElement(element) {
-  if (!this.options.enableHighlight && !store.debugMode) return;
+  if (!this.options.highlightElement && !store.debugMode) return;
 
   highlightElement(element, this.browser);
 }


### PR DESCRIPTION
## Motivation/Description of the PR
The 'highlightElement' option (described in the helper docs) was not correctly checked in the code, so that this option had no effect. Furthermore no default value was defined. So this fix sets the option per default to false
- Resolves #3777

Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`) (too many errors not from my side)
- [x] Local tests are passed (Run `npm test`)
