### PR TITLE
fix: Puppeteer helper doc broken link

### DIFF
--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -2476,7 +2476,7 @@ Returns **void** automatically synchronized promise through #recorder
 
 [18]: https://codecept.io/helpers/FileSystem
 
-[19]: https://pptr.dev/next/guides/request-interception
+[19]: https://pptr.dev/guides/network-interception
 
 [20]: https://github.com/GoogleChrome/puppeteer/issues/1313
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2472,12 +2472,12 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * Mocks network request using [`Request Interception`](https://pptr.dev/next/guides/request-interception)
+   * Mocks network request using [`Request Interception`](https://pptr.dev/guides/network-interception)
    *
    * ```js
    * I.mockRoute(/(\.png$)|(\.jpg$)/, route => route.abort());
    * ```
-   * This method allows intercepting and mocking requests & responses. [Learn more about it](https://pptr.dev/next/guides/request-interception)
+   * This method allows intercepting and mocking requests & responses. [Learn more about it](https://pptr.dev/guides/network-interception)
    *
    * @param {string|RegExp} [url] URL, regex or pattern for to match URL
    * @param {function} [handler] a function to process request


### PR DESCRIPTION
## Motivation/Description of the PR

- Description of this PR, which problem it solves

Broken link in puppeteer helper documentation

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
