### PR TITLE
fix: missing steps of test when running with workers

### DIFF
--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -11,6 +11,7 @@ module.exports = async function (workerCount, selectedRuns, options) {
   const passedTestArr = [];
   const failedTestArr = [];
   const skippedTestArr = [];
+  const stepArr = [];
 
   const { config: testConfig, override = '' } = options;
   const overrideConfigs = tryOrDefault(() => JSON.parse(override), {});
@@ -36,6 +37,14 @@ module.exports = async function (workerCount, selectedRuns, options) {
     suiteArr.push(suite);
   });
 
+  workers.on(event.step.passed, (step) => {
+    stepArr.push(step);
+  });
+
+  workers.on(event.step.failed, (step) => {
+    stepArr.push(step);
+  });
+
   workers.on(event.test.failed, (test) => {
     failedTestArr.push(test);
     output.test.failed(test);
@@ -53,6 +62,28 @@ module.exports = async function (workerCount, selectedRuns, options) {
 
   workers.on(event.all.result, () => {
     // expose test stats after all workers finished their execution
+    function addStepsToTest(test, stepArr) {
+      stepArr.test.steps.forEach(step => {
+        if (test.steps.length === 0) {
+          test.steps.push(step);
+        }
+      });
+    }
+
+    stepArr.forEach(step => {
+      passedTestArr.forEach(test => {
+        if (step.test.title === test.title) {
+          addStepsToTest(test, step);
+        }
+      });
+
+      failedTestArr.forEach(test => {
+        if (step.test.title === test.title) {
+          addStepsToTest(test, step);
+        }
+      });
+    });
+
     event.dispatcher.emit(event.workers.result, {
       suites: suiteArr,
       tests: {

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -132,7 +132,7 @@ function initializeListeners() {
       duration: test.duration || 0,
       err,
       parent,
-      steps: test.steps ? simplifyStepsInTestObject(test.steps, err) : [],
+      steps: test.steps && test.steps.length > 0 ? simplifyStepsInTestObject(test.steps, err) : [],
     };
   }
 
@@ -161,7 +161,7 @@ function initializeListeners() {
         actor: step.actor,
         name: step.name,
         status: step.status,
-        agrs: _args,
+        args: _args,
         startedAt: step.startedAt,
         startTime: step.startTime,
         endTime: step.endTime,


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4126 

```
Scenario('Verify getting list of users', async () => {
	let res = await I.getUserPerPage(2);
	res.data = []; // this line causes the issue
	await I.expectEqual(res.data.data[0].id, 7);
}); 
```

at this time, `res.data.data[0].id` would throw undefined error and somehow the test is missing all its steps.

## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
