### PR TITLE
Bump sprintf-js to 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "parse5": "7.2.1",
     "promise-retry": "1.1.1",
     "resq": "1.11.0",
-    "sprintf-js": "1.1.1",
+    "sprintf-js": "1.1.3",
     "uuid": "11.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "parse5": "7.2.1",
     "promise-retry": "1.1.1",
     "resq": "1.11.0",
-    "sprintf-js": "1.1.2",
+    "sprintf-js": "1.1.3",
     "uuid": "11.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "parse5": "7.2.1",
     "promise-retry": "1.1.1",
     "resq": "1.11.0",
-    "sprintf-js": "1.1.3",
+    "sprintf-js": "1.1.2",
     "uuid": "11.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump sprintf-js to 1.1.3
- Resolves #4689 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
