### PR TITLE
fix: missing exit condition

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2582,6 +2582,7 @@ class Playwright extends Helper {
       let count = 0;
       do {
         waiter = await _contextObject.locator(`:has-text('${text}')`).first().isVisible();
+        if (waiter) break;
         await this.wait(1);
         count += 1000;
       } while (count <= waitTimeout);


### PR DESCRIPTION
## Motivation/Description of the PR
- missing exit condition for waitForText which leads to the situation it waits until it reaches timeout.

Applicable helpers:
- [ ] Playwright

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
