### PR TITLE
fix: grabRecordedNetworkTraffics throws error when being called twice

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2974,27 +2974,27 @@ class Playwright extends Helper {
       throw new Error('Failure in test automation. You use "I.grabRecordedNetworkTraffics", but "I.startRecordingTraffic" was never called before.');
     }
 
-    const requests = await this.requests;
-    const promises = requests.map(async (request) => request.response.then(
-      async (response) => {
-        let body;
-        try {
-          // There's no 'body' for some requests (redirect etc...)
-          body = JSON.parse((await response.body()).toString());
-        } catch (e) {
-          // only interested in JSON, not HTML responses.
-        }
+    const promises = this.requests.map(async (request) => {
+      const resp = await request.response;
+      let body;
+      try {
+        // There's no 'body' for some requests (redirect etc...)
+        body = JSON.parse((await resp.body()).toString());
+      } catch (e) {
+        // only interested in JSON, not HTML responses.
+      }
 
-        request.response = {
-          status: response.status(),
-          statusText: response.statusText(),
+      return {
+        url: resp.url(),
+        response: {
+          status: resp.status(),
+          statusText: resp.statusText(),
           body,
-        };
-      },
-    ));
-    await Promise.all(promises);
+        },
+      };
+    });
 
-    return this.requests;
+    return Promise.all(promises);
   }
 
   /**

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -983,6 +983,7 @@ describe('Playwright', function () {
       await I.see('this was another mocked');
 
       const traffics = await I.grabRecordedNetworkTraffics();
+      await I.grabRecordedNetworkTraffics();
       expect(traffics[0].url).to.equal('https://reqres.in/api/comments/1');
       expect(traffics[0].response.status).to.equal(200);
       expect(traffics[0].response.body).to.contain({ name: 'this was mocked' });


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4142 

Applicable helpers:

- [ ] Playwright


## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
