### PR TITLE
fix: playwright v1.38 and later update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ WORKDIR /tests
 RUN npm i puppeteer@21.1.1
 RUN google-chrome --version
 
+# Install playwright browsers
+RUN npx playwright install
+
 # Allow to pass argument to codecept run via env variable
 ENV CODECEPT_ARGS=""
 ENV RUN_MULTIPLE=false

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -27,6 +27,10 @@ or
 
     npm i playwright-core@^1.18 --save
 
+Breaking Changes: if you use Playwright v1.38 and later, it will no longer download browsers automatically.
+
+Run `npx playwright install` to download browsers after `npm install`.
+
 Using playwright-core package, will prevent the download of browser binaries and allow connecting to an existing browser installation or for connecting to a remote one.
 
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -116,6 +116,10 @@ const config = {};
  * npm i playwright-core@^1.18 --save
  * ```
  *
+ * Breaking Changes: if you use Playwright v1.38 and later, it will no longer download browsers automatically.
+ *
+ * Run `npx playwright install` to download browsers after `npm install`.
+ *
  * Using playwright-core package, will prevent the download of browser binaries and allow connecting to an existing browser installation or for connecting to a remote one.
  *
  *


### PR DESCRIPTION
## Motivation/Description of the PR
- Breaking Changes: Playwright no longer downloads browsers automatically. Run `npx playwright install` to download browsers after `npm install`.

Applicable helpers:
- [ ] Playwright

## Type of change
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
