### PR TITLE
feat(wd): screenshots for sessions

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1795,14 +1795,21 @@ class WebDriver extends Helper {
    * {{> saveScreenshot }}
    */
   async saveScreenshot(fileName, fullPage = false) {
-    const outputFile = screenshotOutputFolder(fileName);
+    let outputFile = screenshotOutputFolder(fileName);
 
     if (this.activeSessionName) {
       const browser = this.sessionWindows[this.activeSessionName];
 
-      if (browser) {
-        this.debug(`Screenshot of ${this.activeSessionName} session has been saved to ${outputFile}`);
-        return browser.saveScreenshot(outputFile);
+      for (const sessionName in this.sessionWindows) {
+        const activeSessionPage = this.sessionWindows[sessionName];
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
+
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
+
+        if (browser) {
+          this.debug(`Screenshot of ${sessionName} session has been saved to ${outputFile}`);
+          return browser.saveScreenshot(outputFile);
+        }
       }
     }
 

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -110,7 +110,8 @@ module.exports = function (config) {
           allureReporter.addAttachment('Main session - Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), dataType);
 
           if (helper.activeSessionName) {
-            for (const sessionName in helper.sessionPages) {
+            const sessions = helper.sessionPages || helper.sessionWindows;
+            for (const sessionName in sessions) {
               const screenshotFileName = `${sessionName}_${fileName}`;
               test.artifacts[`${sessionName.replace(/ /g, '_')}_screenshot`] = path.join(global.output_dir, screenshotFileName);
               allureReporter.addAttachment(`${sessionName} - Last Seen Screenshot`, fs.readFileSync(path.join(global.output_dir, screenshotFileName)), dataType);

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -33,7 +33,7 @@ Scenario('screenshots reflect the current page of current session @Puppeteer @Pl
   const [default1Digest, default2Digest, john1Digest, john2Digest] = await I.getSHA256Digests([
     `${output_dir}/session_default_1.png`,
     `${output_dir}/session_default_2.png`,
-    `${output_dir}/session_john_1.png`,
+    `${output_dir}/john_session_john_1.png`,
     `${output_dir}/session_john_2.png`,
   ]);
 

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -77,7 +77,7 @@ Scenario('Different cookies for different sessions @Playwright @Puppeteer', asyn
   I.expectNotEqual(cookies.john, cookies.mary);
 });
 
-Scenario('should save screenshot for sessions @WebDriverIO @Puppeteer @Playwright', async ({ I }) => {
+Scenario('should save screenshot for sessions @WebDriverIO @Puppeteer @Playwright', async function ({ I }) {
   await I.amOnPage('/form/bug1467');
   await I.saveScreenshot('original.png');
   await I.amOnPage('/');
@@ -87,7 +87,7 @@ Scenario('should save screenshot for sessions @WebDriverIO @Puppeteer @Playwrigh
     event.dispatcher.emit(event.test.failed, this);
   });
 
-  const fileName = clearString('should save screenshot for active session @WebDriverIO @Puppeteer @Playwright');
+  const fileName = clearString(this.title);
   const [original, failed] = await I.getSHA256Digests([
     `${output_dir}/original.png`,
     `${output_dir}/john_${fileName}.failed.png`,

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -77,24 +77,31 @@ Scenario('Different cookies for different sessions @Playwright @Puppeteer', asyn
   I.expectNotEqual(cookies.john, cookies.mary);
 });
 
-Scenario('should save screenshot for active session @WebDriverIO @Puppeteer @Playwright', async function ({ I }) {
-  I.amOnPage('/form/bug1467');
-  I.saveScreenshot('original.png');
-  I.amOnPage('/');
+Scenario('should save screenshot for sessions @WebDriverIO @Puppeteer @Playwright', async ({ I }) => {
+  await I.amOnPage('/form/bug1467');
+  await I.saveScreenshot('original.png');
+  await I.amOnPage('/');
+  await I.saveScreenshot('main_session.png');
   session('john', async () => {
     await I.amOnPage('/form/bug1467');
     event.dispatcher.emit(event.test.failed, this);
   });
 
-  const fileName = clearString(this.title);
-
+  const fileName = clearString('should save screenshot for active session @WebDriverIO @Puppeteer @Playwright');
   const [original, failed] = await I.getSHA256Digests([
     `${output_dir}/original.png`,
-    `${output_dir}/${fileName}.failed.png`,
+    `${output_dir}/john_${fileName}.failed.png`,
   ]);
 
   // Assert that screenshots of same page in same session are equal
-  I.expectEqual(original, failed);
+  await I.expectEqual(original, failed);
+
+  // Assert that screenshots of sessions are created
+  const [main_original, session_failed] = await I.getSHA256Digests([
+    `${output_dir}/main_session.png`,
+    `${output_dir}/john_${fileName}.failed.png`,
+  ]);
+  await I.expectNotEqual(main_original, session_failed);
 });
 
 Scenario('should throw exception and close correctly @WebDriverIO @Puppeteer @Playwright', ({ I }) => {

--- a/test/support/ScreenshotSessionHelper.js
+++ b/test/support/ScreenshotSessionHelper.js
@@ -4,14 +4,6 @@ const crypto = require('crypto');
 const fs = require('fs');
 
 class ScreenshotSessionHelper extends Helper {
-  _finishTest() {
-    // Cleanup screenshots created by session screenshot test
-    const screenshotDir = fs.readdirSync(this.outputPath, { withFileTypes: true })
-      .filter(item => item.isFile() && item.name.includes('session'));
-
-    screenshotDir.forEach(file => fs.unlinkSync(`${this.outputPath}/${file.name}`));
-  }
-
   constructor(config) {
     super(config);
     this.outputPath = output_dir;


### PR DESCRIPTION
## Motivation/Description of the PR
- WD Helper: Currently only screenshot of the active session is saved, this PR aims to save the screenshot of every session for easy debugging

```
Scenario('should save screenshot for sessions @WebDriverIO @Puppeteer @Playwright', async ({ I }) => {
  await I.amOnPage('/form/bug1467');
  await I.saveScreenshot('original.png');
  await I.amOnPage('/');
  await I.saveScreenshot('main_session.png');
  session('john', async () => {
    await I.amOnPage('/form/bug1467');
    event.dispatcher.emit(event.test.failed, this);
  });

  const fileName = clearString('should save screenshot for active session @WebDriverIO @Puppeteer @Playwright');
  const [original, failed] = await I.getSHA256Digests([
    `${output_dir}/original.png`,
    `${output_dir}/john_${fileName}.failed.png`,
  ]);

  // Assert that screenshots of same page in same session are equal
  await I.expectEqual(original, failed);

  // Assert that screenshots of sessions are created
  const [main_original, session_failed] = await I.getSHA256Digests([
    `${output_dir}/main_session.png`,
    `${output_dir}/john_${fileName}.failed.png`,
  ]);
  await I.expectNotEqual(main_original, session_failed);
});
```
![Screenshot 2024-04-29 at 11 07 47](https://github.com/codeceptjs/CodeceptJS/assets/7845001/5dddf85a-ed77-474b-adfd-2f208d3c16a8)

Applicable helpers:
- [ ] WebDriver


Applicable plugins:
- [ ] screenshotOnFail


## Type of change
- [ ] :rocket: New functionality

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
