### PR TITLE
fix: move to sha256

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -124,7 +124,7 @@ function executeRun(runName, runConfig) {
   if (browserConfig.outputName) {
     outputDir += typeof browserConfig.outputName === 'function' ? browserConfig.outputName() : browserConfig.outputName;
   } else {
-    const hash = crypto.createHash('md5');
+    const hash = crypto.createHash('sha256');
     hash.update(JSON.stringify(browserConfig));
     outputDir += hash.digest('hex');
   }

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -89,8 +89,8 @@ module.exports = function (config) {
   const reportDir = config.output ? path.resolve(global.codecept_dir, config.output) : defaultConfig.output;
 
   event.dispatcher.on(event.test.before, (test) => {
-    const md5hash = crypto.createHash('md5').update(test.file + test.title).digest('hex');
-    dir = path.join(reportDir, `record_${md5hash}`);
+    const sha256hash = crypto.createHash('sha256').update(test.file + test.title).digest('hex');
+    dir = path.join(reportDir, `record_${sha256hash}`);
     mkdirp.sync(dir);
     stepNum = 0;
     error = null;

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -30,7 +30,7 @@ Scenario('screenshots reflect the current page of current session @Puppeteer @Pl
     I.saveScreenshot('session_john_2.png');
   });
 
-  const [default1Digest, default2Digest, john1Digest, john2Digest] = await I.getMD5Digests([
+  const [default1Digest, default2Digest, john1Digest, john2Digest] = await I.getSHA256Digests([
     `${output_dir}/session_default_1.png`,
     `${output_dir}/session_default_2.png`,
     `${output_dir}/session_john_1.png`,
@@ -88,7 +88,7 @@ Scenario('should save screenshot for active session @WebDriverIO @Puppeteer @Pla
 
   const fileName = clearString(this.title);
 
-  const [original, failed] = await I.getMD5Digests([
+  const [original, failed] = await I.getSHA256Digests([
     `${output_dir}/original.png`,
     `${output_dir}/${fileName}.failed.png`,
   ]);

--- a/test/support/ScreenshotSessionHelper.js
+++ b/test/support/ScreenshotSessionHelper.js
@@ -17,11 +17,11 @@ class ScreenshotSessionHelper extends Helper {
     this.outputPath = output_dir;
   }
 
-  getMD5Digests(files = []) {
+  getSHA256Digests(files = []) {
     const digests = [];
 
     for (const file of files) {
-      const hash = crypto.createHash('md5');
+      const hash = crypto.createHash('sha256');
       const data = fs.readFileSync(file);
       hash.update(data);
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Some leftovers are still using 'md5'.
- Resolves https://github.com/codeceptjs/CodeceptJS/issues/3973#issuecomment-1830635064

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
