### PR TITLE
feat: parallel execution by workers on multiple browsers results with multiple output folders

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -96,8 +96,13 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
   const workersToExecute = [];
 
   const currentOutputFolder = config.output;
-  const currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
-  const currentMochaJunitReporterFile = config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile;
+  let currentMochawesomeReportDir;
+  let currentMochaJunitReporterFile;
+
+  if (config.mocha.reporterOptions) {
+    currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
+    currentMochaJunitReporterFile = config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile;
+  }
 
   collection.createRuns(selectedRuns, config).forEach((worker) => {
     const separator = path.sep;

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -96,7 +96,7 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
   const workersToExecute = [];
 
   const currentOutputFolder = config.output;
-  const currentMochawesomeReportDir = config.mocha.reporterOptions.mochawesome.options.reportDir;
+  const currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
 
   collection.createRuns(selectedRuns, config).forEach((worker) => {
     const _config = { ...config };

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -96,13 +96,8 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
   const workersToExecute = [];
 
   const currentOutputFolder = config.output;
-  let currentMochawesomeReportDir;
-  let currentMochaJunitReporterFile;
-
-  if (config.mocha.reporterOptions) {
-    currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
-    currentMochaJunitReporterFile = config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile;
-  }
+  const currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
+  const currentMochaJunitReporterFile = config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile;
 
   collection.createRuns(selectedRuns, config).forEach((worker) => {
     const separator = path.sep;
@@ -112,8 +107,8 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
     if (config.mocha && config.mocha.reporterOptions) {
       _config.mocha.reporterOptions.mochawesome.options.reportDir = `${currentMochawesomeReportDir}${separator}${workerName}`;
 
-      let _tempArray = currentMochaJunitReporterFile.split(separator);
-      _tempArray = _tempArray.splice(_tempArray.length - 2, 0, workerName);
+      const _tempArray = currentMochaJunitReporterFile.split(separator);
+      _tempArray.splice(_tempArray.findIndex(item => item.includes('.xml')), 0, workerName);
       _config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile = _tempArray.join(separator);
     }
     workerName = worker.getOriginalName() || worker.getName();

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -97,7 +97,7 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
 
   const currentOutputFolder = config.output;
   const currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
-  const currentMochaJunitReporterFile = config.mocha.reporterOptions?["mocha-junit-reporter"].options.mochaFile;
+  const currentMochaJunitReporterFile = config.mocha.reporterOptions["mocha-junit-reporter"].options.mochaFile;
 
   collection.createRuns(selectedRuns, config).forEach((worker) => {
     const _config = { ...config };

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -99,7 +99,7 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
   let currentMochawesomeReportDir;
   let currentMochaJunitReporterFile;
 
-  if (config.mocha.reporterOptions) {
+  if (config.mocha && config.mocha.reporterOptions) {
     currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
     currentMochaJunitReporterFile = config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile;
   }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -94,10 +94,19 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
     });
   }
   const workersToExecute = [];
+
+  const currentOutputFolder = config.output;
+  const currentMochawesomeReportDir = config.mocha.reporterOptions.mochawesome.options.reportDir;
+
   collection.createRuns(selectedRuns, config).forEach((worker) => {
+    const _config = { ...config };
+    _config.output = `${currentOutputFolder}/${worker.config.browser.browser}`;
+    if (config.mocha && config.mocha.reporterOptions) {
+      _config.mocha.reporterOptions.mochawesome.options.reportDir = `${currentMochawesomeReportDir}/${worker.config.browser.browser}`;
+    }
     const workerName = worker.getOriginalName() || worker.getName();
     const workerConfig = worker.getConfig();
-    workersToExecute.push(getOverridenConfig(workerName, workerConfig, config));
+    workersToExecute.push(getOverridenConfig(workerName, workerConfig, _config));
   });
   const workers = [];
   let index = 0;

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -97,21 +97,19 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
 
   const currentOutputFolder = config.output;
   const currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
-  const currentMochaJunitReporterFile = config.mocha.reporterOptions["mocha-junit-reporter"].options.mochaFile;
+  const currentMochaJunitReporterFile = config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile;
 
   collection.createRuns(selectedRuns, config).forEach((worker) => {
+    const separator = path.sep;
     const _config = { ...config };
-    const workerName = worker.name.replace(":", "_");
-    _config.output = `${currentOutputFolder}/${workerName}`;
+    let workerName = worker.name.replace(':', '_');
+    _config.output = `${currentOutputFolder}${separator}${workerName}`;
     if (config.mocha && config.mocha.reporterOptions) {
-      _config.mocha.reporterOptions.mochawesome.options.reportDir = `${currentMochawesomeReportDir}/${workerName}`;
+      _config.mocha.reporterOptions.mochawesome.options.reportDir = `${currentMochawesomeReportDir}${separator}${workerName}`;
 
-let _tempArray = currentMochaJunitReporterFile.split("/");
-
-_tempArray = _tempArray.splice(_tempArray.length - 2, 0, workerName);
-
-_config.mocha.reporterOptions?["mocha-junit-reporter"].options.mochaFile = _tempArray.join("/");
-
+      let _tempArray = currentMochaJunitReporterFile.split(separator);
+      _tempArray = _tempArray.splice(_tempArray.length - 2, 0, workerName);
+      _config.mocha.reporterOptions['mocha-junit-reporter'].options.mochaFile = _tempArray.join(separator);
     }
     workerName = worker.getOriginalName() || worker.getName();
     const workerConfig = worker.getConfig();

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -97,14 +97,23 @@ const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns
 
   const currentOutputFolder = config.output;
   const currentMochawesomeReportDir = config.mocha.reporterOptions?.mochawesome.options.reportDir;
+  const currentMochaJunitReporterFile = config.mocha.reporterOptions?["mocha-junit-reporter"].options.mochaFile;
 
   collection.createRuns(selectedRuns, config).forEach((worker) => {
     const _config = { ...config };
-    _config.output = `${currentOutputFolder}/${worker.config.browser.browser}`;
+    const workerName = worker.name.replace(":", "_");
+    _config.output = `${currentOutputFolder}/${workerName}`;
     if (config.mocha && config.mocha.reporterOptions) {
-      _config.mocha.reporterOptions.mochawesome.options.reportDir = `${currentMochawesomeReportDir}/${worker.config.browser.browser}`;
+      _config.mocha.reporterOptions.mochawesome.options.reportDir = `${currentMochawesomeReportDir}/${workerName}`;
+
+let _tempArray = currentMochaJunitReporterFile.split("/");
+
+_tempArray = _tempArray.splice(_tempArray.length - 2, 0, workerName);
+
+_config.mocha.reporterOptions?["mocha-junit-reporter"].options.mochaFile = _tempArray.join("/");
+
     }
-    const workerName = worker.getOriginalName() || worker.getName();
+    workerName = worker.getOriginalName() || worker.getName();
     const workerConfig = worker.getConfig();
     workersToExecute.push(getOverridenConfig(workerName, workerConfig, _config));
   });


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #3970 

![Screenshot 2023-11-04 at 10 49 56](https://github.com/codeceptjs/CodeceptJS/assets/7845001/8eaecc54-de14-4597-b148-1e087bec3c76)
![Screenshot 2023-11-03 at 15 56 38](https://github.com/codeceptjs/CodeceptJS/assets/7845001/715aed17-3535-48df-80dd-84f7024f08e3)


## Type of change
- [ ] :rocket: New functionality

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
