### PR TITLE
fix: waitForText locator issue

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2652,7 +2652,7 @@ class Playwright extends Helper {
       const _contextObject = this.frame ? this.frame : contextObject;
       let count = 0;
       do {
-        waiter = await _contextObject.locator(`:has-text('${text}')`).first().isVisible();
+        waiter = await _contextObject.locator(`:has-text("${text}")`).first().isVisible();
         if (waiter) break;
         await this.wait(1);
         count += 1000;


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4037 

Fix error
```
locator.isVisible: Unexpected token "s" while parsing selector ":has-text('Were you able to resolve the resident's issue?') >> nth=0"
      at Playwright.waitForText (node_modules\codeceptjs\lib\helper\Playwright.js:2584:79)
```

Applicable helpers:
- [ ] Playwright

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
