### PR TITLE
fix: improve def command

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -37,7 +37,7 @@ const getDefinitionsFileContent = ({
     customHelpers,
   }) => {
     if (hasCustomHelper && hasCustomStepsFile) {
-      return `${['ReturnType<steps_file>', ...customHelpers].join(', ')}`;
+      return `${['ReturnType<steps_file>', 'WithTranslation<Methods>'].join(', ')}`;
     }
 
     if (hasCustomStepsFile) {

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -17,7 +17,6 @@ const actingHelpers = [...require('../plugin/standardActingHelpers'), 'REST'];
  * @param {Map} params.supportObject
  * @param {Array<string>} params.helperNames
  * @param {Array<string>} params.importPaths
- * @param {Array<string>} params.customHelpers
  * @param params.translations
  *
  * @returns {string}
@@ -29,12 +28,10 @@ const getDefinitionsFileContent = ({
   supportObject,
   importPaths,
   translations,
-  customHelpers,
 }) => {
   const getHelperListFragment = ({
     hasCustomHelper,
     hasCustomStepsFile,
-    customHelpers,
   }) => {
     if (hasCustomHelper && hasCustomStepsFile) {
       return `${['ReturnType<steps_file>', 'WithTranslation<Methods>'].join(', ')}`;
@@ -50,7 +47,6 @@ const getDefinitionsFileContent = ({
   const helpersListFragment = getHelperListFragment({
     hasCustomHelper,
     hasCustomStepsFile,
-    customHelpers,
   });
 
   const importPathsFragment = importPaths.join('\n');
@@ -143,7 +139,7 @@ module.exports = function (genPath, options) {
     }
 
     if (!actingHelpers.includes(name)) {
-      customHelpers.push(`WithTranslation<${name}>`);
+      customHelpers.push(name);
     }
   }
 
@@ -186,7 +182,6 @@ module.exports = function (genPath, options) {
     translations,
     hasCustomStepsFile,
     hasCustomHelper,
-    customHelpers,
   });
 
   // add aliases for translations

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,26 @@
 {
+  "ts-node": {
+    "files": true
+  },
   "compilerOptions": {
+    "target": "es2018",
+    "lib": ["es2018", "DOM"],
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "types": ["node"],
+    "declaration": true,
+    "skipLibCheck": true,
     "allowJs": true,
     "checkJs": true,
-    "module": "commonjs",
     "noImplicitAny": false,
     "noImplicitThis": false,
     "noEmit": true,
-    "strictNullChecks": true,
-    "types": [
-        "node"
-    ],
-    "target": "es2018"
+    "strictNullChecks": true
   },
+  "exclude": ["node_modules", "typings/tests"],
   "compileOnSave": true,
   "include": [
     "lib",
     "typings"
-  ],
-  "exclude": [
-    "typings/tests"
   ]
 }


### PR DESCRIPTION
## Motivation/Description of the PR
- improve def command, so when we have multiple custom helpers, `WithTranslation<Methods>` would be enough instead of `WithTranslation<GraphQL>, WithTranslation<CustomGraphQL>`

```
/// <reference types='codeceptjs' />
type steps_file = typeof import('./steps_file');
type CustomGraphQL = import('./CustomGraphQL');

declare namespace CodeceptJS {
  interface SupportObject { I: I, current: any }
  interface Methods extends GraphQL, CustomGraphQL {}
  interface I extends ReturnType<steps_file>, WithTranslation<Methods> {}
  namespace Translation {
    interface Actions {}
  }
}
```

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
