### PR TITLE
Bump monocart-coverage-reports to 2.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "lodash.merge": "4.6.2",
     "mkdirp": "1.0.4",
     "mocha": "11.0.2",
-    "monocart-coverage-reports": "2.11.3",
+    "monocart-coverage-reports": "2.11.5",
     "ms": "2.1.3",
     "ora-classic": "5.4.2",
     "parse-function": "5.6.10",


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump monocart-coverage-reports to 2.11.5
- Resolves #4674 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
