### PR TITLE
#4480-added new method for sending payload in delete request

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -148,6 +148,7 @@ REST helper can send GET/POST/PATCH/etc requests to REST API endpoint:
 * [`I.sendPutRequest()`](/helpers/REST#sendPutRequest)
 * [`I.sendPatchRequest()`](/helpers/REST#sendPatchRequest)
 * [`I.sendDeleteRequest()`](/helpers/REST#sendDeleteRequest)
+* [`I.sendDeleteRequestWithPayload()`](/helpers/REST#sendDeleteRequestWithPayload)
 * ...
 
 Authentication headers can be set in [helper's config](https://codecept.io/helpers/REST/#configuration) or per test with headers or special methods like `I.amBearerAuthenticated`.

--- a/docs/data.md
+++ b/docs/data.md
@@ -54,6 +54,7 @@ I.sendPostRequest()
 I.sendPutRequest()
 I.sendPatchRequest()
 I.sendDeleteRequest()
+I.sendDeleteRequestWithPayload()
 ```
 
 As well as a method for setting headers: `haveRequestHeaders`.

--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -156,6 +156,22 @@ I.sendDeleteRequest('/api/users/1');
 
 Returns **[Promise][2]&lt;any>** response
 
+### sendDeleteRequestWithPayload
+
+Sends DELETE request to API with payload.
+
+```js
+I.sendDeleteRequestWithPayload('/api/users/1', { author: 'john' });
+```
+
+#### Parameters
+
+-   `url` **any** 
+-   `payload` **any** the payload to be sent. By default it is sent as an empty object 
+-   `headers` **[object][4]** the headers object to be sent. By default, it is sent as an empty object 
+
+Returns **[Promise][2]&lt;any>** response
+
 ### sendGetRequest
 
 Send GET request to REST API

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -408,6 +408,30 @@ class REST extends Helper {
 
     return this._executeRequest(request)
   }
+
+  /**
+   * Sends DELETE request to API with payload.
+   *
+   * ```js
+   * I.sendDeleteRequestWithPayload('/api/users/1', { author: 'john' });
+   * ```
+   *
+   * @param {*} url
+   * @param {*} [payload={}] - the payload to be sent. By default it is sent as an empty object
+   * @param {object} [headers={}] - the headers object to be sent. By default, it is sent as an empty object
+   *
+   * @returns {Promise<*>} response
+   */
+  async sendDeleteRequestWithPayload(url, payload = {}, headers = {}) {
+    const request = {
+      baseURL: this._url(url),
+      method: 'DELETE',
+      data: payload,
+      headers,
+    }
+
+    return this._executeRequest(request)
+  }
 }
 
 module.exports = REST

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -109,6 +109,13 @@ describe('REST', () => {
       getResponse.data.should.be.empty
     })
 
+    it('should send DELETE requests with payload', async () => {
+      await I.sendDeleteRequestWithPayload('/posts/1', { author: 'john' })
+      const getResponse = await I.sendGetRequest('/posts')
+
+      getResponse.data.should.be.empty
+    })
+
     it('should update request with onRequest', async () => {
       I.config.onRequest = (request) => (request.data = { name: 'Vasya' })
 

--- a/translations/de-DE.js
+++ b/translations/de-DE.js
@@ -68,6 +68,7 @@ module.exports = {
     sendGetRequest: 'mache_einen_get_request',
     sendPutRequest: 'mache_einen_put_request',
     sendDeleteRequest: 'mache_einen_delete_request',
+    sendDeleteRequestWithPayload: 'mache_einen_delete_request_mit_payload',
     sendPostRequest: 'mache_einen_post_request',
     switchTo: 'wechlse_in_iframe',
   },

--- a/translations/fr-FR.js
+++ b/translations/fr-FR.js
@@ -70,7 +70,7 @@ module.exports = {
     scrollTo: 'défileVers',
     sendGetRequest: 'envoieLaRequêteGet',
     sendPutRequest: 'envoieLaRequêtePut',
-    sendDeleteRequest: 'envoieLaRequêteDelete',
+    sendDeleteRequest: 'envoieLaRequêteDeleteAvecPayload',
     sendPostRequest: 'envoieLaRequêtePost',
   },
 }


### PR DESCRIPTION
## Motivation/Description of the PR
- Allow sending request body in sendDeleteRequest function for REST helper
- Resolves [#4480](https://github.com/codeceptjs/CodeceptJS/discussions/4480)

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [X] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [X] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
