### PR TITLE
feat: waitForNumberOfTabs

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -2492,6 +2492,21 @@ See [Playwright's reference][41]
 
 -   `options` **any**  
 
+### waitForNumberOfTabs
+
+Waits for number of tabs.
+
+```js
+I.waitForNumberOfTabs(2);
+```
+
+#### Parameters
+
+-   `expectedTabs` **[number][20]** expecting the number of tabs.
+-   `sec` **[number][20]** number of secs to wait.
+
+Returns **void** automatically synchronized promise through #recorder
+
 ### waitForRequest
 
 Waits for a network request.

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -2101,6 +2101,21 @@ See [Puppeteer's reference][23]
 
 -   `opts` **any**  
 
+### waitForNumberOfTabs
+
+Waits for number of tabs.
+
+```js
+I.waitForNumberOfTabs(2);
+```
+
+#### Parameters
+
+-   `expectedTabs` **[number][10]** expecting the number of tabs.
+-   `sec` **[number][10]** number of secs to wait.
+
+Returns **void** automatically synchronized promise through #recorder
+
 ### waitForRequest
 
 Waits for a network request.

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -2288,6 +2288,21 @@ I.waitForInvisible('#popup');
 
 Returns **void** automatically synchronized promise through #recorder
 
+### waitForNumberOfTabs
+
+Waits for number of tabs.
+
+```js
+I.waitForNumberOfTabs(2);
+```
+
+#### Parameters
+
+-   `expectedTabs` **[number][22]** expecting the number of tabs.
+-   `sec` **[number][22]** number of secs to wait.
+
+Returns **void** automatically synchronized promise through #recorder
+
 ### waitForText
 
 Waits for a text to appear (by default waits for 1sec).

--- a/docs/webapi/waitForNumberOfTabs.mustache
+++ b/docs/webapi/waitForNumberOfTabs.mustache
@@ -1,0 +1,9 @@
+Waits for number of tabs.
+
+```js
+I.waitForNumberOfTabs(2);
+```
+
+@param {number} expectedTabs expecting the number of tabs.
+@param {number} sec number of secs to wait.
+@returns {void} automatically synchronized promise through #recorder

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2583,6 +2583,24 @@ class Playwright extends Helper {
     });
   }
 
+  /**
+   * {{> waitForNumberOfTabs }}
+   */
+  async waitForNumberOfTabs(expectedTabs, sec) {
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    let currentTabs;
+    let count = 0;
+
+    do {
+      currentTabs = await this.grabNumberOfOpenTabs();
+      await this.wait(1);
+      count += 1000;
+      if (currentTabs >= expectedTabs) return;
+    } while (count <= waitTimeout);
+
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
+  }
+
   async _getContext() {
     if (this.context && this.context.constructor.name === 'FrameLocator') {
       return this.context;

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2151,6 +2151,24 @@ class Puppeteer extends Helper {
     });
   }
 
+  /**
+   * {{> waitForNumberOfTabs }}
+   */
+  async waitForNumberOfTabs(expectedTabs, sec) {
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    let currentTabs;
+    let count = 0;
+
+    do {
+      currentTabs = await this.grabNumberOfOpenTabs();
+      await this.wait(1);
+      count += 1000;
+      if (currentTabs >= expectedTabs) return;
+    } while (count <= waitTimeout);
+
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
+  }
+
   async _getContext() {
     if (this.context && this.context.constructor.name === 'Frame') {
       return this.context;

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2307,6 +2307,24 @@ class WebDriver extends Helper {
   }
 
   /**
+   * {{> waitForNumberOfTabs }}
+   */
+  async waitForNumberOfTabs(expectedTabs, sec) {
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeoutInSeconds;
+    let currentTabs;
+    let count = 0;
+
+    do {
+      currentTabs = await this.grabNumberOfOpenTabs();
+      await this.wait(1);
+      count += 1000;
+      if (currentTabs >= expectedTabs) return;
+    } while (count <= waitTimeout);
+
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
+  }
+
+  /**
    * {{> switchTo }}
    */
   async switchTo(locator) {

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -256,7 +256,7 @@ describe('Playwright', function () {
       .then(() => I.dontSee('Hovered', '#show')));
   });
 
-  describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs', () => {
+  describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', () => I.amOnPage('/')
       .then(() => I.wait(1))
       .then(() => I.grabNumberOfOpenTabs())
@@ -298,13 +298,13 @@ describe('Playwright', function () {
 
     it('should close other tabs', () => I.amOnPage('/')
       .then(() => I.openNewTab())
-      .then(() => I.wait(1))
+      .then(() => I.waitForNumberOfTabs(2))
       .then(() => I.seeInCurrentUrl('about:blank'))
       .then(() => I.amOnPage('/info'))
       .then(() => I.openNewTab())
       .then(() => I.amOnPage('/login'))
       .then(() => I.closeOtherTabs())
-      .then(() => I.wait(1))
+      .then(() => I.waitForNumberOfTabs(1))
       .then(() => I.seeInCurrentUrl('/login'))
       .then(() => I.grabNumberOfOpenTabs())
       .then(numPages => assert.equal(numPages, 1)));

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -226,7 +226,7 @@ describe('Puppeteer', function () {
       .then(() => I.dontSee('Hovered', '#show')));
   });
 
-  describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs', () => {
+  describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', () => I.amOnPage('/')
       .then(() => I.wait(1))
       .then(() => I.grabNumberOfOpenTabs())
@@ -238,7 +238,7 @@ describe('Puppeteer', function () {
       .then(numPages => assert.equal(numPages, 1))
       .then(() => I.click('New tab'))
       .then(() => I.switchToNextTab())
-      .then(() => I.wait(2))
+      .then(() => I.waitForNumberOfTabs(2))
       .then(() => I.seeCurrentUrlEquals('/login'))
       .then(() => I.grabNumberOfOpenTabs())
       .then(numPages => assert.equal(numPages, 2)));

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -601,7 +601,7 @@ describe('WebDriver', function () {
     });
   });
 
-  describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs', () => {
+  describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', async () => {
       await wd.amOnPage('/');
       const numPages = await wd.grabNumberOfOpenTabs();
@@ -614,6 +614,7 @@ describe('WebDriver', function () {
       assert.equal(numPages, 1);
 
       await wd.click('New tab');
+      await wd.waitForNumberOfTabs(2);
       await wd.switchToNextTab();
       await wd.waitInUrl('/login');
       const numPagesAfter = await wd.grabNumberOfOpenTabs();


### PR DESCRIPTION
## Motivation/Description of the PR

### waitForNumberOfTabs

Waits for number of tabs.

```js
I.waitForNumberOfTabs(2);
```

#### Parameters

-   `expectedTabs` **[number][20]** expecting the number of tabs.
-   `sec` **[number][20]** number of secs to wait.

Returns **void** automatically synchronized promise through #recorder

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver

## Type of change
- [ ] :rocket: New functionality


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
