### PR TITLE
fix: customLocator draws error in dry-mode

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,6 +152,18 @@ If a plugin needs to be enabled in `dry-run` mode, pass its name in `-p` option:
 npx codeceptjs dry-run --steps -p allure
 ```
 
+If some plugins need to be enabled in `dry-run` mode, pass its name in `-p` option:
+
+```
+npx codeceptjs dry-run --steps -p allure,customLocator
+```
+
+If all plugins need to be enabled in `dry-run` mode, pass its name in `-p` option:
+
+```
+npx codeceptjs dry-run --steps -p all
+```
+
 To enable bootstrap script in dry-run mode, pass in `--bootstrap` option when running with `--steps` or `--debug`
 
 ```

--- a/lib/command/dryRun.js
+++ b/lib/command/dryRun.js
@@ -20,8 +20,8 @@ module.exports = async function (test, options) {
   if (config.plugins) {
     // disable all plugins by default, they can be enabled with -p option
     for (const plugin in config.plugins) {
-      // this to make sure the custom locator could be parsed when running under dry-mode
-      config.plugins[plugin].enabled = plugin === 'customLocator';
+      // if `-p all` is passed, then enabling all plugins, otherwise plugins could be enabled by `-p customLocator,commentStep,tryTo`
+      config.plugins[plugin].enabled = options.plugins === 'all';
     }
   }
 

--- a/lib/command/dryRun.js
+++ b/lib/command/dryRun.js
@@ -20,7 +20,8 @@ module.exports = async function (test, options) {
   if (config.plugins) {
     // disable all plugins by default, they can be enabled with -p option
     for (const plugin in config.plugins) {
-      config.plugins[plugin].enabled = false;
+      // this to make sure the custom locator could be parsed when running under dry-mode
+      config.plugins[plugin].enabled = plugin === 'customLocator';
     }
   }
 

--- a/test/data/sandbox/codecept.customLocator.js
+++ b/test/data/sandbox/codecept.customLocator.js
@@ -1,0 +1,23 @@
+exports.config = {
+  tests: './*.customLocator.js',
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    Playwright: {
+      url: 'http://localhost',
+      show: true,
+      browser: 'chromium',
+    },
+  },
+  include: {},
+  bootstrap: false,
+  mocha: {},
+  name: 'sandbox',
+  plugins: {
+    customLocator: {
+      enabled: false,
+      prefix: '$',
+      attribute: 'data-testid',
+    },
+  },
+};

--- a/test/data/sandbox/test.customLocator.js
+++ b/test/data/sandbox/test.customLocator.js
@@ -1,0 +1,6 @@
+const I = actor();
+Feature('Custom Locator');
+
+Scenario('no error with dry-mode', () => {
+  I.seeElement(locate('$COURSE').find('a'));
+});

--- a/test/runner/dry_run_test.js
+++ b/test/runner/dry_run_test.js
@@ -174,4 +174,15 @@ describe('dry-run command', () => {
       done();
     });
   });
+
+  it('should enable customLocator plugin in dry-mode', (done) => {
+    exec(`${codecept_run_config('codecept.customLocator.js')} --verbose`, (err, stdout) => {
+      expect(stdout).toContain('Plugins: customLocator');
+      expect(stdout).toContain('I see element {xpath: .//*[@data-testid=\'COURSE\']//a}');
+      expect(stdout).toContain('OK  | 1 passed');
+      expect(stdout).toContain('--- DRY MODE: No tests were executed ---');
+      expect(err).toBeFalsy();
+      done();
+    });
+  });
 });

--- a/test/runner/dry_run_test.js
+++ b/test/runner/dry_run_test.js
@@ -175,8 +175,19 @@ describe('dry-run command', () => {
     });
   });
 
-  it('should enable customLocator plugin in dry-mode', (done) => {
-    exec(`${codecept_run_config('codecept.customLocator.js')} --verbose`, (err, stdout) => {
+  it('should enable all plugins in dry-mode when passing -p all', (done) => {
+    exec(`${codecept_run_config('codecept.customLocator.js')} --verbose -p all`, (err, stdout) => {
+      expect(stdout).toContain('Plugins: screenshotOnFail, customLocator');
+      expect(stdout).toContain('I see element {xpath: .//*[@data-testid=\'COURSE\']//a}');
+      expect(stdout).toContain('OK  | 1 passed');
+      expect(stdout).toContain('--- DRY MODE: No tests were executed ---');
+      expect(err).toBeFalsy();
+      done();
+    });
+  });
+
+  it('should enable a particular plugin in dry-mode when passing it to -p', (done) => {
+    exec(`${codecept_run_config('codecept.customLocator.js')} --verbose -p customLocator`, (err, stdout) => {
       expect(stdout).toContain('Plugins: customLocator');
       expect(stdout).toContain('I see element {xpath: .//*[@data-testid=\'COURSE\']//a}');
       expect(stdout).toContain('OK  | 1 passed');


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3657
- Closes #3330
- customLocator is disabled when running the dry-mode command leads to the error

```
Error: Could not include object coursePage from module '/home/mirao/tmp/pages/Course.ts'
Lexical error on line 1. Unrecognized text.
$COURSE
^
Error: Lexical error on line 1. Unrecognized text.
$COURSE
^
```

After the fix, running `dry-run` command with `-p all` or `-p customLocator`

```
CodeceptJS v3.5.6 #StandWithUkraine
Using test root "/Users/t/Desktop/CodeceptJS/test/data/sandbox"
Helpers: Playwright
Plugins: customLocator

Custom Locator --
    [1]  Starting recording promises
Warning: Timeout was set to 10000secs.
Global timeout should be specified in seconds.
    Timeouts: 10000
  no error with dry-mode
 › Test Timeout: 10000s
    I see element {xpath: .//*[@data-testid='COURSE']//a}
  ✔ OK in 5ms


  OK  | 1 passed   // 7ms

--- DRY MODE: No tests were executed ---

```

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
