### PR TITLE
fix: respect retries from retryfailedstep plugin in helpers

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -474,7 +474,7 @@ class Playwright extends Helper {
   async _before(test) {
     this.currentRunningTest = test;
     recorder.retry({
-      retries: 5,
+      retries: process.env.FAILED_STEP_RETIRES || 3,
       when: err => {
         if (!err || typeof (err.message) !== 'string') {
           return false;

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -297,7 +297,7 @@ class Puppeteer extends Helper {
     this.sessionPages = {};
     this.currentRunningTest = test;
     recorder.retry({
-      retries: 3,
+      retries: process.env.FAILED_STEP_RETIRES || 3,
       when: err => {
         if (!err || typeof (err.message) !== 'string') {
           return false;

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -114,6 +114,8 @@ module.exports = (config) => {
 
   event.dispatcher.on(event.test.before, (test) => {
     if (test && test.disableRetryFailedStep) return; // disable retry when a test is not active
+    // this env var is used to set the retries inside _before() block of helpers
+    process.env.FAILED_STEP_RETIRES = config.retries;
     recorder.retry(config);
   });
 };

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -36,6 +36,7 @@ describe('retryFailedStep', () => {
     }, undefined, undefined, true);
     return recorder.promise();
   });
+
   it('should not retry within', async () => {
     retryFailedStep({ retries: 1, minTimeout: 1 });
     event.dispatcher.emit(event.test.before, {});
@@ -51,9 +52,10 @@ describe('retryFailedStep', () => {
       });
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
+    expect(process.env.FAILED_STEP_RETIRES).to.equal('1');
     // expects to retry only once
     counter.should.equal(2);
   });
@@ -65,7 +67,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'waitForElement' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -73,7 +75,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -87,7 +89,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'amOnPage' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -95,7 +97,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -109,7 +111,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'somethingNew' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -117,7 +119,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -131,7 +133,7 @@ describe('retryFailedStep', () => {
     let counter = 0;
     event.dispatcher.emit(event.step.started, { name: 'somethingNew' });
     try {
-      recorder.add(() => {
+      await recorder.add(() => {
         counter++;
         if (counter < 3) {
           throw new Error();
@@ -139,7 +141,7 @@ describe('retryFailedStep', () => {
       }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     expect(counter).to.equal(1);
@@ -161,7 +163,7 @@ describe('retryFailedStep', () => {
       });
       await recorder.promise();
     } catch (e) {
-      recorder.catchWithoutStop((err) => err);
+      await recorder.catchWithoutStop((err) => err);
     }
 
     // expects to retry only once


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #3268 
- Closes #2829 

Currently inside the _before() of helpers for example Playwright, the retries is set there https://github.com/codeceptjs/CodeceptJS/blob/3.x/lib/helper/Playwright.js#L477, however, when `retryFailedStep` plugin is enabled, the retries of recorder is still using the value from _before() not the value from `retryFailedStep` plugin.

Fix:
- introduce the `process.env.FAILED_STEP_RETIRES` which could be access everywhere as the helper won't know anything about the plugin.
- set default retries of Playwright to 3 to be on the same page with Puppeteer.

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer

Applicable plugins:
- [ ] retryFailedStep

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
