### PR TITLE
fix(cli): gherkin command init with TypeScript

### DIFF
--- a/lib/command/gherkin/init.js
+++ b/lib/command/gherkin/init.js
@@ -27,6 +27,19 @@ Given('I have a defined step', () => {
 module.exports = function (genPath) {
   const testsPath = getTestRoot(genPath);
   const config = getConfig(testsPath);
+  let extension = "js";
+  let configFile = path.join(testsPath, `codecept.conf.${extension}`);
+
+  if (!fileExists(configFile)) {
+    extension = "ts";
+    configFile = path.join(testsPath, `codecept.conf.${extension}`);
+    if (!fileExists(configFile)) {
+      output.error(
+        `Can't initializing Gherkin. This command must run on already initialized project`
+      );
+      process.exit(1);
+    }
+  }
 
   output.print('Initializing Gherkin (Cucumber BDD) for CodeceptJS');
   output.print('--------------------------');
@@ -53,18 +66,18 @@ module.exports = function (genPath) {
     output.success(`Created ${dir}, place step definitions into it`);
   }
 
-  if (safeFileWrite(path.join(dir, 'steps.js'), stepsFile)) {
-    output.success('Created sample steps file: step_definitions/steps.js');
+  if (safeFileWrite(path.join(dir, `steps.${extension}`), stepsFile)) {
+    output.success(
+      `Created sample steps file: step_definitions/steps.${extension}`
+    );
   }
 
   config.gherkin = {
-    features: './features/*.feature',
-    steps: [
-      './step_definitions/steps.js',
-    ],
+    features: "./features/*.feature",
+    steps: [`./step_definitions/steps.${extension}`],
   };
 
-  updateConfig(testsPath, config);
+  updateConfig(testsPath, config, extension);
 
   output.success('Gherkin setup is done.');
   output.success('Start writing feature files and implement corresponding steps.');

--- a/lib/command/gherkin/init.js
+++ b/lib/command/gherkin/init.js
@@ -4,7 +4,7 @@ const mkdirp = require('mkdirp');
 const output = require('../../output');
 const { fileExists } = require('../../utils');
 const {
-  getConfig, getTestRoot, updateConfig, safeFileWrite,
+  getConfig, getTestRoot, updateConfig, safeFileWrite, findConfigFile,
 } = require('../utils');
 
 const featureFile = `Feature: Business rules
@@ -26,20 +26,17 @@ Given('I have a defined step', () => {
 
 module.exports = function (genPath) {
   const testsPath = getTestRoot(genPath);
-  const config = getConfig(testsPath);
-  let extension = "js";
-  let configFile = path.join(testsPath, `codecept.conf.${extension}`);
+  const configFile = findConfigFile(testsPath);
 
-  if (!fileExists(configFile)) {
-    extension = "ts";
-    configFile = path.join(testsPath, `codecept.conf.${extension}`);
-    if (!fileExists(configFile)) {
-      output.error(
-        `Can't initializing Gherkin. This command must run on already initialized project`
-      );
-      process.exit(1);
-    }
+  if (!configFile) {
+    output.error(
+      "Can't initialize Gherkin. This command must be run in an already initialized project."
+    );
+    process.exit(1);
   }
+
+  const config = getConfig(testsPath);
+  const extension = path.extname(configFile).substring(1);
 
   output.print('Initializing Gherkin (Cucumber BDD) for CodeceptJS');
   output.print('--------------------------');

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -42,7 +42,7 @@ function fail(msg) {
 module.exports.fail = fail;
 
 function updateConfig(testsPath, config, extension) {
-  let configFile = path.join(testsPath, `codecept.conf.${extension}`);
+  const configFile = path.join(testsPath, `codecept.conf.${extension}`);
   if (!fileExists(configFile)) {
     const msg = `codecept.conf.${extension} config can\'t be updated automatically`;
     console.log();

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -104,3 +104,14 @@ module.exports.createOutputDir = (config, testRoot) => {
     mkdirp.sync(outputDir);
   }
 };
+
+module.exports.findConfigFile = (testsPath) => {
+  const extensions = ['js', 'ts'];
+  for (const ext of extensions) {
+    const configFile = path.join(testsPath, `codecept.conf.${ext}`);
+    if (fileExists(configFile)) {
+      return configFile;
+    }
+  }
+  return null;
+}

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -41,15 +41,15 @@ function fail(msg) {
 
 module.exports.fail = fail;
 
-function updateConfig(testsPath, config, key, extension = 'js') {
-  const configFile = path.join(testsPath, `codecept.conf.${extension}`);
+function updateConfig(testsPath, config, extension) {
+  let configFile = path.join(testsPath, `codecept.conf.${extension}`);
   if (!fileExists(configFile)) {
-    console.log();
     const msg = `codecept.conf.${extension} config can\'t be updated automatically`;
-    console.log(`${output.colors.bold.red(msg)}`);
-    console.log('Please update it manually:');
     console.log();
-    console.log(`${key}: ${config[key]}`);
+    console.log(`${output.colors.bold.red(msg)}`);
+    console.log(`${output.colors.bold.red("Please update it manually:")}`);
+    console.log();
+    console.log(config);
     console.log();
     return;
   }

--- a/test/data/sandbox/configs/gherkin/config_js/codecept.conf.init.js
+++ b/test/data/sandbox/configs/gherkin/config_js/codecept.conf.init.js
@@ -1,0 +1,16 @@
+/** @type {CodeceptJS.MainConfig} */
+exports.config = {
+  tests: "./*_test.js",
+  output: "./output",
+  helpers: {
+    Playwright: {
+      browser: "chromium",
+      url: "http://localhost",
+      show: true,
+    },
+  },
+  include: {
+    I: "./steps_file.js",
+  },
+  name: "CodeceptJS",
+};

--- a/test/data/sandbox/configs/gherkin/config_ts/codecept.conf.init.ts
+++ b/test/data/sandbox/configs/gherkin/config_ts/codecept.conf.init.ts
@@ -1,0 +1,15 @@
+export const config: CodeceptJS.MainConfig = {
+  tests: "./*_test.ts",
+  output: "./output",
+  helpers: {
+    Playwright: {
+      browser: "chromium",
+      url: "http://localhost",
+      show: true
+    }
+  },
+  include: {
+    I: "./steps_file"
+  },
+  name: "CodeceptJS"
+}

--- a/test/runner/gherkin_test.js
+++ b/test/runner/gherkin_test.js
@@ -1,0 +1,93 @@
+const assert = require("assert");
+const path = require("path");
+const fs = require("fs");
+const exec = require("child_process").exec;
+
+const runner = path.join(__dirname, "/../../bin/codecept.js");
+const codecept_dir = path.join(__dirname, "/../data/sandbox/configs/gherkin/");
+
+describe("gherkin bdd commands", () => {
+  describe("bdd:init", () => {
+    let codecept_dir_js = path.join(codecept_dir, "config_js");
+    let codecept_dir_ts = path.join(codecept_dir, "config_ts");
+
+    beforeEach(() => {
+      fs.copyFileSync(
+        path.join(codecept_dir_js, "codecept.conf.init.js"),
+        path.join(codecept_dir_js, "codecept.conf.js")
+      );
+      fs.copyFileSync(
+        path.join(codecept_dir_ts, "codecept.conf.init.ts"),
+        path.join(codecept_dir_ts, "codecept.conf.ts")
+      );
+    });
+
+    afterEach(() => {
+      try {
+        fs.rmSync(path.join(codecept_dir_js, "codecept.conf.js"));
+        fs.rmSync(path.join(codecept_dir_js, "features"), {
+          recursive: true,
+        });
+        fs.rmSync(path.join(codecept_dir_js, "step_definitions"), {
+          recursive: true,
+        });
+      } catch (e) {}
+      try {
+        fs.rmSync(path.join(codecept_dir_ts, "codecept.conf.ts"));
+        fs.rmSync(path.join(codecept_dir_ts, "features"), {
+          recursive: true,
+        });
+        fs.rmSync(path.join(codecept_dir_ts, "step_definitions"), {
+          recursive: true,
+        });
+      } catch (e) {}
+    });
+
+    [
+      {
+        codecept_dir_test: codecept_dir_js,
+        extension: "js",
+      },
+      {
+        codecept_dir_test: codecept_dir_ts,
+        extension: "ts",
+      },
+    ].forEach(({ codecept_dir_test, extension }) => {
+      it(`prepare CodeceptJS to run feature files (codecept.conf.${extension})`, (done) => {
+        exec(`${runner} gherkin:init ${codecept_dir_test}`, (err, stdout) => {
+          let dir = path.join(codecept_dir_test, "features");
+
+          stdout.should.include(
+            "Initializing Gherkin (Cucumber BDD) for CodeceptJS"
+          );
+          stdout.should.include(
+            `Created ${dir}, place your *.feature files in it`
+          );
+          stdout.should.include(
+            "Created sample feature file: features/basic.feature"
+          );
+
+          dir = path.join(codecept_dir_test, "step_definitions");
+          stdout.should.include(
+            `Created ${dir}, place step definitions into it`
+          );
+          stdout.should.include(
+            `Created sample steps file: step_definitions/steps.${extension}`
+          );
+          assert(!err);
+
+          const configResult = fs
+            .readFileSync(
+              path.join(codecept_dir_test, `codecept.conf.${extension}`)
+            )
+            .toString();
+          configResult.should.contain(`features: './features/*.feature'`);
+          configResult.should.contain(
+            `steps: ['./step_definitions/steps.${extension}']`
+          );
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
fix this command when project is initialized with TypeScript:

```
npx codeceptjs gherkin:init
```

## Motivation/Description of the PR
- Resolves #4350

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
