### PR TITLE
fix: expect helper to have custom error message as optional param

### DIFF
--- a/docs/helpers/Expect.md
+++ b/docs/helpers/Expect.md
@@ -32,16 +32,16 @@ Zero-configuration when paired with other helpers like REST, Playwright:
 #### Parameters
 
 -   `targetData` **any** 
--   `aboveThan` **any** number | Date
--   `customErrorMsg` **any**  
+-   `aboveThan` **any** 
+-   `customErrorMsg` **any?**  
 
 ### expectBelow
 
 #### Parameters
 
 -   `targetData` **any** 
--   `belowThan` **any** number | Date
--   `customErrorMsg` **any**  
+-   `belowThan` **any** 
+-   `customErrorMsg` **any?**  
 
 ### expectContain
 
@@ -49,7 +49,7 @@ Zero-configuration when paired with other helpers like REST, Playwright:
 
 -   `actualValue` **any** 
 -   `expectedValueToContain` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectDeepEqual
 
@@ -57,7 +57,7 @@ Zero-configuration when paired with other helpers like REST, Playwright:
 
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectDeepEqualExcluding
 
@@ -68,7 +68,7 @@ expects members of two JSON objects are deeply equal excluding some properties
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
 -   `fieldsToExclude` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectDeepIncludeMembers
 
@@ -78,7 +78,7 @@ expects an array to be a superset of another array
 
 -   `superset` **any** 
 -   `set` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectDeepMembers
 
@@ -88,14 +88,14 @@ expects members of two arrays are deeply equal
 
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectEmpty
 
 #### Parameters
 
 -   `targetData` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectEndsWith
 
@@ -103,7 +103,7 @@ expects members of two arrays are deeply equal
 
 -   `actualValue` **any** 
 -   `expectedValueToEndWith` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectEqual
 
@@ -111,7 +111,7 @@ expects members of two arrays are deeply equal
 
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectEqualIgnoreCase
 
@@ -119,14 +119,14 @@ expects members of two arrays are deeply equal
 
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectFalse
 
 #### Parameters
 
 -   `targetData` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectHasAProperty
 
@@ -134,7 +134,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `propertyName` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectHasProperty
 
@@ -142,7 +142,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `propertyName` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectJsonSchema
 
@@ -150,7 +150,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `jsonSchema` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectJsonSchemaUsingAJV
 
@@ -158,7 +158,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `jsonSchema` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 -   `ajvOptions` **any** Pass AJV options 
 
 ### expectLengthAboveThan
@@ -167,7 +167,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `lengthAboveThan` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectLengthBelowThan
 
@@ -175,7 +175,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `lengthBelowThan` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectLengthOf
 
@@ -183,7 +183,7 @@ expects members of two arrays are deeply equal
 
 -   `targetData` **any** 
 -   `length` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectMatchesPattern
 
@@ -193,7 +193,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedPattern` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectMatchRegex
 
@@ -201,7 +201,7 @@ expects a JSON object matches a provided pattern
 
 -   `targetData` **any** 
 -   `regex` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectNotContain
 
@@ -209,7 +209,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedValueToNotContain` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectNotDeepEqual
 
@@ -217,7 +217,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectNotEndsWith
 
@@ -225,7 +225,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedValueToNotEndWith` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectNotEqual
 
@@ -233,7 +233,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedValue` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectNotStartsWith
 
@@ -241,7 +241,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedValueToNotStartWith` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectStartsWith
 
@@ -249,7 +249,7 @@ expects a JSON object matches a provided pattern
 
 -   `actualValue` **any** 
 -   `expectedValueToStartWith` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectToBeA
 
@@ -257,7 +257,7 @@ expects a JSON object matches a provided pattern
 
 -   `targetData` **any** 
 -   `type` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectToBeAn
 
@@ -265,11 +265,11 @@ expects a JSON object matches a provided pattern
 
 -   `targetData` **any** 
 -   `type` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  
 
 ### expectTrue
 
 #### Parameters
 
 -   `targetData` **any** 
--   `customErrorMsg` **any**  
+-   `customErrorMsg` **any?**  

--- a/lib/helper/Expect.js
+++ b/lib/helper/Expect.js
@@ -32,7 +32,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValue
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectEqual(actualValue, expectedValue, customErrorMsg = '') {
     // @ts-ignore
@@ -44,7 +44,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValue
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectNotEqual(actualValue, expectedValue, customErrorMsg = '') {
     // @ts-ignore
@@ -56,7 +56,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValue
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
 
      */
   expectDeepEqual(actualValue, expectedValue, customErrorMsg = '') {
@@ -69,7 +69,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValue
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectNotDeepEqual(actualValue, expectedValue, customErrorMsg = '') {
     // @ts-ignore
@@ -81,7 +81,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValueToContain
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectContain(actualValue, expectedValueToContain, customErrorMsg = '') {
     // @ts-ignore
@@ -95,7 +95,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValueToNotContain
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectNotContain(
     actualValue,
@@ -113,7 +113,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValueToStartWith
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectStartsWith(actualValue, expectedValueToStartWith, customErrorMsg = '') {
     // @ts-ignore
@@ -127,7 +127,7 @@ class ExpectHelper {
      *
      * @param {*} actualValue
      * @param {*} expectedValueToNotStartWith
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectNotStartsWith(
     actualValue,
@@ -144,7 +144,7 @@ class ExpectHelper {
   /**
      * @param {*} actualValue
      * @param {*} expectedValueToEndWith
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectEndsWith(actualValue, expectedValueToEndWith, customErrorMsg = '') {
     // @ts-ignore
@@ -157,7 +157,7 @@ class ExpectHelper {
   /**
      * @param {*} actualValue
      * @param {*} expectedValueToNotEndWith
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectNotEndsWith(
     actualValue,
@@ -174,7 +174,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} jsonSchema
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectJsonSchema(targetData, jsonSchema, customErrorMsg = '') {
     // @ts-ignore
@@ -186,7 +186,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} jsonSchema
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      * @param {*} ajvOptions Pass AJV options
      */
   expectJsonSchemaUsingAJV(
@@ -204,7 +204,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} propertyName
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectHasProperty(targetData, propertyName, customErrorMsg = '') {
     // @ts-ignore
@@ -215,7 +215,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} propertyName
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectHasAProperty(targetData, propertyName, customErrorMsg = '') {
     // @ts-ignore
@@ -226,7 +226,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} type
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectToBeA(targetData, type, customErrorMsg = '') {
     // @ts-ignore
@@ -237,7 +237,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} type
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectToBeAn(targetData, type, customErrorMsg = '') {
     // @ts-ignore
@@ -248,7 +248,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} regex
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectMatchRegex(targetData, regex, customErrorMsg = '') {
     // @ts-ignore
@@ -259,7 +259,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} length
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectLengthOf(targetData, length, customErrorMsg = '') {
     // @ts-ignore
@@ -269,7 +269,7 @@ class ExpectHelper {
 
   /**
      * @param {*} targetData
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectEmpty(targetData, customErrorMsg = '') {
     // @ts-ignore
@@ -279,7 +279,7 @@ class ExpectHelper {
 
   /**
      * @param {*} targetData
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectTrue(targetData, customErrorMsg = '') {
     // @ts-ignore
@@ -289,7 +289,7 @@ class ExpectHelper {
 
   /**
      * @param {*} targetData
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectFalse(targetData, customErrorMsg = '') {
     // @ts-ignore
@@ -300,7 +300,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} aboveThan number | Date
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectAbove(targetData, aboveThan, customErrorMsg = '') {
     // @ts-ignore
@@ -311,7 +311,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} belowThan number | Date
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectBelow(targetData, belowThan, customErrorMsg = '') {
     // @ts-ignore
@@ -322,7 +322,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} lengthAboveThan
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectLengthAboveThan(targetData, lengthAboveThan, customErrorMsg = '') {
     // @ts-ignore
@@ -335,7 +335,7 @@ class ExpectHelper {
   /**
      * @param {*} targetData
      * @param {*} lengthBelowThan
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectLengthBelowThan(targetData, lengthBelowThan, customErrorMsg = '') {
     // @ts-ignore
@@ -348,7 +348,7 @@ class ExpectHelper {
   /**
      * @param {*} actualValue
      * @param {*} expectedValue
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectEqualIgnoreCase(actualValue, expectedValue, customErrorMsg = '') {
     // @ts-ignore
@@ -362,7 +362,7 @@ class ExpectHelper {
      * expects members of two arrays are deeply equal
      * @param {*} actualValue
      * @param {*} expectedValue
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectDeepMembers(actualValue, expectedValue, customErrorMsg = '') {
     // @ts-ignore
@@ -376,7 +376,7 @@ class ExpectHelper {
      * expects an array to be a superset of another array
      * @param {*} superset
      * @param {*} set
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectDeepIncludeMembers(superset, set, customErrorMsg = '') {
     // @ts-ignore
@@ -391,7 +391,7 @@ class ExpectHelper {
      * @param {*} actualValue
      * @param {*} expectedValue
      * @param {*} fieldsToExclude
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectDeepEqualExcluding(
     actualValue,
@@ -410,7 +410,7 @@ class ExpectHelper {
      * expects a JSON object matches a provided pattern
      * @param {*} actualValue
      * @param {*} expectedPattern
-     * @param {*} customErrorMsg
+     * @param {*} [customErrorMsg]
      */
   expectMatchesPattern(actualValue, expectedPattern, customErrorMsg = '') {
     // @ts-ignore

--- a/lib/helper/Expect.js
+++ b/lib/helper/Expect.js
@@ -299,7 +299,7 @@ class ExpectHelper {
 
   /**
      * @param {*} targetData
-     * @param {*} aboveThan number | Date
+     * @param {*} aboveThan
      * @param {*} [customErrorMsg]
      */
   expectAbove(targetData, aboveThan, customErrorMsg = '') {
@@ -310,7 +310,7 @@ class ExpectHelper {
 
   /**
      * @param {*} targetData
-     * @param {*} belowThan number | Date
+     * @param {*} belowThan
      * @param {*} [customErrorMsg]
      */
   expectBelow(targetData, belowThan, customErrorMsg = '') {


### PR DESCRIPTION
## Motivation/Description of the PR
- fix: expect helper to have custom error message as optional param


## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
