### PR TITLE
fix: uses chromium in testcafe tests

### DIFF
--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -44,10 +44,10 @@ const getHtmlSource = (t) =>
  * * `windowSize`: (optional) - set browser window width and height
  * * `getPageTimeout` (optional, default: '30000') config option to set maximum navigation time in milliseconds.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 5000.
- * * `browser`: (optional, default: chromium)  - See https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/browsers/browser-support.html
+ * * `browser`: (optional, default: chrome)  - See https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/browsers/browser-support.html
  *
  *
- * #### Example #1: Show chromium browser window
+ * #### Example #1: Show chrome browser window
  *
  * ```js
  * {
@@ -56,7 +56,7 @@ const getHtmlSource = (t) =>
  *        url: "http://localhost",
  *        waitForTimeout: 15000,
  *        show: true,
- *        browser: "chromium"
+ *        browser: "chrome"
  *      }
  *    }
  * }
@@ -108,7 +108,7 @@ class TestCafe extends Helper {
     this.options = {
       url: 'http://localhost',
       show: false,
-      browser: 'chromium',
+      browser: 'chrome',
       restart: true, // TODO Test if restart false works
       manualStart: false,
       keepBrowserState: false,
@@ -133,7 +133,7 @@ class TestCafe extends Helper {
   static _config() {
     return [
       { name: 'url', message: 'Base url of site to be tested', default: 'http://localhost' },
-      { name: 'browser', message: 'Browser to be used', default: 'chromium' },
+      { name: 'browser', message: 'Browser to be used', default: 'chrome' },
       {
         name: 'show',
         message: 'Show browser window',

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -44,10 +44,10 @@ const getHtmlSource = (t) =>
  * * `windowSize`: (optional) - set browser window width and height
  * * `getPageTimeout` (optional, default: '30000') config option to set maximum navigation time in milliseconds.
  * * `waitForTimeout`: (optional) default wait* timeout in ms. Default: 5000.
- * * `browser`: (optional, default: chrome)  - See https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/browsers/browser-support.html
+ * * `browser`: (optional, default: chromium)  - See https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/browsers/browser-support.html
  *
  *
- * #### Example #1: Show chrome browser window
+ * #### Example #1: Show chromium browser window
  *
  * ```js
  * {
@@ -56,7 +56,7 @@ const getHtmlSource = (t) =>
  *        url: "http://localhost",
  *        waitForTimeout: 15000,
  *        show: true,
- *        browser: "chrome"
+ *        browser: "chromium"
  *      }
  *    }
  * }
@@ -108,7 +108,7 @@ class TestCafe extends Helper {
     this.options = {
       url: 'http://localhost',
       show: false,
-      browser: 'chrome',
+      browser: 'chromium',
       restart: true, // TODO Test if restart false works
       manualStart: false,
       keepBrowserState: false,
@@ -133,7 +133,7 @@ class TestCafe extends Helper {
   static _config() {
     return [
       { name: 'url', message: 'Base url of site to be tested', default: 'http://localhost' },
-      { name: 'browser', message: 'Browser to be used', default: 'chrome' },
+      { name: 'browser', message: 'Browser to be used', default: 'chromium' },
       {
         name: 'show',
         message: 'Show browser window',

--- a/test/helper/TestCafe_test.js
+++ b/test/helper/TestCafe_test.js
@@ -22,7 +22,7 @@ describe('TestCafe', function () {
       url: siteUrl,
       windowSize: '1000x700',
       show: false,
-      browser: 'chrome',
+      browser: 'chromium',
       restart: false,
       waitForTimeout: 5000,
     })


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
