### PR TITLE
fix(playwright): no async save video page

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3920,15 +3920,18 @@ async function refreshContextSession() {
 function saveVideoForPage(page, name) {
   if (!page.video()) return null
   const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`
-  page.video().saveAs(fileName)
-  if (!page) return
   page
     .video()
-    .delete()
-    .catch((e) => {})
+    .saveAs(fileName)
+    .then(() => {
+      if (!page) return
+      page
+        .video()
+        .delete()
+        .catch(() => {})
+    })
   return fileName
 }
-
 async function saveTraceForContext(context, name) {
   if (!context) return
   if (!context.tracing) return

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2396,9 +2396,9 @@ class Playwright extends Helper {
     }
 
     if (this.options.recordVideo && this.page && this.page.video()) {
-      test.artifacts.video = await saveVideoForPage(this.page, `${test.title}.failed`)
+      test.artifacts.video = saveVideoForPage(this.page, `${test.title}.failed`)
       for (const sessionName in this.sessionPages) {
-        test.artifacts[`video_${sessionName}`] = await saveVideoForPage(
+        test.artifacts[`video_${sessionName}`] = saveVideoForPage(
           this.sessionPages[sessionName],
           `${test.title}_${sessionName}.failed`,
         )
@@ -2424,9 +2424,9 @@ class Playwright extends Helper {
   async _passed(test) {
     if (this.options.recordVideo && this.page && this.page.video()) {
       if (this.options.keepVideoForPassedTests) {
-        test.artifacts.video = await saveVideoForPage(this.page, `${test.title}.passed`)
+        test.artifacts.video = saveVideoForPage(this.page, `${test.title}.passed`)
         for (const sessionName of Object.keys(this.sessionPages)) {
-          test.artifacts[`video_${sessionName}`] = await saveVideoForPage(
+          test.artifacts[`video_${sessionName}`] = saveVideoForPage(
             this.sessionPages[sessionName],
             `${test.title}_${sessionName}.passed`,
           )
@@ -3917,19 +3917,12 @@ async function refreshContextSession() {
   }
 }
 
-async function saveVideoForPage(page, name) {
+function saveVideoForPage(page, name) {
   if (!page.video()) return null
   const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`
-  page
-    .video()
-    .saveAs(fileName)
-    .then(() => {
-      if (!page) return
-      page
-        .video()
-        .delete()
-        .catch((e) => {})
-    })
+  page.video().saveAs(fileName)
+  if (!page) return
+  page.video().delete().catch(e => {})
   return fileName
 }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3922,7 +3922,10 @@ function saveVideoForPage(page, name) {
   const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`
   page.video().saveAs(fileName)
   if (!page) return
-  page.video().delete().catch(e => {})
+  page
+    .video()
+    .delete()
+    .catch((e) => {})
   return fileName
 }
 


### PR DESCRIPTION
## Motivation/Description of the PR
- it seems we don't need await/async for video. -> https://playwright.dev/docs/api/class-page#page-video

Applicable helpers:
- [ ] Playwright

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
