### PR TITLE
fix: display custom steps friendly

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -250,7 +250,7 @@ class MetaStep extends Step {
       return `${this.prefix}${actorText} ${this.name} "${this.humanizeArgs()}${this.suffix}"`;
     }
 
-    return `${this.prefix}${actorText}: I ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
+    return `${this.prefix}${actorText}: I ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
   }
 
   humanize() {

--- a/lib/step.js
+++ b/lib/step.js
@@ -188,9 +188,6 @@ class Step {
 
   /** @return {string} */
   toString() {
-    if (this.actor !== 'I') {
-      return `${this.prefix}${this.actor}: ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
-    }
     return `${this.prefix}${this.actor} ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
   }
 
@@ -246,7 +243,7 @@ class MetaStep extends Step {
   toString() {
     const actorText = this.actor;
 
-    if (this.isBDD()) {
+    if (this.isBDD() || this.isWithin()) {
       return `${this.prefix}${actorText} ${this.name} "${this.humanizeArgs()}${this.suffix}"`;
     }
 
@@ -254,7 +251,7 @@ class MetaStep extends Step {
       return `${this.prefix}${actorText} ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
     }
 
-    return `On ${this.prefix}${actorText}: I ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
+    return `On ${this.prefix}${actorText}: ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
   }
 
   humanize() {
@@ -325,8 +322,14 @@ function dryRunResolver() {
 
 function humanizeString(string) {
   // split strings by words, then make them all lowercase
-  return string.replace(/([a-z](?=[A-Z]))/g, '$1 ')
+  const _result = string.replace(/([a-z](?=[A-Z]))/g, '$1 ')
     .split(' ')
-    .map(word => word.toLowerCase())
-    .join(' ');
+    .map(word => word.toLowerCase());
+
+  _result[0] = _result[0] === 'i' ? capitalizeFLetter(_result[0]) : _result[0];
+  return _result.join(' ').trim();
+}
+
+function capitalizeFLetter(string) {
+  return (string[0].toUpperCase() + string.slice(1));
 }

--- a/lib/step.js
+++ b/lib/step.js
@@ -138,13 +138,7 @@ class Step {
 
   /** @return {string} */
   humanize() {
-    return this.name
-    // insert a space before all caps
-      .replace(/([A-Z])/g, ' $1')
-    // _ chars to spaces
-      .replace('_', ' ')
-    // uppercase the first character
-      .replace(/^(.)|\s(.)/g, $1 => $1.toLowerCase());
+    return humanizeString(this.name);
   }
 
   /** @return {string} */
@@ -247,12 +241,12 @@ class MetaStep extends Step {
   }
 
   toString() {
-    const actorText = !this.isBDD() && !this.isWithin() ? `${this.actor}:` : this.actor;
-    return `${this.prefix}${actorText} ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
+    const actorText = !this.isBDD() && !this.isWithin() ? `${this.actor}` : this.actor;
+    return `${this.prefix}${actorText} ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
   }
 
   humanize() {
-    return this.name;
+    return humanizeString(this.name);
   }
 
   setTrace() {
@@ -315,4 +309,12 @@ function dryRunResolver() {
       return new Proxy({}, dryRunResolver());
     },
   };
+}
+
+function humanizeString(string) {
+  // split strings by words, then make them all lowercase
+  return string.replace(/([a-z](?=[A-Z]))/g, '$1 ')
+    .split(' ')
+    .map(word => word.toLowerCase())
+    .join(' ');
 }

--- a/lib/step.js
+++ b/lib/step.js
@@ -244,7 +244,7 @@ class MetaStep extends Step {
   }
 
   toString() {
-    const actorText = !this.isBDD() && !this.isWithin() ? this.actor : `${this.actor}:`;
+    const actorText = !this.isBDD() && !this.isWithin() ? this.actor : `${this.actor}: I `;
     return `${this.prefix}${actorText}: ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
   }
 

--- a/lib/step.js
+++ b/lib/step.js
@@ -250,7 +250,7 @@ class MetaStep extends Step {
       return `${this.prefix}${actorText} ${this.name} "${this.humanizeArgs()}${this.suffix}"`;
     }
 
-    return `${this.prefix}${actorText}: ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
+    return `${this.prefix}${actorText}: I ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
   }
 
   humanize() {

--- a/lib/step.js
+++ b/lib/step.js
@@ -250,7 +250,11 @@ class MetaStep extends Step {
       return `${this.prefix}${actorText} ${this.name} "${this.humanizeArgs()}${this.suffix}"`;
     }
 
-    return `${this.prefix}${actorText}: I ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
+    if (actorText === 'I') {
+      return `${this.prefix}${actorText} ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
+    }
+
+    return `On ${this.prefix}${actorText}: I ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
   }
 
   humanize() {

--- a/lib/step.js
+++ b/lib/step.js
@@ -188,6 +188,9 @@ class Step {
 
   /** @return {string} */
   toString() {
+    if (this.actor !== 'I') {
+      return `${this.prefix}${this.actor}: ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
+    }
     return `${this.prefix}${this.actor} ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`;
   }
 
@@ -241,8 +244,8 @@ class MetaStep extends Step {
   }
 
   toString() {
-    const actorText = !this.isBDD() && !this.isWithin() ? `${this.actor}` : this.actor;
-    return `${this.prefix}${actorText} ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
+    const actorText = !this.isBDD() && !this.isWithin() ? this.actor : `${this.actor}:`;
+    return `${this.prefix}${actorText}: ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
   }
 
   humanize() {

--- a/lib/step.js
+++ b/lib/step.js
@@ -244,7 +244,12 @@ class MetaStep extends Step {
   }
 
   toString() {
-    const actorText = !this.isBDD() && !this.isWithin() ? this.actor : `${this.actor}: I `;
+    const actorText = this.actor;
+
+    if (this.isBDD()) {
+      return `${this.prefix}${actorText} ${this.name} "${this.humanizeArgs()}${this.suffix}"`;
+    }
+
     return `${this.prefix}${actorText}: ${this.humanize()} "${this.humanizeArgs()}${this.suffix}"`;
   }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint bin/ examples/ lib/ test/ translations/ runok.js",
     "lint-fix": "eslint bin/ examples/ lib/ test/ translations/ runok.js --fix",
     "docs": "./runok.js docs",
-    "test:unit": "mocha test/unit --recursive",
+    "test:unit": "mocha test/unit --recursive --timeout 5000",
     "test:runner": "mocha test/runner --recursive --timeout 5000",
     "test": "npm run test:unit && npm run test:runner",
     "test:appium-quick": "mocha test/helper/Appium_test.js --grep 'quick'",

--- a/test/runner/dry_run_test.js
+++ b/test/runner/dry_run_test.js
@@ -81,10 +81,10 @@ describe('dry-run command', () => {
       expect(lines).toEqual(
         expect.arrayContaining([
           '  check current dir',
-          '    I: openDir "aaa"',
+          '    I open dir "aaa"',
           '      I am in path "."',
           '      I see file "codecept.class.js"',
-          '    MyPage: hasFile "First arg", "Second arg"',
+          '    On MyPage: has file "First arg", "Second arg"',
           '      I see file "codecept.class.js"',
           '      I see file "codecept.po.js"',
           '    I see file "codecept.po.js"',
@@ -150,10 +150,10 @@ describe('dry-run command', () => {
       expect(lines).toEqual(
         expect.arrayContaining([
           '  check current dir',
-          '    I: openDir "aaa"',
+          '    I open dir "aaa"',
           '      I am in path "."',
           '      I see file "codecept.class.js"',
-          '    MyPage: hasFile "uu"',
+          '    On MyPage: has file "uu"',
           '      I see file "codecept.class.js"',
           '      I see file "codecept.po.js"',
           '    I see file "codecept.po.js"',

--- a/test/runner/pageobject_test.js
+++ b/test/runner/pageobject_test.js
@@ -36,9 +36,9 @@ describe('CodeceptJS PageObject', () => {
     it('should inject page objects by class', (done) => {
       exec(`${config_run_config('codecept.class.js', '@ClassPageObject')} --debug`, (err, stdout) => {
         expect(stdout).not.toContain('classpage.type is not a function');
-        expect(stdout).toContain('classpage: type "Class Page Type"');
+        expect(stdout).toContain('On classpage: type "Class Page Type"');
         expect(stdout).toContain('I print message "Class Page Type"');
-        expect(stdout).toContain('classpage: purgeDomains');
+        expect(stdout).toContain('On classpage: purge domains');
         expect(stdout).toContain('I print message "purgeDomains"');
         expect(stdout).toContain('Class Page Type');
         expect(stdout).toContain('OK  | 1 passed');
@@ -50,10 +50,10 @@ describe('CodeceptJS PageObject', () => {
     it('should inject page objects by class which nested base clas', (done) => {
       exec(`${config_run_config('codecept.class.js', '@NestedClassPageObject')} --debug`, (err, stdout) => {
         expect(stdout).not.toContain('classnestedpage.type is not a function');
-        expect(stdout).toContain('classnestedpage: type "Nested Class Page Type"');
+        expect(stdout).toContain('On classnestedpage: type "Nested Class Page Type"');
         expect(stdout).toContain('user => User1');
         expect(stdout).toContain('I print message "Nested Class Page Type"');
-        expect(stdout).toContain('classnestedpage: purgeDomains');
+        expect(stdout).toContain('On classnestedpage: purge domains');
         expect(stdout).toContain('I print message "purgeDomains"');
         expect(stdout).toContain('Nested Class Page Type');
         expect(stdout).toContain('OK  | 1 passed');
@@ -89,10 +89,10 @@ describe('CodeceptJS PageObject', () => {
         expect(lines).toEqual(
           expect.arrayContaining([
             '  check current dir',
-            '    I: openDir "aaa"',
+            '    I open dir "aaa"',
             '      I am in path "."',
             '      I see file "codecept.class.js"',
-            '    MyPage: hasFile "First arg", "Second arg"',
+            '    On MyPage: has file "First arg", "Second arg"',
             '      I see file "codecept.class.js"',
             '      I see file "codecept.po.js"',
             '    I see file "codecept.po.js"',
@@ -113,10 +113,10 @@ describe('CodeceptJS PageObject', () => {
         expect(lines).toEqual(
           expect.arrayContaining([
             '  check current dir',
-            '    I: openDir "aaa"',
+            '    I open dir "aaa"',
             '      I am in path "."',
             '      I see file "codecept.class.js"',
-            '    MyPage: hasFile "uu"',
+            '    On MyPage: has file "uu"',
             '      I see file "codecept.class.js"',
             '      I see file "codecept.po.js"',
             '    I see file "codecept.po.js"',
@@ -136,10 +136,10 @@ describe('CodeceptJS PageObject', () => {
         expect(lines).toEqual(
           expect.arrayContaining([
             '  pageobject with context',
-            '    I: openDir "aaa"',
+            '    I open dir "aaa"',
             '      I am in path "."',
             '      I see file "codecept.class.js"',
-            '    MyPage: hasFile "uu"',
+            '    On MyPage: has file "uu"',
             '      I see file "codecept.class.js"',
             '      I see file "codecept.po.js"',
             '    I see file "codecept.po.js"',

--- a/test/runner/within_test.js
+++ b/test/runner/within_test.js
@@ -24,12 +24,12 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withoutGeneratorList.should.eql([
         'I small promise ',
-        'I small  Promise was finished ',
-        'I  Hey!  I am within  Begin.  I get blabla ',
-        'Within "blabla" ',
+        'I small promise was finished ',
+        'I hey! i am within begin. i get blabla ',
+        'Within "blabla" ""',
         'I small promise ',
-        'I small  Promise was finished ',
-        'I oh!  I am within end( ',
+        'I small promise was finished ',
+        'I oh! i am within end( ',
       ], 'check steps execution order');
       done();
     });
@@ -44,16 +44,16 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withGeneratorList.should.eql([
         'I small promise ',
-        'I small  Promise was finished ',
+        'I small promise was finished ',
         'I small yield ',
         'I am small yield string await',
-        'I  Hey!  I am within  Begin.  I get blabla ',
-        'Within "blabla" ',
+        'I hey! i am within begin. i get blabla ',
+        'Within "blabla" ""',
         'I small yield ',
         'I am small yield string await',
         'I small promise ',
-        'I small  Promise was finished ',
-        'I oh!  I am within end( ',
+        'I small promise was finished ',
+        'I oh! i am within end( ',
       ], 'check steps execution order');
 
       done();
@@ -69,16 +69,16 @@ describe('CodeceptJS within', function () {
       testStatus.should.include('OK');
       withGeneratorList.should.eql([
         'I small promise ',
-        'I small  Promise was finished ',
+        'I small promise was finished ',
         'I small yield ',
         'I am small yield string await',
-        'I  Hey!  I am within  Begin.  I get blabla ',
-        'Within "blabla" ',
+        'I hey! i am within begin. i get blabla ',
+        'Within "blabla" ""',
         'I small promise ',
-        'I small  Promise was finished ',
+        'I small promise was finished ',
         'I small yield ',
         'I am small yield string await',
-        'I oh!  I am within end( ',
+        'I oh! i am within end( ',
       ], 'check steps execution order');
 
       done();

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -111,7 +111,7 @@ describe('Steps', () => {
 
       it('should correct print step info for simple PageObject', () => {
         const metaStep = new MetaStep('MyPage', 'clickByName');
-        expect(metaStep.toString()).to.include('MyPage: clickByName');
+        expect(metaStep.toString()).to.include('MyPage click by name');
       });
 
       it('should correct print step with args', () => {
@@ -120,7 +120,7 @@ describe('Steps', () => {
         const msg2 = 'second message';
         const fn = (msg) => `result from callback = ${msg}`;
         metaStep.run.bind(metaStep, fn)(msg, msg2);
-        expect(metaStep.toString()).eql(`MyPage: clickByName "${msg}", "${msg2}"`);
+        expect(metaStep.toString()).eql(`MyPage click by name "${msg}", "${msg2}"`);
       });
     });
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -111,7 +111,7 @@ describe('Steps', () => {
 
       it('should correct print step info for simple PageObject', () => {
         const metaStep = new MetaStep('MyPage', 'clickByName');
-        expect(metaStep.toString()).to.include('On MyPage: I click by name');
+        expect(metaStep.toString()).to.include('On MyPage: click by name');
       });
 
       it('should correct print step info for custom step', () => {
@@ -125,7 +125,7 @@ describe('Steps', () => {
         const msg2 = 'second message';
         const fn = (msg) => `result from callback = ${msg}`;
         metaStep.run.bind(metaStep, fn)(msg, msg2);
-        expect(metaStep.toString()).eql(`On MyPage: I click by name "${msg}", "${msg2}"`);
+        expect(metaStep.toString()).eql(`On MyPage: click by name "${msg}", "${msg2}"`);
       });
     });
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -111,7 +111,12 @@ describe('Steps', () => {
 
       it('should correct print step info for simple PageObject', () => {
         const metaStep = new MetaStep('MyPage', 'clickByName');
-        expect(metaStep.toString()).to.include('MyPage: I click by name');
+        expect(metaStep.toString()).to.include('On MyPage: I click by name');
+      });
+
+      it('should correct print step info for custom step', () => {
+        const metaStep = new MetaStep('I', 'clickByName');
+        expect(metaStep.toString()).to.include('I click by name');
       });
 
       it('should correct print step with args', () => {
@@ -120,7 +125,7 @@ describe('Steps', () => {
         const msg2 = 'second message';
         const fn = (msg) => `result from callback = ${msg}`;
         metaStep.run.bind(metaStep, fn)(msg, msg2);
-        expect(metaStep.toString()).eql(`MyPage: I click by name "${msg}", "${msg2}"`);
+        expect(metaStep.toString()).eql(`On MyPage: I click by name "${msg}", "${msg2}"`);
       });
     });
 

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -111,7 +111,7 @@ describe('Steps', () => {
 
       it('should correct print step info for simple PageObject', () => {
         const metaStep = new MetaStep('MyPage', 'clickByName');
-        expect(metaStep.toString()).to.include('MyPage click by name');
+        expect(metaStep.toString()).to.include('MyPage: I click by name');
       });
 
       it('should correct print step with args', () => {
@@ -120,7 +120,7 @@ describe('Steps', () => {
         const msg2 = 'second message';
         const fn = (msg) => `result from callback = ${msg}`;
         metaStep.run.bind(metaStep, fn)(msg, msg2);
-        expect(metaStep.toString()).eql(`MyPage click by name "${msg}", "${msg2}"`);
+        expect(metaStep.toString()).eql(`MyPage: I click by name "${msg}", "${msg2}"`);
       });
     });
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #1534 

```
login --
  Incorrect username or password.
    I get user per page 2
      I send get request "/api/users?page=2"
    I am on page "/login"
    I fill field "Username or email address", "michael.lawson@reqres.in"
    I fill field "Password", *****
    I click "Sign in"
    I see "Incorrect username or password.", ".flash-error"
  ✔ OK in 1780ms


  OK  | 1 passed   // 3s
```

## Type of change
- [ ] :bug: Bug fix

## Checklist:
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
