### PR TITLE
fix: cannot locate complicated locator

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -1,4 +1,4 @@
-const cssToXPath = require('convert-cssxpath');
+const cssToXPath = require('csstoxpath');
 const { sprintf } = require('sprintf-js');
 
 const { xpathLocator } = require('./utils');
@@ -162,7 +162,7 @@ class Locator {
    */
   toXPath() {
     if (this.isXPath()) return this.value;
-    if (this.isCSS()) return cssToXPath.convert(this.value);
+    if (this.isCSS()) return cssToXPath(this.value);
 
     throw new Error('Can\'t be converted to XPath');
   }

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "chai-string": "^1.5.0",
     "chalk": "4.1.2",
     "commander": "11.1.0",
-    "convert-cssxpath": "1.0.2",
     "cross-spawn": "7.0.3",
+    "csstoxpath": "1.6.0",
     "envinfo": "7.11.0",
     "escape-string-regexp": "4.0.0",
     "figures": "3.2.0",
@@ -121,6 +121,7 @@
     "@wdio/sauce-service": "8.27.0",
     "@wdio/selenium-standalone-service": "8.3.2",
     "@wdio/utils": "8.27.0",
+    "@xmldom/xmldom": "0.8.10",
     "apollo-server-express": "2.25.3",
     "chai-as-promised": "7.1.1",
     "chai-subset": "1.6.0",
@@ -157,7 +158,6 @@
     "wdio-docker-service": "1.5.0",
     "webdriverio": "8.3.8",
     "xml2js": "0.6.2",
-    "@xmldom/xmldom": "0.8.10",
     "xpath": "0.0.34"
   },
   "engines": {

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -52,6 +52,19 @@ const xml = `<body>
   <label class="n-1">Hello<a href="#">Please click</a></label>
   </div>
   <input type="hidden" name="return_url" value="" id="return_url" />
+
+  <div class="ps-submenu-root">
+    <ul class="ps-submenu-root">
+      <li class="ps-menu-button">Adhemar da Silva</li>
+      <li class="ps-menu-button">HelloWorld</li>
+      <li class="ps-menu-button">Hallo</li>
+    </ul>
+    <ul class="ps-submenu-root">
+      <li class="ps-menu-button">Adhemar da Silva</li>
+      <li class="ps-menu-button">HelloWorld</li>
+      <li class="ps-menu-button">Authoring</li>
+    </ul>
+  </div>
 </body>`;
 
 describe('Locator', () => {
@@ -271,5 +284,15 @@ describe('Locator', () => {
     expect(nodes).to.have.length(1, l.toXPath());
     expect(nodes[0].firstChild.data).to.eql('Sign In', l.toXPath());
     Locator.filters = [];
+  });
+
+  it('should be able to locate complicated locator', () => {
+    const l = Locator.build('.ps-menu-button')
+      .withText('Authoring')
+      .inside('.ps-submenu-root:nth-child(2)');
+
+    const nodes = xpath.select(l.toXPath(), doc);
+    expect(nodes).to.have.length(1, l.toXPath());
+    expect(nodes[0].firstChild.data).to.eql('Authoring', l.toXPath());
   });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
Locator issue due to the lib changes

```
The locator locate(".ps-menu-button").withText("Authoring").inside(".ps-submenu-root:nth-child(3)") is translated to
3.5.8: //*[contains(concat(' ', normalize-space(./@class), ' '), ' ps-menu-button ')][contains(., 'Authoring')][ancestor::*[(contains(concat(' ', normalize-space(./@class), ' '), ' ps-submenu-root ') and count(preceding-sibling::*) = 2)]] and works well
3.5.11: //*[contains(@class, "ps-menu-button")][contains(., 'Authoring')][ancestor::*[3][contains(@class, "ps-submenu-root")]] and doesn't work (no clickable element found). Even if you test it in browser inspector, it doesn't work.
```

## Type of change
- [ ] :bug: Bug fix


## Checklist:
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
