### PR TITLE
fix: ensure docs include `@returns Promise<void>` where appropriate

### DIFF
--- a/docs/webapi/amOnPage.mustache
+++ b/docs/webapi/amOnPage.mustache
@@ -8,4 +8,4 @@ I.amOnPage('/login'); // opens a login page
 ```
 
 @param {string} url url path or global url.
-@return {void} automatically synchronized promise with recorder #! 
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/appendField.mustache
+++ b/docs/webapi/appendField.mustache
@@ -8,4 +8,4 @@ I.appendField('password', secret('123456'));
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator
 @param {string} value text value to append.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/attachFile.mustache
+++ b/docs/webapi/attachFile.mustache
@@ -9,4 +9,4 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 @param {CodeceptJS.LocatorOrString} locator field located by label|name|CSS|XPath|strict locator.
 @param {string} pathToFile local file path relative to codecept.conf.ts or codecept.conf.js config file.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/blur.mustache
+++ b/docs/webapi/blur.mustache
@@ -15,3 +15,4 @@ I.dontSee('#add-to-cart-btn');
 
 @param {CodeceptJS.LocatorOrString} locator field located by label|name|CSS|XPath|strict locator.
 @param {any} [options] Playwright only: [Additional options](https://playwright.dev/docs/api/class-locator#locator-blur) for available options object as 2nd argument.
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/checkOption.mustache
+++ b/docs/webapi/checkOption.mustache
@@ -10,4 +10,4 @@ I.checkOption('agree', '//form');
 ```
 @param {CodeceptJS.LocatorOrString} field checkbox located by label | name | CSS | XPath | strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS | XPath | strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/clearCookie.mustache
+++ b/docs/webapi/clearCookie.mustache
@@ -7,4 +7,4 @@ I.clearCookie('test');
 ```
 
 @param {?string} [cookie=null] (optional, `null` by default) cookie name
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/clearField.mustache
+++ b/docs/webapi/clearField.mustache
@@ -6,4 +6,4 @@ I.clearField('user[email]');
 I.clearField('#email');
 ```
 @param {LocatorOrString} editable field located by label|name|CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder.
+@returns {Promise<void>} automatically synchronized promise through #recorder.

--- a/docs/webapi/click.mustache
+++ b/docs/webapi/click.mustache
@@ -22,4 +22,4 @@ I.click({css: 'nav a.login'});
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString | null} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/clickLink.mustache
+++ b/docs/webapi/clickLink.mustache
@@ -5,4 +5,4 @@ I.clickLink('Logout', '#nav');
 ```
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/closeCurrentTab.mustache
+++ b/docs/webapi/closeCurrentTab.mustache
@@ -4,4 +4,4 @@ Close current tab.
 I.closeCurrentTab();
 ```
 
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/closeOtherTabs.mustache
+++ b/docs/webapi/closeOtherTabs.mustache
@@ -5,4 +5,4 @@ Close all tabs except for the current one.
 I.closeOtherTabs();
 ```
 
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSee.mustache
+++ b/docs/webapi/dontSee.mustache
@@ -8,4 +8,4 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 @param {string} text which is not present.
 @param {CodeceptJS.LocatorOrString} [context] (optional) element located by CSS|XPath|strict locator in which to perfrom search.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeCheckboxIsChecked.mustache
+++ b/docs/webapi/dontSeeCheckboxIsChecked.mustache
@@ -7,4 +7,4 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 ```
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeCookie.mustache
+++ b/docs/webapi/dontSeeCookie.mustache
@@ -5,4 +5,4 @@ I.dontSeeCookie('auth'); // no auth cookie
 ```
 
 @param {string} name cookie name.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeCurrentUrlEquals.mustache
+++ b/docs/webapi/dontSeeCurrentUrlEquals.mustache
@@ -7,4 +7,4 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 ```
 
 @param {string} url value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeElement.mustache
+++ b/docs/webapi/dontSeeElement.mustache
@@ -5,4 +5,4 @@ I.dontSeeElement('.modal'); // modal is not shown
 ```
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|Strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeElementInDOM.mustache
+++ b/docs/webapi/dontSeeElementInDOM.mustache
@@ -5,4 +5,4 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 ```
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|Strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeInCurrentUrl.mustache
+++ b/docs/webapi/dontSeeInCurrentUrl.mustache
@@ -1,4 +1,4 @@
 Checks that current url does not contain a provided fragment.
 
 @param {string} url value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeInField.mustache
+++ b/docs/webapi/dontSeeInField.mustache
@@ -8,4 +8,4 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
 @param {CodeceptJS.StringOrSecret} value value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeInSource.mustache
+++ b/docs/webapi/dontSeeInSource.mustache
@@ -5,4 +5,4 @@ I.dontSeeInSource('<!--'); // no comments in source
 ```
 
 @param {string} value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dontSeeInTitle.mustache
+++ b/docs/webapi/dontSeeInTitle.mustache
@@ -5,4 +5,4 @@ I.dontSeeInTitle('Error');
 ```
 
 @param {string} text value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/doubleClick.mustache
+++ b/docs/webapi/doubleClick.mustache
@@ -10,4 +10,4 @@ I.doubleClick('.btn.edit');
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/downloadFile.mustache
+++ b/docs/webapi/downloadFile.mustache
@@ -9,4 +9,4 @@ I.downloadFile('td[class="text-right file-link"] a', 'thisIsCustomName');
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by CSS|XPath locator.
 @param {string} file custom file name.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dragAndDrop.mustache
+++ b/docs/webapi/dragAndDrop.mustache
@@ -6,4 +6,4 @@ I.dragAndDrop('#dragHandle', '#container');
 
 @param {LocatorOrString} srcElement located by CSS|XPath|strict locator.
 @param {LocatorOrString} destElement located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/dragSlider.mustache
+++ b/docs/webapi/dragSlider.mustache
@@ -8,4 +8,4 @@ I.dragSlider('#slider', -70);
 
 @param {CodeceptJS.LocatorOrString} locator located by label|name|CSS|XPath|strict locator.
 @param {number} offsetX position to drag.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/executeAsyncScript.mustache
+++ b/docs/webapi/executeAsyncScript.mustache
@@ -22,5 +22,3 @@ let val = await I.executeAsyncScript(function(url, done) {
 @param {string|function} fn function to be executed in browser context.
 @param {...any} args to be passed to function.
 @returns {Promise<any>} script return value
-
-⚠️ returns a _promise_ which is synchronized internally by recorder

--- a/docs/webapi/executeScript.mustache
+++ b/docs/webapi/executeScript.mustache
@@ -24,5 +24,3 @@ let date = await I.executeScript(function(el) {
 @param {string|function} fn function to be executed in browser context.
 @param {...any} args to be passed to function.
 @returns {Promise<any>} script return value
-
-⚠️ returns a _promise_ which is synchronized internally by recorder

--- a/docs/webapi/fillField.mustache
+++ b/docs/webapi/fillField.mustache
@@ -13,4 +13,4 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
 @param {CodeceptJS.StringOrSecret} value text value to fill.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/focus.mustache
+++ b/docs/webapi/focus.mustache
@@ -10,3 +10,4 @@ I.see('#add-to-cart-bnt');
 
 @param {CodeceptJS.LocatorOrString} locator field located by label|name|CSS|XPath|strict locator.
 @param {any} [options] Playwright only: [Additional options](https://playwright.dev/docs/api/class-locator#locator-focus) for available options object as 2nd argument.
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/forceClick.mustache
+++ b/docs/webapi/forceClick.mustache
@@ -25,4 +25,4 @@ I.forceClick({css: 'nav a.login'});
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/forceRightClick.mustache
+++ b/docs/webapi/forceRightClick.mustache
@@ -15,4 +15,4 @@ I.forceRightClick('Menu');
 
 @param {CodeceptJS.LocatorOrString} locator clickable link or button located by text, or any element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element to search in CSS|XPath|Strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/grabDataFromPerformanceTiming.mustache
+++ b/docs/webapi/grabDataFromPerformanceTiming.mustache
@@ -17,4 +17,4 @@ let data = await I.grabDataFromPerformanceTiming();
   loadEventEnd: 241
 }
 ```
-@return {Promise<any>} automatically synchronized promise through #recorder 
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/moveCursorTo.mustache
+++ b/docs/webapi/moveCursorTo.mustache
@@ -9,4 +9,4 @@ I.moveCursorTo('#submit', 5,5);
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {number} [offsetX=0] (optional, `0` by default) X-axis offset.
 @param {number} [offsetY=0] (optional, `0` by default) Y-axis offset.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/openNewTab.mustache
+++ b/docs/webapi/openNewTab.mustache
@@ -4,4 +4,4 @@ Open new tab and switch to it.
 I.openNewTab();
 ```
 
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/pressKey.mustache
+++ b/docs/webapi/pressKey.mustache
@@ -9,4 +9,4 @@ I.pressKey(['Control','a']);
 ```
 
 @param {string|string[]} key key or array of keys to press.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/pressKeyDown.mustache
+++ b/docs/webapi/pressKeyDown.mustache
@@ -9,4 +9,4 @@ I.pressKeyUp('Control');
 ```
 
 @param {string} key name of key to press down.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/pressKeyUp.mustache
+++ b/docs/webapi/pressKeyUp.mustache
@@ -9,4 +9,4 @@ I.pressKeyUp('Control');
 ```
 
 @param {string} key name of key to release.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/pressKeyWithKeyNormalization.mustache
+++ b/docs/webapi/pressKeyWithKeyNormalization.mustache
@@ -57,4 +57,4 @@ Some of the supported key names are:
 - `'Tab'`
 
 @param {string|string[]} key key or array of keys to press.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/refreshPage.mustache
+++ b/docs/webapi/refreshPage.mustache
@@ -3,4 +3,4 @@ Reload the current page.
 ```js
 I.refreshPage();
 ```
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/resizeWindow.mustache
+++ b/docs/webapi/resizeWindow.mustache
@@ -3,4 +3,4 @@ First parameter can be set to `maximize`.
 
 @param {number} width width in pixels or `maximize`.
 @param {number} height height in pixels.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/rightClick.mustache
+++ b/docs/webapi/rightClick.mustache
@@ -11,4 +11,4 @@ I.rightClick('Click me', '.context');
 
 @param {CodeceptJS.LocatorOrString} locator clickable element located by CSS|XPath|strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/saveElementScreenshot.mustache
+++ b/docs/webapi/saveElementScreenshot.mustache
@@ -7,4 +7,4 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {string} fileName file name to save.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/saveScreenshot.mustache
+++ b/docs/webapi/saveScreenshot.mustache
@@ -9,4 +9,4 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 
 @param {string} fileName file name to save.
 @param {boolean} [fullPage=false] (optional, `false` by default) flag to enable fullscreen screenshot mode.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/say.mustache
+++ b/docs/webapi/say.mustache
@@ -7,4 +7,4 @@ I.say('This is by default'); //cyan is used
 ```
 @param {string} text expected on console log.
 @param {string} [color='cyan'] color you want to use.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/scrollIntoView.mustache
+++ b/docs/webapi/scrollIntoView.mustache
@@ -8,4 +8,4 @@ I.scrollIntoView('#submit', { behavior: "smooth", block: "center", inline: "cent
 
 @param {LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {ScrollIntoViewOptions} scrollIntoViewOptions see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/scrollPageToBottom.mustache
+++ b/docs/webapi/scrollPageToBottom.mustache
@@ -3,4 +3,4 @@ Scroll page to the bottom.
 ```js
 I.scrollPageToBottom();
 ```
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/scrollPageToTop.mustache
+++ b/docs/webapi/scrollPageToTop.mustache
@@ -3,4 +3,4 @@ Scroll page to the top.
 ```js
 I.scrollPageToTop();
 ```
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/scrollTo.mustache
+++ b/docs/webapi/scrollTo.mustache
@@ -9,4 +9,4 @@ I.scrollTo('#submit', 5, 5);
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {number} [offsetX=0] (optional, `0` by default) X-axis offset.
 @param {number} [offsetY=0] (optional, `0` by default) Y-axis offset.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/see.mustache
+++ b/docs/webapi/see.mustache
@@ -8,4 +8,4 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 ```
 @param {string} text expected on page.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeAttributesOnElements.mustache
+++ b/docs/webapi/seeAttributesOnElements.mustache
@@ -6,4 +6,4 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {object} attributes attributes and their values to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeCheckboxIsChecked.mustache
+++ b/docs/webapi/seeCheckboxIsChecked.mustache
@@ -7,4 +7,4 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 ```
 
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeCookie.mustache
+++ b/docs/webapi/seeCookie.mustache
@@ -5,4 +5,4 @@ I.seeCookie('Auth');
 ```
 
 @param {string} name cookie name.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeCssPropertiesOnElements.mustache
+++ b/docs/webapi/seeCssPropertiesOnElements.mustache
@@ -6,4 +6,4 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
 @param {object} cssProperties object with CSS properties and their values to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeCurrentUrlEquals.mustache
+++ b/docs/webapi/seeCurrentUrlEquals.mustache
@@ -8,4 +8,4 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 ```
 
 @param {string} url value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeElement.mustache
+++ b/docs/webapi/seeElement.mustache
@@ -5,4 +5,4 @@ Element is located by CSS or XPath.
 I.seeElement('#modal');
 ```
 @param {CodeceptJS.LocatorOrString} locator located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeElementInDOM.mustache
+++ b/docs/webapi/seeElementInDOM.mustache
@@ -5,4 +5,4 @@ Element is located by CSS or XPath.
 I.seeElementInDOM('#modal');
 ```
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeInCurrentUrl.mustache
+++ b/docs/webapi/seeInCurrentUrl.mustache
@@ -5,4 +5,4 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 ```
 
 @param {string} url a fragment to check
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeInField.mustache
+++ b/docs/webapi/seeInField.mustache
@@ -9,4 +9,4 @@ I.seeInField('#searchform input','Search');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
 @param {CodeceptJS.StringOrSecret} value value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeInPopup.mustache
+++ b/docs/webapi/seeInPopup.mustache
@@ -5,4 +5,4 @@ given string.
 I.seeInPopup('Popup text');
 ```
 @param {string} text value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeInSource.mustache
+++ b/docs/webapi/seeInSource.mustache
@@ -4,4 +4,4 @@ Checks that the current page contains the given string in its raw source code.
 I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 ```
 @param {string} text value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeInTitle.mustache
+++ b/docs/webapi/seeInTitle.mustache
@@ -5,4 +5,4 @@ I.seeInTitle('Home Page');
 ```
 
 @param {string} text text value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeNumberOfElements.mustache
+++ b/docs/webapi/seeNumberOfElements.mustache
@@ -8,4 +8,4 @@ I.seeNumberOfElements('#submitBtn', 1);
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} num number of elements.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeNumberOfVisibleElements.mustache
+++ b/docs/webapi/seeNumberOfVisibleElements.mustache
@@ -7,4 +7,4 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} num number of elements.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeTextEquals.mustache
+++ b/docs/webapi/seeTextEquals.mustache
@@ -6,4 +6,4 @@ I.seeTextEquals('text', 'h1');
 
 @param {string} text element value to check.
 @param {CodeceptJS.LocatorOrString?} [context=null]  element located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/seeTitleEquals.mustache
+++ b/docs/webapi/seeTitleEquals.mustache
@@ -5,4 +5,4 @@ I.seeTitleEquals('Test title.');
 ```
 
 @param {string} text value to check.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/selectOption.mustache
+++ b/docs/webapi/selectOption.mustache
@@ -18,4 +18,4 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 ```
 @param {LocatorOrString} select field located by label|name|CSS|XPath|strict locator.
 @param {string|Array<*>} option visible text or value of option.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/setCookie.mustache
+++ b/docs/webapi/setCookie.mustache
@@ -13,4 +13,4 @@ I.setCookie([
 ```
 
 @param {Cookie|Array<Cookie>} cookie a cookie object or array of cookie objects.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/setGeoLocation.mustache
+++ b/docs/webapi/setGeoLocation.mustache
@@ -9,4 +9,4 @@ I.setGeoLocation(121.21, 11.56, 10);
 @param {number} latitude to set.
 @param {number} longitude to set
 @param {number=} altitude (optional, null by default) to set
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/switchTo.mustache
+++ b/docs/webapi/switchTo.mustache
@@ -6,4 +6,4 @@ I.switchTo(); // switch back to main page
 ```
 
 @param {?CodeceptJS.LocatorOrString} [locator=null] (optional, `null` by default) element located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/switchToNextTab.mustache
+++ b/docs/webapi/switchToNextTab.mustache
@@ -7,4 +7,4 @@ I.switchToNextTab(2);
 
 @param {number} [num] (optional) number of tabs to switch forward, default: 1.
 @param {number | null} [sec] (optional) time in seconds to wait.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/switchToPreviousTab.mustache
+++ b/docs/webapi/switchToPreviousTab.mustache
@@ -7,4 +7,4 @@ I.switchToPreviousTab(2);
 
 @param {number} [num] (optional) number of tabs to switch backward, default: 1.
 @param {number?} [sec] (optional) time in seconds to wait.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/type.mustache
+++ b/docs/webapi/type.mustache
@@ -18,4 +18,4 @@ I.type(secret('123456'));
 
 @param {string|string[]} key or array of keys to type.
 @param {?number} [delay=null] (optional) delay in ms between key presses
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/uncheckOption.mustache
+++ b/docs/webapi/uncheckOption.mustache
@@ -10,4 +10,4 @@ I.uncheckOption('agree', '//form');
 ```
 @param {CodeceptJS.LocatorOrString} field checkbox located by label | name | CSS | XPath | strict locator.
 @param {?CodeceptJS.LocatorOrString} [context=null] (optional, `null` by default) element located by CSS | XPath | strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/wait.mustache
+++ b/docs/webapi/wait.mustache
@@ -5,4 +5,4 @@ I.wait(2); // wait 2 secs
 ```
 
 @param {number} sec number of second to wait.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForClickable.mustache
+++ b/docs/webapi/waitForClickable.mustache
@@ -8,4 +8,4 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForDetached.mustache
+++ b/docs/webapi/waitForDetached.mustache
@@ -7,4 +7,4 @@ I.waitForDetached('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForElement.mustache
+++ b/docs/webapi/waitForElement.mustache
@@ -8,4 +8,4 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForEnabled.mustache
+++ b/docs/webapi/waitForEnabled.mustache
@@ -3,4 +3,4 @@ Element can be located by CSS or XPath.
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional) time in seconds to wait, 1 by default.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForFunction.mustache
+++ b/docs/webapi/waitForFunction.mustache
@@ -14,4 +14,4 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 @param {string|function} fn to be executed in browser context.
 @param {any[]|number} [argsOrSec] (optional, `1` by default) arguments for function or seconds.
 @param {number} [sec] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForInvisible.mustache
+++ b/docs/webapi/waitForInvisible.mustache
@@ -7,4 +7,4 @@ I.waitForInvisible('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForText.mustache
+++ b/docs/webapi/waitForText.mustache
@@ -10,4 +10,4 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 @param {string }text to wait for.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
 @param {CodeceptJS.LocatorOrString} [context] (optional) element located by CSS|XPath|strict locator.
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForValue.mustache
+++ b/docs/webapi/waitForValue.mustache
@@ -7,4 +7,4 @@ I.waitForValue('//input', "GoodValue");
 @param {LocatorOrString} field input field.
 @param {string }value expected value.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitForVisible.mustache
+++ b/docs/webapi/waitForVisible.mustache
@@ -7,4 +7,4 @@ I.waitForVisible('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitInUrl.mustache
+++ b/docs/webapi/waitInUrl.mustache
@@ -6,4 +6,4 @@ I.waitInUrl('/info', 2);
 
 @param {string} urlPart value to check.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitNumberOfVisibleElements.mustache
+++ b/docs/webapi/waitNumberOfVisibleElements.mustache
@@ -7,4 +7,4 @@ I.waitNumberOfVisibleElements('a', 3);
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} num number of elements.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitToHide.mustache
+++ b/docs/webapi/waitToHide.mustache
@@ -7,4 +7,4 @@ I.waitToHide('#popup');
 
 @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/docs/webapi/waitUrlEquals.mustache
+++ b/docs/webapi/waitUrlEquals.mustache
@@ -7,4 +7,4 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 @param {string} urlPart value to check.
 @param {number} [sec=1] (optional, `1` by default) time in seconds to wait
-⚠️ returns a _promise_ which is synchronized internally by recorder
+@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/typings/tests/helpers/Appium.types.ts
+++ b/typings/tests/helpers/Appium.types.ts
@@ -66,14 +66,14 @@ appium.rotate(); // $ExpectType Promise<void>
 appium.setImmediateValue(); // $ExpectType Promise<void>
 appium.simulateTouchId(); // $ExpectType Promise<void>
 appium.closeApp(); // $ExpectType Promise<void>
-appium.appendField(str, str); // $ExpectType void
-appium.checkOption(str); // $ExpectType void
-appium.click(str); // $ExpectType void
-appium.dontSeeCheckboxIsChecked(str); // $ExpectType void
-appium.dontSeeElement(str); // $ExpectType void
-appium.dontSeeInField(str, str); // $ExpectType void
-appium.dontSee(str); // $ExpectType void
-appium.fillField(str, str); // $ExpectType void
+appium.appendField(str, str); // $ExpectType Promise<void>
+appium.checkOption(str); // $ExpectType Promise<void>
+appium.click(str); // $ExpectType Promise<void>
+appium.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<void>
+appium.dontSeeElement(str); // $ExpectType Promise<void>
+appium.dontSeeInField(str, str); // $ExpectType Promise<void>
+appium.dontSee(str); // $ExpectType Promise<void>
+appium.fillField(str, str); // $ExpectType Promise<void>
 appium.grabTextFromAll(str); // $ExpectType Promise<string[]>
 appium.grabTextFrom(str); // $ExpectType Promise<string>
 appium.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
@@ -82,13 +82,13 @@ appium.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
 appium.grabValueFromAll(str); // $ExpectType Promise<string[]>
 appium.grabValueFrom(str); // $ExpectType Promise<string>
 appium.saveScreenshot(str); // $ExpectType Promise<void>
-appium.scrollIntoView(str, {}); // $ExpectType void
-appium.seeCheckboxIsChecked(str); // $ExpectType void
-appium.seeElement(str); // $ExpectType void
-appium.seeInField(str, str); // $ExpectType void
-appium.see(str); // $ExpectType void
-appium.selectOption(str, str); // $ExpectType void
-appium.waitForElement(str); // $ExpectType void
-appium.waitForVisible(str); // $ExpectType void
-appium.waitForInvisible(str); // $ExpectType void
-appium.waitForText(str); // $ExpectType void
+appium.scrollIntoView(str, {}); // $ExpectType Promise<void>
+appium.seeCheckboxIsChecked(str); // $ExpectType Promise<void>
+appium.seeElement(str); // $ExpectType Promise<void>
+appium.seeInField(str, str); // $ExpectType Promise<void>
+appium.see(str); // $ExpectType Promise<void>
+appium.selectOption(str, str); // $ExpectType Promise<void>
+appium.waitForElement(str); // $ExpectType Promise<void>
+appium.waitForVisible(str); // $ExpectType Promise<void>
+appium.waitForInvisible(str); // $ExpectType Promise<void>
+appium.waitForText(str); // $ExpectType Promise<void>

--- a/typings/tests/helpers/AppiumTs.types.ts
+++ b/typings/tests/helpers/AppiumTs.types.ts
@@ -66,14 +66,14 @@ appium.rotate(); // $ExpectType Promise<void>
 appium.setImmediateValue(); // $ExpectType Promise<void>
 appium.simulateTouchId(); // $ExpectType Promise<void>
 appium.closeApp(); // $ExpectType Promise<void>
-appium.appendField(str, str); // $ExpectType Promise<any>
-appium.checkOption(str); // $ExpectType Promise<any>
-appium.click(str); // $ExpectType Promise<any>
-appium.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<any>
-appium.dontSeeElement(str); // $ExpectType Promise<any>
-appium.dontSeeInField(str, str); // $ExpectType Promise<any>
-appium.dontSee(str); // $ExpectType Promise<any>
-appium.fillField(str, str); // $ExpectType Promise<any>
+appium.appendField(str, str); // $ExpectType Promise<void>
+appium.checkOption(str); // $ExpectType Promise<void>
+appium.click(str); // $ExpectType Promise<void>
+appium.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<void>
+appium.dontSeeElement(str); // $ExpectType Promise<void>
+appium.dontSeeInField(str, str); // $ExpectType Promise<void>
+appium.dontSee(str); // $ExpectType Promise<void>
+appium.fillField(str, str); // $ExpectType Promise<void>
 appium.grabTextFromAll(str); // $ExpectType Promise<string[]>
 appium.grabTextFrom(str); // $ExpectType Promise<string>
 appium.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
@@ -82,13 +82,13 @@ appium.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
 appium.grabValueFromAll(str); // $ExpectType Promise<string[]>
 appium.grabValueFrom(str); // $ExpectType Promise<string>
 appium.saveScreenshot(str); // $ExpectType Promise<void>
-appium.scrollIntoView(str, {}); // $ExpectType Promise<any>
-appium.seeCheckboxIsChecked(str); // $ExpectType Promise<any>
-appium.seeElement(str); // $ExpectType Promise<any>
-appium.seeInField(str, str); // $ExpectType Promise<any>
-appium.see(str); // $ExpectType Promise<any>
-appium.selectOption(str, str); // $ExpectType Promise<any>
-appium.waitForElement(str); // $ExpectType Promise<any>
-appium.waitForVisible(str); // $ExpectType Promise<any>
-appium.waitForInvisible(str); // $ExpectType Promise<any>
-appium.waitForText(str); // $ExpectType Promise<any>
+appium.scrollIntoView(str, {}); // $ExpectType Promise<void>
+appium.seeCheckboxIsChecked(str); // $ExpectType Promise<void>
+appium.seeElement(str); // $ExpectType Promise<void>
+appium.seeInField(str, str); // $ExpectType Promise<void>
+appium.see(str); // $ExpectType Promise<void>
+appium.selectOption(str, str); // $ExpectType Promise<void>
+appium.waitForElement(str); // $ExpectType Promise<void>
+appium.waitForVisible(str); // $ExpectType Promise<void>
+appium.waitForInvisible(str); // $ExpectType Promise<void>
+appium.waitForText(str); // $ExpectType Promise<void>

--- a/typings/tests/helpers/Playwright.types.ts
+++ b/typings/tests/helpers/Playwright.types.ts
@@ -13,30 +13,30 @@ playwright.amAcceptingPopups(); // $ExpectType void
 playwright.acceptPopup(); // $ExpectType void
 playwright.amCancellingPopups(); // $ExpectType void
 playwright.cancelPopup(); // $ExpectType void
-playwright.seeInPopup(str); // $ExpectType void
+playwright.seeInPopup(str); // $ExpectType Promise<void>
 playwright._setPage(str); // $ExpectType void
 playwright._addPopupListener(); // $ExpectType void
 playwright._getPageUrl(); // $ExpectType void
 playwright.grabPopupText(); // $ExpectType Promise<string | null>
 playwright._createContextPage(); // $ExpectType void
 playwright._createContextPage({}); // $ExpectType void
-playwright.amOnPage(str); // $ExpectType void
-playwright.resizeWindow(num, num); // $ExpectType void
+playwright.amOnPage(str); // $ExpectType Promise<void>
+playwright.resizeWindow(num, num); // $ExpectType Promise<void>
 playwright.haveRequestHeaders(str); // $ExpectType void
-playwright.moveCursorTo(str, num, num); // $ExpectType void
+playwright.moveCursorTo(str, num, num); // $ExpectType Promise<void>
 playwright.dragAndDrop(str); // $ExpectError
-playwright.dragAndDrop(str, str); // $ExpectType void
-playwright.dragAndDrop(str, str, { sourcePosition, targetPosition }); // $ExpectType void
+playwright.dragAndDrop(str, str); // $ExpectType Promise<void>
+playwright.dragAndDrop(str, str, { sourcePosition, targetPosition }); // $ExpectType Promise<void>
 playwright.restartBrowser(); // $ExpectType void
 playwright.restartBrowser({}); // $ExpectType void
-playwright.refreshPage(); // $ExpectType void
-playwright.scrollPageToTop(); // $ExpectType void
-playwright.scrollPageToBottom(); // $ExpectType void
-playwright.scrollTo(str, num, num); // $ExpectType void
-playwright.seeInTitle(str); // $ExpectType void
+playwright.refreshPage(); // $ExpectType Promise<void>
+playwright.scrollPageToTop(); // $ExpectType Promise<void>
+playwright.scrollPageToBottom(); // $ExpectType Promise<void>
+playwright.scrollTo(str, num, num); // $ExpectType Promise<void>
+playwright.seeInTitle(str); // $ExpectType Promise<void>
 playwright.grabPageScrollPosition(); // $ExpectType Promise<PageScrollPosition>
-playwright.seeTitleEquals(str); // $ExpectType void
-playwright.dontSeeInTitle(str); // $ExpectType void
+playwright.seeTitleEquals(str); // $ExpectType Promise<void>
+playwright.dontSeeInTitle(str); // $ExpectType Promise<void>
 playwright.grabTitle(); // $ExpectType Promise<string>
 playwright._locate(); // $ExpectType void
 playwright._locateCheckable(); // $ExpectType void
@@ -48,55 +48,55 @@ playwright.closeCurrentTab(); // $ExpectType void
 playwright.closeOtherTabs(); // $ExpectType void
 playwright.openNewTab(); // $ExpectType void
 playwright.grabNumberOfOpenTabs(); // $ExpectType Promise<number>
-playwright.seeElement(str); // $ExpectType void
-playwright.dontSeeElement(str); // $ExpectType void
-playwright.seeElementInDOM(str); // $ExpectType void
-playwright.dontSeeElementInDOM(str); // $ExpectType void
+playwright.seeElement(str); // $ExpectType Promise<void>
+playwright.dontSeeElement(str); // $ExpectType Promise<void>
+playwright.seeElementInDOM(str); // $ExpectType Promise<void>
+playwright.dontSeeElementInDOM(str); // $ExpectType Promise<void>
 playwright.handleDownloads(str); // $ExpectType Promise<void>
-playwright.click(str); // $ExpectType void
-playwright.click(str, str); // $ExpectType void
-playwright.click(str, null, { position }); // $ExpectType void
+playwright.click(str); // $ExpectType Promise<void>
+playwright.click(str, str); // $ExpectType Promise<void>
+playwright.click(str, null, { position }); // $ExpectType Promise<void>
 playwright.clickLink(); // $ExpectType void
-playwright.forceClick(str); // $ExpectType void
-playwright.focus(str); // $ExpectType void
-playwright.blur(str); // $ExpectType void
-playwright.doubleClick(str); // $ExpectType void
-playwright.rightClick(str); // $ExpectType void
-playwright.checkOption(str); // $ExpectType void
-playwright.uncheckOption(str); // $ExpectType void
-playwright.seeCheckboxIsChecked(str); // $ExpectType void
-playwright.dontSeeCheckboxIsChecked(str); // $ExpectType void
-playwright.pressKeyDown(str); // $ExpectType void
-playwright.pressKeyUp(str); // $ExpectType void
-playwright.pressKey(str); // $ExpectType void
-playwright.type(str); // $ExpectType void
-playwright.fillField(str, str); // $ExpectType void
+playwright.forceClick(str); // $ExpectType Promise<void>
+playwright.focus(str); // $ExpectType Promise<void>
+playwright.blur(str); // $ExpectType Promise<void>
+playwright.doubleClick(str); // $ExpectType Promise<void>
+playwright.rightClick(str); // $ExpectType Promise<void>
+playwright.checkOption(str); // $ExpectType Promise<void>
+playwright.uncheckOption(str); // $ExpectType Promise<void>
+playwright.seeCheckboxIsChecked(str); // $ExpectType Promise<void>
+playwright.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<void>
+playwright.pressKeyDown(str); // $ExpectType Promise<void>
+playwright.pressKeyUp(str); // $ExpectType Promise<void>
+playwright.pressKey(str); // $ExpectType Promise<void>
+playwright.type(str); // $ExpectType Promise<void>
+playwright.fillField(str, str); // $ExpectType Promise<void>
 playwright.clearField(str); // $ExpectType void
-playwright.appendField(str, str); // $ExpectType void
-playwright.seeInField(str, str); // $ExpectType void
-playwright.dontSeeInField(str, str); // $ExpectType void
-playwright.attachFile(str, str); // $ExpectType void
-playwright.selectOption(str, str); // $ExpectType void
+playwright.appendField(str, str); // $ExpectType Promise<void>
+playwright.seeInField(str, str); // $ExpectType Promise<void>
+playwright.dontSeeInField(str, str); // $ExpectType Promise<void>
+playwright.attachFile(str, str); // $ExpectType Promise<void>
+playwright.selectOption(str, str); // $ExpectType Promise<void>
 playwright.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
-playwright.seeInCurrentUrl(str); // $ExpectType void
-playwright.dontSeeInCurrentUrl(str); // $ExpectType void
-playwright.seeCurrentUrlEquals(str); // $ExpectType void
-playwright.dontSeeCurrentUrlEquals(str); // $ExpectType void
-playwright.see(str); // $ExpectType void
-playwright.seeTextEquals(str); // $ExpectType void
-playwright.dontSee(str); // $ExpectType void
+playwright.seeInCurrentUrl(str); // $ExpectType Promise<void>
+playwright.dontSeeInCurrentUrl(str); // $ExpectType Promise<void>
+playwright.seeCurrentUrlEquals(str); // $ExpectType Promise<void>
+playwright.dontSeeCurrentUrlEquals(str); // $ExpectType Promise<void>
+playwright.see(str); // $ExpectType Promise<void>
+playwright.seeTextEquals(str); // $ExpectType Promise<void>
+playwright.dontSee(str); // $ExpectType Promise<void>
 playwright.grabSource(); // $ExpectType Promise<string>
 playwright.grabBrowserLogs(); // $ExpectType Promise<any[]>
 playwright.grabCurrentUrl(); // $ExpectType Promise<string>
-playwright.seeInSource(str); // $ExpectType void
-playwright.dontSeeInSource(str); // $ExpectType void
-playwright.seeNumberOfElements(str, num); // $ExpectType void
-playwright.seeNumberOfVisibleElements(str, num); // $ExpectType void
-playwright.setCookie({ name: str, value: str}); // $ExpectType void
-playwright.seeCookie(str); // $ExpectType void
-playwright.dontSeeCookie(str); // $ExpectType void
+playwright.seeInSource(str); // $ExpectType Promise<void>
+playwright.dontSeeInSource(str); // $ExpectType Promise<void>
+playwright.seeNumberOfElements(str, num); // $ExpectType Promise<void>
+playwright.seeNumberOfVisibleElements(str, num); // $ExpectType Promise<void>
+playwright.setCookie({ name: str, value: str}); // $ExpectType Promise<void>
+playwright.seeCookie(str); // $ExpectType Promise<void>
+playwright.dontSeeCookie(str); // $ExpectType Promise<void>
 playwright.grabCookie(); // $ExpectType any
-playwright.clearCookie(); // $ExpectType void
+playwright.clearCookie(); // $ExpectType Promise<void>
 playwright.executeScript(() => {}); // $ExpectType Promise<any>
 playwright.grabTextFrom(str); // $ExpectType Promise<string>
 playwright.grabTextFromAll(str); // $ExpectType Promise<string[]>
@@ -106,33 +106,33 @@ playwright.grabHTMLFrom(str); // $ExpectType Promise<string>
 playwright.grabHTMLFromAll(str); // $ExpectType Promise<string[]>
 playwright.grabCssPropertyFrom(str, str); // $ExpectType Promise<string>
 playwright.grabCssPropertyFromAll(str, str); // $ExpectType Promise<string[]>
-playwright.seeCssPropertiesOnElements(str, str); // $ExpectType void
-playwright.seeAttributesOnElements(str, str); // $ExpectType void
-playwright.dragSlider(str, num); // $ExpectType void
+playwright.seeCssPropertiesOnElements(str, str); // $ExpectType Promise<void>
+playwright.seeAttributesOnElements(str, str); // $ExpectType Promise<void>
+playwright.dragSlider(str, num); // $ExpectType Promise<void>
 playwright.grabAttributeFrom(str, str); // $ExpectType Promise<string>
 playwright.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
-playwright.saveElementScreenshot(str, str); // $ExpectType void
-playwright.saveScreenshot(str); // $ExpectType void
+playwright.saveElementScreenshot(str, str); // $ExpectType Promise<void>
+playwright.saveScreenshot(str); // $ExpectType Promise<void>
 playwright.makeApiRequest(str, str, str); // $ExpectType Promise<object>
-playwright.wait(num); // $ExpectType void
-playwright.waitForEnabled(str); // $ExpectType void
-playwright.waitForValue(str, str); // $ExpectType void
-playwright.waitNumberOfVisibleElements(str, num); // $ExpectType void
-playwright.waitForClickable(str); // $ExpectType void
-playwright.waitForElement(str); // $ExpectType void
-playwright.waitForVisible(str); // $ExpectType void
-playwright.waitForInvisible(str); // $ExpectType void
-playwright.waitToHide(str); // $ExpectType void
-playwright.waitInUrl(str); // $ExpectType void
-playwright.waitUrlEquals(str); // $ExpectType void
-playwright.waitForText(str); // $ExpectType void
+playwright.wait(num); // $ExpectType Promise<void>
+playwright.waitForEnabled(str); // $ExpectType Promise<void>
+playwright.waitForValue(str, str); // $ExpectType Promise<void>
+playwright.waitNumberOfVisibleElements(str, num); // $ExpectType Promise<void>
+playwright.waitForClickable(str); // $ExpectType Promise<void>
+playwright.waitForElement(str); // $ExpectType Promise<void>
+playwright.waitForVisible(str); // $ExpectType Promise<void>
+playwright.waitForInvisible(str); // $ExpectType Promise<void>
+playwright.waitToHide(str); // $ExpectType Promise<void>
+playwright.waitInUrl(str); // $ExpectType Promise<void>
+playwright.waitUrlEquals(str); // $ExpectType Promise<void>
+playwright.waitForText(str); // $ExpectType Promise<void>
 playwright.waitForRequest(str); // $ExpectType void
 playwright.waitForResponse(str); // $ExpectType void
-playwright.switchTo(); // $ExpectType void
-playwright.waitForFunction(() => { }); // $ExpectType void
+playwright.switchTo(); // $ExpectType Promise<void>
+playwright.waitForFunction(() => { }); // $ExpectType Promise<void>
 playwright.waitForNavigation(str); // $ExpectType void
-playwright.waitForDetached(str); // $ExpectType void
-playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<any>
+playwright.waitForDetached(str); // $ExpectType Promise<void>
+playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<void>
 playwright.grabElementBoundingRect(str); // $ExpectType Promise<number> | Promise<DOMRect>
 playwright.mockRoute(str); // $ExpectType void
 playwright.stopMockingRoute(str); // $ExpectType void

--- a/typings/tests/helpers/PlaywrightTs.types.ts
+++ b/typings/tests/helpers/PlaywrightTs.types.ts
@@ -13,26 +13,26 @@ playwright.amAcceptingPopups(); // $ExpectType Promise<any>
 playwright.acceptPopup(); // $ExpectType Promise<any>
 playwright.amCancellingPopups(); // $ExpectType Promise<any>
 playwright.cancelPopup(); // $ExpectType Promise<any>
-playwright.seeInPopup(str); // $ExpectType Promise<any>
+playwright.seeInPopup(str); // $ExpectType Promise<void>
 playwright._setPage(str); // $ExpectType Promise<any>
 playwright._addPopupListener(); // $ExpectType Promise<any>
 playwright._getPageUrl(); // $ExpectType Promise<any>
 playwright.grabPopupText(); // $ExpectType Promise<string | null>
-playwright.amOnPage(str); // $ExpectType Promise<any>
-playwright.resizeWindow(num, num); // $ExpectType Promise<any>
+playwright.amOnPage(str); // $ExpectType Promise<void>
+playwright.resizeWindow(num, num); // $ExpectType Promise<void>
 playwright.haveRequestHeaders(str); // $ExpectType Promise<any>
-playwright.moveCursorTo(str, num, num); // $ExpectType Promise<any>
+playwright.moveCursorTo(str, num, num); // $ExpectType Promise<void>
 playwright.dragAndDrop(str); // $ExpectError
-playwright.dragAndDrop(str, str); // $ExpectType Promise<any>
-playwright.dragAndDrop(str, str, { sourcePosition, targetPosition }); // $ExpectType Promise<any>
-playwright.refreshPage(); // $ExpectType Promise<any>
-playwright.scrollPageToTop(); // $ExpectType Promise<any>
-playwright.scrollPageToBottom(); // $ExpectType Promise<any>
-playwright.scrollTo(str, num, num); // $ExpectType Promise<any>
-playwright.seeInTitle(str); // $ExpectType Promise<any>
+playwright.dragAndDrop(str, str); // $ExpectType Promise<void>
+playwright.dragAndDrop(str, str, { sourcePosition, targetPosition }); // $ExpectType Promise<void>
+playwright.refreshPage(); // $ExpectType Promise<void>
+playwright.scrollPageToTop(); // $ExpectType Promise<void>
+playwright.scrollPageToBottom(); // $ExpectType Promise<void>
+playwright.scrollTo(str, num, num); // $ExpectType Promise<void>
+playwright.seeInTitle(str); // $ExpectType Promise<void>
 playwright.grabPageScrollPosition(); // $ExpectType Promise<PageScrollPosition>
-playwright.seeTitleEquals(str); // $ExpectType Promise<any>
-playwright.dontSeeInTitle(str); // $ExpectType Promise<any>
+playwright.seeTitleEquals(str); // $ExpectType Promise<void>
+playwright.dontSeeInTitle(str); // $ExpectType Promise<void>
 playwright.grabTitle(); // $ExpectType Promise<string>
 playwright._locate(); // $ExpectType Promise<any>
 playwright._locateCheckable(); // $ExpectType Promise<any>
@@ -44,55 +44,55 @@ playwright.closeCurrentTab(); // $ExpectType Promise<any>
 playwright.closeOtherTabs(); // $ExpectType Promise<any>
 playwright.openNewTab(); // $ExpectType Promise<any>
 playwright.grabNumberOfOpenTabs(); // $ExpectType Promise<number>
-playwright.seeElement(str); // $ExpectType Promise<any>
-playwright.dontSeeElement(str); // $ExpectType Promise<any>
-playwright.seeElementInDOM(str); // $ExpectType Promise<any>
-playwright.dontSeeElementInDOM(str); // $ExpectType Promise<any>
+playwright.seeElement(str); // $ExpectType Promise<void>
+playwright.dontSeeElement(str); // $ExpectType Promise<void>
+playwright.seeElementInDOM(str); // $ExpectType Promise<void>
+playwright.dontSeeElementInDOM(str); // $ExpectType Promise<void>
 playwright.handleDownloads(str); // $ExpectType Promise<void>
-playwright.click(str); // $ExpectType Promise<any>
-playwright.click(str, str); // $ExpectType Promise<any>
-playwright.click(str, null, { position }); // $ExpectType Promise<any>
+playwright.click(str); // $ExpectType Promise<void>
+playwright.click(str, str); // $ExpectType Promise<void>
+playwright.click(str, null, { position }); // $ExpectType Promise<void>
 playwright.clickLink(); // $ExpectType Promise<any>
-playwright.forceClick(str); // $ExpectType Promise<any>
-playwright.focus(str); // $ExpectType Promise<any>
-playwright.blur(str); // $ExpectType Promise<any>
-playwright.doubleClick(str); // $ExpectType Promise<any>
-playwright.rightClick(str); // $ExpectType Promise<any>
-playwright.checkOption(str); // $ExpectType Promise<any>
-playwright.uncheckOption(str); // $ExpectType Promise<any>
-playwright.seeCheckboxIsChecked(str); // $ExpectType Promise<any>
-playwright.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<any>
-playwright.pressKeyDown(str); // $ExpectType Promise<any>
-playwright.pressKeyUp(str); // $ExpectType Promise<any>
-playwright.pressKey(str); // $ExpectType Promise<any>
-playwright.type(str); // $ExpectType Promise<any>
-playwright.fillField(str, str); // $ExpectType Promise<any>
+playwright.forceClick(str); // $ExpectType Promise<void>
+playwright.focus(str); // $ExpectType Promise<void>
+playwright.blur(str); // $ExpectType Promise<void>
+playwright.doubleClick(str); // $ExpectType Promise<void>
+playwright.rightClick(str); // $ExpectType Promise<void>
+playwright.checkOption(str); // $ExpectType Promise<void>
+playwright.uncheckOption(str); // $ExpectType Promise<void>
+playwright.seeCheckboxIsChecked(str); // $ExpectType Promise<void>
+playwright.dontSeeCheckboxIsChecked(str); // $ExpectType Promise<void>
+playwright.pressKeyDown(str); // $ExpectType Promise<void>
+playwright.pressKeyUp(str); // $ExpectType Promise<void>
+playwright.pressKey(str); // $ExpectType Promise<void>
+playwright.type(str); // $ExpectType Promise<void>
+playwright.fillField(str, str); // $ExpectType Promise<void>
 playwright.clearField(str); // $ExpectType Promise<any>
-playwright.appendField(str, str); // $ExpectType Promise<any>
-playwright.seeInField(str, str); // $ExpectType Promise<any>
-playwright.dontSeeInField(str, str); // $ExpectType Promise<any>
-playwright.attachFile(str, str); // $ExpectType Promise<any>
-playwright.selectOption(str, str); // $ExpectType Promise<any>
+playwright.appendField(str, str); // $ExpectType Promise<void>
+playwright.seeInField(str, str); // $ExpectType Promise<void>
+playwright.dontSeeInField(str, str); // $ExpectType Promise<void>
+playwright.attachFile(str, str); // $ExpectType Promise<void>
+playwright.selectOption(str, str); // $ExpectType Promise<void>
 playwright.grabNumberOfVisibleElements(str); // $ExpectType Promise<number>
-playwright.seeInCurrentUrl(str); // $ExpectType Promise<any>
-playwright.dontSeeInCurrentUrl(str); // $ExpectType Promise<any>
-playwright.seeCurrentUrlEquals(str); // $ExpectType Promise<any>
-playwright.dontSeeCurrentUrlEquals(str); // $ExpectType Promise<any>
-playwright.see(str); // $ExpectType Promise<any>
-playwright.seeTextEquals(str); // $ExpectType Promise<any>
-playwright.dontSee(str); // $ExpectType Promise<any>
+playwright.seeInCurrentUrl(str); // $ExpectType Promise<void>
+playwright.dontSeeInCurrentUrl(str); // $ExpectType Promise<void>
+playwright.seeCurrentUrlEquals(str); // $ExpectType Promise<void>
+playwright.dontSeeCurrentUrlEquals(str); // $ExpectType Promise<void>
+playwright.see(str); // $ExpectType Promise<void>
+playwright.seeTextEquals(str); // $ExpectType Promise<void>
+playwright.dontSee(str); // $ExpectType Promise<void>
 playwright.grabSource(); // $ExpectType Promise<string>
 playwright.grabBrowserLogs(); // $ExpectType Promise<any[]>
 playwright.grabCurrentUrl(); // $ExpectType Promise<string>
-playwright.seeInSource(str); // $ExpectType Promise<any>
-playwright.dontSeeInSource(str); // $ExpectType Promise<any>
-playwright.seeNumberOfElements(str, num); // $ExpectType Promise<any>
-playwright.seeNumberOfVisibleElements(str, num); // $ExpectType Promise<any>
-playwright.setCookie({ name: str, value: str}); // $ExpectType Promise<any>
-playwright.seeCookie(str); // $ExpectType Promise<any>
-playwright.dontSeeCookie(str); // $ExpectType Promise<any>
+playwright.seeInSource(str); // $ExpectType Promise<void>
+playwright.dontSeeInSource(str); // $ExpectType Promise<void>
+playwright.seeNumberOfElements(str, num); // $ExpectType Promise<void>
+playwright.seeNumberOfVisibleElements(str, num); // $ExpectType Promise<void>
+playwright.setCookie({ name: str, value: str}); // $ExpectType Promise<void>
+playwright.seeCookie(str); // $ExpectType Promise<void>
+playwright.dontSeeCookie(str); // $ExpectType Promise<void>
 playwright.grabCookie(); // $ExpectType Promise<any>
-playwright.clearCookie(); // $ExpectType Promise<any>
+playwright.clearCookie(); // $ExpectType Promise<void>
 playwright.executeScript(() => {}); // $ExpectType Promise<any>
 playwright.grabTextFrom(str); // $ExpectType Promise<string>
 playwright.grabTextFromAll(str); // $ExpectType Promise<string[]>
@@ -102,33 +102,33 @@ playwright.grabHTMLFrom(str); // $ExpectType Promise<string>
 playwright.grabHTMLFromAll(str); // $ExpectType Promise<string[]>
 playwright.grabCssPropertyFrom(str, str); // $ExpectType Promise<string>
 playwright.grabCssPropertyFromAll(str, str); // $ExpectType Promise<string[]>
-playwright.seeCssPropertiesOnElements(str, str); // $ExpectType Promise<any>
-playwright.seeAttributesOnElements(str, str); // $ExpectType Promise<any>
-playwright.dragSlider(str, num); // $ExpectType Promise<any>
+playwright.seeCssPropertiesOnElements(str, str); // $ExpectType Promise<void>
+playwright.seeAttributesOnElements(str, str); // $ExpectType Promise<void>
+playwright.dragSlider(str, num); // $ExpectType Promise<void>
 playwright.grabAttributeFrom(str, str); // $ExpectType Promise<string>
 playwright.grabAttributeFromAll(str, str); // $ExpectType Promise<string[]>
-playwright.saveElementScreenshot(str, str); // $ExpectType Promise<any>
-playwright.saveScreenshot(str); // $ExpectType Promise<any>
+playwright.saveElementScreenshot(str, str); // $ExpectType Promise<void>
+playwright.saveScreenshot(str); // $ExpectType Promise<void>
 playwright.makeApiRequest(str, str, str); // $ExpectType Promise<object>
-playwright.wait(num); // $ExpectType Promise<any>
-playwright.waitForEnabled(str); // $ExpectType Promise<any>
-playwright.waitForValue(str, str); // $ExpectType Promise<any>
-playwright.waitNumberOfVisibleElements(str, num); // $ExpectType Promise<any>
-playwright.waitForClickable(str); // $ExpectType Promise<any>
-playwright.waitForElement(str); // $ExpectType Promise<any>
-playwright.waitForVisible(str); // $ExpectType Promise<any>
-playwright.waitForInvisible(str); // $ExpectType Promise<any>
-playwright.waitToHide(str); // $ExpectType Promise<any>
-playwright.waitInUrl(str); // $ExpectType Promise<any>
-playwright.waitUrlEquals(str); // $ExpectType Promise<any>
-playwright.waitForText(str); // $ExpectType Promise<any>
+playwright.wait(num); // $ExpectType Promise<void>
+playwright.waitForEnabled(str); // $ExpectType Promise<void>
+playwright.waitForValue(str, str); // $ExpectType Promise<void>
+playwright.waitNumberOfVisibleElements(str, num); // $ExpectType Promise<void>
+playwright.waitForClickable(str); // $ExpectType Promise<void>
+playwright.waitForElement(str); // $ExpectType Promise<void>
+playwright.waitForVisible(str); // $ExpectType Promise<void>
+playwright.waitForInvisible(str); // $ExpectType Promise<void>
+playwright.waitToHide(str); // $ExpectType Promise<void>
+playwright.waitInUrl(str); // $ExpectType Promise<void>
+playwright.waitUrlEquals(str); // $ExpectType Promise<void>
+playwright.waitForText(str); // $ExpectType Promise<void>
 playwright.waitForRequest(str); // $ExpectType Promise<any>
 playwright.waitForResponse(str); // $ExpectType Promise<any>
-playwright.switchTo(); // $ExpectType Promise<any>
-playwright.waitForFunction(() => { }); // $ExpectType Promise<any>
+playwright.switchTo(); // $ExpectType Promise<void>
+playwright.waitForFunction(() => { }); // $ExpectType Promise<void>
 playwright.waitForNavigation(str); // $ExpectType Promise<any>
-playwright.waitForDetached(str); // $ExpectType Promise<any>
-playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<any>
+playwright.waitForDetached(str); // $ExpectType Promise<void>
+playwright.grabDataFromPerformanceTiming(); // $ExpectType Promise<void>
 playwright.grabElementBoundingRect(str); // $ExpectType Promise<number> | Promise<DOMRect>
 playwright.mockRoute(str); // $ExpectType Promise<any>
 playwright.stopMockingRoute(str); // $ExpectType Promise<any>

--- a/typings/tests/helpers/WebDriverIO.types.ts
+++ b/typings/tests/helpers/WebDriverIO.types.ts
@@ -6,10 +6,10 @@ const str = 'text';
 const num = 1;
 
 wd.amOnPage(); // $ExpectError
-wd.amOnPage(''); // $ExpectType void
+wd.amOnPage(''); // $ExpectType Promise<void>
 
 wd.focus(); // $ExpectError
-wd.focus('div'); // $ExpectType void
+wd.focus('div'); // $ExpectType Promise<void>
 wd.focus({ css: 'div' });
 wd.focus({ xpath: '//div' });
 wd.focus({ name: 'div' });
@@ -27,7 +27,7 @@ wd.focus('div', { android: '//div' });
 wd.focus('div', { ios: '//div' });
 
 wd.blur(); // $ExpectError
-wd.blur('div'); // $ExpectType void
+wd.blur('div'); // $ExpectType Promise<void>
 wd.blur({ css: 'div' });
 wd.blur({ xpath: '//div' });
 wd.blur({ name: 'div' });
@@ -45,7 +45,7 @@ wd.blur('div', { android: '//div' });
 wd.blur('div', { ios: '//div' });
 
 wd.click(); // $ExpectError
-wd.click('div'); // $ExpectType void
+wd.click('div'); // $ExpectType Promise<void>
 wd.click({ css: 'div' });
 wd.click({ xpath: '//div' });
 wd.click({ name: 'div' });
@@ -63,7 +63,7 @@ wd.click('div', { android: '//div' });
 wd.click('div', { ios: '//div' });
 
 wd.forceClick(); // $ExpectError
-wd.forceClick('div'); // $ExpectType void
+wd.forceClick('div'); // $ExpectType Promise<void>
 wd.forceClick({ css: 'div' });
 wd.forceClick({ xpath: '//div' });
 wd.forceClick({ name: 'div' });
@@ -81,7 +81,7 @@ wd.forceClick('div', { android: '//div' });
 wd.forceClick('div', { ios: '//div' });
 
 wd.doubleClick(); // $ExpectError
-wd.doubleClick('div'); // $ExpectType void
+wd.doubleClick('div'); // $ExpectType Promise<void>
 wd.doubleClick({ css: 'div' });
 wd.doubleClick({ xpath: '//div' });
 wd.doubleClick({ name: 'div' });
@@ -99,7 +99,7 @@ wd.doubleClick('div', { android: '//div' });
 wd.doubleClick('div', { ios: '//div' });
 
 wd.rightClick(); // $ExpectError
-wd.rightClick('div'); // $ExpectType void
+wd.rightClick('div'); // $ExpectType Promise<void>
 wd.rightClick({ css: 'div' });
 wd.rightClick({ xpath: '//div' });
 wd.rightClick({ name: 'div' });
@@ -118,7 +118,7 @@ wd.rightClick('div', { ios: '//div' });
 
 wd.fillField(); // $ExpectError
 wd.fillField('div'); // $ExpectError
-wd.fillField('div', str); // $ExpectType void
+wd.fillField('div', str); // $ExpectType Promise<void>
 wd.fillField({ css: 'div' }, str);
 wd.fillField({ xpath: '//div' }, str);
 wd.fillField({ name: 'div' }, str);
@@ -129,7 +129,7 @@ wd.fillField(locate('div'), str);
 
 wd.appendField(); // $ExpectError
 wd.appendField('div'); // $ExpectError
-wd.appendField('div', str); // $ExpectType void
+wd.appendField('div', str); // $ExpectType Promise<void>
 wd.appendField({ css: 'div' }, str);
 wd.appendField({ xpath: '//div' }, str);
 wd.appendField({ name: 'div' }, str);
@@ -149,98 +149,98 @@ wd.clearField({ ios: 'div' });
 
 wd.selectOption(); // $ExpectError
 wd.selectOption('div'); // $ExpectError
-wd.selectOption('div', str); // $ExpectType void
+wd.selectOption('div', str); // $ExpectType Promise<void>
 
 wd.attachFile(); // $ExpectError
 wd.attachFile('div'); // $ExpectError
-wd.attachFile('div', str); // $ExpectType void
+wd.attachFile('div', str); // $ExpectType Promise<void>
 
 wd.checkOption(); // $ExpectError
-wd.checkOption('div'); // $ExpectType void
+wd.checkOption('div'); // $ExpectType Promise<void>
 
 wd.uncheckOption(); // $ExpectError
-wd.uncheckOption('div'); // $ExpectType void
+wd.uncheckOption('div'); // $ExpectType Promise<void>
 
 wd.seeInTitle(); // $ExpectError
-wd.seeInTitle(str); // $ExpectType void
+wd.seeInTitle(str); // $ExpectType Promise<void>
 
 wd.seeTitleEquals(); // $ExpectError
-wd.seeTitleEquals(str); // $ExpectType void
+wd.seeTitleEquals(str); // $ExpectType Promise<void>
 
 wd.dontSeeInTitle(); // $ExpectError
-wd.dontSeeInTitle(str); // $ExpectType void
+wd.dontSeeInTitle(str); // $ExpectType Promise<void>
 
 wd.see(); // $ExpectError
-wd.see(str); // $ExpectType void
-wd.see(str, 'div'); // $ExpectType void
+wd.see(str); // $ExpectType Promise<void>
+wd.see(str, 'div'); // $ExpectType Promise<void>
 
 wd.dontSee(); // $ExpectError
-wd.dontSee(str); // $ExpectType void
-wd.dontSee(str, 'div'); // $ExpectType void
+wd.dontSee(str); // $ExpectType Promise<void>
+wd.dontSee(str, 'div'); // $ExpectType Promise<void>
 
 wd.seeTextEquals(); // $ExpectError
-wd.seeTextEquals(str); // $ExpectType void
-wd.seeTextEquals(str, 'div'); // $ExpectType void
+wd.seeTextEquals(str); // $ExpectType Promise<void>
+wd.seeTextEquals(str, 'div'); // $ExpectType Promise<void>
 
 wd.seeInField(); // $ExpectError
 wd.seeInField('div'); // $ExpectError
-wd.seeInField('div', str); // $ExpectType void
+wd.seeInField('div', str); // $ExpectType Promise<void>
 
 wd.dontSeeInField(); // $ExpectError
 wd.dontSeeInField('div'); // $ExpectError
-wd.dontSeeInField('div', str); // $ExpectType void
+wd.dontSeeInField('div', str); // $ExpectType Promise<void>
 
 wd.seeCheckboxIsChecked(); // $ExpectError
-wd.seeCheckboxIsChecked('div'); // $ExpectType void
+wd.seeCheckboxIsChecked('div'); // $ExpectType Promise<void>
 
 wd.dontSeeCheckboxIsChecked(); // $ExpectError
-wd.dontSeeCheckboxIsChecked('div'); // $ExpectType void
+wd.dontSeeCheckboxIsChecked('div'); // $ExpectType Promise<void>
 
 wd.seeElement(); // $ExpectError
-wd.seeElement('div'); // $ExpectType void
+wd.seeElement('div'); // $ExpectType Promise<void>
 
 wd.dontSeeElement(); // $ExpectError
-wd.dontSeeElement('div'); // $ExpectType void
+wd.dontSeeElement('div'); // $ExpectType Promise<void>
 
 wd.seeElementInDOM(); // $ExpectError
-wd.seeElementInDOM('div'); // $ExpectType void
+wd.seeElementInDOM('div'); // $ExpectType Promise<void>
 
 wd.dontSeeElementInDOM(); // $ExpectError
-wd.dontSeeElementInDOM('div'); // $ExpectType void
+wd.dontSeeElementInDOM('div'); // $ExpectType Promise<void>
 
 wd.seeInSource(); // $ExpectError
-wd.seeInSource(str); // $ExpectType void
+wd.seeInSource(str); // $ExpectType Promise<void>
 
 wd.dontSeeInSource(); // $ExpectError
-wd.dontSeeInSource(str); // $ExpectType void
+wd.dontSeeInSource(str); // $ExpectType Promise<void>
 
 wd.seeNumberOfElements(); // $ExpectError
 wd.seeNumberOfElements('div'); // $ExpectError
-wd.seeNumberOfElements('div', num); // $ExpectType void
+wd.seeNumberOfElements('div', num); // $ExpectType Promise<void>
 
 wd.seeNumberOfVisibleElements(); // $ExpectError
 wd.seeNumberOfVisibleElements('div'); // $ExpectError
-wd.seeNumberOfVisibleElements('div', num); // $ExpectType void
+wd.seeNumberOfVisibleElements('div', num); // $ExpectType Promise<void>
 
 wd.seeCssPropertiesOnElements(); // $ExpectError
 wd.seeCssPropertiesOnElements('div'); // $ExpectError
-wd.seeCssPropertiesOnElements('div', str); // $ExpectType void
+wd.seeCssPropertiesOnElements('div', str); // $ExpectType Promise<void>
 
 wd.seeAttributesOnElements(); // $ExpectError
 wd.seeAttributesOnElements('div'); // $ExpectError
-wd.seeAttributesOnElements('div', str); // $ExpectType void
+wd.seeAttributesOnElements('div', str); // $ExpectType Promise<void>
 
 wd.seeInCurrentUrl(); // $ExpectError
-wd.seeInCurrentUrl(str); // $ExpectType void
+wd.seeInCurrentUrl(str); // $ExpectType Promise<void>
 
 wd.seeCurrentUrlEquals(); // $ExpectError
-wd.seeCurrentUrlEquals(str); // $ExpectType void
+wd.seeCurrentUrlEquals(str); // $ExpectType Promise<void>
 
 wd.dontSeeInCurrentUrl(); // $ExpectError
-wd.dontSeeInCurrentUrl(str); // $ExpectType void
+wd.dontSeeInCurrentUrl(str); // $ExpectType Promise<void>
 
 wd.dontSeeCurrentUrlEquals(); // $ExpectError
-wd.dontSeeCurrentUrlEquals(str); // $ExpectType void
+wd.dontSeeCurrentUrlEquals(str); // $ExpectType Promise<void>
 
 wd.executeScript(); // $ExpectError
 wd.executeScript(str); // $ExpectType Promise<any>
@@ -257,26 +257,26 @@ wd.scrollIntoView('div'); // $ExpectError
 wd.scrollIntoView('div', { behavior: 'auto', block: 'center', inline: 'center' });
 
 wd.scrollTo(); // $ExpectError
-wd.scrollTo('div'); // $ExpectType void
-wd.scrollTo('div', num, num); // $ExpectType void
+wd.scrollTo('div'); // $ExpectType Promise<void>
+wd.scrollTo('div', num, num); // $ExpectType Promise<void>
 
 wd.moveCursorTo(); // $ExpectError
-wd.moveCursorTo('div'); // $ExpectType void
-wd.moveCursorTo('div', num, num); // $ExpectType void
+wd.moveCursorTo('div'); // $ExpectType Promise<void>
+wd.moveCursorTo('div', num, num); // $ExpectType Promise<void>
 
 wd.saveScreenshot(); // $ExpectError
-wd.saveScreenshot(str); // $ExpectType void
-wd.saveScreenshot(str, true); // $ExpectType void
+wd.saveScreenshot(str); // $ExpectType Promise<void>
+wd.saveScreenshot(str, true); // $ExpectType Promise<void>
 
 wd.setCookie(); // $ExpectError
-wd.setCookie({ name: str, value: str }); // $ExpectType void
-wd.setCookie([{ name: str, value: str }]); // $ExpectType void
+wd.setCookie({ name: str, value: str }); // $ExpectType Promise<void>
+wd.setCookie([{ name: str, value: str }]); // $ExpectType Promise<void>
 
-wd.clearCookie(); // $ExpectType void
-wd.clearCookie(str); // $ExpectType void
+wd.clearCookie(); // $ExpectType Promise<void>
+wd.clearCookie(str); // $ExpectType Promise<void>
 
 wd.seeCookie(); // $ExpectError
-wd.seeCookie(str); // $ExpectType void
+wd.seeCookie(str); // $ExpectType Promise<void>
 
 wd.acceptPopup(); // $ExpectType void
 
@@ -286,116 +286,116 @@ wd.seeInPopup(); // $ExpectError
 wd.seeInPopup(str); // $ExpectType void
 
 wd.pressKeyDown(); // $ExpectError
-wd.pressKeyDown(str); // $ExpectType void
+wd.pressKeyDown(str); // $ExpectType Promise<void>
 
 wd.pressKeyUp(); // $ExpectError
-wd.pressKeyUp(str); // $ExpectType void
+wd.pressKeyUp(str); // $ExpectType Promise<void>
 
 wd.pressKey(); // $ExpectError
-wd.pressKey(str); // $ExpectType void
+wd.pressKey(str); // $ExpectType Promise<void>
 
 wd.type(); // $ExpectError
-wd.type(str); // $ExpectType void
+wd.type(str); // $ExpectType Promise<void>
 
 wd.resizeWindow(); // $ExpectError
 wd.resizeWindow(num); // $ExpectError
-wd.resizeWindow(num, num); // $ExpectType void
+wd.resizeWindow(num, num); // $ExpectType Promise<void>
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('div'); // $ExpectError
-wd.dragAndDrop('div', 'div'); // $ExpectType void
+wd.dragAndDrop('div', 'div'); // $ExpectType Promise<void>
 
 wd.dragSlider(); // $ExpectError
-wd.dragSlider('div', num); // $ExpectType void
+wd.dragSlider('div', num); // $ExpectType Promise<void>
 
 wd.switchToWindow(); // $ExpectError
 wd.switchToWindow(str); // $ExpectType void
 
-wd.closeOtherTabs(); // $ExpectType void
+wd.closeOtherTabs(); // $ExpectType Promise<void>
 
 wd.wait(); // $ExpectError
-wd.wait(num); // $ExpectType void
+wd.wait(num); // $ExpectType Promise<void>
 
 wd.waitForEnabled(); // $ExpectError
-wd.waitForEnabled('div'); // $ExpectType void
-wd.waitForEnabled('div', num); // $ExpectType void
+wd.waitForEnabled('div'); // $ExpectType Promise<void>
+wd.waitForEnabled('div', num); // $ExpectType Promise<void>
 
 wd.waitForElement(); // $ExpectError
-wd.waitForElement('div'); // $ExpectType void
-wd.waitForElement('div', num); // $ExpectType void
+wd.waitForElement('div'); // $ExpectType Promise<void>
+wd.waitForElement('div', num); // $ExpectType Promise<void>
 
 wd.waitForClickable(); // $ExpectError
-wd.waitForClickable('div'); // $ExpectType void
-wd.waitForClickable('div', num); // $ExpectType void
+wd.waitForClickable('div'); // $ExpectType Promise<void>
+wd.waitForClickable('div', num); // $ExpectType Promise<void>
 
 wd.waitForVisible(); // $ExpectError
-wd.waitForVisible('div'); // $ExpectType void
-wd.waitForVisible('div', num); // $ExpectType void
+wd.waitForVisible('div'); // $ExpectType Promise<void>
+wd.waitForVisible('div', num); // $ExpectType Promise<void>
 
 wd.waitForInvisible(); // $ExpectError
-wd.waitForInvisible('div'); // $ExpectType void
-wd.waitForInvisible('div', num); // $ExpectType void
+wd.waitForInvisible('div'); // $ExpectType Promise<void>
+wd.waitForInvisible('div', num); // $ExpectType Promise<void>
 
 wd.waitToHide(); // $ExpectError
-wd.waitToHide('div'); // $ExpectType void
-wd.waitToHide('div', num); // $ExpectType void
+wd.waitToHide('div'); // $ExpectType Promise<void>
+wd.waitToHide('div', num); // $ExpectType Promise<void>
 
 wd.waitForDetached(); // $ExpectError
-wd.waitForDetached('div'); // $ExpectType void
-wd.waitForDetached('div', num); // $ExpectType void
+wd.waitForDetached('div'); // $ExpectType Promise<void>
+wd.waitForDetached('div', num); // $ExpectType Promise<void>
 
 wd.waitForFunction(); // $ExpectError
-wd.waitForFunction('div'); // $ExpectType void
-wd.waitForFunction(() => {}); // $ExpectType void
-wd.waitForFunction(() => {}, [num], num); // $ExpectType void
-wd.waitForFunction(() => {}, [str], num); // $ExpectType void
+wd.waitForFunction('div'); // $ExpectType Promise<void>
+wd.waitForFunction(() => {}); // $ExpectType Promise<void>
+wd.waitForFunction(() => {}, [num], num); // $ExpectType Promise<void>
+wd.waitForFunction(() => {}, [str], num); // $ExpectType Promise<void>
 
 wd.waitInUrl(); // $ExpectError
-wd.waitInUrl(str); // $ExpectType void
-wd.waitInUrl(str, num); // $ExpectType void
+wd.waitInUrl(str); // $ExpectType Promise<void>
+wd.waitInUrl(str, num); // $ExpectType Promise<void>
 
 wd.waitForText(); // $ExpectError
-wd.waitForText(str); // $ExpectType void
-wd.waitForText(str, num, str); // $ExpectType void
+wd.waitForText(str); // $ExpectType Promise<void>
+wd.waitForText(str, num, str); // $ExpectType Promise<void>
 
 wd.waitForValue(); // $ExpectError
 wd.waitForValue(str); // $ExpectError
-wd.waitForValue(str, str); // $ExpectType void
-wd.waitForValue(str, str, num); // $ExpectType void
+wd.waitForValue(str, str); // $ExpectType Promise<void>
+wd.waitForValue(str, str, num); // $ExpectType Promise<void>
 
 wd.waitNumberOfVisibleElements(); // $ExpectError
 wd.waitNumberOfVisibleElements('div'); // $ExpectError
-wd.waitNumberOfVisibleElements(str, num); // $ExpectType void
-wd.waitNumberOfVisibleElements(str, num, num); // $ExpectType void
+wd.waitNumberOfVisibleElements(str, num); // $ExpectType Promise<void>
+wd.waitNumberOfVisibleElements(str, num, num); // $ExpectType Promise<void>
 
 wd.waitUrlEquals(); // $ExpectError
-wd.waitUrlEquals(str); // $ExpectType void
-wd.waitUrlEquals(str, num); // $ExpectType void
+wd.waitUrlEquals(str); // $ExpectType Promise<void>
+wd.waitUrlEquals(str, num); // $ExpectType Promise<void>
 
-wd.switchTo(); // $ExpectType void
-wd.switchTo('div'); // $ExpectType void
+wd.switchTo(); // $ExpectType Promise<void>
+wd.switchTo('div'); // $ExpectType Promise<void>
 
-wd.switchToNextTab(num, num); // $ExpectType void
+wd.switchToNextTab(num, num); // $ExpectType Promise<void>
 
-wd.switchToPreviousTab(num, num); // $ExpectType void
+wd.switchToPreviousTab(num, num); // $ExpectType Promise<void>
 
-wd.closeCurrentTab(); // $ExpectType void
+wd.closeCurrentTab(); // $ExpectType Promise<void>
 
-wd.openNewTab(); // $ExpectType void
+wd.openNewTab(); // $ExpectType Promise<void>
 
-wd.refreshPage(); // $ExpectType void
+wd.refreshPage(); // $ExpectType Promise<void>
 
-wd.scrollPageToTop(); // $ExpectType void
+wd.scrollPageToTop(); // $ExpectType Promise<void>
 
-wd.scrollPageToBottom(); // $ExpectType void
+wd.scrollPageToBottom(); // $ExpectType Promise<void>
 
 wd.setGeoLocation(); // $ExpectError
 wd.setGeoLocation(num); // $ExpectError
-wd.setGeoLocation(num, num); // $ExpectType void
-wd.setGeoLocation(num, num, num); // $ExpectType void
+wd.setGeoLocation(num, num); // $ExpectType Promise<void>
+wd.setGeoLocation(num, num, num); // $ExpectType Promise<void>
 
 wd.dontSeeCookie(); // $ExpectError
-wd.dontSeeCookie(str); // $ExpectType void
+wd.dontSeeCookie(str); // $ExpectType Promise<void>
 
 wd.dragAndDrop(); // $ExpectError
 wd.dragAndDrop('#dragHandle'); // $ExpectError


### PR DESCRIPTION
## Motivation/Description of the PR

This PR fixes the generated `typings/types.d.ts` definitions for methods that use Mustache docs. The intention is similar to https://github.com/codeceptjs/CodeceptJS/pull/3465, but it fixes the original helper types instead.

Note that there are still various methods that aren't typed properly, such as `Playwright._getPageUrl()` (currently typed as `void`), because they are missing `@return` JSDoc annotations. This should also be fixed, although it may make more sense to do this in a separate PR to keep this one focused.

This fixes https://github.com/codeceptjs/CodeceptJS/issues/3324.

Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] TestCafe

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been ~added~ updated
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
