### PR TITLE
Fix process.env.profile when --profile isn't set in run-multiple mode

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -28,7 +28,9 @@ let processesDone;
 
 module.exports = async function (selectedRuns, options) {
   // registering options globally to use in config
-  process.env.profile = options.profile;
+  if (options.profile) {
+    process.env.profile = options.profile;
+  }
   const configFile = options.config;
 
   const testRoot = getTestRoot(configFile);


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #4130 .

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
