### PR TITLE
fix(gherkin): long text cuts off

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -141,7 +141,7 @@ function transformTable(table) {
   let str = '';
   for (const id in table.rows) {
     const cells = table.rows[id].cells;
-    str += cells.map(c => c.value).map(c => c.slice(0, 15).padEnd(15)).join(' | ');
+    str += cells.map(c => c.value).map(c => c.padEnd(15)).join(' | ');
     str += '\n';
   }
   return str;

--- a/test/data/sandbox/features/tables.feature
+++ b/test/data/sandbox/features/tables.feature
@@ -11,3 +11,12 @@ Feature: Checkout products
       | Nuclear Bomb | Weapons     | 100000 |
     When I go to checkout
     Then my order amount is $101205
+
+  Scenario: checkout 3 products with long name
+    Given I have products in my cart
+      | name                                 | category    | price  |
+      | Harry Potter and the deathly hallows | Books       | 5      |
+      | iPhone 5                             | Smartphones | 1200   |
+      | Nuclear Bomb                         | Weapons     | 100000 |
+    When I go to checkout
+    Then my order amount is $101205

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -112,6 +112,16 @@ describe('BDD Gherkin', () => {
     });
   });
 
+  it('should run feature with tables contain long text', (done) => {
+    exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout products"', (err, stdout, stderr) => { //eslint-disable-line
+      stdout.should.include('Given I have products in my cart');
+      stdout.should.include('name');
+      stdout.should.include('Harry Potter and the deathly hallows');
+      assert(!err);
+      done();
+    });
+  });
+
   it('should run feature with long strings', (done) => {
     exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout string"', (err, stdout, stderr) => { //eslint-disable-line
       stdout.should.include('Given I have product described as');


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #3694 

```
#language: de
Funktionalität: Faker examples

   Szenariogrundriss: Atualizar senha do usuário
        Angenommen que estou logado via REST com o usuário "<customer>"
          | protocol             | https:               |
          | hostname             | https://cucumber.io/docs/gherkin/languages/            |
```

```
Faker examples --
  Atualizar senha do usuário {"product":"{{vehicle.vehicle}}","customer":"Dr. {{name.findName}}","price":"{{commerce.price}}","cashier":"cashier 2"}
   On Angenommen: que estou logado via rest com o usuário "dr. {{name.find name}}" 
    protocol        | https:         
    hostname        | https://cucumber.io/docs/gherkin/languages/
    
Dr. {{name.findName}}
  ✔ OK in 13ms

```

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
