### PR TITLE
fix(cli): missing failure counts when there is failedHooks

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -219,7 +219,6 @@ class Cli extends Base {
 
     this.failures.forEach((failure) => {
       if (failure.constructor.name === 'Hook') {
-        stats.failures -= stats.failures
         stats.failedHooks += 1
       }
     })

--- a/test/runner/before_failure_test.js
+++ b/test/runner/before_failure_test.js
@@ -12,7 +12,7 @@ describe('Failure in before', function () {
       stdout.should.include('First test will be passed @grep')
       stdout.should.include('Third test will be skipped @grep')
       stdout.should.include('Fourth test will be skipped')
-      stdout.should.include('1 passed, 1 failedHooks, 2 skipped')
+      stdout.should.include('1 passed, 1 failed, 1 failedHooks, 2 skipped')
       err.code.should.eql(1)
       done()
     })
@@ -22,7 +22,7 @@ describe('Failure in before', function () {
     exec(`${codecept_run} --grep @grep`, (err, stdout) => {
       stdout.should.include('First test will be passed @grep')
       stdout.should.include('Third test will be skipped @grep')
-      stdout.should.include('1 passed, 1 failedHooks, 1 skipped')
+      stdout.should.include('1 passed, 1 failed, 1 failedHooks, 1 skipped')
       err.code.should.eql(1)
       done()
     })

--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -44,7 +44,8 @@ describe('CodeceptJS Workers Runner', function () {
       expect(stdout).not.toContain('this is running inside worker')
       expect(stdout).toContain('failed')
       expect(stdout).toContain('File notafile not found')
-      expect(stdout).toContain('5 passed, 1 failed, 1 failedHooks')
+      expect(stdout).toContain('Scenario Steps:')
+      expect(stdout).toContain('5 passed, 2 failed, 1 failedHooks')
       // We are not testing order in logs, because it depends on race condition between workers
       expect(stdout).toContain(') Workers Failing\n') // first fail log
       expect(stdout).toContain(') Workers\n') // second fail log


### PR DESCRIPTION
## Motivation/Description of the PR
- Failure count is wrong calculated when there is failed hook.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
