### PR TITLE
Release 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 3.6.5
+
+❤️ Thanks all to those who contributed to make this release! ❤️
+
+🛩️ *Features*
+* feat(helper): playwright > wait for disabled (#4412) - by @kobenguyent
+```
+it('should wait for input text field to be disabled', () =>
+      I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)))
+
+    it('should wait for input text field to be enabled by xpath', () =>
+      I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled("//*[@name = 'test']", 1)))
+
+    it('should wait for a button to be disabled', () =>
+      I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)))
+
+Waits for element to become disabled (by default waits for 1sec).
+Element can be located by CSS or XPath.
+
+@param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
+@param {number} [sec=1] (optional) time in seconds to wait, 1 by default.
+@returns {void} automatically synchronized promise through #recorder
+```
+
+🐛 *Bug Fixes*
+* fix(AI): AI is not triggered (#4422) - by @kobenguyent
+* fix(plugin): stepByStep > report doesn't sync properly (#4413) - by @kobenguyent
+* fix: Locator > Unsupported pseudo selector 'has' (#4448) - by @anils92
+
+📖 *Documentation*
+* docs: setup azure open ai using bearer token (#4434) - by @kobenguyent
+
 ## 3.6.4
 
 ❤️ Thanks all to those who contributed to make this release! ❤️

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Supercharged End 2 End Testing Framework for NodeJS",
   "keywords": [
     "acceptance",

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -302,9 +302,9 @@ describe('Locator', () => {
 
   it('should transform CSS having has pseudo to xpath', () => {
     const l = new Locator('#submit-element:has(button)', 'css')
-    const convertedXpath = l.toXPath();
+    const convertedXpath = l.toXPath()
     const nodes = xpath.select(l.toXPath(), doc)
-    expect(convertedXpath).to.equal('.//*[(./@id = \'submit-element\' and .//button)]')
+    expect(convertedXpath).to.equal(".//*[(./@id = 'submit-element' and .//button)]")
     expect(nodes).to.have.length(1)
     expect(nodes[0].firstChild.data.trim()).to.eql('')
   })


### PR DESCRIPTION
## 3.6.5

❤️ Thanks all to those who contributed to make this release! ❤️

🛩️ *Features*
* feat(helper): playwright > wait for disabled (#4412) - by @kobenguyent
```
it('should wait for input text field to be disabled', () =>
      I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)))
    it('should wait for input text field to be enabled by xpath', () =>
      I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled("//*[@name = 'test']", 1)))
    it('should wait for a button to be disabled', () =>
      I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)))
Waits for element to become disabled (by default waits for 1sec).
Element can be located by CSS or XPath.
@param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
@param {number} [sec=1] (optional) time in seconds to wait, 1 by default.
@returns {void} automatically synchronized promise through #recorder
```

🐛 *Bug Fixes*
* fix(AI): AI is not triggered (#4422) - by @kobenguyent
* fix(plugin): stepByStep > report doesn't sync properly (#4413) - by @kobenguyent
* fix: Locator > Unsupported pseudo selector 'has' (#4448) - by @anils92

📖 *Documentation*
* docs: setup azure open ai using bearer token (#4434) - by @kobenguyent