### PR TITLE
fix: handle the way to load apifactory nicely

### DIFF
--- a/lib/helper/ApiDataFactory.js
+++ b/lib/helper/ApiDataFactory.js
@@ -309,7 +309,8 @@ class ApiDataFactory extends Helper {
       } catch (e) {
         modulePath = path.join(global.codecept_dir, modulePath);
       }
-      const builder = require(modulePath);
+      // check if the new syntax `export default new Factory()` is used and loads the builder, otherwise loads the module that used old syntax `module.exports = new Factory()`.
+      const builder = require(modulePath).default || require(modulePath);
       return builder.build(data, options);
     } catch (err) {
       throw new Error(`Couldn't load factory file from ${modulePath}, check that


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3469 
- With this fix, we could now use the following syntax:

```typescript
export = new Factory()
   .attr('name', () => faker.name.findName())
   .attr('job', () => 'leader');
```
```typescript
export default new Factory()
   .attr('name', () => faker.name.findName())
   .attr('job', () => 'leader');
```

```javascript
modules.export = new Factory()
   .attr('name', () => faker.name.findName())
   .attr('job', () => 'leader');
```

@DavertMik may have concern on this, we encountered this once here https://github.com/codeceptjs/CodeceptJS/pull/3691#issuecomment-1583923749

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
