### PR TITLE
Fixed Issue #4165

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -161,7 +161,7 @@ function initializeListeners() {
         actor: step.actor,
         name: step.name,
         status: step.status,
-        args: _args,
+        args: JSON.stringify(_args),
         startedAt: step.startedAt,
         startTime: step.startTime,
         endTime: step.endTime,


### PR DESCRIPTION
### Motivation/Description of the PR
Fix for Codeceptjs version 3.5.10 and above - Throws DataCloneError when I.executeScript command is used with run-workers
`npx codeceptjs run-workers 2`

resolves #4165
### Type of change
 🐛 Bug fix



