### PR TITLE
fix: retryFailedStep is disabled for non tryTo steps

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -721,7 +721,7 @@ Run tests with plugin enabled:
 -   `factor` - The exponential factor to use. Default is 1.5.
 -   `minTimeout` - The number of milliseconds before starting the first retry. Default is 1000.
 -   `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
--   `randomize` - Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
+-   `randomize` - Randomizes the timeouts by multiplying with a factor from 1 to 2. Default is false.
 -   `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
     -   `amOnPage`
     -   `wait*`
@@ -1085,7 +1085,7 @@ plugins: {
 
 ## tryTo
 
-Adds global `tryTo` function inside of which all failed steps won't fail a test but will return true/false.
+Adds global `tryTo` function in which all failed steps won't fail a test but will return true/false.
 
 Enable this plugin in `codecept.conf.js` (enabled by default for new setups):
 
@@ -1124,7 +1124,7 @@ Add assert requires first:
 const assert = require('assert');
 ````
 
-Then use the assert:
+Then use the assertion:
 const result1 = await tryTo(() => I.see('Hello, user'));
 const result2 = await tryTo(() => I.seeElement('.welcome'));
 assert.ok(result1 && result2, 'Assertions were not succesful');

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -43,7 +43,7 @@ const defaultConfig = {
  * * `factor` - The exponential factor to use. Default is 1.5.
  * * `minTimeout` - The number of milliseconds before starting the first retry. Default is 1000.
  * * `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
- * * `randomize` - Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
+ * * `randomize` - Randomizes the timeouts by multiplying with a factor from 1 to 2. Default is false.
  * * `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
  *     * `amOnPage`
  *     * `wait*`
@@ -99,7 +99,7 @@ module.exports = (config) => {
   config.when = when;
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (container.plugins('tryTo')) return;
+    if (process.env.TRY_TO) return;
 
     // if a step is ignored - return
     for (const ignored of config.ignoredSteps) {

--- a/lib/plugin/tryTo.js
+++ b/lib/plugin/tryTo.js
@@ -1,5 +1,4 @@
 const recorder = require('../recorder');
-const store = require('../store');
 const { debug } = require('../output');
 
 const defaultConfig = {
@@ -9,7 +8,7 @@ const defaultConfig = {
 /**
  *
  *
- * Adds global `tryTo` function inside of which all failed steps won't fail a test but will return true/false.
+ * Adds global `tryTo` function in which all failed steps won't fail a test but will return true/false.
  *
  * Enable this plugin in `codecept.conf.js` (enabled by default for new setups):
  *
@@ -47,7 +46,7 @@ const defaultConfig = {
  * ```js
  * const assert = require('assert');
  * ```
- * Then use the assert:
+ * Then use the assertion:
  * const result1 = await tryTo(() => I.see('Hello, user'));
  * const result2 = await tryTo(() => I.seeElement('.welcome'));
  * assert.ok(result1 && result2, 'Assertions were not succesful');
@@ -70,7 +69,7 @@ const defaultConfig = {
  * const tryTo = codeceptjs.container.plugins('tryTo');
  * ```
  *
-*/
+ */
 module.exports = function (config) {
   config = Object.assign(defaultConfig, config);
 
@@ -84,6 +83,7 @@ function tryTo(callback) {
   let result = false;
   return recorder.add('tryTo', () => {
     recorder.session.start('tryTo');
+    process.env.TRY_TO = 'true';
     callback();
     recorder.add(() => {
       result = true;
@@ -98,6 +98,7 @@ function tryTo(callback) {
       return result;
     });
     return recorder.add('result', () => {
+      process.env.TRY_TO = undefined;
       return result;
     }, true, false);
   }, false, false);


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4068 

Fixed an issue where there is no retry for failed step for non tryTo step.

Applicable plugins:
- [ ] tryTo
- [ ] retryFailedStep


## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
