### PR TITLE
fix: deprecate some JSON Wire Protocol commands

### DIFF
--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -1200,6 +1200,8 @@ Returns **([Promise][25]&lt;DOMRect> | [Promise][25]&lt;[number][22]>)** Element
 
 ### grabGeoLocation
 
+This method is **deprecated**.
+
 Return the current geo location 
 Resumes test execution, so **should be used inside async function with `await`** operator.
 
@@ -2017,6 +2019,8 @@ I.setCookie([
 Returns **void** automatically synchronized promise through #recorder
 
 ### setGeoLocation
+
+This method is **deprecated**.
 
 Set the current geo location
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2448,21 +2448,25 @@ class WebDriver extends Helper {
   }
 
   /**
+   * This method is **deprecated**.
+   *
+   *
    * {{> setGeoLocation }}
    */
   async setGeoLocation(latitude, longitude, altitude = null) {
-    if (altitude) {
-      return this.browser.setGeoLocation({ latitude, longitude });
-    }
-    return this.browser.setGeoLocation({ latitude, longitude, altitude });
+    console.log(`setGeoLocation deprecated:
+    * This command is deprecated due to using deprecated JSON Wire Protocol command. More info: https://webdriver.io/docs/api/jsonwp/#setgeolocation`);
   }
 
   /**
+   * This method is **deprecated**.
+   *
    * {{> grabGeoLocation }}
    *
    */
   async grabGeoLocation() {
-    return this.browser.getGeoLocation();
+    console.log(`grabGeoLocation deprecated:
+    * This command is deprecated due to using deprecated JSON Wire Protocol command. More info: https://webdriver.io/docs/api/jsonwp/#getgeolocation`);
   }
 
   /**

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -1163,7 +1163,8 @@ describe('WebDriver', function () {
   });
 
   describe('GeoLocation', () => {
-    it('should set the geoLocation', async () => {
+    // deprecated JSON Wire method commands
+    it.skip('should set the geoLocation', async () => {
       await wd.setGeoLocation(37.4043, -122.0748);
       const geoLocation = await wd.grabGeoLocation();
       assert.equal(geoLocation.latitude, 37.4043, 'The latitude is not properly set');


### PR DESCRIPTION
## Motivation/Description of the PR
-  deprecate some JSON Wire Protocol commands: `grabGeoLocation`, `setGeoLocation`



Applicable helpers:
- [ ] WebDriver

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
