### PR TITLE
fix(rest): validation of httpAgent config

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -69,6 +69,22 @@ Type: [object][4]
 }
 ```
 
+```js
+{
+  helpers: {
+    REST: {
+      endpoint: 'http://site.com/api',
+      prettyPrintJson: true,
+      httpAgent: {
+         ca: fs.readFileSync(__dirname + '/path/to/ca.pem'),
+         rejectUnauthorized: false,
+         keepAlive: true
+      }
+    }
+  }
+}
+```
+
 ## Access From Helpers
 
 Send REST requests by accessing `_executeRequest` method:

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -63,6 +63,22 @@ const config = {}
  * }
  * ```
  *
+ * ```js
+ * {
+ *   helpers: {
+ *     REST: {
+ *       endpoint: 'http://site.com/api',
+ *       prettyPrintJson: true,
+ *       httpAgent: {
+ *          ca: fs.readFileSync(__dirname + '/path/to/ca.pem'),
+ *          rejectUnauthorized: false,
+ *          keepAlive: true
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
  * ## Access From Helpers
  *
  * Send REST requests by accessing `_executeRequest` method:
@@ -101,9 +117,13 @@ class REST extends Helper {
 
     // Create an agent with SSL certificate
     if (this.options.httpAgent) {
-      if (!this.options.httpAgent.key || !this.options.httpAgent.cert)
+      // if one of those keys is there, all good to go
+      if (this.options.httpAgent.ca || this.options.httpAgent.key || this.options.httpAgent.cert) {
+        this.httpsAgent = new Agent(this.options.httpAgent)
+      } else {
+        // otherwise, throws an error of httpAgent config
         throw Error('Please recheck your httpAgent config!')
-      this.httpsAgent = new Agent(this.options.httpAgent)
+      }
     }
 
     this.axios = this.httpsAgent ? axios.create({ httpsAgent: this.httpsAgent }) : axios.create()


### PR DESCRIPTION
## Motivation/Description of the PR
- fix the validation of httpAgent config. we could now pass ca, instead of key/cert.

```js
{
  helpers: {
    REST: {
      endpoint: 'http://site.com/api',
      prettyPrintJson: true,
      httpAgent: {
         ca: fs.readFileSync(__dirname + '/path/to/ca.pem'),
         rejectUnauthorized: false,
         keepAlive: true
      }
    }
  }
}
```

Applicable helpers:
- [ ] REST

## Type of change
- [ ] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
