### PR TITLE
Bump json-server to version 0.17.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": "Codeception/codeceptjs",
   "scripts": {
-    "json-server": "./node_modules/json-server/bin/index.js test/data/rest/db.json -p 8010 --watch -m test/data/rest/headers.js",
+    "json-server": "json-server test/data/rest/db.json -p 8010 --watch -m test/data/rest/headers.js",
     "json-server:graphql": "node test/data/graphql/index.js",
     "lint": "eslint bin/ examples/ lib/ test/ translations/ runok.js",
     "lint-fix": "eslint bin/ examples/ lib/ test/ translations/ runok.js --fix",
@@ -146,7 +146,7 @@
     "inquirer-test": "2.0.1",
     "jsdoc": "4.0.4",
     "jsdoc-typeof-plugin": "1.0.0",
-    "json-server": "0.10.1",
+    "json-server": "0.17.4",
     "playwright": "1.48.2",
     "prettier": "^3.3.2",
     "puppeteer": "23.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": "Codeception/codeceptjs",
   "scripts": {
-    "json-server": "json-server test/data/rest/db.json -p 8010 --watch -m test/data/rest/headers.js",
+    "json-server": "json-server test/data/rest/db.json --host 0.0.0.0 -p 8010 --watch -m test/data/rest/headers.js",
     "json-server:graphql": "node test/data/graphql/index.js",
     "lint": "eslint bin/ examples/ lib/ test/ translations/ runok.js",
     "lint-fix": "eslint bin/ examples/ lib/ test/ translations/ runok.js --fix",


### PR DESCRIPTION
## Motivation/Description of the PR
- Update json-server to more recent version to get rid of security issues
- Resolves #4576 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
