### PR TITLE
fix(appium): missing await on some steps of runOnIOS and runOnAndroid

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -423,8 +423,8 @@ class Appium extends Webdriver {
   async runOnIOS(caps, fn) {
     if (this.platform !== 'ios') return;
     recorder.session.start('iOS-only actions');
-    this._runWithCaps(caps, fn);
-    recorder.add('restore from iOS session', () => recorder.session.restore());
+    await this._runWithCaps(caps, fn);
+    await recorder.add('restore from iOS session', () => recorder.session.restore());
     return recorder.promise();
   }
 
@@ -465,8 +465,8 @@ class Appium extends Webdriver {
   async runOnAndroid(caps, fn) {
     if (this.platform !== 'android') return;
     recorder.session.start('Android-only actions');
-    this._runWithCaps(caps, fn);
-    recorder.add('restore from Android session', () => recorder.session.restore());
+    await this._runWithCaps(caps, fn);
+    await recorder.add('restore from Android session', () => recorder.session.restore());
     return recorder.promise();
   }
 

--- a/test/helper/AppiumV2_test.js
+++ b/test/helper/AppiumV2_test.js
@@ -716,23 +716,23 @@ describe('Appium', function () {
       await app.see('Welcome to register a new User');
     });
 
-    it('should execute only on Android @quick', () => {
+    it.only('should execute only on Android @quick', async () => {
       let platform = null;
-      app.runOnIOS(() => {
+      await app.runOnIOS(() => {
         platform = 'ios';
       });
-      app.runOnAndroid(() => {
+      await app.runOnAndroid(() => {
         platform = 'android';
       });
-      app.runOnAndroid({ platformVersion: '7.0' }, () => {
+      await app.runOnAndroid({ platformVersion: '7.0' }, () => {
         platform = 'android7';
       });
 
       assert.equal('android', platform);
     });
 
-    it('should execute only on Android >= 5.0 @quick', () => {
-      app.runOnAndroid(caps => caps.platformVersion >= 5, () => {});
+    it('should execute only on Android >= 5.0 @quick', async () => {
+      await app.runOnAndroid(caps => caps.platformVersion >= 5, () => {});
     });
 
     it('should execute only in Web', () => {

--- a/test/helper/AppiumV2_test.js
+++ b/test/helper/AppiumV2_test.js
@@ -716,7 +716,7 @@ describe('Appium', function () {
       await app.see('Welcome to register a new User');
     });
 
-    it.only('should execute only on Android @quick', async () => {
+    it('should execute only on Android @quick', async () => {
       let platform = null;
       await app.runOnIOS(() => {
         platform = 'ios';


### PR DESCRIPTION
## Motivation/Description of the PR
- Fix missing await on some steps of `runOnIOS` and `runOnAndroid`

Applicable helpers:
- [ ] Appium

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
