### PR TITLE
fix: use this.options instead of this.config

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2329,14 +2329,14 @@ class Playwright extends Helper {
     this.debugSection('Response', await response.text());
 
     // hook to allow JSON response handle this
-    if (this.config.onResponse) {
+    if (this.options.onResponse) {
       const axiosResponse = {
         data: await response.json(),
         status: response.status(),
         statusText: response.statusText(),
         headers: response.headers(),
       };
-      this.config.onResponse(axiosResponse);
+      this.options.onResponse(axiosResponse);
     }
 
     return response;

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2329,14 +2329,14 @@ class Playwright extends Helper {
     this.debugSection('Response', await response.text());
 
     // hook to allow JSON response handle this
-    if (this.options.onResponse) {
+    if (this.config.onResponse) {
       const axiosResponse = {
         data: await response.json(),
         status: response.status(),
         statusText: response.statusText(),
         headers: response.headers(),
       };
-      this.options.onResponse(axiosResponse);
+      this.config.onResponse(axiosResponse);
     }
 
     return response;

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -486,7 +486,7 @@ class Puppeteer extends Helper {
     if (!page) return;
     page.setDefaultNavigationTimeout(this.options.getPageTimeout);
     this.context = await this.page.$('body');
-    if (this.config.browser === 'chrome') {
+    if (this.options.browser === 'chrome') {
       await page.bringToFront();
     }
   }
@@ -658,9 +658,9 @@ class Puppeteer extends Helper {
       url = this.options.url + url;
     }
 
-    if (this.config.basicAuth && (this.isAuthenticated !== true)) {
+    if (this.options.basicAuth && (this.isAuthenticated !== true)) {
       if (url.includes(this.options.url)) {
-        await this.page.authenticate(this.config.basicAuth);
+        await this.page.authenticate(this.options.basicAuth);
         this.isAuthenticated = true;
       }
     }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -72,9 +72,12 @@ class REST extends Helper {
       this.options.maxBodyLength = maxContentLength;
     }
 
-    this.options = { ...this.options, ...config };
+    // override defaults with config
+    this._setConfig(config);
+
     this.headers = { ...this.options.defaultHeaders };
     this.axios = axios.create();
+    // @ts-ignore
     this.axios.defaults.headers = this.options.defaultHeaders;
   }
 
@@ -157,8 +160,8 @@ class REST extends Helper {
       }
     }
 
-    if (this.options.onRequest) {
-      await this.options.onRequest(request);
+    if (this.config.onRequest) {
+      await this.config.onRequest(request);
     }
 
     this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
@@ -171,8 +174,8 @@ class REST extends Helper {
       this.debugSection('Response', `Response error. Status code: ${err.response.status}`);
       response = err.response;
     }
-    if (this.options.onResponse) {
-      await this.options.onResponse(response);
+    if (this.config.onResponse) {
+      await this.config.onResponse(response);
     }
     this.options.prettyPrintJson ? this.debugSection('Response', beautify(JSON.stringify(response.data))) : this.debugSection('Response', JSON.stringify(response.data));
     return response;

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -157,8 +157,8 @@ class REST extends Helper {
       }
     }
 
-    if (this.config.onRequest) {
-      await this.config.onRequest(request);
+    if (this.options.onRequest) {
+      await this.options.onRequest(request);
     }
 
     this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
@@ -171,8 +171,8 @@ class REST extends Helper {
       this.debugSection('Response', `Response error. Status code: ${err.response.status}`);
       response = err.response;
     }
-    if (this.config.onResponse) {
-      await this.config.onResponse(response);
+    if (this.options.onResponse) {
+      await this.options.onResponse(response);
     }
     this.options.prettyPrintJson ? this.debugSection('Response', beautify(JSON.stringify(response.data))) : this.debugSection('Response', JSON.stringify(response.data));
     return response;

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -977,12 +977,12 @@ class WebDriver extends Helper {
    */
   amOnPage(url) {
     let split_url;
-    if (this.config.basicAuth) {
+    if (this.options.basicAuth) {
       if (url.startsWith('/')) {
-        url = this.config.url + url;
+        url = this.options.url + url;
       }
       split_url = url.split('//');
-      url = `${split_url[0]}//${this.config.basicAuth.username}:${this.config.basicAuth.password}@${split_url[1]}`;
+      url = `${split_url[0]}//${this.options.basicAuth.username}:${this.options.basicAuth.password}@${split_url[1]}`;
     }
     return this.browser.url(url);
   }


### PR DESCRIPTION
## Motivation/Description of the PR
- as we called `this._setConfig()` in helper, so using `this.options` would be the right one, as some places still call `this.config`

Applicable helpers:
- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver


## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
