### PR TITLE
fix(appium): updated performSwipe with w3c protocol v2

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -2,6 +2,7 @@ let webdriverio;
 
 const fs = require('fs');
 const axios = require('axios').default;
+const { v4: uuidv4 } = require('uuid');
 
 const Webdriver = require('./WebDriver');
 const AssertionFailedError = require('../assert/error');
@@ -1088,17 +1089,40 @@ class Appium extends Webdriver {
    * Appium: support Android and iOS
    */
   async performSwipe(from, to) {
-    await this.browser.touchPerform([{
-      action: 'press',
-      options: from,
-    }, {
-      action: 'wait',
-      options: { ms: 1000 },
-    }, {
-      action: 'moveTo',
-      options: to,
-    }, {
-      action: 'release',
+    await this.browser.performActions([{
+      id: uuidv4(),
+      type: 'pointer',
+      parameters: {
+        pointerType: 'touch',
+      },
+      actions: [
+        {
+          duration: 0,
+          x: from.x,
+          y: from.y,
+          type: 'pointerMove',
+          origin: 'viewport',
+        },
+        {
+          button: 1,
+          type: 'pointerDown',
+        },
+        {
+          duration: 200,
+          type: 'pause',
+        },
+        {
+          duration: 600,
+          x: to.x,
+          y: to.y,
+          type: 'pointerMove',
+          origin: 'viewport',
+        },
+        {
+          button: 1,
+          type: 'pointerUp',
+        },
+      ],
     }]);
     await this.browser.pause(1000);
   }
@@ -1128,7 +1152,7 @@ class Appium extends Webdriver {
       yoffset = 100;
     }
 
-    return this.swipe(locator, 0, yoffset, speed);
+    return this.swipe(parseLocator.call(this, locator), 0, yoffset, speed);
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR
- After Action was removed from appium-android-driver (https://github.com/appium/appium-android-driver/commit/70e623352f3c547535598951e294100d49e81826) swipe stopped to work. So Swipe was changes to used w3c performActions protocol (https://w3c.github.io/webdriver/#dfn-perform-actions)
- Resolves #[3949](https://github.com/codeceptjs/CodeceptJS/issues/3949)

**Updated pause time in the script and checked tests which were failing in** https://github.com/codeceptjs/CodeceptJS/pull/4154

Applicable helpers:

- [ ] Appium


## Type of change

- [ ] :bug: Bug fix


## Checklist:

- [ ] Lint checking (Run `npm run lint`)
