### PR TITLE
feat: mask sensitive data in logs

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -92,6 +92,9 @@ class Codecept {
 
       // debug mode
       global.debugMode = false;
+
+      // mask sensitive data
+      global.maskSensitiveData = this.config.maskSensitiveData || false;
     }
   }
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,5 +1,6 @@
 const colors = require('chalk');
 const figures = require('figures');
+const { maskSensitiveData } = require('invisi-data')
 
 const styles = {
   error: colors.bgRed.white.bold,
@@ -57,8 +58,9 @@ module.exports = {
    * @param {string} msg
    */
   debug(msg) {
+    const _msg = isMaskedData() ? maskSensitiveData(msg) : msg
     if (outputLevel >= 2) {
-      print(' '.repeat(this.stepShift), styles.debug(`${figures.pointerSmall} ${msg}`));
+      print(' '.repeat(this.stepShift), styles.debug(`${figures.pointerSmall} ${_msg}`));
     }
   },
 
@@ -67,8 +69,9 @@ module.exports = {
    * @param {string} msg
    */
   log(msg) {
+    const _msg = isMaskedData() ? maskSensitiveData(msg) : msg
     if (outputLevel >= 3) {
-      print(' '.repeat(this.stepShift), styles.log(truncate(`   ${msg}`, this.spaceShift)));
+      print(' '.repeat(this.stepShift), styles.log(truncate(`   ${_msg}`, this.spaceShift)));
     }
   },
 
@@ -120,7 +123,8 @@ module.exports = {
       stepLine += colors.grey(step.comment.split('\n').join('\n' + ' '.repeat(4)));
     }
 
-    print(' '.repeat(this.stepShift), truncate(stepLine, this.spaceShift));
+    const _stepLine = isMaskedData() ? maskSensitiveData(stepLine) : stepLine
+    print(' '.repeat(this.stepShift), truncate(_stepLine, this.spaceShift));
   },
 
   /** @namespace */
@@ -167,7 +171,7 @@ module.exports = {
   scenario: {
     /**
      * @param {Mocha.Test} test
-    */
+     */
 
     started(test) {},
 
@@ -253,4 +257,8 @@ function truncate(msg, gap = 0) {
     msg = msg.substr(0, width - 1) + figures.ellipsis;
   }
   return msg;
+}
+
+function isMaskedData() {
+  return global.maskSensitiveData === true || false
 }

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "graphql": "16.9.0",
     "husky": "9.1.7",
     "inquirer-test": "2.0.1",
+    "invisi-data": "^1.0.0",
     "jsdoc": "4.0.4",
     "jsdoc-typeof-plugin": "1.0.0",
     "json-server": "0.17.4",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -115,6 +115,14 @@ declare namespace CodeceptJS {
      */
     emptyOutputFolder?: boolean;
     /**
+     * mask sensitive data in output logs
+     *
+     * ```js
+     * maskSensitiveData: true
+     * ```
+     */
+    maskSensitiveData?: boolean;
+    /**
      * Pattern to filter tests by name.
      * This option is useful if you plan to use multiple configs for different environments.
      *


### PR DESCRIPTION
## Motivation/Description of the PR
- add this to config to mask sensitive data

```
export const config: CodeceptJS.MainConfig = {
  tests:  '**/*.e2e.test.ts',
  retry: 4,
  output: './output',
  maskSensitiveData: true,
  emptyOutputFolder: true,
...

    I login {"username":"helloworld@test.com","password": "****"}
      I send post request "https://localhost:8000/login", {"username":"helloworld@test.com","password": "****"}
      › [Request] {"baseURL":"https://localhost:8000/login","method":"POST","data":{"username":"helloworld@test.com","password": "****"},"headers":{}}
      › [Response] {"access-token": "****"}
```

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
