### PR TITLE
Bump apollo-server-express from 2.x to 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
     ignore:
       - dependency-name: "escape-string-regexp"
         versions: [">=5.0"]
-      - dependency-name: "apollo-server-express"
-        versions: [">=3.0"]
       - dependency-name: "eslint"
         versions: [ ">8.57.0" ]
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@wdio/selenium-standalone-service": "8.3.2",
     "@wdio/utils": "9.2.8",
     "@xmldom/xmldom": "0.9.4",
-    "apollo-server-express": "2.25.3",
+    "apollo-server-express": "3.13.0",
     "chai-as-promised": "7.1.2",
     "chai-subset": "1.6.0",
     "cheerio": "^1.0.0",

--- a/test/data/graphql/index.js
+++ b/test/data/graphql/index.js
@@ -17,8 +17,9 @@ const server = new ApolloServer({
   playground: true,
 });
 
-server.applyMiddleware({ app });
-
-app.use(middleware);
-app.use(router);
-module.exports = app.listen(PORT, () => console.log(`test graphQL server listening on port ${PORT}...`));
+server.start().then(res => {
+  server.applyMiddleware({ app });
+  app.use(middleware);
+  app.use(router);
+  module.exports = app.listen(PORT, () => console.log(`test graphQL server listening on port ${PORT}...`));
+})

--- a/test/data/graphql/index.js
+++ b/test/data/graphql/index.js
@@ -17,9 +17,9 @@ const server = new ApolloServer({
   playground: true,
 });
 
-server.start().then(res => {
+server.start().then(() => {
   server.applyMiddleware({ app });
   app.use(middleware);
   app.use(router);
   module.exports = app.listen(PORT, () => console.log(`test graphQL server listening on port ${PORT}...`));
-})
+});


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump Apollo-server-express from 2.x to 3.x, remove security issues and make script work again
- Resolves #4578

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
