### PR TITLE
fix(playwright): session doesn't respect the context options

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -517,8 +517,9 @@ class Playwright extends Helper {
       if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent;
       if (this.options.locale) contextOptions.locale = this.options.locale;
       if (this.options.colorScheme) contextOptions.colorScheme = this.options.colorScheme;
+      this.contextOptions = contextOptions;
       if (!this.browserContext || !restartsSession()) {
-        this.browserContext = await this.browser.newContext(contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
+        this.browserContext = await this.browser.newContext(this.contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
       }
     }
 
@@ -606,7 +607,7 @@ class Playwright extends Helper {
           page = await browser.firstWindow();
         } else {
           try {
-            browserContext = await this.browser.newContext(Object.assign(this.options, config));
+            browserContext = await this.browser.newContext(Object.assign(this.contextOptions, config));
             page = await browserContext.newPage();
           } catch (e) {
             if (this.playwrightOptions.userDataDir) {


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4109 

Before:

```
Helpers: Playwright
Plugins: screenshotOnFail, tryTo, retryFailedStep, retryTo, eachElement

Repro --
    [1]  Starting recording promises
    Timeouts: 
 › [Session] Starting singleton browser session
  Reproduce issue
    I am on page "https://example.com"
 › [New Context] {}
 › [Browser:Error] Failed to load resource: the server responded with a status of 404 ()
    user1: I am on page "https://example.com"
    user1: I execute script () => {
      return { width: window.screen.width, height: window.screen.height };
    }
sessionScreen is {"width":1280,"height":720}
    [1] <session:user1> Error | AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(sessionScreen.width === 375)
 undefined...
    [1] <teardown> Stopping recording promises
 › <screenshotOnFail> Test failed, try to save a screenshot
 › Screenshot is saving to /Users/t/Desktop/projects/codeceptjs-playwright-device-bug-reproduction/output/Reproduce_issue.failed.png
 › user1 - Screenshot is saving to /Users/t/Desktop/projects/codeceptjs-playwright-device-bug-reproduction/output/user1_Reproduce_issue.failed.png
  ✖ FAILED in 1542ms

    [2]  Starting recording promises

-- FAILURES:

  1) Repro
       Reproduce issue:

      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert(sessionScreen.width === 375)

      + expected - actual

      -false
      +true
      
      at /Users/t/Desktop/projects/codeceptjs-playwright-device-bug-reproduction/repro_test.js:16:5
  
  
  Artifacts:
  - screenshot: /Users/t/Desktop/projects/codeceptjs-playwright-device-bug-reproduction/output/Reproduce_issue.failed.png


  FAIL  | 0 passed, 1 failed   // 3s
```

After:
```
Helpers: Playwright
Plugins: screenshotOnFail, tryTo, retryFailedStep, retryTo, eachElement

Repro --
    [1]  Starting recording promises
    Timeouts: 
 › [Session] Starting singleton browser session
  Reproduce issue
    I am on page "https://example.com"
    › [Browser:Error] Failed to load resource: the server responded with a status of 404 ()
 › [New Context] {}
    user1: I am on page "https://example.com"
    user1: I execute script () => {
      return { width: window.screen.width, height: window.screen.height };
    }
sessionScreen is {"width":375,"height":667}
  ✔ OK in 1890ms


  OK  | 1 passed   // 4s
```

Applicable helpers:
- [ ] Playwright

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
