### PR TITLE
fixed 4447

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -175,7 +175,7 @@ class Locator {
    */
   toXPath(pseudoSelector = '') {
     const locator = `${this.value}${pseudoSelector}`;
-    const limitation = [':nth-of-type', ':first-of-type', ':last-of-type', ':nth-last-child', ':nth-last-of-type', ':checked', ':disabled', ':enabled', ':required', ':lang', ':nth-child'];
+    const limitation = [':nth-of-type', ':first-of-type', ':last-of-type', ':nth-last-child', ':nth-last-of-type', ':checked', ':disabled', ':enabled', ':required', ':lang', ':nth-child', ':has'];
 
     if (limitation.some(item => locator.includes(item))) {
       cssToXPath = require('css-to-xpath');

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -300,6 +300,15 @@ describe('Locator', () => {
     expect(nodes[0].firstChild.data).to.eql('davert')
   })
 
+  it('should transform CSS having has pseudo to xpath', () => {
+    const l = new Locator('#submit-element:has(button)', 'css')
+    const convertedXpath = l.toXPath();
+    const nodes = xpath.select(l.toXPath(), doc)
+    expect(convertedXpath).to.equal('.//*[(./@id = \'submit-element\' and .//button)]')
+    expect(nodes).to.have.length(1)
+    expect(nodes[0].firstChild.data.trim()).to.eql('')
+  })
+
   it('should build locator to match element by attr', () => {
     const l = Locator.build('input').withAttr({ 'data-value': 'yes' })
     const nodes = xpath.select(l.toXPath(), doc)


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently ":has" pseudo in CSS is not permitted and hence by adding it to the "limitation" list inside 'toXPath' method will solve the issue.
- Resolves #4447

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
