### PR TITLE
Bump wdio/sauce-service from 9.2.8 to 9.2.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/chai": "4.3.19",
     "@types/inquirer": "9.0.3",
     "@types/node": "22.5.5",
-    "@wdio/sauce-service": "9.2.8",
+    "@wdio/sauce-service": "9.2.13",
     "@wdio/selenium-standalone-service": "8.3.2",
     "@wdio/utils": "9.2.8",
     "@xmldom/xmldom": "0.9.4",


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump wdio/sauce-service from 9.2.8 to 9.2.13 to remove security issues
- Resolves #4569 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
