### PR TITLE
fix: seeCssPropertiesOnElements failed when font-weight is a number

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2116,7 +2116,9 @@ class Playwright extends Helper {
     let chunked = chunkArray(props, values.length);
     chunked = chunked.filter((val) => {
       for (let i = 0; i < val.length; ++i) {
-        if (val[i] !== values[i]) return false;
+        const _acutal = Number.isNaN(val[i]) || (typeof values[i]) === 'string' ? val[i] : Number.parseInt(val[i], 10);
+        const _expected = Number.isNaN(values[i]) || (typeof values[i]) === 'string' ? values[i] : Number.parseInt(values[i], 10);
+        if (_acutal !== _expected) return false;
       }
       return true;
     });

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1815,7 +1815,9 @@ class Puppeteer extends Helper {
     let chunked = chunkArray(attrs, values.length);
     chunked = chunked.filter((val) => {
       for (let i = 0; i < val.length; ++i) {
-        if (val[i] !== values[i]) return false;
+        const _acutal = Number.isNaN(val[i]) || (typeof values[i]) === 'string' ? val[i] : Number.parseInt(val[i], 10);
+        const _expected = Number.isNaN(values[i]) || (typeof values[i]) === 'string' ? values[i] : Number.parseInt(values[i], 10);
+        if (_acutal !== _expected) return false;
       }
       return true;
     });

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1784,7 +1784,9 @@ class Puppeteer extends Helper {
     let chunked = chunkArray(props, values.length);
     chunked = chunked.filter((val) => {
       for (let i = 0; i < val.length; ++i) {
-        if (val[i] !== values[i]) return false;
+        const _acutal = Number.isNaN(val[i]) || (typeof values[i]) === 'string' ? val[i] : Number.parseInt(val[i], 10);
+        const _expected = Number.isNaN(values[i]) || (typeof values[i]) === 'string' ? values[i] : Number.parseInt(values[i], 10);
+        if (_acutal !== _expected) return false;
       }
       return true;
     });

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1508,7 +1508,9 @@ class WebDriver extends Helper {
     let chunked = chunkArray(props, values.length);
     chunked = chunked.filter((val) => {
       for (let i = 0; i < val.length; ++i) {
-        if (val[i] !== values[i]) return false;
+        const _acutal = Number.isNaN(val[i]) || (typeof values[i]) === 'string' ? val[i] : Number.parseInt(val[i], 10);
+        const _expected = Number.isNaN(values[i]) || (typeof values[i]) === 'string' ? values[i] : Number.parseInt(values[i], 10);
+        if (_acutal !== _expected) return false;
       }
       return true;
     });

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1535,7 +1535,9 @@ class WebDriver extends Helper {
     let chunked = chunkArray(attrs, values.length);
     chunked = chunked.filter((val) => {
       for (let i = 0; i < val.length; ++i) {
-        if (val[i] !== values[i]) return false;
+        const _acutal = Number.isNaN(val[i]) || (typeof values[i]) === 'string' ? val[i] : Number.parseInt(val[i], 10);
+        const _expected = Number.isNaN(values[i]) || (typeof values[i]) === 'string' ? values[i] : Number.parseInt(values[i], 10);
+        if (_acutal !== _expected) return false;
       }
       return true;
     });

--- a/test/data/app/view/info.php
+++ b/test/data/app/view/info.php
@@ -7,6 +7,9 @@
     .span {
         height: 15px; 
     }
+    h4 {
+        font-weight: 300;
+    }
 </style>
 <body>
 
@@ -23,6 +26,7 @@
 <div class="notice"><?php if (isset($notice)) echo $notice; ?></div>
 
 <h3>Don't do that at home!</h3>
+<h4>Check font-weight!</h4>
 
 <p>Is that interesting?</p>
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -1369,8 +1369,8 @@ module.exports.tests = function () {
 
       try {
         await I.amOnPage('/info');
-        await I.seeCssPropertiesOnElements('h3', {
-          'font-weight': 'bold',
+        await I.seeCssPropertiesOnElements('h4', {
+          'font-weight': 300,
         });
         await I.seeCssPropertiesOnElements('h3', {
           'font-weight': 'bold',


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #3327 

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
