### PR TITLE
fix:  no error thrown from rerun script

### DIFF
--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -17,6 +17,10 @@ module.exports = async function (test, options) {
   const testRoot = getTestRoot(configFile)
   createOutputDir(config, testRoot)
 
+  function processError(err) {
+    printError(err)
+    process.exit(1)
+  }
   const codecept = new Codecept(config, options)
 
   try {

--- a/lib/command/run-rerun.js
+++ b/lib/command/run-rerun.js
@@ -17,10 +17,6 @@ module.exports = async function (test, options) {
   const testRoot = getTestRoot(configFile)
   createOutputDir(config, testRoot)
 
-  function processError(err) {
-    printError(err)
-    process.exit(1)
-  }
   const codecept = new Codecept(config, options)
 
   try {

--- a/lib/rerun.js
+++ b/lib/rerun.js
@@ -70,7 +70,6 @@ class CodeceptRerunner extends BaseCodecept {
       await this.runTests(test);
     } catch (e) {
       output.error(e.stack);
-      throw e;
     } finally {
       event.emit(event.all.result, this);
       event.emit(event.all.after, this);

--- a/lib/rerun.js
+++ b/lib/rerun.js
@@ -70,6 +70,7 @@ class CodeceptRerunner extends BaseCodecept {
       await this.runTests(test);
     } catch (e) {
       output.error(e.stack);
+      throw e;
     } finally {
       event.emit(event.all.result, this);
       event.emit(event.all.after, this);

--- a/test/data/sandbox/configs/run-rerun/codecept.conf.pass_all_test.js
+++ b/test/data/sandbox/configs/run-rerun/codecept.conf.pass_all_test.js
@@ -1,0 +1,16 @@
+exports.config = {
+  tests: './*_ftest.js',
+  output: './output',
+  helpers: {
+    CustomHelper: {
+      require: './customHelper.js',
+    },
+  },
+  rerun: {
+    minSuccess: 3,
+    maxReruns: 3,
+  },
+  bootstrap: null,
+  mocha: {},
+  name: 'run-rerun',
+};

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -83,7 +83,7 @@ describe('run-rerun command', () => {
     )
   })
 
-  it('should display success run if test was fail one time of two attepmts and 3 reruns', (done) => {
+  it('should display success run if test was fail one time of two attempts and 3 reruns', (done) => {
     exec(
       `FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - fail second test')} --debug`,
       (err, stdout) => {
@@ -92,6 +92,20 @@ describe('run-rerun command', () => {
         expect(stdout).toContain('Process run 3 of max 3, success runs 2/2')
         expect(stdout).not.toContain('Flaky tests detected!')
         expect(err).toBeNull()
+        done()
+      },
+    )
+  })
+
+  it('should throw exit code 1 if all tests were supposed to pass', (done) => {
+    exec(
+      `FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.pass_all_test.js', '@RunRerun - fail second test')} --debug`,
+      (err, stdout) => {
+        expect(stdout).toContain('Process run 1 of max 3, success runs 1/3')
+        expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3')
+        expect(stdout).toContain('Process run 3 of max 3, success runs 2/3')
+        expect(stdout).toContain('Flaky tests detected!')
+        expect(err.code).toBe(1)
         done()
       },
     )

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -96,4 +96,18 @@ describe('run-rerun command', () => {
       },
     )
   })
+
+  it('should throw exit code 1 if all tests were supposed to pass', (done) => {
+    exec(
+      `FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.pass_all_test.js', '@RunRerun - fail second test')} --debug`,
+      (err, stdout) => {
+        expect(stdout).toContain('Process run 1 of max 3, success runs 1/3')
+        expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3')
+        expect(stdout).toContain('Process run 3 of max 3, success runs 2/3')
+        expect(stdout).toContain('Flaky tests detected!')
+        expect(err.code).toBe(1)
+        done()
+      },
+    )
+  })
 })

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -96,18 +96,4 @@ describe('run-rerun command', () => {
       },
     )
   })
-
-  it('should throw exit code 1 if all tests were supposed to pass', (done) => {
-    exec(
-      `FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.pass_all_test.js', '@RunRerun - fail second test')} --debug`,
-      (err, stdout) => {
-        expect(stdout).toContain('Process run 1 of max 3, success runs 1/3')
-        expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3')
-        expect(stdout).toContain('Process run 3 of max 3, success runs 2/3')
-        expect(stdout).toContain('Flaky tests detected!')
-        expect(err.code).toBe(1)
-        done()
-      },
-    )
-  })
 })


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves

Our team observed that using `codeceptjs run-rerun` would only throw an exit code of `1` if the last test failed, making it difficult to reliably determine if a test in the suite actually was flaky. After some investigating, we determined that it's because the `catch` statement in `run-rerun.js` was never being called due to `rerun.js` never actually throwing the error. 

- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)