### PR TITLE
fix: config path without selenium

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -497,7 +497,6 @@ class WebDriver extends Helper {
     if (config.host) {
       // webdriverio spec
       config.hostname = config.host;
-      config.path = '/wd/hub';
     }
     config.baseUrl = config.url || config.baseUrl;
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -497,9 +497,8 @@ class WebDriver extends Helper {
     if (config.host) {
       // webdriverio spec
       config.hostname = config.host;
+      config.path = config.path ? config.path : '/wd/hub';
     }
-
-    config.path = config.path ? config.path : '/wd/hub';
 
     config.baseUrl = config.url || config.baseUrl;
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -498,6 +498,9 @@ class WebDriver extends Helper {
       // webdriverio spec
       config.hostname = config.host;
     }
+
+    config.path = config.path ? config.path : '/wd/hub';
+
     config.baseUrl = config.url || config.baseUrl;
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
       config.capabilities = config.desiredCapabilities;


### PR DESCRIPTION
## Motivation/Description of the PR
- fix the issue as path is hardcoded as '/wd/hub' 
- Resolves #4182 

Applicable helpers:
- [ ] WebDriver

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
