### PR TITLE
fix: remove node 16

### DIFF
--- a/.github/workflows/appiumV2_Android.yml
+++ b/.github/workflows/appiumV2_Android.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 3.x
-      - appium-v1-deprecation
 
 env:
   CI: true
@@ -13,11 +12,11 @@ env:
 
 jobs:
   appium1:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -37,11 +36,11 @@ jobs:
 
   appium2:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/appiumV2_iOS.yml
+++ b/.github/workflows/appiumV2_iOS.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 3.x
-      - appium-v1-deprecation
 
 env:
   CI: true
@@ -13,11 +12,11 @@ env:
 
 jobs:
   appium1:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -37,11 +36,11 @@ jobs:
 
   appium2:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/doc-generation.yml
+++ b/.github/workflows/doc-generation.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   update-documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [ 16.x ]
+        node-version: [ 18.x ]
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/dtslint.yml
+++ b/.github/workflows/dtslint.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/webdriver.yml
+++ b/.github/workflows/webdriver.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - run: docker run -d --net=host --shm-size=2g selenium/standalone-chrome:3.141.0


### PR DESCRIPTION
## Motivation/Description of the PR
- Remove node 16.x from GHA, as it reached end of life.


Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
