### PR TITLE
fix: some assertion methods

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -47,6 +47,9 @@ const {
   setRestartStrategy, restartsSession, restartsContext, restartsBrowser,
 } = require('./extras/PlaywrightRestartOpts');
 const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine');
+const {
+  seeElementError, dontSeeElementError, dontSeeElementInDOMError, seeElementInDOMError,
+} = require('./errors/ElementAssertion');
 
 const pathSeparator = path.sep;
 
@@ -1451,7 +1454,11 @@ class Playwright extends Helper {
   async seeElement(locator) {
     let els = await this._locate(locator);
     els = await Promise.all(els.map(el => el.isVisible()));
-    return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      dontSeeElementError(locator);
+    }
   }
 
   /**
@@ -1461,7 +1468,11 @@ class Playwright extends Helper {
   async dontSeeElement(locator) {
     let els = await this._locate(locator);
     els = await Promise.all(els.map(el => el.isVisible()));
-    return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      seeElementError(locator);
+    }
   }
 
   /**
@@ -1469,7 +1480,11 @@ class Playwright extends Helper {
    */
   async seeElementInDOM(locator) {
     const els = await this._locate(locator);
-    return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      dontSeeElementInDOMError(locator);
+    }
   }
 
   /**
@@ -1477,7 +1492,11 @@ class Playwright extends Helper {
    */
   async dontSeeElementInDOM(locator) {
     const els = await this._locate(locator);
-    return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      seeElementInDOMError(locator);
+    }
   }
 
   /**

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -39,6 +39,9 @@ const findReact = require('./extras/React');
 const { highlightElement } = require('./scripts/highlightElement');
 const { blurElement } = require('./scripts/blurElement');
 const { focusElement } = require('./scripts/focusElement');
+const {
+  dontSeeElementError, seeElementError, dontSeeElementInDOMError, seeElementInDOMError,
+} = require('./errors/ElementAssertion');
 
 let puppeteer;
 let perfTiming;
@@ -1038,8 +1041,11 @@ class Puppeteer extends Helper {
     els = (await Promise.all(els.map(el => el.boundingBox() && el))).filter(v => v);
     // Puppeteer visibility was ignored? | Remove when Puppeteer is fixed
     els = await Promise.all(els.map(async el => (await el.evaluate(node => window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none')) && el));
-
-    return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      dontSeeElementError(locator);
+    }
   }
 
   /**
@@ -1051,8 +1057,11 @@ class Puppeteer extends Helper {
     els = (await Promise.all(els.map(el => el.boundingBox() && el))).filter(v => v);
     // Puppeteer visibility was ignored? | Remove when Puppeteer is fixed
     els = await Promise.all(els.map(async el => (await el.evaluate(node => window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none')) && el));
-
-    return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      seeElementError(locator);
+    }
   }
 
   /**
@@ -1060,7 +1069,11 @@ class Puppeteer extends Helper {
    */
   async seeElementInDOM(locator) {
     const els = await this._locate(locator);
-    return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      dontSeeElementInDOMError(locator);
+    }
   }
 
   /**
@@ -1068,7 +1081,11 @@ class Puppeteer extends Helper {
    */
   async dontSeeElementInDOM(locator) {
     const els = await this._locate(locator);
-    return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'));
+    try {
+      return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'));
+    } catch (e) {
+      seeElementInDOMError(locator);
+    }
   }
 
   /**

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -32,6 +32,9 @@ const { highlightElement } = require('./scripts/highlightElement');
 const store = require('../store');
 const { focusElement } = require('./scripts/focusElement');
 const { blurElement } = require('./scripts/blurElement');
+const {
+  dontSeeElementError, seeElementError, seeElementInDOMError, dontSeeElementInDOMError,
+} = require('./errors/ElementAssertion');
 
 const SHADOW = 'shadow';
 const webRoot = 'body';
@@ -1461,7 +1464,11 @@ class WebDriver extends Helper {
     const res = await this._locate(locator, true);
     assertElementExists(res, locator);
     const selected = await forEachAsync(res, async el => el.isDisplayed());
-    return truth(`elements of ${(new Locator(locator))}`, 'to be seen').assert(selected);
+    try {
+      return truth(`elements of ${(new Locator(locator))}`, 'to be seen').assert(selected);
+    } catch (e) {
+      dontSeeElementError(locator);
+    }
   }
 
   /**
@@ -1474,7 +1481,11 @@ class WebDriver extends Helper {
       return truth(`elements of ${(new Locator(locator))}`, 'to be seen').negate(false);
     }
     const selected = await forEachAsync(res, async el => el.isDisplayed());
-    return truth(`elements of ${(new Locator(locator))}`, 'to be seen').negate(selected);
+    try {
+      return truth(`elements of ${(new Locator(locator))}`, 'to be seen').negate(selected);
+    } catch (e) {
+      seeElementError(locator);
+    }
   }
 
   /**
@@ -1483,7 +1494,11 @@ class WebDriver extends Helper {
    */
   async seeElementInDOM(locator) {
     const res = await this._res(locator);
-    return empty('elements').negate(res);
+    try {
+      return empty('elements').negate(res);
+    } catch (e) {
+      dontSeeElementInDOMError(locator);
+    }
   }
 
   /**
@@ -1492,7 +1507,11 @@ class WebDriver extends Helper {
    */
   async dontSeeElementInDOM(locator) {
     const res = await this._res(locator);
-    return empty('elements').assert(res);
+    try {
+      return empty('elements').assert(res);
+    } catch (e) {
+      seeElementInDOMError(locator);
+    }
   }
 
   /**

--- a/lib/helper/errors/ElementAssertion.js
+++ b/lib/helper/errors/ElementAssertion.js
@@ -1,0 +1,38 @@
+const Locator = require('../../locator');
+
+const prefixMessage = 'Element';
+
+function seeElementError(locator) {
+  if (typeof locator === 'object') {
+    locator = JSON.stringify(locator);
+  }
+  throw new Error(`${prefixMessage} "${(new Locator(locator))}" is still visible on page.`);
+}
+
+function seeElementInDOMError(locator) {
+  if (typeof locator === 'object') {
+    locator = JSON.stringify(locator);
+  }
+  throw new Error(`${prefixMessage} "${(new Locator(locator))}" is still seen in DOM.`);
+}
+
+function dontSeeElementError(locator) {
+  if (typeof locator === 'object') {
+    locator = JSON.stringify(locator);
+  }
+  throw new Error(`${prefixMessage} "${(new Locator(locator))}" is not visible on page.`);
+}
+
+function dontSeeElementInDOMError(locator) {
+  if (typeof locator === 'object') {
+    locator = JSON.stringify(locator);
+  }
+  throw new Error(`${prefixMessage} "${(new Locator(locator))}" is not seen in DOM.`);
+}
+
+module.exports = {
+  seeElementError,
+  dontSeeElementError,
+  seeElementInDOMError,
+  dontSeeElementInDOMError,
+};


### PR DESCRIPTION
## Motivation/Description of the PR
- Improve the error message for `seeElement`, `dontSeeElement`, `seeElementInDOM`, `dontSeeElementInDOM`

The current error message doesn't really help when debugging issue also causes some problem described in #4140 

Actual

```
      expected visible elements '[ELEMENT]' to be empty
      + expected - actual

      -[
      -  "ELEMENT"
      -]
      +[]
```

Updated

```
     Error: Element "h1" is still visible
      at seeElementError (lib/helper/errors/ElementAssertion.js:9:9)
      at Playwright.dontSeeElement (lib/helper/Playwright.js:1472:7)
```

- Resolves #4140 

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
