### PR TITLE
fix: seeattributesonelements throws error when attribute doesn't exist

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2167,7 +2167,8 @@ class Playwright extends Helper {
     let chunked = chunkArray(attrs, values.length);
     chunked = chunked.filter((val) => {
       for (let i = 0; i < val.length; ++i) {
-        if (!val[i].includes(values[i])) return false;
+        // if the attribute doesn't exist, returns false as well
+        if (!val[i] || !val[i].includes(values[i])) return false;
       }
       return true;
     });

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1822,7 +1822,8 @@ class Puppeteer extends Helper {
       for (let i = 0; i < val.length; ++i) {
         const _actual = Number.isNaN(val[i]) || (typeof values[i]) === 'string' ? val[i] : Number.parseInt(values[i], 10);
         const _expected = Number.isNaN(values[i]) || (typeof values[i]) === 'string' ? values[i] : Number.parseInt(values[i], 10);
-        if (!_actual.includes(_expected)) return false;
+        // if the attribute doesn't exist, returns false as well
+        if (!_actual || !_actual.includes(_expected)) return false;
       }
       return true;
     });

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -1374,6 +1374,19 @@ module.exports.tests = function () {
         e.message.should.include('all elements (a) to have attributes {"qa-id":"test","href":"/info"}');
       }
     });
+
+    it('should return error when using non existing attribute', async function () {
+      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip();
+
+      try {
+        await I.amOnPage('https://github.com/codeceptjs/CodeceptJS/');
+        await I.seeAttributesOnElements({ css: 'a[href="/team"]' }, {
+          disable: true,
+        });
+      } catch (e) {
+        e.message.should.include('expected all elements ({css: a[href="/team"]}) to have attributes {"disable":true} "0" to equal "1"');
+      }
+    });
   });
 
   describe('#seeCssPropertiesOnElements', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4072 

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer

## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
