### PR TITLE
feat(REST): support httpAgent conf

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -26,6 +26,7 @@ Type: [object][4]
 -   `prettyPrintJson` **[boolean][6]?** pretty print json for response/request on console logs
 -   `timeout` **[number][5]?** timeout for requests in milliseconds. 10000ms by default
 -   `defaultHeaders` **[object][4]?** a list of default headers
+-   `httpAgent` **[object][4]?** create an agent with SSL certificate
 -   `onRequest` **[function][7]?** a async function which can update request object.
 -   `onResponse` **[function][7]?** a async function which can update response object.
 -   `maxUploadFileSize` **[number][5]?** set the max content file size in MB when performing api calls.
@@ -42,6 +43,25 @@ Type: [object][4]
       prettyPrintJson: true,
       onRequest: (request) => {
         request.headers.auth = '123';
+      }
+    }
+  }
+}
+```
+
+ With httpAgent
+
+```js
+{
+  helpers: {
+    REST: {
+      endpoint: 'http://site.com/api',
+      prettyPrintJson: true,
+      httpAgent: {
+         key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
+         cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
+         rejectUnauthorized: false,
+         keepAlive: true
       }
     }
   }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -1,5 +1,6 @@
 const axios = require('axios').default;
 const Helper = require('@codeceptjs/helper');
+const { Agent } = require('https');
 const Secret = require('../secret');
 
 const { beautify } = require('../utils');
@@ -13,6 +14,7 @@ const { beautify } = require('../utils');
  * @prop {boolean} [prettyPrintJson=false] - pretty print json for response/request on console logs
  * @prop {number} [timeout=1000] - timeout for requests in milliseconds. 10000ms by default
  * @prop {object} [defaultHeaders] - a list of default headers
+ * @prop {object} [httpAgent] - create an agent with SSL certificate
  * @prop {function} [onRequest] - a async function which can update request object.
  * @prop {function} [onResponse] - a async function which can update response object.
  * @prop {number} [maxUploadFileSize] - set the max content file size in MB when performing api calls.
@@ -39,6 +41,24 @@ const config = {};
  *     }
  *   }
  *}
+ * ```
+ *  With httpAgent
+ *
+ * ```js
+ * {
+ *   helpers: {
+ *     REST: {
+ *       endpoint: 'http://site.com/api',
+ *       prettyPrintJson: true,
+ *       httpAgent: {
+ *          key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
+ *          cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
+ *          rejectUnauthorized: false,
+ *          keepAlive: true
+ *       }
+ *     }
+ *   }
+ * }
  * ```
  *
  * ## Access From Helpers
@@ -76,7 +96,14 @@ class REST extends Helper {
     this._setConfig(config);
 
     this.headers = { ...this.options.defaultHeaders };
-    this.axios = axios.create();
+
+    // Create an agent with SSL certificate
+    if (this.options.httpAgent) {
+      if (!this.options.httpAgent.key || !this.options.httpAgent.cert) throw Error('Please recheck your httpAgent config!');
+      this.httpsAgent = new Agent(this.options.httpAgent);
+    }
+
+    this.axios = this.httpsAgent ? axios.create({ httpsAgent: this.httpsAgent }) : axios.create();
     // @ts-ignore
     this.axios.defaults.headers = this.options.defaultHeaders;
   }


### PR DESCRIPTION
## Motivation/Description of the PR
- Support the httpAgent conf to create the TSL connection via REST helper

```
{
  helpers: {
    REST: {
      endpoint: 'http://site.com/api',
      prettyPrintJson: true,
      httpAgent: {
         key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
         cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
         rejectUnauthorized: false,
         keepAlive: true
      }
    }
  }
}
```

Applicable helpers:
- [ ] REST


## Type of change
- [ ] :rocket: New functionality


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
