### PR TITLE
fix(cli): no error of failed tests when using retry with scenario only

### DIFF
--- a/lib/interfaces/scenarioConfig.js
+++ b/lib/interfaces/scenarioConfig.js
@@ -35,6 +35,7 @@ class ScenarioConfig {
    * @returns {this}
    */
   retry(retries) {
+    if (process.env.SCENARIO_ONLY) retries = -retries;
     this.test.retries(retries);
     return this;
   }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -167,7 +167,7 @@ module.exports = function (suite) {
      */
     context.Scenario.only = function (title, opts, fn) {
       const reString = `^${escapeRe(`${suites[0].title}: ${title}`.replace(/( \| {.+})?$/g, ''))}`;
-      mocha.grep(reString);
+      mocha.grep(new RegExp(reString));
       process.env.SCENARIO_ONLY = true;
       return addScenario(title, opts, fn);
     };

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -167,7 +167,8 @@ module.exports = function (suite) {
      */
     context.Scenario.only = function (title, opts, fn) {
       const reString = `^${escapeRe(`${suites[0].title}: ${title}`.replace(/( \| {.+})?$/g, ''))}`;
-      mocha.grep(new RegExp(reString));
+      mocha.grep(reString);
+      process.env.SCENARIO_ONLY = true;
       return addScenario(title, opts, fn);
     };
 


### PR DESCRIPTION
## Motivation/Description of the PR
- So I guess we don't need to get deep into the source code here to find out how there is no retry with `Scenario.only`, as mostly we use this one to run a specific test and very less chance in real world that we want to see the retry with `Scenario.only`. The fix here is to show the error when the test failed when using `Scenario.only` + `retry`.
- Resolves #4001 
- Closes #3439  
- Closes #3283

## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
