### PR TITLE
fix(webApi): selectOption method

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1805,7 +1805,7 @@ class Playwright extends Helper {
     let optionToSelect = '';
 
     try {
-      optionToSelect = await el.locator('option', { hasText: option }).textContent();
+      optionToSelect = (await el.locator('option', { hasText: option }).textContent()).trim();
     } catch (e) {
       optionToSelect = option;
     }

--- a/test/data/app/view/form/select_additional_spaces.php
+++ b/test/data/app/view/form/select_additional_spaces.php
@@ -1,0 +1,25 @@
+<html>
+<body>
+<form action="/form/complex" method="POST">
+    <label for="age">Select your age</label>
+    <select name="age" id="age">
+        <option value="child">
+            below 13
+        </option>
+        <option value="teenage">
+            13-21
+        </option>
+        <option value="adult">
+            21-60
+        </option>
+        <option value="oldfag" selected="selected">
+            60-100
+        </option>
+        <option value="dead">
+            100-210
+        </option>
+    </select>
+    <input type="submit" value="Submit" />
+</form>
+</body>
+</html>

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -433,6 +433,13 @@ module.exports.tests = function () {
       await I.click('Submit');
       assert.deepEqual(formContents('like'), ['play', 'adult']);
     });
+
+    it('should select option by label and option text with additional spaces', async () => {
+      await I.amOnPage('/form/select_additional_spaces');
+      await I.selectOption('Select your age', '21-60');
+      await I.click('Submit');
+      assert.equal(formContents('age'), 'adult');
+    });
   });
 
   describe('#executeScript', () => {


### PR DESCRIPTION
## Motivation/Description of the PR

I was trying to select an option by value '1999' from year of birth select and I used Playwright 'selectOption' method for this. But I got error:
![image](https://github.com/codeceptjs/CodeceptJS/assets/11326654/10740d97-f6fe-4db0-841c-cfd0cbd4438c)

Then I debugged method 'selectOption' and found that '.textContent()' method return value with spaces: ' 1999 ', that why I got error. I think this is a realistic case, many template engines can produce additional spaces.

Here HTML of select element:
![image](https://github.com/codeceptjs/CodeceptJS/assets/11326654/ed8c9486-97da-4cc2-855e-47eb682cd5d6)

I suggest to trim the value returned by the 'textContent' method. If 'textContent' returned 'null' we will get type error, but 'catch' block will catch this error and return 'option' argument.
What do you think?

https://github.com/codeceptjs/CodeceptJS/blob/439364ec0a9e0787de2a112f851599715a2538e5/lib/helper/Playwright.js#L1808

Applicable helpers:

- [x] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
