### PR TITLE
fix: screenshot error in beforeSuite/AfterSuite

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -73,6 +73,10 @@ module.exports = function (config) {
   }
 
   event.dispatcher.on(event.test.failed, (test) => {
+    if (test.ctx?._runnable.title.includes('hook: ')) {
+      output.plugin('screenshotOnFail', 'BeforeSuite/AfterSuite do not have any access to the browser, hence it could not take screenshot.');
+      return;
+    }
     recorder.add('screenshot of failed test', async () => {
       let fileName = clearString(test.title);
       const dataType = 'image/png';

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -99,11 +99,11 @@ module.exports = function (config) {
     currentTest = test;
   });
 
-  event.dispatcher.on(event.step.failed, persistStep);
-
-  event.dispatcher.on(event.step.after, (step) => {
+  event.dispatcher.on(event.step.failed, (step) => {
     recorder.add('screenshot of failed test', async () => persistStep(step), true);
   });
+
+  event.dispatcher.on(event.step.after, persistStep);
 
   event.dispatcher.on(event.test.passed, (test) => {
     if (!config.deleteSuccessful) return persist(test);

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -112,8 +112,10 @@ module.exports = function (config) {
   });
 
   event.dispatcher.on(event.test.failed, (test, err) => {
-    // BeforeSuite/AfterSuite don't have any access to the browser, hence it could not take screenshot.
-    if (test.ctx._runnable.title.includes('hook: BeforeSuite')) return;
+    if (test.ctx._runnable.title.includes('hook: ')) {
+      output.plugin('stepByStepReport', 'BeforeSuite/AfterSuite do not have any access to the browser, hence it could not take screenshot.');
+      return;
+    }
     persist(test, err);
   });
 

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -64,5 +64,19 @@ describe('screenshotOnFail', () => {
     const regexpFileName = /test1_[0-9]{10}.failed.png/;
     expect(fileName.match(regexpFileName).length).is.equal(1);
   });
+
+  it('should not save screenshot in BeforeSuite', async () => {
+    screenshotOnFail({ uniqueScreenshotNames: true });
+    event.dispatcher.emit(event.test.failed, { title: 'test1', ctx: { _runnable: { title: 'hook: BeforeSuite' } } });
+    await recorder.promise();
+    expect(!screenshotSaved.called).is.ok;
+  });
+
+  it('should not save screenshot in AfterSuite', async () => {
+    screenshotOnFail({ uniqueScreenshotNames: true });
+    event.dispatcher.emit(event.test.failed, { title: 'test1', ctx: { _runnable: { title: 'hook: AfterSuite' } } });
+    await recorder.promise();
+    expect(!screenshotSaved.called).is.ok;
+  });
   // TODO: write more tests for different options
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- fix: screenshot error in beforeSuite/AfterSuite
- fix one more scenario

```
     Cannot read properties of undefined (reading 'toString')
      at persistStep (node_modules/codeceptjs/lib/plugin/stepByStepReport.js:148:63)
      at /Users/t/Desktop/projects/codeceptjs-playwright-fun/node_modules/codeceptjs/lib/plugin/stepByStepReport.js:105:59
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Applicable plugins:
- [x] screenshotOnFail
- [x] stepByStepReport


## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
