### PR TITLE
bump cross-spawn from 7.0.3 to 7.0.5 (#4550)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "chai-string": "1.5.0",
     "chalk": "4.1.2",
     "commander": "11.1.0",
-    "cross-spawn": "7.0.3",
+    "cross-spawn": "7.0.5",
     "css-to-xpath": "0.1.0",
     "csstoxpath": "1.6.0",
     "devtools": "8.40.2",


### PR DESCRIPTION
## Motivation/Description of the PR
- Raise cross-spawn from 7.0.3 to 7.0.5 due to security issues
- Resolves #4550 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
