### PR TITLE
chore: disable redundant ppt tests

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -6,5 +6,4 @@ cd test
 
 docker-compose run --rm test-unit &&
 docker-compose run --rm test-rest &&
-docker-compose run --rm test-acceptance.webdriverio &&
-docker-compose run --rm test-acceptance.puppeteer
+docker-compose run --rm test-acceptance.webdriverio

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -27,9 +27,15 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      - name: Extract ppt version from package.json
+        uses: sergeysova/jq-action@v2
+        id: version
+        with:
+          cmd: 'jq .devDependencies.puppeteer package.json -r'
+
       # Run acceptance tests using docker-compose
       - name: Run Puppeteer Acceptance Tests
-        run: docker-compose run --rm test-acceptance.puppeteer
+        run: 'PPT_VERSION=${{ steps.version.outputs.value }}" docker-compose run --rm test-acceptance.puppeteer'
         working-directory: test
 
       # Run rest tests using docker-compose

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -27,17 +27,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
-      - name: Extract ppt version from package.json
-        uses: sergeysova/jq-action@v2
-        id: version
-        with:
-          cmd: 'jq .devDependencies.puppeteer package.json -r'
-
-      # Run acceptance tests using docker-compose
-      - name: Run Puppeteer Acceptance Tests
-        run: 'PPT_VERSION=${{ steps.version.outputs.value }} docker-compose run --rm test-acceptance.puppeteer'
-        working-directory: test
-
       # Run rest tests using docker-compose
       - name: Run REST Tests
         run: docker-compose run --rm test-rest

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Run acceptance tests using docker-compose
       - name: Run Puppeteer Acceptance Tests
-        run: 'PPT_VERSION=${{ steps.version.outputs.value }}" docker-compose run --rm test-acceptance.puppeteer'
+        run: 'PPT_VERSION=${{ steps.version.outputs.value }} docker-compose run --rm test-acceptance.puppeteer'
         working-directory: test
 
       # Run rest tests using docker-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,13 @@ COPY . /codecept
 RUN chown -R pptruser:pptruser /codecept
 RUN runuser -l pptruser -c 'npm i --force --loglevel=warn --prefix /codecept'
 
-RUN ln -s /codecept/bin/codecept.js /usr/local/bin/codeceptjs
-RUN mkdir /tests
-WORKDIR /tests
 # Install puppeteer so it's available in the container.
 RUN npm i puppeteer@$(jq .devDependencies.puppeteer package.json -r) && npx puppeteer browsers install chrome
 RUN google-chrome --version
+
+RUN ln -s /codecept/bin/codecept.js /usr/local/bin/codeceptjs
+RUN mkdir /tests
+WORKDIR /tests
 
 # Install playwright browsers
 RUN npx playwright install

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN chown -R pptruser:pptruser /codecept
 RUN runuser -l pptruser -c 'npm i --force --loglevel=warn --prefix /codecept'
 
 # Install puppeteer so it's available in the container.
-RUN npm i puppeteer@$(jq .devDependencies.puppeteer package.json -r) && npx puppeteer browsers install chrome
+RUN npm i puppeteer@$(echo $PPT_VERSION) && npx puppeteer browsers install chrome
 RUN google-chrome --version
 
 RUN ln -s /codecept/bin/codecept.js /usr/local/bin/codeceptjs
@@ -49,6 +49,7 @@ RUN npx playwright install
 ENV CODECEPT_ARGS=""
 ENV RUN_MULTIPLE=false
 ENV NO_OF_WORKERS=""
+ENV PPT_VERSION=$PPT_VERSION
 
 # Set HOST ENV variable for Selenium Server
 ENV HOST=selenium

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update && \
       apt-get install -y libgtk2.0-0 libgconf-2-4 \
       libasound2 libxtst6 libxss1 libnss3 xvfb
 
+# Install jq
+RUN apt-get update && apt-get install -y jq
+
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
@@ -35,7 +38,7 @@ RUN ln -s /codecept/bin/codecept.js /usr/local/bin/codeceptjs
 RUN mkdir /tests
 WORKDIR /tests
 # Install puppeteer so it's available in the container.
-RUN npm i puppeteer@$(npm view puppeteer version) && npx puppeteer browsers install chrome
+RUN npm i puppeteer@$(jq .devDependencies.puppeteer package.json -r) && npx puppeteer browsers install chrome
 RUN google-chrome --version
 
 # Install playwright browsers

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN chown -R pptruser:pptruser /codecept
 RUN runuser -l pptruser -c 'npm i --force --loglevel=warn --prefix /codecept'
 
 # Install puppeteer so it's available in the container.
-RUN npm i puppeteer@$(echo $PPT_VERSION) && npx puppeteer browsers install chrome
+RUN echo $PPT_VERSION
+RUN npm i puppeteer@$(echo $PPT_VERSION) --force && npx puppeteer browsers install chrome
 RUN google-chrome --version
 
 RUN ln -s /codecept/bin/codecept.js /usr/local/bin/codeceptjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update && \
       apt-get install -y libgtk2.0-0 libgconf-2-4 \
       libasound2 libxtst6 libxss1 libnss3 xvfb
 
-# Install jq
-RUN apt-get update && apt-get install -y jq
-
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
 # installs, work.
@@ -34,14 +31,12 @@ COPY . /codecept
 RUN chown -R pptruser:pptruser /codecept
 RUN runuser -l pptruser -c 'npm i --force --loglevel=warn --prefix /codecept'
 
-# Install puppeteer so it's available in the container.
-RUN echo $PPT_VERSION
-RUN npm i puppeteer@$(echo $PPT_VERSION) --force && npx puppeteer browsers install chrome
-RUN google-chrome --version
-
 RUN ln -s /codecept/bin/codecept.js /usr/local/bin/codeceptjs
 RUN mkdir /tests
 WORKDIR /tests
+# Install puppeteer so it's available in the container.
+RUN npm i puppeteer@$(npm view puppeteer version) && npx puppeteer browsers install chrome
+RUN google-chrome --version
 
 # Install playwright browsers
 RUN npx playwright install
@@ -50,7 +45,6 @@ RUN npx playwright install
 ENV CODECEPT_ARGS=""
 ENV RUN_MULTIPLE=false
 ENV NO_OF_WORKERS=""
-ENV PPT_VERSION=$PPT_VERSION
 
 # Set HOST ENV variable for Selenium Server
 ENV HOST=selenium

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     env_file: .env
     environment:
       - CODECEPT_ARGS=-c codecept.Puppeteer.js --grep @Puppeteer
+      - PPT_VERSION=$PPT_VERSION
     depends_on:
       - php
       - puppeteer-image


### PR DESCRIPTION
## Motivation/Description of the PR
we already have ppt tests in https://github.com/codeceptjs/CodeceptJS/blob/3.x/.github/workflows/puppeteer.yml so perhaps to disable ppt tests at the other places like circle ci, etc.

## Type of change
- [ ] 🧹  chore


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
