### PR TITLE
fix: dont publish docs to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "files": [
     "bin",
-    "docs",
     "lib",
     "translations",
     "typings/**/*.d.ts"


### PR DESCRIPTION
## Motivation/Description of the PR
- Reduce the npm package size up to 2MB
- Resolves #4128 


## Type of change

- [ ] :fire: optimize package size


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
