### PR TITLE
fix: cli init translation use correct actor instead of I

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -201,7 +201,13 @@ module.exports = function (initPath) {
       // no extra step file for typescript (as it doesn't match TS conventions)
       const stepFile = `./steps_file.${extension}`;
       fs.writeFileSync(path.join(testsPath, stepFile), extension === 'ts' ? defaultActorTs : defaultActor);
-      config.include.I = isTypeScript === true ? './steps_file' : stepFile;
+
+      if (isTypeScript) {
+        config.include = _actorTranslation('./steps_file', config.translation);
+      } else {
+        config.include = _actorTranslation(stepFile, config.translation);
+      }
+
       print(`Steps file created at ${stepFile}`);
 
       let configSource;
@@ -316,7 +322,7 @@ module.exports = function (initPath) {
     };
 
     print('Configure helpers...');
-    inquirer.prompt(helperConfigs).then((helperResult) => {
+    inquirer.prompt(helperConfigs).then(async (helperResult) => {
       if (helperResult.Playwright_browser === 'electron') {
         delete helperResult.Playwright_url;
         delete helperResult.Playwright_show;
@@ -336,12 +342,12 @@ module.exports = function (initPath) {
       });
 
       print('');
-      finish();
+      await finish();
     });
   });
 };
 
-function install(dependencies, verbose) {
+function install(dependencies) {
   let command;
   let args;
 
@@ -374,9 +380,35 @@ function install(dependencies, verbose) {
     ].concat(dependencies);
   }
 
+  if (process.env._INIT_DRY_RUN_INSTALL) {
+    args.push('--dry-run');
+  }
+
   const { status } = spawn.sync(command, args, { stdio: 'inherit' });
   if (status !== 0) {
     throw new Error(`${command} ${args.join(' ')} failed`);
   }
   return true;
+}
+
+function _actorTranslation(stepFile, translationSelected) {
+  let actor;
+
+  for (const translationAvailable of translations) {
+    if (translationSelected === translationAvailable) {
+      const nameOfActor = require('../../translations')[translationAvailable].I;
+
+      actor = {
+        [nameOfActor]: stepFile,
+      };
+    }
+  }
+
+  if (!actor) {
+    actor = {
+      I: stepFile,
+    };
+  }
+
+  return actor;
 }

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -395,6 +395,10 @@ function _actorTranslation(stepFile, translationSelected) {
   let actor;
 
   for (const translationAvailable of translations) {
+    if (actor) {
+      break;
+    }
+
     if (translationSelected === translationAvailable) {
       const nameOfActor = require('../../translations')[translationAvailable].I;
 

--- a/test/runner/init_test.js
+++ b/test/runner/init_test.js
@@ -1,14 +1,41 @@
 const { DOWN, ENTER } = require('inquirer-test');
 const run = require('inquirer-test');
 const path = require('path');
+const fs = require('fs');
 
 const runner = path.join(__dirname, '../../bin/codecept.js');
+const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/init');
 
 describe('Init Command', function () {
   this.timeout(20000);
 
-  it('steps are showing', async () => {
-    const result = await run([runner, 'init'], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y']);
+  beforeEach(() => {
+    process.env._INIT_DRY_RUN_INSTALL = true;
+  });
+
+  afterEach(() => {
+    try {
+      fs.unlinkSync(`${codecept_dir}/codecept.conf.ts`);
+      fs.unlinkSync(`${codecept_dir}/steps_file.ts`);
+      fs.unlinkSync(`${codecept_dir}/tsconfig.json`);
+    } catch (e) {
+      // continue regardless of error
+    }
+
+    try {
+      fs.unlinkSync(`${codecept_dir}/codecept.conf.js`);
+      fs.unlinkSync(`${codecept_dir}/steps_file.js`);
+      fs.unlinkSync(`${codecept_dir}/jsconfig.json`);
+    } catch (e) {
+      // continue regardless of error
+    }
+
+    delete process.env._INIT_DRY_RUN_INSTALL;
+  });
+
+  it('should init Codecept with TypeScript REST JSONResponse English', async () => {
+    const result = await run([runner, 'init', codecept_dir], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y', ENTER, codecept_dir, ENTER, ENTER, ENTER, ENTER]);
+
     result.should.include('Welcome to CodeceptJS initialization tool');
     result.should.include('It will prepare and configure a test environment for you');
     result.should.include('Installing to');
@@ -16,5 +43,34 @@ describe('Init Command', function () {
     result.should.include('Where are your tests located? ./*_test.ts');
     result.should.include('What helpers do you want to use? REST');
     result.should.include('? Do you want to use JSONResponse helper for assertions on JSON responses?');
+    result.should.include('? Where should logs, screenshots, and reports to be stored?');
+    result.should.include('? Do you want to enable localization for tests?');
+
+    const config = fs.readFileSync(`${codecept_dir}/codecept.conf.ts`).toString();
+    config.should.include('I: \'./steps_file\'');
+
+    fs.accessSync(`${codecept_dir}/steps_file.ts`, fs.constants.R_OK);
+    fs.accessSync(`${codecept_dir}/tsconfig.json`, fs.constants.R_OK);
+  });
+
+  it('should init Codecept with JavaScript REST JSONResponse de-DE', async () => {
+    const result = await run([runner, 'init', codecept_dir], [ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y', ENTER, codecept_dir, ENTER, DOWN, ENTER, ENTER, ENTER]);
+
+    result.should.include('Welcome to CodeceptJS initialization tool');
+    result.should.include('It will prepare and configure a test environment for you');
+    result.should.include('Installing to');
+    result.should.include('? Do you plan to write tests in TypeScript? (y/N)');
+    result.should.include('Where are your tests located? ./*_test.js');
+    result.should.include('What helpers do you want to use? REST');
+    result.should.include('? Do you want to use JSONResponse helper for assertions on JSON responses?');
+    result.should.include('? Where should logs, screenshots, and reports to be stored?');
+    result.should.include('? Do you want to enable localization for tests?');
+    result.should.include('de-DE');
+
+    const config = fs.readFileSync(`${codecept_dir}/codecept.conf.js`).toString();
+    config.should.include('Ich: \'./steps_file.js\'');
+
+    fs.accessSync(`${codecept_dir}/steps_file.js`, fs.constants.R_OK);
+    fs.accessSync(`${codecept_dir}/jsconfig.json`, fs.constants.R_OK);
   });
 });

--- a/test/runner/init_test.js
+++ b/test/runner/init_test.js
@@ -2,6 +2,7 @@ const { DOWN, ENTER } = require('inquirer-test');
 const run = require('inquirer-test');
 const path = require('path');
 const fs = require('fs');
+const mkdirp = require('mkdirp');
 
 const runner = path.join(__dirname, '../../bin/codecept.js');
 const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/init');
@@ -10,6 +11,7 @@ describe('Init Command', function () {
   this.timeout(20000);
 
   beforeEach(() => {
+    mkdirp.sync(codecept_dir);
     process.env._INIT_DRY_RUN_INSTALL = true;
   });
 


### PR DESCRIPTION
## Motivation/Description of the PR
I wanted to generate a new project with codeceptjs with french's locale (i.e. use `Je.suisSurLaPage('...'))` instead of `I.amOnPage('...')`).
So I type on a blank project `npx codeceptjs init` and selected french translation. Then create new simple test and immediatly run the project with `npx codeceptjs run`. 

But I got:

```
Object of type Je is not defined in container
```

Fixed this by replacing actor on `codecept.conf.js`:

```js
  include: {
    Je: './steps_file.js'
  }
```

-This PR fix this issue by setting the correct basic's actor `I` with the one write in translation.
-This also improves an existing test `test/runner/init_test.js`

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
