### PR TITLE
improvement: Typescript typings

### DIFF
--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -379,9 +379,10 @@ let val = await I.executeAsyncScript(function(url, done) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorderWrapper for asynchronous [evaluate][7].
-    Unlike NightmareJS implementation calling `done` will return its first argument.
--   `fn` **([string][3] | [function][8])** function to be executed in browser context.
+-   `fn` **([string][3] | [function][7])** function to be executed in browser context.
+
+Returns **[Promise][8]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorderWrapper for asynchronous [evaluate][9].
+Unlike NightmareJS implementation calling `done` will return its first argument.
 
 ### executeScript
 
@@ -412,8 +413,9 @@ let date = await I.executeScript(function(el) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorderWrapper for synchronous [evaluate][7]
--   `fn` **([string][3] | [function][8])** function to be executed in browser context.
+-   `fn` **([string][3] | [function][7])** function to be executed in browser context.
+
+Returns **[Promise][8]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorderWrapper for synchronous [evaluate][9]
 
 ### fillField
 
@@ -452,7 +454,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][3]** attribute name.
 
-Returns **[Promise][9]&lt;[string][3]>** attribute value
+Returns **[Promise][8]&lt;[string][3]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -468,7 +470,7 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][3]** attribute name.
 
-Returns **[Promise][9]&lt;[Array][10]&lt;[string][3]>>** attribute value
+Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** attribute value
 
 ### grabCookie
 
@@ -485,7 +487,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][3]?** cookie name. 
 
-Returns **([Promise][9]&lt;[string][3]> | [Promise][9]&lt;[Array][10]&lt;[string][3]>>)** attribute valueCookie in JSON format. If name not passed returns all cookies for this domain.Multiple cookies can be received by passing query object `I.grabCookie({ secure: true});`. If you'd like get all cookies for all urls, use: `.grabCookie({ url: null }).`
+Returns **([Promise][8]&lt;[string][3]> | [Promise][8]&lt;[Array][10]&lt;[string][3]>>)** attribute valueCookie in JSON format. If name not passed returns all cookies for this domain.Multiple cookies can be received by passing query object `I.grabCookie({ secure: true});`. If you'd like get all cookies for all urls, use: `.grabCookie({ url: null }).`
 
 ### grabCssPropertyFrom
 
@@ -502,7 +504,7 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][3]** CSS property name.
 
-Returns **[Promise][9]&lt;[string][3]>** CSS value
+Returns **[Promise][8]&lt;[string][3]>** CSS value
 
 ### grabCurrentUrl
 
@@ -514,7 +516,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][9]&lt;[string][3]>** current URL
+Returns **[Promise][8]&lt;[string][3]>** current URL
 
 ### grabElementBoundingRect
 
@@ -542,7 +544,7 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 -   `prop`  
 -   `elementSize` **[string][3]?** x, y, width or height of the given element.
 
-Returns **([Promise][9]&lt;DOMRect> | [Promise][9]&lt;[number][11]>)** Element bounding rectangle
+Returns **([Promise][8]&lt;DOMRect> | [Promise][8]&lt;[number][11]>)** Element bounding rectangle
 
 ### grabHAR
 
@@ -568,7 +570,7 @@ let postHTML = await I.grabHTMLFrom('#post');
 -   `locator`  
 -   `element` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[string][3]>** HTML code for an element
+Returns **[Promise][8]&lt;[string][3]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -584,7 +586,7 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 -   `locator`  
 -   `element` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[Array][10]&lt;[string][3]>>** HTML code for an element
+Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** HTML code for an element
 
 ### grabNumberOfVisibleElements
 
@@ -599,7 +601,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][3] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[number][11]>** number of visible elements
+Returns **[Promise][8]&lt;[number][11]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -610,7 +612,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][9]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][8]&lt;PageScrollPosition>** scroll position
 
 ### grabTextFrom
 
@@ -627,7 +629,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[string][3]>** attribute value
+Returns **[Promise][8]&lt;[string][3]>** attribute value
 
 ### grabTextFromAll
 
@@ -642,7 +644,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][3] | [object][4])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[Array][10]&lt;[string][3]>>** attribute value
+Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** attribute value
 
 ### grabTitle
 
@@ -653,7 +655,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][9]&lt;[string][3]>** title
+Returns **[Promise][8]&lt;[string][3]>** title
 
 ### grabValueFrom
 
@@ -669,7 +671,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[string][3]>** attribute value
+Returns **[Promise][8]&lt;[string][3]>** attribute value
 
 ### grabValueFromAll
 
@@ -684,7 +686,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][3] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][9]&lt;[Array][10]&lt;[string][3]>>** attribute value
+Returns **[Promise][8]&lt;[Array][10]&lt;[string][3]>>** attribute value
 
 ### haveHeader
 
@@ -1159,7 +1161,7 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][3] | [function][8])** to be executed in browser context.
+-   `fn` **([string][3] | [function][7])** to be executed in browser context.
 -   `argsOrSec` **([Array][10]&lt;any> | [number][11])?** (optional, `1` by default) arguments for function or seconds. 
 -   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
     ⚠️ returns a _promise_ which is synchronized internally by recorder 
@@ -1239,11 +1241,11 @@ I.waitToHide('#popup');
 
 [6]: https://vuejs.org/v2/api/#Vue-nextTick
 
-[7]: https://github.com/segmentio/nightmare#evaluatefn-arg1-arg2
+[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[9]: https://github.com/segmentio/nightmare#evaluatefn-arg1-arg2
 
 [10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -530,7 +530,8 @@ let val = await I.executeAsyncScript(function(url, done) {
 
 -   `fn` **([string][9] | [function][12])** function to be executed in browser context.
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorder
+
+Returns **[Promise][13]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorder
 
 ### executeScript
 
@@ -562,7 +563,8 @@ let date = await I.executeScript(function(el) {
 
 -   `fn` **([string][9] | [function][12])** function to be executed in browser context.
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorder
+
+Returns **[Promise][13]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorder
 
 ### fillField
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -712,8 +712,9 @@ let val = await I.executeAsyncScript(function(url, done) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorderAsynchronous scripts can also be executed with `executeScript` if a function returns a Promise.
 -   `fn` **([string][6] | [function][12])** function to be executed in browser context.
+
+Returns **[Promise][13]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorderAsynchronous scripts can also be executed with `executeScript` if a function returns a Promise.
 
 ### executeScript
 
@@ -744,8 +745,9 @@ let date = await I.executeScript(function(el) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorderIf a function returns a Promise It will wait for it resolution.
 -   `fn` **([string][6] | [function][12])** function to be executed in browser context.
+
+Returns **[Promise][13]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorderIf a function returns a Promise It will wait for it resolution.
 
 ### fillField
 
@@ -788,7 +790,7 @@ I.see('#add-to-cart-bnt');
 #### Parameters
 
 -   `locator` **([string][6] | [object][4])** field located by label|name|CSS|XPath|strict locator.
--   `options` **any?** Playwright only: [Additional options][13] for available options object as 2nd argument.
+-   `options` **any?** Playwright only: [Additional options][14] for available options object as 2nd argument.
 
 ### forceClick
 
@@ -842,7 +844,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][6]** attribute name.
 
-Returns **[Promise][14]&lt;[string][6]>** attribute value
+Returns **[Promise][13]&lt;[string][6]>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -862,7 +864,7 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 -   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][6]** attribute name.
 
-Returns **[Promise][14]&lt;[Array][15]&lt;[string][6]>>** attribute value
+Returns **[Promise][13]&lt;[Array][15]&lt;[string][6]>>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -877,7 +879,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **[Promise][14]&lt;[Array][15]&lt;any>>** 
+Returns **[Promise][13]&lt;[Array][15]&lt;any>>** 
 
 ### grabCookie
 
@@ -894,7 +896,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][6]?** cookie name. 
 
-Returns **([Promise][14]&lt;[string][6]> | [Promise][14]&lt;[Array][15]&lt;[string][6]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][13]&lt;[string][6]> | [Promise][13]&lt;[Array][15]&lt;[string][6]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCssPropertyFrom
 
@@ -911,7 +913,7 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 -   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][6]** CSS property name.
 
-Returns **[Promise][14]&lt;[string][6]>** CSS value
+Returns **[Promise][13]&lt;[string][6]>** CSS value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -931,7 +933,7 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 -   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][6]** CSS property name.
 
-Returns **[Promise][14]&lt;[Array][15]&lt;[string][6]>>** CSS value
+Returns **[Promise][13]&lt;[Array][15]&lt;[string][6]>>** CSS value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -947,7 +949,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][14]&lt;[string][6]>** current URL
+Returns **[Promise][13]&lt;[string][6]>** current URL
 
 ### grabDataFromPerformanceTiming
 
@@ -972,7 +974,7 @@ let data = await I.grabDataFromPerformanceTiming();
 }
 ```
 
-Returns **[Promise][14]&lt;any>** automatically synchronized promise through #recorder
+Returns **[Promise][13]&lt;any>** automatically synchronized promise through #recorder
 
 ### grabElementBoundingRect
 
@@ -1000,7 +1002,7 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 -   `prop`  
 -   `elementSize` **[string][6]?** x, y, width or height of the given element.
 
-Returns **([Promise][14]&lt;DOMRect> | [Promise][14]&lt;[number][10]>)** Element bounding rectangle
+Returns **([Promise][13]&lt;DOMRect> | [Promise][13]&lt;[number][10]>)** Element bounding rectangle
 
 ### grabHTMLFrom
 
@@ -1017,7 +1019,7 @@ let postHTML = await I.grabHTMLFrom('#post');
 -   `locator`  
 -   `element` **([string][6] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[string][6]>** HTML code for an element
+Returns **[Promise][13]&lt;[string][6]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -1033,7 +1035,7 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 -   `locator`  
 -   `element` **([string][6] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[Array][15]&lt;[string][6]>>** HTML code for an element
+Returns **[Promise][13]&lt;[Array][15]&lt;[string][6]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -1044,7 +1046,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][14]&lt;[number][10]>** number of open tabs
+Returns **[Promise][13]&lt;[number][10]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -1059,7 +1061,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][6] | [object][4])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[number][10]>** number of visible elements
+Returns **[Promise][13]&lt;[number][10]>** number of visible elements
 
 
 
@@ -1075,7 +1077,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][14]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][13]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -1085,7 +1087,7 @@ Grab the text within the popup. If no popup is visible then it will return null
 await I.grabPopupText();
 ```
 
-Returns **[Promise][14]&lt;([string][6] | null)>** 
+Returns **[Promise][13]&lt;([string][6] | null)>** 
 
 ### grabSource
 
@@ -1096,7 +1098,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][14]&lt;[string][6]>** source code
+Returns **[Promise][13]&lt;[string][6]>** source code
 
 ### grabTextFrom
 
@@ -1113,7 +1115,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[string][6]>** attribute value
+Returns **[Promise][13]&lt;[string][6]>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1132,7 +1134,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[Array][15]&lt;[string][6]>>** attribute value
+Returns **[Promise][13]&lt;[Array][15]&lt;[string][6]>>** attribute value
 
 
 This action supports [React locators](https://codecept.io/react#locators)
@@ -1147,7 +1149,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][14]&lt;[string][6]>** title
+Returns **[Promise][13]&lt;[string][6]>** title
 
 ### grabValueFrom
 
@@ -1163,7 +1165,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][6] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[string][6]>** attribute value
+Returns **[Promise][13]&lt;[string][6]>** attribute value
 
 ### grabValueFromAll
 
@@ -1178,7 +1180,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][6] | [object][4])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][14]&lt;[Array][15]&lt;[string][6]>>** attribute value
+Returns **[Promise][13]&lt;[Array][15]&lt;[string][6]>>** attribute value
 
 ### handleDownloads
 
@@ -2166,9 +2168,9 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[13]: https://playwright.dev/docs/api/class-locator#locator-focus
+[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[14]: https://playwright.dev/docs/api/class-locator#locator-focus
 
 [15]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -420,7 +420,8 @@ let date = await I.executeScript(function(el) {
 
 -   `fn` **([string][4] | [function][8])** function to be executed in browser context.
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorderIf a function returns a Promise It will wait for its resolution.
+
+Returns **[Promise][9]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorderIf a function returns a Promise It will wait for its resolution.
 
 ### fillField
 
@@ -459,7 +460,7 @@ I.see('#add-to-cart-bnt');
 #### Parameters
 
 -   `locator` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
--   `options` **any?** Playwright only: [Additional options][9] for available options object as 2nd argument.
+-   `options` **any?** Playwright only: [Additional options][10] for available options object as 2nd argument.
 
 ### grabAttributeFrom
 
@@ -476,7 +477,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][4]** attribute name.
 
-Returns **[Promise][10]&lt;[string][4]>** attribute value
+Returns **[Promise][9]&lt;[string][4]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -493,7 +494,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][4]** attribute name.
 
-Returns **[Promise][10]&lt;[string][4]>** attribute value
+Returns **[Promise][9]&lt;[string][4]>** attribute value
 
 ### grabBrowserLogs
 
@@ -519,7 +520,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][4]?** cookie name. 
 
-Returns **([Promise][10]&lt;[string][4]> | [Promise][10]&lt;[Array][11]&lt;[string][4]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][9]&lt;[string][4]> | [Promise][9]&lt;[Array][11]&lt;[string][4]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCurrentUrl
 
@@ -531,7 +532,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][10]&lt;[string][4]>** current URL
+Returns **[Promise][9]&lt;[string][4]>** current URL
 
 ### grabNumberOfVisibleElements
 
@@ -546,7 +547,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][4] | [object][5])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][10]&lt;[number][12]>** number of visible elements
+Returns **[Promise][9]&lt;[number][12]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -557,7 +558,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][10]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][9]&lt;PageScrollPosition>** scroll position
 
 ### grabSource
 
@@ -568,7 +569,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][10]&lt;[string][4]>** source code
+Returns **[Promise][9]&lt;[string][4]>** source code
 
 ### grabTextFrom
 
@@ -585,7 +586,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][10]&lt;[string][4]>** attribute value
+Returns **[Promise][9]&lt;[string][4]>** attribute value
 
 ### grabTextFromAll
 
@@ -600,7 +601,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][4] | [object][5])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][10]&lt;[Array][11]&lt;[string][4]>>** attribute value
+Returns **[Promise][9]&lt;[Array][11]&lt;[string][4]>>** attribute value
 
 ### grabValueFrom
 
@@ -616,7 +617,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][10]&lt;[string][4]>** attribute value
+Returns **[Promise][9]&lt;[string][4]>** attribute value
 
 ### grabValueFromAll
 
@@ -631,7 +632,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][4] | [object][5])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][10]&lt;[Array][11]&lt;[string][4]>>** attribute value
+Returns **[Promise][9]&lt;[Array][11]&lt;[string][4]>>** attribute value
 
 ### moveCursorTo
 
@@ -1253,9 +1254,9 @@ Client Functions
 
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[9]: https://playwright.dev/docs/api/class-locator#locator-focus
+[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[10]: https://playwright.dev/docs/api/class-locator#locator-focus
 
 [11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -865,8 +865,9 @@ let val = await I.executeAsyncScript(function(url, done) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorder
 -   `fn` **([string][17] | [function][24])** function to be executed in browser context.
+
+Returns **[Promise][25]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorder
 
 ### executeScript
 
@@ -897,8 +898,9 @@ let date = await I.executeScript(function(el) {
 #### Parameters
 
 -   `args` **...any** to be passed to function.
-    ⚠️ returns a _promise_ which is synchronized internally by recorderWraps [execute][25] command.
 -   `fn` **([string][17] | [function][24])** function to be executed in browser context.
+
+Returns **[Promise][25]&lt;any>** script return value⚠️ returns a _promise_ which is synchronized internally by recorderWraps [execute][26] command.
 
 ### fillField
 
@@ -942,7 +944,7 @@ I.see('#add-to-cart-bnt');
 #### Parameters
 
 -   `locator` **([string][17] | [object][16])** field located by label|name|CSS|XPath|strict locator.
--   `options` **any?** Playwright only: [Additional options][26] for available options object as 2nd argument.
+-   `options` **any?** Playwright only: [Additional options][27] for available options object as 2nd argument.
 
 ### forceClick
 
@@ -1017,7 +1019,7 @@ Useful for referencing a specific handle when calling `I.switchToWindow(handle)`
 const windows = await I.grabAllWindowHandles();
 ```
 
-Returns **[Promise][27]&lt;[Array][28]&lt;[string][17]>>** 
+Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** 
 
 ### grabAttributeFrom
 
@@ -1034,7 +1036,7 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 -   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][17]** attribute name.
 
-Returns **[Promise][27]&lt;[string][17]>** attribute value
+Returns **[Promise][25]&lt;[string][17]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -1050,7 +1052,7 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 -   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
 -   `attr` **[string][17]** attribute name.
 
-Returns **[Promise][27]&lt;[Array][28]&lt;[string][17]>>** attribute value
+Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** attribute value
 
 ### grabBrowserLogs
 
@@ -1062,7 +1064,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **([Promise][27]&lt;[Array][28]&lt;[object][16]>> | [undefined][29])** all browser logs
+Returns **([Promise][25]&lt;[Array][28]&lt;[object][16]>> | [undefined][29])** all browser logs
 
 ### grabCookie
 
@@ -1079,7 +1081,7 @@ assert(cookie.value, '123456');
 
 -   `name` **[string][17]?** cookie name. 
 
-Returns **([Promise][27]&lt;[string][17]> | [Promise][27]&lt;[Array][28]&lt;[string][17]>>)** attribute value
+Returns **([Promise][25]&lt;[string][17]> | [Promise][25]&lt;[Array][28]&lt;[string][17]>>)** attribute value
 
 ### grabCssPropertyFrom
 
@@ -1096,7 +1098,7 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 -   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][17]** CSS property name.
 
-Returns **[Promise][27]&lt;[string][17]>** CSS value
+Returns **[Promise][25]&lt;[string][17]>** CSS value
 
 ### grabCssPropertyFromAll
 
@@ -1112,7 +1114,7 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 -   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
 -   `cssProperty` **[string][17]** CSS property name.
 
-Returns **[Promise][27]&lt;[Array][28]&lt;[string][17]>>** CSS value
+Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** CSS value
 
 ### grabCurrentUrl
 
@@ -1124,7 +1126,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][27]&lt;[string][17]>** current URL
+Returns **[Promise][25]&lt;[string][17]>** current URL
 
 ### grabCurrentWindowHandle
 
@@ -1135,7 +1137,7 @@ Useful for referencing it when calling `I.switchToWindow(handle)`
 const window = await I.grabCurrentWindowHandle();
 ```
 
-Returns **[Promise][27]&lt;[string][17]>** 
+Returns **[Promise][25]&lt;[string][17]>** 
 
 ### grabElementBoundingRect
 
@@ -1163,7 +1165,7 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 -   `prop`  
 -   `elementSize` **[string][17]?** x, y, width or height of the given element.
 
-Returns **([Promise][27]&lt;DOMRect> | [Promise][27]&lt;[number][22]>)** Element bounding rectangle
+Returns **([Promise][25]&lt;DOMRect> | [Promise][25]&lt;[number][22]>)** Element bounding rectangle
 
 ### grabGeoLocation
 
@@ -1174,7 +1176,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let geoLocation = await I.grabGeoLocation();
 ```
 
-Returns **[Promise][27]&lt;{latitude: [number][22], longitude: [number][22], altitude: [number][22]}>** 
+Returns **[Promise][25]&lt;{latitude: [number][22], longitude: [number][22], altitude: [number][22]}>** 
 
 ### grabHTMLFrom
 
@@ -1191,7 +1193,7 @@ let postHTML = await I.grabHTMLFrom('#post');
 -   `locator`  
 -   `element` **([string][17] | [object][16])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[string][17]>** HTML code for an element
+Returns **[Promise][25]&lt;[string][17]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -1207,7 +1209,7 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 -   `locator`  
 -   `element` **([string][17] | [object][16])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[Array][28]&lt;[string][17]>>** HTML code for an element
+Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -1218,7 +1220,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][27]&lt;[number][22]>** number of open tabs
+Returns **[Promise][25]&lt;[number][22]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -1233,7 +1235,7 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 -   `locator` **([string][17] | [object][16])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[number][22]>** number of visible elements
+Returns **[Promise][25]&lt;[number][22]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -1244,7 +1246,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][27]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][25]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -1254,7 +1256,7 @@ Grab the text within the popup. If no popup is visible then it will return null.
 await I.grabPopupText();
 ```
 
-Returns **[Promise][27]&lt;[string][17]>** 
+Returns **[Promise][25]&lt;[string][17]>** 
 
 ### grabSource
 
@@ -1265,7 +1267,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][27]&lt;[string][17]>** source code
+Returns **[Promise][25]&lt;[string][17]>** source code
 
 ### grabTextFrom
 
@@ -1282,7 +1284,7 @@ If multiple elements found returns first element.
 
 -   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[string][17]>** attribute value
+Returns **[Promise][25]&lt;[string][17]>** attribute value
 
 ### grabTextFromAll
 
@@ -1297,7 +1299,7 @@ let pins = await I.grabTextFromAll('#pin li');
 
 -   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[Array][28]&lt;[string][17]>>** attribute value
+Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** attribute value
 
 ### grabTitle
 
@@ -1308,7 +1310,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][27]&lt;[string][17]>** title
+Returns **[Promise][25]&lt;[string][17]>** title
 
 ### grabValueFrom
 
@@ -1324,7 +1326,7 @@ let email = await I.grabValueFrom('input[name=email]');
 
 -   `locator` **([string][17] | [object][16])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[string][17]>** attribute value
+Returns **[Promise][25]&lt;[string][17]>** attribute value
 
 ### grabValueFromAll
 
@@ -1339,7 +1341,7 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 -   `locator` **([string][17] | [object][16])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][27]&lt;[Array][28]&lt;[string][17]>>** attribute value
+Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** attribute value
 
 ### moveCursorTo
 
@@ -2344,11 +2346,11 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[25]: http://webdriver.io/api/protocol/execute.html
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[26]: https://playwright.dev/docs/api/class-locator#locator-focus
+[26]: http://webdriver.io/api/protocol/execute.html
 
-[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[27]: https://playwright.dev/docs/api/class-locator#locator-focus
 
 [28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 

--- a/docs/webapi/executeAsyncScript.mustache
+++ b/docs/webapi/executeAsyncScript.mustache
@@ -21,4 +21,6 @@ let val = await I.executeAsyncScript(function(url, done) {
 
 @param {string|function} fn function to be executed in browser context.
 @param {...any} args to be passed to function.
+@returns {Promise<any>} script return value
+
 ⚠️ returns a _promise_ which is synchronized internally by recorder

--- a/docs/webapi/executeScript.mustache
+++ b/docs/webapi/executeScript.mustache
@@ -23,4 +23,6 @@ let date = await I.executeScript(function(el) {
 
 @param {string|function} fn function to be executed in browser context.
 @param {...any} args to be passed to function.
+@returns {Promise<any>} script return value
+
 ⚠️ returns a _promise_ which is synchronized internally by recorder

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -176,6 +176,7 @@ class Codecept {
    * Run a specific test or all loaded tests.
    *
    * @param {string} [test]
+   * @returns {Promise<void>}
    */
   async run(test) {
     return new Promise((resolve, reject) => {

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -22,6 +22,7 @@ const aiAssistant = new AiAssistant();
 
 /**
  * Pauses test execution and starts interactive shell
+ * @param {Partial<CodeceptJS.SupportObject>} [passedObject]
  */
 const pause = function (passedObject = {}) {
   if (store.dryRun) return;

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -22,7 +22,7 @@ const aiAssistant = new AiAssistant();
 
 /**
  * Pauses test execution and starts interactive shell
- * @param {Partial<CodeceptJS.SupportObject> | Function | Object<string, *>} [passedObject]
+ * @param {Object<string, *>} [passedObject]
  */
 const pause = function (passedObject = {}) {
   if (store.dryRun) return;

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -22,7 +22,7 @@ const aiAssistant = new AiAssistant();
 
 /**
  * Pauses test execution and starts interactive shell
- * @param {Partial<CodeceptJS.SupportObject>} [passedObject]
+ * @param {Partial<CodeceptJS.SupportObject> | Function | Object<string, *>} [passedObject]
  */
 const pause = function (passedObject = {}) {
   if (store.dryRun) return;

--- a/typings/tests/helpers/WebDriverIO.types.ts
+++ b/typings/tests/helpers/WebDriverIO.types.ts
@@ -243,14 +243,14 @@ wd.dontSeeCurrentUrlEquals(); // $ExpectError
 wd.dontSeeCurrentUrlEquals(str); // $ExpectType void
 
 wd.executeScript(); // $ExpectError
-wd.executeScript(str); // $ExpectType void
-wd.executeScript(() => {}); // $ExpectType void
-wd.executeScript(() => {}, {}); // $ExpectType void
+wd.executeScript(str); // $ExpectType Promise<any>
+wd.executeScript(() => {}); // $ExpectType Promise<any>
+wd.executeScript(() => {}, {}); // $ExpectType Promise<any>
 
 wd.executeAsyncScript(); // $ExpectError
-wd.executeAsyncScript(str); // $ExpectType void
-wd.executeAsyncScript(() => {}); // $ExpectType void
-wd.executeAsyncScript(() => {}, {}); // $ExpectType void
+wd.executeAsyncScript(str); // $ExpectType Promise<any>
+wd.executeAsyncScript(() => {}); // $ExpectType Promise<any>
+wd.executeAsyncScript(() => {}, {}); // $ExpectType Promise<any>
 
 wd.scrollIntoView(); // $ExpectError
 wd.scrollIntoView('div'); // $ExpectError


### PR DESCRIPTION
## Motivation/Description of the PR
When using Codecept in Typescript, few typings are inconsistent with documentation:
- `codecept.run()` is async and should return `Promise<void>` instead of simply `void` (return value is awaited [here](https://codecept.io/internal-api/#custom-runner))
- Interactive `pause()` should accept [optional object](https://codecept.io/basics/#pause)
- [executeScript](https://codecept.io/helpers/Puppeteer/#executescript) and [executeAsyncScript](https://codecept.io/helpers/WebDriver/#executeasyncscript) should have the ability to return values

Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added (only updated existing tests)
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
