### PR TITLE
Fix for 3835: TypeScript: allow secret value in I.seeInField, I.dontSeeInField

### DIFF
--- a/docs/webapi/dontSeeInField.mustache
+++ b/docs/webapi/dontSeeInField.mustache
@@ -7,5 +7,5 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 ```
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
-@param {string} value value to check.
+@param {CodeceptJS.StringOrSecret} value value to check.
 ⚠️ returns a _promise_ which is synchronized internally by recorder

--- a/docs/webapi/seeInField.mustache
+++ b/docs/webapi/seeInField.mustache
@@ -8,5 +8,5 @@ I.seeInField('form input[type=hidden]','hidden_value');
 I.seeInField('#searchform input','Search');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
-@param {string} value value to check.
+@param {CodeceptJS.StringOrSecret} value value to check.
 ⚠️ returns a _promise_ which is synchronized internally by recorder


### PR DESCRIPTION
## Motivation/Description of the PR

fixes #3835 

Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
