### PR TITLE
feat(rest): print curl

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -23,12 +23,12 @@ Type: [object][4]
 ### Properties
 
 -   `endpoint` **[string][3]?** API base URL
--   `prettyPrintJson` **[boolean][6]?** pretty print json for response/request on console logs
--   `timeout` **[number][5]?** timeout for requests in milliseconds. 10000ms by default
--   `defaultHeaders` **[object][4]?** a list of default headers
--   `httpAgent` **[object][4]?** create an agent with SSL certificate
--   `onRequest` **[function][7]?** a async function which can update request object.
--   `onResponse` **[function][7]?** a async function which can update response object.
+-   `prettyPrintJson` **[boolean][6]?** pretty print json for response/request on console logs.
+-   `printCurl` **[boolean][6]?** print cURL request on console logs. False by default.
+-   `timeout` **[number][5]?** timeout for requests in milliseconds. 10000ms by default.
+-   `defaultHeaders` **[object][4]?** a list of default headers.
+-   `onRequest` **[function][7]?** an async function which can update request object.
+-   `onResponse` **[function][7]?** an async function which can update response object.
 -   `maxUploadFileSize` **[number][5]?** set the max content file size in MB when performing api calls.
 
 
@@ -43,25 +43,6 @@ Type: [object][4]
       prettyPrintJson: true,
       onRequest: (request) => {
         request.headers.auth = '123';
-      }
-    }
-  }
-}
-```
-
- With httpAgent
-
-```js
-{
-  helpers: {
-    REST: {
-      endpoint: 'http://site.com/api',
-      prettyPrintJson: true,
-      httpAgent: {
-         key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
-         cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
-         rejectUnauthorized: false,
-         keepAlive: true
       }
     }
   }

--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -27,6 +27,7 @@ Type: [object][4]
 -   `printCurl` **[boolean][6]?** print cURL request on console logs. False by default.
 -   `timeout` **[number][5]?** timeout for requests in milliseconds. 10000ms by default.
 -   `defaultHeaders` **[object][4]?** a list of default headers.
+-   `httpAgent` **[object][4]?** create an agent with SSL certificate
 -   `onRequest` **[function][7]?** an async function which can update request object.
 -   `onResponse` **[function][7]?** an async function which can update response object.
 -   `maxUploadFileSize` **[number][5]?** set the max content file size in MB when performing api calls.
@@ -43,6 +44,25 @@ Type: [object][4]
       prettyPrintJson: true,
       onRequest: (request) => {
         request.headers.auth = '123';
+      }
+    }
+  }
+}
+```
+
+ With httpAgent
+
+```js
+{
+  helpers: {
+    REST: {
+      endpoint: 'http://site.com/api',
+      prettyPrintJson: true,
+      httpAgent: {
+         key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
+         cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
+         rejectUnauthorized: false,
+         keepAlive: true
       }
     }
   }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -1,5 +1,6 @@
 const axios = require('axios').default;
 const Helper = require('@codeceptjs/helper');
+const { Agent } = require('https');
 const Secret = require('../secret');
 
 const { beautify } = require('../utils');
@@ -14,6 +15,7 @@ const { beautify } = require('../utils');
  * @prop {boolean} [printCurl=false] - print cURL request on console logs. False by default.
  * @prop {number} [timeout=1000] - timeout for requests in milliseconds. 10000ms by default.
  * @prop {object} [defaultHeaders] - a list of default headers.
+ * @prop {object} [httpAgent] - create an agent with SSL certificate
  * @prop {function} [onRequest] - an async function which can update request object.
  * @prop {function} [onResponse] - an async function which can update response object.
  * @prop {number} [maxUploadFileSize] - set the max content file size in MB when performing api calls.
@@ -40,6 +42,25 @@ const config = {};
  *     }
  *   }
  *}
+ * ```
+ *
+ *  With httpAgent
+ *
+ * ```js
+ * {
+ *   helpers: {
+ *     REST: {
+ *       endpoint: 'http://site.com/api',
+ *       prettyPrintJson: true,
+ *       httpAgent: {
+ *          key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
+ *          cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
+ *          rejectUnauthorized: false,
+ *          keepAlive: true
+ *       }
+ *     }
+ *   }
+ * }
  * ```
  *
  * ## Access From Helpers
@@ -77,7 +98,14 @@ class REST extends Helper {
     this._setConfig(config);
 
     this.headers = { ...this.options.defaultHeaders };
-    this.axios = axios.create();
+
+    // Create an agent with SSL certificate
+    if (this.options.httpAgent) {
+      if (!this.options.httpAgent.key || !this.options.httpAgent.cert) throw Error('Please recheck your httpAgent config!');
+      this.httpsAgent = new Agent(this.options.httpAgent);
+    }
+
+    this.axios = this.httpsAgent ? axios.create({ httpsAgent: this.httpsAgent }) : axios.create();
     // @ts-ignore
     this.axios.defaults.headers = this.options.defaultHeaders;
   }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -195,11 +195,7 @@ class REST extends Helper {
 
     this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
     if (this.options.printCurl) {
-      if (request.data && !isValidJSON(request.data)) {
-        this.debugSection('CURL Request', 'cURL is not printed as the request body is not a JSON');
-      } else {
-        this.debugSection('CURL Request', curlize(request));
-      }
+      this.debugSection('CURL Request', curlize(request));
     }
 
     let response;
@@ -383,6 +379,7 @@ class REST extends Helper {
 module.exports = REST;
 
 function curlize(request) {
+  if (request.data?.constructor.name.toLowerCase() === 'formdata') return 'cURL is not printed as the request body is not a JSON';
   let curl = `curl --location --request ${request.method ? request.method.toUpperCase() : 'GET'} ${request.baseURL} `.replace("'", '');
 
   if (request.headers) {
@@ -399,18 +396,4 @@ function curlize(request) {
     curl += `-d '${JSON.stringify(request.data)}'`;
   }
   return curl;
-}
-
-/**
- * Checks if the given text is valid JSON.
- * @param {string} text - The text to check.
- * @returns {boolean} - Returns true if the text is valid JSON, otherwise false.
- */
-function isValidJSON(text) {
-  try {
-    JSON.parse(text);
-    return true;
-  } catch (error) {
-    return false;
-  }
 }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -194,7 +194,13 @@ class REST extends Helper {
     }
 
     this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
-    if (this.options.printCurl) this.debugSection('CURL Request', curlize(request));
+    if (this.options.printCurl) {
+      if (request.data && !isValidJSON(request.data)) {
+        this.debugSection('CURL Request', 'cURL is not printed as the request body is not a JSON');
+      } else {
+        this.debugSection('CURL Request', curlize(request));
+      }
+    }
 
     let response;
     try {
@@ -393,4 +399,18 @@ function curlize(request) {
     curl += `-d '${JSON.stringify(request.data)}'`;
   }
   return curl;
+}
+
+/**
+ * Checks if the given text is valid JSON.
+ * @param {string} text - The text to check.
+ * @returns {boolean} - Returns true if the text is valid JSON, otherwise false.
+ */
+function isValidJSON(text) {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch (error) {
+    return false;
+  }
 }

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -1,6 +1,5 @@
 const axios = require('axios').default;
 const Helper = require('@codeceptjs/helper');
-const { Agent } = require('https');
 const Secret = require('../secret');
 
 const { beautify } = require('../utils');
@@ -11,12 +10,12 @@ const { beautify } = require('../utils');
  * @typedef RESTConfig
  * @type {object}
  * @prop {string} [endpoint] - API base URL
- * @prop {boolean} [prettyPrintJson=false] - pretty print json for response/request on console logs
- * @prop {number} [timeout=1000] - timeout for requests in milliseconds. 10000ms by default
- * @prop {object} [defaultHeaders] - a list of default headers
- * @prop {object} [httpAgent] - create an agent with SSL certificate
- * @prop {function} [onRequest] - a async function which can update request object.
- * @prop {function} [onResponse] - a async function which can update response object.
+ * @prop {boolean} [prettyPrintJson=false] - pretty print json for response/request on console logs.
+ * @prop {boolean} [printCurl=false] - print cURL request on console logs. False by default.
+ * @prop {number} [timeout=1000] - timeout for requests in milliseconds. 10000ms by default.
+ * @prop {object} [defaultHeaders] - a list of default headers.
+ * @prop {function} [onRequest] - an async function which can update request object.
+ * @prop {function} [onResponse] - an async function which can update response object.
  * @prop {number} [maxUploadFileSize] - set the max content file size in MB when performing api calls.
  */
 const config = {};
@@ -41,24 +40,6 @@ const config = {};
  *     }
  *   }
  *}
- * ```
- *  With httpAgent
- *
- * ```js
- * {
- *   helpers: {
- *     REST: {
- *       endpoint: 'http://site.com/api',
- *       prettyPrintJson: true,
- *       httpAgent: {
- *          key: fs.readFileSync(__dirname + '/path/to/keyfile.key'),
- *          cert: fs.readFileSync(__dirname + '/path/to/certfile.cert'),
- *          rejectUnauthorized: false,
- *          keepAlive: true
- *       }
- *     }
- *   }
- * }
  * ```
  *
  * ## Access From Helpers
@@ -96,14 +77,7 @@ class REST extends Helper {
     this._setConfig(config);
 
     this.headers = { ...this.options.defaultHeaders };
-
-    // Create an agent with SSL certificate
-    if (this.options.httpAgent) {
-      if (!this.options.httpAgent.key || !this.options.httpAgent.cert) throw Error('Please recheck your httpAgent config!');
-      this.httpsAgent = new Agent(this.options.httpAgent);
-    }
-
-    this.axios = this.httpsAgent ? axios.create({ httpsAgent: this.httpsAgent }) : axios.create();
+    this.axios = axios.create();
     // @ts-ignore
     this.axios.defaults.headers = this.options.defaultHeaders;
   }
@@ -192,6 +166,7 @@ class REST extends Helper {
     }
 
     this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest));
+    if (this.options.printCurl) this.debugSection('CURL Request', curlize(request));
 
     let response;
     try {
@@ -372,3 +347,22 @@ class REST extends Helper {
   }
 }
 module.exports = REST;
+
+function curlize(request) {
+  let curl = `curl --location --request ${request.method ? request.method.toUpperCase() : 'GET'} ${request.baseURL} `.replace("'", '');
+
+  if (request.headers) {
+    Object.entries(request.headers).forEach(([key, value]) => {
+      curl += `-H "${key}: ${value}" `;
+    });
+  }
+
+  if (!curl.toLowerCase().includes('content-type: application/json')) {
+    curl += '-H "Content-Type: application/json" ';
+  }
+
+  if (request.data) {
+    curl += `-d '${JSON.stringify(request.data)}'`;
+  }
+  return curl;
+}


### PR DESCRIPTION
## Motivation/Description of the PR
- That's very high chance you need to share the request for debugging purpose, and curl would be the cheapest and fastest way for that purpose. Hence, printing the curl request in console logs would benefit us.

```console
    › [CURL Request] curl --location --request POST https://httpbin.org/post -H "X-API-Key: apiKey-onRequest" -H "Content-Type: application/json" -d '{"_overheadLength":161,"_valueLength":0,"_valuesToMeasure":[{"fd":null,"path":"/Users/t/Desktop/projects/codeceptjs-rest-demo/src/fixtures/test_image.png","flags":"r","mode":438,"end":null,"bytesRead":0,"_readableState":{"state":6176,"highWaterMark":65536,"buffer":{"head":null,"tail":null,"length":0},"length":0,"pipes":[],"flowing":false,"errored":null,"defaultEncoding":"utf8","awaitDrainWriters":null,"decoder":null,"encoding":null},"_events":{},"_eventsCount":3}],"writable":false,"readable":true,"dataSize":0,"maxDataSize":2097152,"pauseStreams":true,"_released":false,"_streams":["----------------------------807986065015258526651649\r\nContent-Disposition: form-data; name=\"attachment\"; filename=\"test_image.png\"\r\nContent-Type: image/png\r\n\r\n",{"source":{"fd":null,"path":"/Users/t/Desktop/projects/codeceptjs-rest-demo/src/fixtures/test_image.png","flags":"r","mode":438,"end":null,"bytesRead":0,"_readableState":{"state":6176,"highWaterMark":65536,"buffer":{"head":null,"tail":null,"length":0},"length":0,"pipes":[],"flowing":false,"errored":null,"defaultEncoding":"utf8","awaitDrainWriters":null,"decoder":null,"encoding":null},"_events":{},"_eventsCount":3},"dataSize":0,"maxDataSize":null,"pauseStream":true,"_maxDataSizeExceeded":false,"_released":false,"_bufferedEvents":[{"0":"pause"}],"_events":{},"_eventsCount":1},null],"_currentStream":null,"_insideLoop":false,"_pendingNext":false,"_boundary":"--------------------------807986065015258526651649"}'
```

Applicable helpers:
- [ ] REST

## Type of change
- [ ] :rocket: New functionality


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
