### PR TITLE
Added hint that "I.seeEmailAttachment" treats parameter as regular expression

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -156,8 +156,8 @@ I.seeEmailIsFrom('@mysite.com');
 I.seeInEmailSubject('Awesome Proposal!');
 I.seeInEmailBody('To unsubscribe click here');
 I.seeNumberOfEmailAttachments(2);
-I.seeEmailAttachment('Attachment_1.pdf')
-I.seeEmailAttachment('Attachment_2.pdf')
+I.seeEmailAttachment('Attachment_1.pdf'); // Regular expression. Escape special characters like '(' or ')' in filename.
+I.seeEmailAttachment('Attachment_2.pdf');
 ```
 
 > More methods are listed in [helper's API reference](https://github.com/codeceptjs/mailslurp-helper/blob/master/README.md#api)


### PR DESCRIPTION
## Motivation/Description of the PR
- Add hint to "I.seeEmailAttachment" that under the hood parameter is treated as RegExp. When you don't know it, it can cause a lot of pain, wondering why your test fails with `I.seeEmailAttachment('Attachment(1).pdf')` although it looks just fine, but actually  `I.seeEmailAttachment('Attachment\\(1\\).pdf` is required to make the test green, in case the attachment is called "Attachment(1).pdf" with special character in it.

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ x ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
