### PR TITLE
fix: add I.say to Test.steps array

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -13,15 +13,18 @@ const output = require('./output');
  */
 class Actor {
   /**
-   * add print comment method`
+   * Print the comment on log. Also, adding a step in the `Test.steps` object
    * @param {string} msg
    * @param {string} color
    * @inner
    *
    * ⚠️ returns a promise which is synchronized internally by recorder
    */
-  say(msg, color = 'cyan') {
-    return recorder.add(`say ${msg}`, () => {
+  async say(msg, color = 'cyan') {
+    const step = new Step('say', 'say');
+    step.status = 'passed';
+    return recordStep(step, [msg]).then(() => {
+      // this is backward compatibility as this event may be used somewhere
       event.emit(event.step.comment, msg);
       output.say(msg, `${color}`);
     });

--- a/lib/step.js
+++ b/lib/step.js
@@ -119,7 +119,9 @@ class Step {
     }
     let result;
     try {
-      result = this.helper[this.helperMethod].apply(this.helper, this.args);
+      if (this.helperMethod !== 'say') {
+        result = this.helper[this.helperMethod].apply(this.helper, this.args);
+      }
       this.setStatus('success');
     } catch (err) {
       this.setStatus('failed');


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently `I.say` is not added into the `Test.steps` array. This PR aims to add this to steps array so that we could use it to print steps in ReportPortal for instance.

![Screenshot 2024-01-19 at 15 41 34](https://github.com/codeceptjs/CodeceptJS/assets/7845001/82af552a-aeb3-487e-ac10-b5bb7e42470f)

## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
