### PR TITLE
fix: missing docs for codecept UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "bin",
     "lib",
     "translations",
-    "typings/**/*.d.ts"
+    "typings/**/*.d.ts",
+    "docs/webapi/**"
   ],
   "main": "lib/index.js",
   "typings": "typings/index.d.ts",


### PR DESCRIPTION
## Motivation/Description of the PR
- Codecept UI is using `docs/webapi` to fetch the documentation.

## Type of change
- [ ] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
