### PR TITLE
Replace deprecated faker.name with faker.person

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -211,7 +211,7 @@ var Factory = require('rosie').Factory;
 var faker = require('@faker-js/faker');
 
 module.exports = new Factory()
-  .attr('name', () => faker.name.findName())
+  .attr('name', () => faker.person.findName())
   .attr('email', () => faker.internet.email());
 ```
 
@@ -271,7 +271,7 @@ module.exports = new Factory((buildObj) => {
     input: { ...buildObj },
   }
 })
-  .attr('name', () => faker.name.findName())
+  .attr('name', () => faker.person.findName())
   .attr('email', () => faker.internet.email());
 ```
 

--- a/docs/helpers/ApiDataFactory.md
+++ b/docs/helpers/ApiDataFactory.md
@@ -58,7 +58,7 @@ const { faker } = require('@faker-js/faker');
 
 module.exports = new Factory()
    // no need to set id, it will be set by REST API
-   .attr('author', () => faker.name.findName())
+   .attr('author', () => faker.person.findName())
    .attr('title', () => faker.lorem.sentence())
    .attr('body', () => faker.lorem.paragraph());
 ```

--- a/docs/helpers/GraphQLDataFactory.md
+++ b/docs/helpers/GraphQLDataFactory.md
@@ -62,7 +62,7 @@ module.exports = new Factory((buildObj) => ({
    input: { ...buildObj },
 }))
    // 'attr'-id can be left out depending on the GraphQl resolvers
-   .attr('name', () => faker.name.findName())
+   .attr('name', () => faker.person.findName())
    .attr('email', () => faker.interact.email())
 ```
 

--- a/lib/helper/ApiDataFactory.js
+++ b/lib/helper/ApiDataFactory.js
@@ -51,7 +51,7 @@ const REST = require('./REST')
  *
  * module.exports = new Factory()
  *    // no need to set id, it will be set by REST API
- *    .attr('author', () => faker.name.findName())
+ *    .attr('author', () => faker.person.findName())
  *    .attr('title', () => faker.lorem.sentence())
  *    .attr('body', () => faker.lorem.paragraph());
  * ```

--- a/lib/helper/GraphQLDataFactory.js
+++ b/lib/helper/GraphQLDataFactory.js
@@ -55,7 +55,7 @@ const GraphQL = require('./GraphQL')
  *    input: { ...buildObj },
  * }))
  *    // 'attr'-id can be left out depending on the GraphQl resolvers
- *    .attr('name', () => faker.name.findName())
+ *    .attr('name', () => faker.person.findName())
  *    .attr('email', () => faker.interact.email())
  * ```
  * For more options see [rosie documentation](https://github.com/rosiejs/rosie).

--- a/test/data/graphql/users_factory.js
+++ b/test/data/graphql/users_factory.js
@@ -4,5 +4,5 @@ const { faker } = require('@faker-js/faker');
 module.exports = new Factory(function (buildObject) {
   this.input = { ...buildObject };
 })
-  .attr('name', () => faker.name.fullName())
+  .attr('name', () => faker.person.fullName())
   .attr('email', () => faker.internet.email());

--- a/test/data/rest/posts_factory.js
+++ b/test/data/rest/posts_factory.js
@@ -2,6 +2,6 @@ const { Factory } = require('rosie');
 const { faker } = require('@faker-js/faker');
 
 module.exports = new Factory()
-  .attr('author', () => faker.name.fullName())
+  .attr('author', () => faker.person.fullName())
   .attr('title', () => faker.lorem.sentence())
   .attr('body', () => faker.lorem.paragraph());


### PR DESCRIPTION
## Motivation/Description of the PR
- Replace deprecated faker.name with faker.person
- Resolves #4580

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
