### PR TITLE
fix: waitfortext doesnt throw error when text doesnt exist

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -6,7 +6,6 @@ const { v4: uuidv4 } = require('uuid');
 const assert = require('assert');
 const promiseRetry = require('promise-retry');
 const Locator = require('../locator');
-const store = require('../store');
 const recorder = require('../recorder');
 const stringIncludes = require('../assert/include').includes;
 const { urlEquals } = require('../assert/equal');
@@ -2679,6 +2678,7 @@ class Playwright extends Helper {
    */
   async waitForText(text, sec = null, context = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const errorMessage = `Text "${text}" was not found on page after ${waitTimeout / 1000} sec.`;
     let waiter;
 
     const contextObject = await this._getContext();
@@ -2689,18 +2689,21 @@ class Playwright extends Helper {
         try {
           await contextObject.locator(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> text=${text}`).first().waitFor({ timeout: waitTimeout, state: 'visible' });
         } catch (e) {
-          console.log(e);
-          throw new Error(`Text "${text}" was not found on page after ${waitTimeout / 1000} sec\n${e.message}`);
+          throw new Error(`${errorMessage}\n${e.message}`);
         }
       }
 
       if (locator.isXPath()) {
-        waiter = contextObject.waitForFunction(([locator, text, $XPath]) => {
-          eval($XPath); // eslint-disable-line no-eval
-          const el = $XPath(null, locator);
-          if (!el.length) return false;
-          return el[0].innerText.indexOf(text) > -1;
-        }, [locator.value, text, $XPath.toString()], { timeout: waitTimeout });
+        try {
+          await contextObject.waitForFunction(([locator, text, $XPath]) => {
+            eval($XPath); // eslint-disable-line no-eval
+            const el = $XPath(null, locator);
+            if (!el.length) return false;
+            return el[0].innerText.indexOf(text) > -1;
+          }, [locator.value, text, $XPath.toString()], { timeout: waitTimeout });
+        } catch (e) {
+          throw new Error(`${errorMessage}\n${e.message}`);
+        }
       }
     } else {
       // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
@@ -2714,7 +2717,7 @@ class Playwright extends Helper {
         count += 1000;
       } while (count <= waitTimeout);
 
-      if (!waiter) throw new Error(`Text "${text}" was not found on page after ${waitTimeout / 1000} sec`);
+      if (!waiter) throw new Error(`${errorMessage}`);
     }
   }
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -990,11 +990,13 @@ module.exports.tests = function () {
     it('should throw error when text not found', async () => {
       await I.amOnPage('/dynamic');
       await I.dontSee('Dynamic text');
+      let failed = false;
       try {
         await I.waitForText('Some text', 1, '//div[@id="text"]');
       } catch (e) {
-        assert.include(e.message, 'Text "Some text" was not found on page');
+        failed = true;
       }
+      assert.ok(failed);
     });
   });
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -986,6 +986,16 @@ module.exports.tests = function () {
       await I.dontSee('Dynamic text');
       await I.waitForText('Dynamic text', 5, '//div[@id="text"]');
     });
+
+    it('should throw error when text not found', async () => {
+      await I.amOnPage('/dynamic');
+      await I.dontSee('Dynamic text');
+      try {
+        await I.waitForText('Some text', 1, '//div[@id="text"]');
+      } catch (e) {
+        assert.include(e.message, 'Text "Some text" was not found on page');
+      }
+    });
   });
 
   describe('#waitForElement', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- fix: waitfortext doesnt throw error when text doesnt exist

This test is passed eventho there is no `Dynamic text 123`

```
    it('should wait for text located by XPath', async () => {
      await I.amOnPage('/dynamic');
      await I.dontSee('Dynamic text');
      await I.waitForText('Dynamic text 123', 5, '//div[@id="text"]');
    });
```

Applicable helpers:
- [ ] Playwright

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
