### PR TITLE
Playwright apply bypassCSP to contextOptions

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -482,7 +482,7 @@ class Playwright extends Helper {
         contextOptions.httpCredentials = this.options.basicAuth;
         this.isAuthenticated = true;
       }
-      if (this.options.disableCSP) contextOptions.disableCSP = this.options.disableCSP;
+      if (this.options.bypassCSP) contextOptions.bypassCSP = this.options.bypassCSP;
       if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
       if (this.storageState) contextOptions.storageState = this.storageState;
       if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent;

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -482,6 +482,7 @@ class Playwright extends Helper {
         contextOptions.httpCredentials = this.options.basicAuth;
         this.isAuthenticated = true;
       }
+      if (this.options.disableCSP) contextOptions.disableCSP = this.options.disableCSP;
       if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
       if (this.storageState) contextOptions.storageState = this.storageState;
       if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent;


### PR DESCRIPTION
## Motivation/Description of the PR
With #3641 the documentation was updated that you can set the bypassCSP property of playwright. Upon further investigation we noticed that the property is not set when creating a playwright context.

Applicable helpers:

- [x] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
