### PR TITLE
fix: step arg is a function

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -145,7 +145,13 @@ function initializeListeners() {
 
       if (step.args) {
         for (const arg of step.args) {
-          arg && arg.$_root ? _args.push(JSON.stringify(arg).slice(0, 300)) : _args.push(arg);
+          if (arg && arg.$_root) {
+            _args.push(JSON.stringify(arg).slice(0, 300));
+          } else if (arg && typeof arg === 'function') {
+            _args.push(arg.name);
+          } else {
+            _args.push(arg);
+          }
         }
       }
 

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -145,8 +145,10 @@ function initializeListeners() {
 
       if (step.args) {
         for (const arg of step.args) {
+          // check if arg is a JOI object
           if (arg && arg.$_root) {
             _args.push(JSON.stringify(arg).slice(0, 300));
+          // check if arg is a function
           } else if (arg && typeof arg === 'function') {
             _args.push(arg.name);
           } else {


### PR DESCRIPTION
## Motivation/Description of the PR
- fix an issue where step arg is a function that breaks the code when running with run-workers

```
Error processing step.start event:
DataCloneError: function (requestParameters, options) {
            return localVarFp.lookupAddresses(requestParameters.lookupA...<omitted>... } could not be cloned.
    at new DOMException (node:internal/per_context/domexception:53:5)
    at sendToParentThread (/Users/pb/Downloads/dfe-test-automation/node_modules/codeceptjs/lib/command/workers/runTests.js:266:14)
    at EventEmitter.<anonymous> (/Users/pb/Downloads/dfe-test-automation/node_modules/codeceptjs/lib/command/workers/runTests.js:221:51)
    at EventEmitter.emit (node:events:525:35)
    at EventEmitter.emit (node:domain:489:12)
    at Object.emit (/Users/pb/Downloads/dfe-test-automation/node_modules/codeceptjs/lib/event.js:149:28)
    at /Users/pb/Downloads/dfe-test-automation/node_modules/codeceptjs/lib/actor.js:132:13
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
