### PR TITLE
docs: Update clearCookie documentation for Playwright helper

### DIFF
--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -147,14 +147,12 @@ if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 #### Parameters
 
 -   `cookie` **[string][3]?** (optional, `null` by default) cookie name 
-
-Returns **[Promise][5]&lt;void>** automatically synchronized promise through #recorder
 
 ### clearField
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -518,12 +518,11 @@ I.checkOption('Agree', '.signup', { position: { x: 5, y: 5 } })
 
 ### clearCookie
 
-Clears a cookie by name,
-if none provided clears all cookies.
+Clears all cookies. Playwright currently doesn't support to delete a certain cookie.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test');  // currently has the same effect as line above
 ```
 
 #### Parameters

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -518,18 +518,17 @@ I.checkOption('Agree', '.signup', { position: { x: 5, y: 5 } })
 
 ### clearCookie
 
-Clears all cookies. Playwright currently doesn't support to delete a certain cookie.
+Clears a cookie by name,
+if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test'); // currently has the same effect as line above
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 #### Parameters
 
 -   `cookie` **[string][8]?** (optional, `null` by default) cookie name 
-
-Returns **[Promise][9]&lt;void>** automatically synchronized promise through #recorder
 
 ### clearField
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -522,7 +522,7 @@ Clears all cookies. Playwright currently doesn't support to delete a certain coo
 
 ```js
 I.clearCookie();
-I.clearCookie('test');  // currently has the same effect as line above
+I.clearCookie('test'); // currently has the same effect as line above
 ```
 
 #### Parameters

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -267,14 +267,12 @@ if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 #### Parameters
 
 -   `cookie` **[string][9]?** (optional, `null` by default) cookie name 
-
-Returns **[Promise][10]&lt;void>** automatically synchronized promise through #recorder
 
 ### clearField
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -396,15 +396,13 @@ if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 #### Parameters
 
 -   `name`  
 -   `cookie` **[string][6]?** (optional, `null` by default) cookie name 
-
-Returns **[Promise][7]&lt;void>** automatically synchronized promise through #recorder
 
 ### clearField
 

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -198,15 +198,13 @@ if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 #### Parameters
 
 -   `cookieName`  
 -   `cookie` **[string][4]?** (optional, `null` by default) cookie name 
-
-Returns **[Promise][5]&lt;void>** automatically synchronized promise through #recorder
 
 ### clearField
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -554,14 +554,12 @@ if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 #### Parameters
 
 -   `cookie` **[string][17]?** (optional, `null` by default) cookie name 
-
-Returns **[Promise][19]&lt;void>** automatically synchronized promise through #recorder
 
 ### clearField
 

--- a/docs/webapi/clearCookie.mustache
+++ b/docs/webapi/clearCookie.mustache
@@ -3,8 +3,7 @@ if none provided clears all cookies.
 
 ```js
 I.clearCookie();
-I.clearCookie('test');
+I.clearCookie('test'); // Playwright currently doesn't support clear a particular cookie name
 ```
 
 @param {?string} [cookie=null] (optional, `null` by default) cookie name
-@returns {Promise<void>} automatically synchronized promise through #recorder

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1892,7 +1892,7 @@ class Playwright extends Helper {
    */
   async clearCookie() {
     // Playwright currently doesn't support to delete a certain cookie
-    // https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md
+    // https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md#async-method-browsercontextclearcookies
     if (!this.browserContext) return;
     return this.browserContext.clearCookies();
   }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1892,7 +1892,7 @@ class Playwright extends Helper {
    */
   async clearCookie() {
     // Playwright currently doesn't support to delete a certain cookie
-    // https://github.com/microsoft/playwright/blob/main/docs/api.md#class-browsercontext
+    // https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md
     if (!this.browserContext) return;
     return this.browserContext.clearCookies();
   }

--- a/typings/tests/helpers/Playwright.types.ts
+++ b/typings/tests/helpers/Playwright.types.ts
@@ -96,7 +96,7 @@ playwright.setCookie({ name: str, value: str}); // $ExpectType Promise<void>
 playwright.seeCookie(str); // $ExpectType Promise<void>
 playwright.dontSeeCookie(str); // $ExpectType Promise<void>
 playwright.grabCookie(); // $ExpectType any
-playwright.clearCookie(); // $ExpectType Promise<void>
+playwright.clearCookie(); // $ExpectType void
 playwright.executeScript(() => {}); // $ExpectType Promise<any>
 playwright.grabTextFrom(str); // $ExpectType Promise<string>
 playwright.grabTextFromAll(str); // $ExpectType Promise<string[]>

--- a/typings/tests/helpers/PlaywrightTs.types.ts
+++ b/typings/tests/helpers/PlaywrightTs.types.ts
@@ -92,7 +92,7 @@ playwright.setCookie({ name: str, value: str}); // $ExpectType Promise<void>
 playwright.seeCookie(str); // $ExpectType Promise<void>
 playwright.dontSeeCookie(str); // $ExpectType Promise<void>
 playwright.grabCookie(); // $ExpectType Promise<any>
-playwright.clearCookie(); // $ExpectType Promise<void>
+playwright.clearCookie(); // $ExpectType Promise<any>
 playwright.executeScript(() => {}); // $ExpectType Promise<any>
 playwright.grabTextFrom(str); // $ExpectType Promise<string>
 playwright.grabTextFromAll(str); // $ExpectType Promise<string[]>

--- a/typings/tests/helpers/WebDriverIO.types.ts
+++ b/typings/tests/helpers/WebDriverIO.types.ts
@@ -272,8 +272,8 @@ wd.setCookie(); // $ExpectError
 wd.setCookie({ name: str, value: str }); // $ExpectType Promise<void>
 wd.setCookie([{ name: str, value: str }]); // $ExpectType Promise<void>
 
-wd.clearCookie(); // $ExpectType Promise<void>
-wd.clearCookie(str); // $ExpectType Promise<void>
+wd.clearCookie(); // $ExpectType void
+wd.clearCookie(str); // $ExpectType void
 
 wd.seeCookie(); // $ExpectError
 wd.seeCookie(str); // $ExpectType Promise<void>


### PR DESCRIPTION
## Motivation/Description of the PR
Me and a co-worker were wondering why all cookies got deleted when calling Playwright helper clearCookie function with the cookie specified. After checking the source code, I saw the comment of this not beeing a feature in playwright.

I updated the broken link in the code comment and the documentation of the helper.


Applicable helpers:

- [X] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [X] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
