### PR TITLE
fix: AppiumTestDistribution/appium-device-farm requires 'platformName'

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -273,6 +273,8 @@ class Appium extends Webdriver {
       if (!key.startsWith(vendorPrefix.appium)) {
         if (key !== 'platformName') {
           _convertedCaps[`${vendorPrefix.appium}:${key}`] = value;
+        } else {
+          _convertedCaps[`${key}`] = value;
         }
       } else {
         _convertedCaps[`${key}`] = value;


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves

I'm trying to run tests with Appium + it's plugin [DeviceFarm](https://github.com/AppiumTestDistribution/appium-device-farm).
At the start, the plugin raises the error then I realize it requires the 'platformName' in the capabilities.
I know I may update such plugins ( include [AppiumDashboard](https://github.com/sudharsan-selvaraj/appium-dashboard-plugin)) but that key is used so many places.
Send duplicated capabilities is easier way to fix it.

- Resolves #issueId (if applicable).

Applicable helpers:
- [x] Appium


## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
