### PR TITLE
release 3.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.6.10
+
+❤️ Thanks all to those who contributed to make this release! ❤️
+
+🐛 *Bug Fixes*
+fix(cli): missing failure counts when there is failedHooks (#4633) - by @kobenguyent
+
+## 3.6.9
+
+❤️ Thanks all to those who contributed to make this release! ❤️
+
+🐛 *Hot Fixes*
+fix: could not run tests due to missing `invisi-data` lib - by @kobenguyent
+
 ## 3.6.8
 
 ❤️ Thanks all to those who contributed to make this release! ❤️

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs",
-  "version": "3.6.9",
+  "version": "3.6.10",
   "description": "Supercharged End 2 End Testing Framework for NodeJS",
   "keywords": [
     "acceptance",


### PR DESCRIPTION
## 3.6.10

❤️ Thanks all to those who contributed to make this release! ❤️

🐛 *Bug Fixes*
fix(cli): missing failure counts when there is failedHooks (#4633) - by @kobenguyent

## 3.6.9

❤️ Thanks all to those who contributed to make this release! ❤️

🐛 *Hot Fixes*
fix: could not run tests due to missing `invisi-data` lib - by @kobenguyent