### PR TITLE
Updated webdriverio from 8.39.1 to 9.2.12 and removed dep to devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "cross-spawn": "7.0.5",
     "css-to-xpath": "0.1.0",
     "csstoxpath": "1.6.0",
-    "devtools": "8.40.2",
     "envinfo": "7.14.0",
     "escape-string-regexp": "4.0.0",
     "figures": "3.2.0",
@@ -167,7 +166,7 @@
     "typedoc-plugin-markdown": "4.2.10",
     "typescript": "5.6.3",
     "wdio-docker-service": "1.5.0",
-    "webdriverio": "8.39.1",
+    "webdriverio": "9.2.12",
     "xml2js": "0.6.2",
     "xpath": "0.0.34"
   },


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
