### PR TITLE
feat: expose WebElement

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -1389,6 +1389,36 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 Returns **[Promise][22]&lt;[Array][10]&lt;[string][9]>>** attribute value
 
+### grabWebElement
+
+Grab WebElement for given locator
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+const webElement = await I.grabWebElement('#button');
+```
+
+#### Parameters
+
+-   `locator` **([string][9] | [object][6])** element located by CSS|XPath|strict locator.
+
+Returns **[Promise][22]&lt;any>** WebElement of being used Web helper
+
+### grabWebElements
+
+Grab WebElements for given locator
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+const webElements = await I.grabWebElements('#button');
+```
+
+#### Parameters
+
+-   `locator` **([string][9] | [object][6])** element located by CSS|XPath|strict locator.
+
+Returns **[Promise][22]&lt;any>** WebElement of being used Web helper
+
 ### grabWebSocketMessages
 
 Grab the recording WS messages

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1216,6 +1216,21 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 Returns **[Promise][13]&lt;[Array][15]&lt;[string][6]>>** attribute value
 
+### grabWebElements
+
+Grab WebElements for given locator
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+const webElements = await I.grabWebElements('#button');
+```
+
+#### Parameters
+
+-   `locator` **([string][6] | [object][4])** element located by CSS|XPath|strict locator.
+
+Returns **[Promise][13]&lt;any>** WebElement of being used Web helper
+
 ### handleDownloads
 
 Sets a directory to where save files. Allows to test file downloads.

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -1367,6 +1367,21 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 Returns **[Promise][25]&lt;[Array][28]&lt;[string][17]>>** attribute value
 
+### grabWebElements
+
+Grab WebElements for given locator
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+const webElements = await I.grabWebElements('#button');
+```
+
+#### Parameters
+
+-   `locator` **([string][17] | [object][16])** element located by CSS|XPath|strict locator.
+
+Returns **[Promise][25]&lt;any>** WebElement of being used Web helper
+
 ### moveCursorTo
 
 Moves cursor to element matched by locator.

--- a/docs/webapi/grabWebElement.mustache
+++ b/docs/webapi/grabWebElement.mustache
@@ -1,0 +1,9 @@
+Grab WebElement for given locator
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+const webElement = await I.grabWebElement('#button');
+```
+
+@param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
+@returns {Promise<*>} WebElement of being used Web helper

--- a/docs/webapi/grabWebElements.mustache
+++ b/docs/webapi/grabWebElements.mustache
@@ -1,0 +1,9 @@
+Grab WebElements for given locator
+Resumes test execution, so **should be used inside an async function with `await`** operator.
+
+```js
+const webElements = await I.grabWebElements('#button');
+```
+
+@param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
+@returns {Promise<*>} WebElement of being used Web helper

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1305,6 +1305,22 @@ class Playwright extends Helper {
   }
 
   /**
+   * {{> grabWebElements }}
+   *
+   */
+  async grabWebElements(locator) {
+    return this._locate(locator);
+  }
+
+  /**
+   * {{> grabWebElement }}
+   *
+   */
+  async grabWebElement(locator) {
+    return this._locateElement(locator);
+  }
+
+  /**
    * Switch focus to a particular tab by its number. It waits tabs loading and then switch tab
    *
    * ```js

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -918,6 +918,14 @@ class Puppeteer extends Helper {
   }
 
   /**
+   * {{> grabWebElements }}
+   *
+   */
+  async grabWebElements(locator) {
+    return this._locate(locator);
+  }
+
+  /**
    * Switch focus to a particular tab by its number. It waits tabs loading and then switch tab
    *
    * ```js

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -870,6 +870,14 @@ class WebDriver extends Helper {
   }
 
   /**
+   * {{> grabWebElements }}
+   *
+   */
+  async grabWebElements(locator) {
+    return this._locate(locator);
+  }
+
+  /**
    * Set [WebDriver timeouts](https://webdriver.io/docs/timeouts.html) in realtime.
    *
    * Timeouts are expected to be passed as object:

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { assert } = require('chai');
 const expect = require('chai').expect;
 const path = require('path');
 const fs = require('fs');
@@ -1637,5 +1637,22 @@ describe('Playwright - HAR', () => {
     await I.replayFromHar(harFile);
     await I.amOnPage('https://demo.playwright.dev/api-mocking');
     await I.see('CodeceptJS');
+  });
+
+  describe('#grabWebElements, #grabWebElement', () => {
+    it('should return an array of WebElement', async () => {
+      await I.amOnPage('/form/focus_blur_elements');
+
+      const webElements = await I.grabWebElements('#button');
+      assert.equal(webElements[0], 'locator(\'#button\').first()');
+      assert.isAbove(webElements.length, 0);
+    });
+
+    it('should return a WebElement', async () => {
+      await I.amOnPage('/form/focus_blur_elements');
+
+      const webElement = await I.grabWebElement('#button');
+      assert.equal(webElement, 'locator(\'#button\').first()');
+    });
   });
 });

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { assert } = require('chai');
 const expect = require('chai').expect;
 const path = require('path');
 
@@ -1082,5 +1082,15 @@ describe('Puppeteer - Trace', () => {
 
     assert.ok(fs.existsSync(test.artifacts.trace));
     expect(test.artifacts.trace).to.include(path.join(global.output_dir, 'trace'));
+  });
+
+  describe('#grabWebElements', () => {
+    it('should return an array of WebElement', async () => {
+      await I.amOnPage('/form/focus_blur_elements');
+
+      const webElements = await I.grabWebElements('#button');
+      assert.include(webElements[0].constructor.name, 'CDPElementHandle');
+      assert.isAbove(webElements.length, 0);
+    });
   });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4042

Now we expose the WebElements that are returned by the WebHelper and you could make the subsequence actions on them.

```
// Playwright helper would return the Locator

I.amOnPage('/form/focus_blur_elements');
const webElements = await I.grabWebElements('#button');
webElements[0].click();
```

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver

## Type of change
- [ ] :rocket: New functionality


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
