### PR TITLE
feat(cli): show environment info in verbose mode

### DIFF
--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -39,6 +39,10 @@ module.exports = async function (workerCount, selectedRuns, options) {
   });
 
   try {
+    if (options.verbose) {
+      const getInfo = require('./info');
+      await getInfo();
+    }
     await workers.bootstrapAll();
     await workers.run();
   } catch (err) {

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -25,6 +25,10 @@ module.exports = async function (test, options) {
   const codecept = new Codecept(config, options);
 
   try {
+    if (options.verbose) {
+      const getInfo = require('./info');
+      await getInfo();
+    }
     codecept.init(testRoot);
     await codecept.bootstrap();
     codecept.loadTests(test);

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -25,13 +25,15 @@ module.exports = async function (test, options) {
   const codecept = new Codecept(config, options);
 
   try {
+    codecept.init(testRoot);
+    await codecept.bootstrap();
+    codecept.loadTests(test);
+
     if (options.verbose) {
       const getInfo = require('./info');
       await getInfo();
     }
-    codecept.init(testRoot);
-    await codecept.bootstrap();
-    codecept.loadTests(test);
+
     await codecept.run();
   } catch (err) {
     printError(err);

--- a/test/runner/timeout_test.js
+++ b/test/runner/timeout_test.js
@@ -66,7 +66,7 @@ describe('CodeceptJS Timeouts', function () {
     });
   });
 
-  it.only('should override timeout config from global object', (done) => {
+  it('should override timeout config from global object', (done) => {
     exec(config_run_config('codecept.timeout.obj.conf.js', '#first', false), (err, stdout) => {
       debug_this_test && console.log(stdout);
       expect(stdout).toContain('Timeout 0.3s exceeded');

--- a/test/runner/timeout_test.js
+++ b/test/runner/timeout_test.js
@@ -66,8 +66,8 @@ describe('CodeceptJS Timeouts', function () {
     });
   });
 
-  it('should override timeout config from global object', (done) => {
-    exec(config_run_config('codecept.timeout.obj.conf.js', '#first', true), (err, stdout) => {
+  it.only('should override timeout config from global object', (done) => {
+    exec(config_run_config('codecept.timeout.obj.conf.js', '#first', false), (err, stdout) => {
       debug_this_test && console.log(stdout);
       expect(stdout).toContain('Timeout 0.3s exceeded');
       expect(err).toBeTruthy();


### PR DESCRIPTION
## Motivation/Description of the PR
- It would be more convenient to show environment info when running tests with verbose mode.

```
 Environment information:-

codeceptVersion:  "3.5.4"
nodeInfo:  18.16.0
osInfo:  macOS 13.5
cpuInfo:  (8) arm64 Apple M1 Pro
chromeInfo:  116.0.5845.179
edgeInfo:  116.0.1938.69
firefoxInfo:  Not Found
safariInfo:  16.6
helpers:  {
 "Playwright": {
  "url": "https://github.com",
  "show": false,
  "browser": "chromium",
  "waitForNavigation": "load",
  "waitForTimeout": 30000,
  "trace": false,
  "keepTraceForPassedTests": true
 },
 "CDPHelper": {
  "require": "./helpers/CDPHelper.ts"
 },
 "OpenAI": {
  "chunkSize": 8000
 },
 "ExpectHelper": {
  "require": "codeceptjs-expect"
 },
 "REST": {
  "endpoint": "https://reqres.in",
  "timeout": 20000
 },
 "AllureHelper": {
  "require": "./helpers/AllureHelper.ts"
 }
}
plugins:  {
 "screenshotOnFail": {
  "enabled": true
 },
 "tryTo": {
  "enabled": true
 },
 "retryFailedStep": {
  "enabled": true
 },
 "retryTo": {
  "enabled": true
 },
 "eachElement": {
  "enabled": true
 },
 "pauseOnFail": {}
}
***************************************
If you have questions ask them in our Slack: http://bit.ly/chat-codeceptjs
Or ask them on our discussion board: https://codecept.discourse.group/
Please copy environment info when you report issues on GitHub: https://github.com/Codeception/CodeceptJS/issues
***************************************
CodeceptJS v3.5.4 #StandWithUkraine

```

## Type of change
- [ ] :rocket: New functionality

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
