### PR TITLE
fix: "codeceptjs" command outputs help message twice

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -236,5 +236,6 @@ program.on('command:*', (cmd) => {
 
 if (process.argv.length <= 2) {
   program.outputHelp();
+} else {
+  program.parse(process.argv);
 }
-program.parse(process.argv);

--- a/test/runner/help_test.js
+++ b/test/runner/help_test.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+const path = require('path');
+const exec = require('child_process').exec;
+
+const runner = path.join(__dirname, '/../../bin/codecept.js');
+
+describe('help option', () => {
+  it('should print help message with --help option', (done) => {
+    exec(`${runner} --help`, (err, stdout) => {
+      stdout.should.include('Usage:');
+      stdout.should.include('Options:');
+      stdout.should.include('Commands:');
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should print help message with -h option', (done) => {
+    exec(`${runner} -h`, (err, stdout) => {
+      stdout.should.include('Usage:');
+      stdout.should.include('Options:');
+      stdout.should.include('Commands:');
+      assert(!err);
+      done();
+    });
+  });
+
+  it('should print help message with no option', (done) => {
+    exec(`${runner}`, (err, stdout) => {
+      stdout.should.include('Usage:');
+      stdout.should.include('Options:');
+      stdout.should.include('Commands:');
+      assert(!err);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Motivation/Description of the PR

This pull-request fixes that `codeceptjs` command with no subcommand and no option outputs the help message twice.

There are two locations where help messages are output:

- https://github.com/codeceptjs/CodeceptJS/blob/ef0e9683e5dc637b096e887c7940e0e9ba5925ed/bin/codecept.js#L238
- https://github.com/tj/commander.js/blob/v11.1.0/lib/command.js#L1275

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
