### PR TITLE
fix: autologin with empty fetch

### DIFF
--- a/docs/webdriver.md
+++ b/docs/webdriver.md
@@ -447,7 +447,7 @@ To share the same user session across different tests CodeceptJS provides [autoL
 This plugin requires some configuration but is very simple in use:
 
 ```js
-Scenario('do something with logged in user', ({ I, login) }) => {
+Scenario('do something with logged in user', ({ I, login }) => {
   login('user');
   I.see('Dashboard','h1');
 });

--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -9,6 +9,7 @@ const isAsyncFunction = require('../utils').isAsyncFunction;
 
 const defaultUser = {
   fetch: I => I.grabCookie(),
+  check: () => {},
   restore: (I, cookies) => {
     I.amOnPage('/'); // open a page
     I.setCookie(cookies);
@@ -251,7 +252,12 @@ module.exports = function (config) {
       } else {
         userSession.login(I);
       }
+
       const cookies = await userSession.fetch(I);
+      if (!cookies) {
+        debug('Cannot save user session with empty cookies from auto login\'s fetch method');
+        return;
+      }
       if (config.saveToFile) {
         debug(`Saved user session into file for ${name}`);
         fs.writeFileSync(path.join(global.output_dir, `${name}_session.json`), JSON.stringify(cookies));


### PR DESCRIPTION
## Motivation/Description of the PR
I was following [autoLogin's example](https://codecept.io/plugins/#example-keep-cookies-between-tests) which can use an empty `fetch` while keeping `saveToFile` to `true`. This leads to me into an error while trying to save an empty `fetch` method with `JSON.stringify(cookies)`:

```sh
[FAILED] Dashboard client - A valid client is able to see his dashboard - 1920x1080 The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
```

My config was:

```js
autoLogin: {  
  enabled: true,  
  saveToFile: true,  // this leads to failure
  inject: 'login',  
  users: {  
    client: {  
      login: async (I) => {  
        // some async methods I use to login 
      },  
      check: (I) => {},  
      fetch: (I) => {},  // return undefined and leads to failure
      restore: (I) => {},  
    },  
  },  
},
```

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [x] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
