### PR TITLE
fixing that testgrep gets ignored when --verbose is set

### DIFF
--- a/lib/command/info.js
+++ b/lib/command/info.js
@@ -4,10 +4,10 @@ const { getConfig, getTestRoot } = require('./utils');
 const Codecept = require('../codecept');
 const output = require('../output');
 
-module.exports = async function (path) {
+module.exports = async function (path, options) {
   const testsPath = getTestRoot(path);
   const config = getConfig(testsPath);
-  const codecept = new Codecept(config, {});
+  const codecept = new Codecept(config, options);
   codecept.init(testsPath);
 
   output.print('\n Environment information:-\n');

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -31,7 +31,7 @@ module.exports = async function (test, options) {
 
     if (options.verbose) {
       const getInfo = require('./info');
-      await getInfo();
+      await getInfo(testRoot, options);
     }
 
     await codecept.run();


### PR DESCRIPTION
## Motivation/Description of the PR
- when --verbose is set codecept gets initialized twice
- the second time by info.js but without options so all tests are running
- Resolves #3898

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
