### PR TITLE
fix: disable retryFailedStep when using with tryTo

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -1,5 +1,6 @@
 const event = require('../event');
 const recorder = require('../recorder');
+const container = require('../container');
 
 const defaultConfig = {
   retries: 3,
@@ -98,6 +99,8 @@ module.exports = (config) => {
   config.when = when;
 
   event.dispatcher.on(event.step.started, (step) => {
+    if (container.plugins('tryTo')) return;
+
     // if a step is ignored - return
     for (const ignored of config.ignoredSteps) {
       if (step.name === ignored) return;

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -28,7 +28,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.step.started, { name: 'click' });
 
     let counter = 0;
-    recorder.add(() => {
+    await recorder.add(() => {
       counter++;
       if (counter < 3) {
         throw new Error();
@@ -51,7 +51,7 @@ describe('retryFailedStep', () => {
       });
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     // expects to retry only once
@@ -65,7 +65,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'waitForElement' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -73,7 +73,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -87,7 +87,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'amOnPage' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -95,7 +95,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -109,7 +109,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'somethingNew' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -117,7 +117,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -131,7 +131,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'somethingNew' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -139,7 +139,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -161,7 +161,7 @@ describe('retryFailedStep', () => {
       });
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     // expects to retry only once


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4021 

```
...
    tryTo: {
      enabled: true
    },
    retryFailedStep: {
      enabled: true,
      retries: 2,
    },
....

// Running tests
Plugins: screenshotOnFail, customLocator, tryTo, retryFailedStep, commentStep, autoLogin

My --
    [1]  Starting recording promises
    Timeouts: 
 › [Session] Starting singleton browser session
  Assert @C3
    --- STARTED "before each" hook: Before for "Assert @C3" ---
 › Cannot save user session with empty cookies from auto login's fetch method
    I am on page "https://google.com"
    --- ENDED "before each" hook: Before for "Assert @C3" ---
    I am on page "https://demo.playwright.dev/api-mocking"
    I see "Welcome"
    [1] <tryTo> Error | Error
 › Unsuccessful try > expected web application to include "Welcome"
  ✔ OK in 568ms


  OK  | 1 passed   // 3s

```

Applicable plugins:
- [ ] tryTo
- [ ] retryFailedStep


## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
