### PR TITLE
fix(browserstack): issue with vendor prefix

### DIFF
--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -99,6 +99,43 @@ helpers: {
 }
 ```
 
+Example Android App using Appiumv2 on BrowserStack:
+
+```js
+{
+helpers: {
+  Appium: {
+        appiumV2: true,
+        host: "hub-cloud.browserstack.com",
+        port: 4444,
+        user: process.env.BROWSERSTACK_USER,
+        key: process.env.BROWSERSTACK_KEY,
+        app: `bs://c700ce60cf1gjhgjh3ae8ed9770ghjg5a55b8e022f13c5827cg`,
+        browser: '',
+        desiredCapabilities: {
+            'appPackage': data.packageName,
+            'deviceName': process.env.DEVICE || 'Google Pixel 3',
+            'platformName': process.env.PLATFORM || 'android',
+            'platformVersion': process.env.OS_VERSION || '10.0',
+            'automationName': process.env.ENGINE || 'UIAutomator2',
+            'newCommandTimeout': 300000,
+            'androidDeviceReadyTimeout': 300000,
+            'androidInstallTimeout': 90000,
+            'appWaitDuration': 300000,
+            'autoGrantPermissions': true,
+            'gpsEnabled': true,
+            'isHeadless': false,
+            'noReset': false,
+            'noSign': true,
+            'bstack:options' : {
+                "appiumVersion" : "2.0.1",
+            },
+        }
+  }
+}
+}
+```
+
 Additional configuration params can be used from [https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md][4]
 
 ## Access From Helpers

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -117,6 +117,43 @@ const vendorPrefix = {
  * }
  * ```
  *
+ * Example Android App using Appiumv2 on BrowserStack:
+ *
+ * ```js
+ * {
+ * helpers: {
+ *   Appium: {
+ *         appiumV2: true,
+ *         host: "hub-cloud.browserstack.com",
+ *         port: 4444,
+ *         user: process.env.BROWSERSTACK_USER,
+ *         key: process.env.BROWSERSTACK_KEY,
+ *         app: `bs://c700ce60cf1gjhgjh3ae8ed9770ghjg5a55b8e022f13c5827cg`,
+ *         browser: '',
+ *         desiredCapabilities: {
+ *             'appPackage': data.packageName,
+ *             'deviceName': process.env.DEVICE || 'Google Pixel 3',
+ *             'platformName': process.env.PLATFORM || 'android',
+ *             'platformVersion': process.env.OS_VERSION || '10.0',
+ *             'automationName': process.env.ENGINE || 'UIAutomator2',
+ *             'newCommandTimeout': 300000,
+ *             'androidDeviceReadyTimeout': 300000,
+ *             'androidInstallTimeout': 90000,
+ *             'appWaitDuration': 300000,
+ *             'autoGrantPermissions': true,
+ *             'gpsEnabled': true,
+ *             'isHeadless': false,
+ *             'noReset': false,
+ *             'noSign': true,
+ *             'bstack:options' : {
+ *                 "appiumVersion" : "2.0.1",
+ *             },
+ *         }
+ *   }
+ * }
+ * }
+ * ```
+ *
  * Additional configuration params can be used from <https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md>
  *
  * ## Access From Helpers
@@ -234,7 +271,9 @@ class Appium extends Webdriver {
     const _convertedCaps = {};
     for (const [key, value] of Object.entries(capabilities)) {
       if (!key.startsWith(vendorPrefix.appium)) {
-        _convertedCaps[`${vendorPrefix.appium}:${key}`] = value;
+        if (key !== 'platformName') {
+          _convertedCaps[`${vendorPrefix.appium}:${key}`] = value;
+        }
       } else {
         _convertedCaps[`${key}`] = value;
       }


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3844 

Tested config:
```
export const caps = {
    androidCaps: {
        appiumV2: true,
        host: "hub-cloud.browserstack.com",
        port: 4444,
        user: process.env.BROWSERSTACK_USER,
        key: process.env.BROWSERSTACK_KEY,
        'app': `bs://c700ce60cf13ae8ed97705a55b8e022f1hjhkjh3c5827c`,
        browser: '',
        desiredCapabilities: {
            'appPackage': data.packageName,
            'deviceName': process.env.DEVICE || 'Google Pixel 3',
            'platformName': process.env.PLATFORM || 'android',
            'platformVersion': process.env.OS_VERSION || '10.0',
            'automationName': process.env.ENGINE || 'UIAutomator2',
            'newCommandTimeout': 300000,
            'androidDeviceReadyTimeout': 300000,
            'androidInstallTimeout': 90000,
            'appWaitDuration': 300000,
            'autoGrantPermissions': true,
            'gpsEnabled': true,
            'isHeadless': false,
            'noReset': false,
            'noSign': true,
            'bstack:options' : {
                "appiumVersion" : "2.0.1",
            },
        }
    },
}
```

```
Helpers: Appium
Plugins: screenshotOnFail

App Installation @android --
    [1]  Starting recording promises
    Timeouts: 
  App is installed successfully
    I see app is installed "org.wikipedia.alpha"
  ✔ OK in 339ms


  OK  | 1 passed   // 2m

```
![Screenshot 2023-09-01 at 13 48 07](https://github.com/codeceptjs/CodeceptJS/assets/7845001/0bbd3aaf-dcf3-42bc-af07-00c0b8617144)


Applicable helpers:
- [ ] Appium

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
