### PR TITLE
fix: error thrown when element text is an empty string

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -32,7 +32,7 @@ const commandFlags = {
 }
 
 const errorHandler =
-  (fn) =>
+  fn =>
   async (...args) => {
     try {
       await fn(...args)
@@ -286,7 +286,7 @@ program
 
   .action(require('../lib/command/run-rerun'))
 
-program.on('command:*', (cmd) => {
+program.on('command:*', cmd => {
   console.log(`\nUnknown command ${cmd}\n`)
   program.outputHelp()
 })

--- a/lib/assert/empty.js
+++ b/lib/assert/empty.js
@@ -5,7 +5,7 @@ const output = require('../output')
 
 class EmptinessAssertion extends Assertion {
   constructor(params) {
-    super((value) => {
+    super(value => {
       if (Array.isArray(value)) {
         return value.length === 0
       }
@@ -22,9 +22,7 @@ class EmptinessAssertion extends Assertion {
     const err = new AssertionFailedError(this.params, "{{customMessage}}expected {{subject}} '{{value}}' {{type}}")
 
     err.cliMessage = () => {
-      const msg = err.template
-        .replace('{{value}}', output.colors.bold('{{value}}'))
-        .replace('{{subject}}', output.colors.bold('{{subject}}'))
+      const msg = err.template.replace('{{value}}', output.colors.bold('{{value}}')).replace('{{subject}}', output.colors.bold('{{subject}}'))
       return template(msg, this.params)
     }
     return err
@@ -39,5 +37,5 @@ class EmptinessAssertion extends Assertion {
 
 module.exports = {
   Assertion: EmptinessAssertion,
-  empty: (subject) => new EmptinessAssertion({ subject }),
+  empty: subject => new EmptinessAssertion({ subject }),
 }

--- a/lib/assert/equal.js
+++ b/lib/assert/equal.js
@@ -18,10 +18,7 @@ class EqualityAssertion extends Assertion {
   getException() {
     const params = this.params
     params.jar = template(params.jar, params)
-    const err = new AssertionFailedError(
-      params,
-      '{{customMessage}}expected {{jar}} "{{expected}}" {{type}} "{{actual}}"',
-    )
+    const err = new AssertionFailedError(params, '{{customMessage}}expected {{jar}} "{{expected}}" {{type}} "{{actual}}"')
     err.showDiff = false
     if (typeof err.cliMessage === 'function') {
       err.message = err.cliMessage()
@@ -42,8 +39,8 @@ class EqualityAssertion extends Assertion {
 
 module.exports = {
   Assertion: EqualityAssertion,
-  equals: (jar) => new EqualityAssertion({ jar }),
-  urlEquals: (baseUrl) => {
+  equals: jar => new EqualityAssertion({ jar }),
+  urlEquals: baseUrl => {
     const assert = new EqualityAssertion({ jar: 'url of current page' })
     assert.comparator = function (expected, actual) {
       if (expected.indexOf('http') !== 0) {
@@ -53,5 +50,5 @@ module.exports = {
     }
     return assert
   },
-  fileEquals: (file) => new EqualityAssertion({ file, jar: 'contents of {{file}}' }),
+  fileEquals: file => new EqualityAssertion({ file, jar: 'contents of {{file}}' }),
 }

--- a/lib/assert/include.js
+++ b/lib/assert/include.js
@@ -10,7 +10,7 @@ class InclusionAssertion extends Assertion {
     params.jar = params.jar || 'string'
     const comparator = function (needle, haystack) {
       if (Array.isArray(haystack)) {
-        return haystack.filter((part) => part.indexOf(needle) >= 0).length > 0
+        return haystack.filter(part => part.indexOf(needle) >= 0).length > 0
       }
       return haystack.indexOf(needle) >= 0
     }
@@ -28,9 +28,7 @@ class InclusionAssertion extends Assertion {
       this.params.haystack = this.params.haystack.join('\n___(next element)___\n')
     }
     err.cliMessage = function () {
-      const msg = this.template
-        .replace('{{jar}}', output.colors.bold('{{jar}}'))
-        .replace('{{needle}}', output.colors.bold('{{needle}}'))
+      const msg = this.template.replace('{{jar}}', output.colors.bold('{{jar}}')).replace('{{needle}}', output.colors.bold('{{needle}}'))
       return template(msg, this.params)
     }
     return err
@@ -66,11 +64,11 @@ class InclusionAssertion extends Assertion {
 
 module.exports = {
   Assertion: InclusionAssertion,
-  includes: (needleType) => {
+  includes: needleType => {
     needleType = needleType || 'string'
     return new InclusionAssertion({ jar: needleType })
   },
-  fileIncludes: (file) => new InclusionAssertion({ file, jar: 'file {{file}}' }),
+  fileIncludes: file => new InclusionAssertion({ file, jar: 'file {{file}}' }),
 }
 
 function escapeRegExp(str) {

--- a/lib/assert/throws.js
+++ b/lib/assert/throws.js
@@ -11,10 +11,8 @@ function errorThrown(actual, expected) {
     throw new Error(`Expected error to be thrown with message ${expected} while '${msg}' caught`)
   }
   if (typeof expected === 'object') {
-    if (actual.constructor.name !== expected.constructor.name)
-      throw new Error(`Expected ${expected} error to be thrown but ${actual} was caught`)
-    if (expected.message && expected.message !== msg)
-      throw new Error(`Expected error to be thrown with message ${expected.message} while '${msg}' caught`)
+    if (actual.constructor.name !== expected.constructor.name) throw new Error(`Expected ${expected} error to be thrown but ${actual} was caught`)
+    if (expected.message && expected.message !== msg) throw new Error(`Expected error to be thrown with message ${expected.message} while '${msg}' caught`)
   }
   return null
 }

--- a/lib/assert/truth.js
+++ b/lib/assert/truth.js
@@ -5,9 +5,9 @@ const output = require('../output')
 
 class TruthAssertion extends Assertion {
   constructor(params) {
-    super((value) => {
+    super(value => {
       if (Array.isArray(value)) {
-        return value.filter((val) => !!val).length > 0
+        return value.filter(val => !!val).length > 0
       }
       return !!value
     }, params)

--- a/lib/command/configMigrate.js
+++ b/lib/command/configMigrate.js
@@ -14,9 +14,7 @@ module.exports = function (initPath) {
 
   print()
   print(`  Welcome to ${colors.magenta.bold('CodeceptJS')} configuration migration tool`)
-  print(
-    `  It will help you switch from ${colors.cyan.bold('.json')} to ${colors.magenta.bold('.js')} config format at ease`,
-  )
+  print(`  It will help you switch from ${colors.cyan.bold('.json')} to ${colors.magenta.bold('.js')} config format at ease`)
   print()
 
   if (!path) {
@@ -53,7 +51,7 @@ module.exports = function (initPath) {
         default: true,
       },
     ])
-    .then((result) => {
+    .then(result => {
       if (result.configFile) {
         const jsonConfigFile = path.join(testsPath, 'codecept.js')
         const config = JSON.parse(fs.readFileSync(jsonConfigFile, 'utf8'))

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -21,14 +21,7 @@ const actingHelpers = [...require('../plugin/standardActingHelpers'), 'REST']
  *
  * @returns {string}
  */
-const getDefinitionsFileContent = ({
-  hasCustomHelper,
-  hasCustomStepsFile,
-  helperNames,
-  supportObject,
-  importPaths,
-  translations,
-}) => {
+const getDefinitionsFileContent = ({ hasCustomHelper, hasCustomStepsFile, helperNames, supportObject, importPaths, translations }) => {
   const getHelperListFragment = ({ hasCustomHelper, hasCustomStepsFile }) => {
     if (hasCustomHelper && hasCustomStepsFile) {
       return `${['ReturnType<steps_file>', 'WithTranslation<Methods>'].join(', ')}`
@@ -73,13 +66,7 @@ const getDefinitionsFileContent = ({
  *
  * @returns {string}
  */
-const generateDefinitionsContent = ({
-  importPathsFragment,
-  supportObjectsTypeFragment,
-  methodsTypeFragment,
-  helpersListFragment,
-  translatedActionsFragment,
-}) => {
+const generateDefinitionsContent = ({ importPathsFragment, supportObjectsTypeFragment, methodsTypeFragment, helpersListFragment, translatedActionsFragment }) => {
   return `/// <reference types='codeceptjs' />
 ${importPathsFragment}
 
@@ -185,15 +172,12 @@ module.exports = function (genPath, options) {
     namespaceTranslationAliases.push(`interface ${translations.vocabulary.I} extends WithTranslation<Methods> {}`)
 
     namespaceTranslationAliases.push('  namespace Translation {')
-    definitionsFileContent = definitionsFileContent.replace(
-      'namespace Translation {',
-      namespaceTranslationAliases.join('\n'),
-    )
+    definitionsFileContent = definitionsFileContent.replace('namespace Translation {', namespaceTranslationAliases.join('\n'))
 
     const translationAliases = []
 
     if (translations.vocabulary.contexts) {
-      Object.keys(translations.vocabulary.contexts).forEach((k) => {
+      Object.keys(translations.vocabulary.contexts).forEach(k => {
         translationAliases.push(`declare const ${translations.vocabulary.contexts[k]}: typeof ${k};`)
       })
     }
@@ -222,11 +206,7 @@ function getPath(originalPath, targetFolderPath, testsPath) {
   if (!parsedPath.dir.startsWith('.')) return path.posix.join(parsedPath.dir, parsedPath.base)
   const relativePath = path.posix.relative(
     targetFolderPath.split(path.sep).join(path.posix.sep),
-    path.posix.join(
-      testsPath.split(path.sep).join(path.posix.sep),
-      parsedPath.dir.split(path.sep).join(path.posix.sep),
-      parsedPath.base.split(path.sep).join(path.posix.sep),
-    ),
+    path.posix.join(testsPath.split(path.sep).join(path.posix.sep), parsedPath.dir.split(path.sep).join(path.posix.sep), parsedPath.base.split(path.sep).join(path.posix.sep)),
   )
 
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`

--- a/lib/command/generate.js
+++ b/lib/command/generate.js
@@ -35,7 +35,7 @@ module.exports.test = function (genPath) {
         type: 'input',
         name: 'feature',
         message: 'Feature which is being tested (ex: account, login, etc)',
-        validate: (val) => !!val,
+        validate: val => !!val,
       },
       {
         type: 'input',
@@ -46,7 +46,7 @@ module.exports.test = function (genPath) {
         },
       },
     ])
-    .then((result) => {
+    .then(result => {
       const testFilePath = path.dirname(path.join(testsPath, config.tests)).replace(/\*\*$/, '')
       let testFile = path.join(testFilePath, result.filename)
       const ext = path.extname(testFile)
@@ -63,9 +63,7 @@ module.exports.test = function (genPath) {
         testContent = testContent.replace('{{actor}}', container.translation().I)
         if (vocabulary.contexts.Feature) testContent = testContent.replace('Feature', vocabulary.contexts.Feature)
         if (vocabulary.contexts.Scenario) testContent = testContent.replace('Scenario', vocabulary.contexts.Scenario)
-        output.print(
-          `Test was created in ${colors.bold(config.translation)} localization. See: https://codecept.io/translation/`,
-        )
+        output.print(`Test was created in ${colors.bold(config.translation)} localization. See: https://codecept.io/translation/`)
       } else {
         testContent = testContent.replace('{{actor}}', 'I')
       }
@@ -128,13 +126,13 @@ module.exports.pageObject = function (genPath, opts) {
         type: 'input',
         name: 'name',
         message: `Name of a ${kind} object`,
-        validate: (val) => !!val,
+        validate: val => !!val,
       },
       {
         type: 'input',
         name: 'filename',
         message: 'Where should it be stored',
-        default: (answers) => `./${kind}s/${answers.name}.${extension}`,
+        default: answers => `./${kind}s/${answers.name}.${extension}`,
       },
       {
         type: 'list',
@@ -144,7 +142,7 @@ module.exports.pageObject = function (genPath, opts) {
         default: 'module',
       },
     ])
-    .then((result) => {
+    .then(result => {
       const pageObjectFile = path.join(testsPath, result.filename)
       const dir = path.dirname(pageObjectFile)
       if (!fileExists(dir)) fs.mkdirSync(dir)
@@ -194,9 +192,7 @@ module.exports.pageObject = function (genPath, opts) {
       try {
         generateDefinitions(testsPath, {})
       } catch (_err) {
-        output.print(
-          `Run ${colors.green('npx codeceptjs def')} to update your types to get auto-completion for object.`,
-        )
+        output.print(`Run ${colors.green('npx codeceptjs def')} to update your types to get auto-completion for object.`)
       }
     })
 }
@@ -241,16 +237,16 @@ module.exports.helper = function (genPath) {
         type: 'input',
         name: 'name',
         message: 'Name of a Helper',
-        validate: (val) => !!val,
+        validate: val => !!val,
       },
       {
         type: 'input',
         name: 'filename',
         message: 'Where should it be stored',
-        default: (answers) => `./${answers.name.toLowerCase()}_helper.${extension}`,
+        default: answers => `./${answers.name.toLowerCase()}_helper.${extension}`,
       },
     ])
-    .then((result) => {
+    .then(result => {
       const name = ucfirst(result.name)
       const helperFile = path.join(testsPath, result.filename)
       const dir = path.dirname(helperFile)

--- a/lib/command/info.js
+++ b/lib/command/info.js
@@ -34,9 +34,7 @@ module.exports = async function (path) {
   output.print('***************************************')
   output.print('If you have questions ask them in our Slack: http://bit.ly/chat-codeceptjs')
   output.print('Or ask them on our discussion board: https://codecept.discourse.group/')
-  output.print(
-    'Please copy environment info when you report issues on GitHub: https://github.com/Codeception/CodeceptJS/issues',
-  )
+  output.print('Please copy environment info when you report issues on GitHub: https://github.com/Codeception/CodeceptJS/issues')
   output.print('***************************************')
 }
 

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -117,7 +117,7 @@ module.exports = function (initPath) {
       {
         name: 'tests',
         type: 'input',
-        default: (answers) => `./*_test.${answers.typescript ? 'ts' : 'js'}`,
+        default: answers => `./*_test.${answers.typescript ? 'ts' : 'js'}`,
         message: 'Where are your tests located?',
       },
       {
@@ -132,7 +132,7 @@ module.exports = function (initPath) {
         type: 'confirm',
         default: true,
         message: 'Do you want to use JSONResponse helper for assertions on JSON responses? http://bit.ly/3ASVPy9',
-        when: (answers) => ['GraphQL', 'REST'].includes(answers.helper) === true,
+        when: answers => ['GraphQL', 'REST'].includes(answers.helper) === true,
       },
       {
         name: 'output',
@@ -146,7 +146,7 @@ module.exports = function (initPath) {
         choices: translations,
       },
     ])
-    .then((result) => {
+    .then(result => {
       if (result.typescript === true) {
         isTypeScript = true
         extension = isTypeScript === true ? 'ts' : 'js'
@@ -189,7 +189,7 @@ module.exports = function (initPath) {
 
         if (!Helper._config()) return
         helperConfigs = helperConfigs.concat(
-          Helper._config().map((config) => {
+          Helper._config().map(config => {
             config.message = `[${helperName}] ${config.message}`
             config.name = `${helperName}_${config.name}`
             config.type = config.type || 'input'
@@ -225,9 +225,7 @@ module.exports = function (initPath) {
           fs.writeFileSync(typeScriptconfigFile, configSource, 'utf-8')
           print(`Config created at ${typeScriptconfigFile}`)
         } else {
-          configSource = beautify(
-            `/** @type {CodeceptJS.MainConfig} */\nexports.config = ${inspect(config, false, 4, false)}`,
-          )
+          configSource = beautify(`/** @type {CodeceptJS.MainConfig} */\nexports.config = ${inspect(config, false, 4, false)}`)
 
           if (hasConfigure) configSource = requireCodeceptConfigure + configHeader + configSource
 
@@ -286,9 +284,7 @@ module.exports = function (initPath) {
           }
         }
 
-        const generateDefinitionsManually = colors.bold(
-          `To get auto-completion support, please generate type definitions: ${colors.green('npx codeceptjs def')}`,
-        )
+        const generateDefinitionsManually = colors.bold(`To get auto-completion support, please generate type definitions: ${colors.green('npx codeceptjs def')}`)
 
         if (packages) {
           try {
@@ -330,7 +326,7 @@ module.exports = function (initPath) {
       }
 
       print('Configure helpers...')
-      inquirer.prompt(helperConfigs).then(async (helperResult) => {
+      inquirer.prompt(helperConfigs).then(async helperResult => {
         if (helperResult.Playwright_browser === 'electron') {
           delete helperResult.Playwright_url
           delete helperResult.Playwright_show
@@ -341,7 +337,7 @@ module.exports = function (initPath) {
           }
         }
 
-        Object.keys(helperResult).forEach((key) => {
+        Object.keys(helperResult).forEach(key => {
           const parts = key.split('_')
           const helperName = parts[0]
           const configName = parts[1]

--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -39,7 +39,7 @@ module.exports = async function (path, options) {
       if (webHelpers.includes(helperName)) {
         const I = enabledHelpers[helperName]
         recorder.add(() => I.amOnPage('/'))
-        recorder.catchWithoutStop((e) => output.print(`Error while loading home page: ${e.message}}`))
+        recorder.catchWithoutStop(e => output.print(`Error while loading home page: ${e.message}}`))
         break
       }
     }

--- a/lib/command/list.js
+++ b/lib/command/list.js
@@ -17,7 +17,7 @@ module.exports = function (path) {
   const actions = []
   for (const name in helpers) {
     const helper = helpers[name]
-    methodsOfObject(helper).forEach((action) => {
+    methodsOfObject(helper).forEach(action => {
       const params = getParamsToString(helper[action])
       actions[action] = 1
       output.print(` ${output.colors.grey(name)} I.${output.colors.bold(action)}(${params})`)

--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -11,20 +11,7 @@ const { getConfig, getTestRoot, fail } = require('./utils')
 const runner = path.join(__dirname, '/../../bin/codecept')
 let config
 const childOpts = {}
-const copyOptions = [
-  'override',
-  'steps',
-  'reporter',
-  'verbose',
-  'config',
-  'reporter-options',
-  'grep',
-  'fgrep',
-  'invert',
-  'debug',
-  'plugins',
-  'colors',
-]
+const copyOptions = ['override', 'steps', 'reporter', 'verbose', 'config', 'reporter-options', 'grep', 'fgrep', 'invert', 'debug', 'plugins', 'colors']
 let overrides = {}
 
 // codeceptjs run-multiple smoke:chrome regression:firefox - will launch smoke run in chrome and regression in firefox
@@ -49,8 +36,8 @@ module.exports = async function (selectedRuns, options) {
 
   // copy opts to run
   Object.keys(options)
-    .filter((key) => copyOptions.indexOf(key) > -1)
-    .forEach((key) => {
+    .filter(key => copyOptions.indexOf(key) > -1)
+    .forEach(key => {
       childOpts[key] = options[key]
     })
 
@@ -96,12 +83,12 @@ module.exports = async function (selectedRuns, options) {
     config.gherkin.features = ''
   }
 
-  const childProcessesPromise = new Promise((resolve) => {
+  const childProcessesPromise = new Promise(resolve => {
     processesDone = resolve
   })
 
   const runsToExecute = []
-  collection.createRuns(selectedRuns, config).forEach((run) => {
+  collection.createRuns(selectedRuns, config).forEach(run => {
     const runName = run.getOriginalName() || run.getName()
     const runConfig = run.getConfig()
     runsToExecute.push(executeRun(runName, runConfig))
@@ -113,7 +100,7 @@ module.exports = async function (selectedRuns, options) {
 
   // Execute all forks
   totalSubprocessCount = runsToExecute.length
-  runsToExecute.forEach((runToExecute) => runToExecute.call(this))
+  runsToExecute.forEach(runToExecute => runToExecute.call(this))
 
   return childProcessesPromise.then(async () => {
     // fire hook
@@ -149,11 +136,7 @@ function executeRun(runName, runConfig) {
   // tweaking default output directories and for mochawesome
   overriddenConfig = replaceValueDeep(overriddenConfig, 'output', path.join(config.output, outputDir))
   overriddenConfig = replaceValueDeep(overriddenConfig, 'reportDir', path.join(config.output, outputDir))
-  overriddenConfig = replaceValueDeep(
-    overriddenConfig,
-    'mochaFile',
-    path.join(config.output, outputDir, `${browserName}_report.xml`),
-  )
+  overriddenConfig = replaceValueDeep(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, `${browserName}_report.xml`))
 
   // override tests configuration
   if (overriddenConfig.tests) {
@@ -165,15 +148,9 @@ function executeRun(runName, runConfig) {
   }
 
   // override grep param and collect all params
-  const params = [
-    'run',
-    '--child',
-    `${runId++}.${runName}:${browserName}`,
-    '--override',
-    JSON.stringify(overriddenConfig),
-  ]
+  const params = ['run', '--child', `${runId++}.${runName}:${browserName}`, '--override', JSON.stringify(overriddenConfig)]
 
-  Object.keys(childOpts).forEach((key) => {
+  Object.keys(childOpts).forEach(key => {
     params.push(`--${key}`)
     if (childOpts[key] !== true) params.push(childOpts[key])
   })
@@ -183,7 +160,7 @@ function executeRun(runName, runConfig) {
     params.push(runConfig.grep)
   }
 
-  const onProcessEnd = (errorCode) => {
+  const onProcessEnd = errorCode => {
     if (errorCode !== 0) {
       process.exitCode = errorCode
     }
@@ -197,7 +174,7 @@ function executeRun(runName, runConfig) {
   // Return function of fork for later execution
   return () =>
     fork(runner, params, { stdio: [0, 1, 2, 'ipc'] })
-      .on('exit', (code) => {
+      .on('exit', code => {
         return onProcessEnd(code)
       })
       .on('error', () => {

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -34,29 +34,29 @@ module.exports = async function (workerCount, selectedRuns, options) {
   const workers = new Workers(numberOfWorkers, config)
   workers.overrideConfig(overrideConfigs)
 
-  workers.on(event.suite.before, (suite) => {
+  workers.on(event.suite.before, suite => {
     suiteArr.push(suite)
   })
 
-  workers.on(event.step.passed, (step) => {
+  workers.on(event.step.passed, step => {
     stepArr.push(step)
   })
 
-  workers.on(event.step.failed, (step) => {
+  workers.on(event.step.failed, step => {
     stepArr.push(step)
   })
 
-  workers.on(event.test.failed, (test) => {
+  workers.on(event.test.failed, test => {
     failedTestArr.push(test)
     output.test.failed(test)
   })
 
-  workers.on(event.test.passed, (test) => {
+  workers.on(event.test.passed, test => {
     passedTestArr.push(test)
     output.test.passed(test)
   })
 
-  workers.on(event.test.skipped, (test) => {
+  workers.on(event.test.skipped, test => {
     skippedTestArr.push(test)
     output.test.skipped(test)
   })
@@ -64,21 +64,21 @@ module.exports = async function (workerCount, selectedRuns, options) {
   workers.on(event.all.result, () => {
     // expose test stats after all workers finished their execution
     function addStepsToTest(test, stepArr) {
-      stepArr.test.steps.forEach((step) => {
+      stepArr.test.steps.forEach(step => {
         if (test.steps.length === 0) {
           test.steps.push(step)
         }
       })
     }
 
-    stepArr.forEach((step) => {
-      passedTestArr.forEach((test) => {
+    stepArr.forEach(step => {
+      passedTestArr.forEach(test => {
         if (step.test.title === test.title) {
           addStepsToTest(test, step)
         }
       })
 
-      failedTestArr.forEach((test) => {
+      failedTestArr.forEach(test => {
         if (step.test.title === test.title) {
           addStepsToTest(test, step)
         }

--- a/lib/command/utils.js
+++ b/lib/command/utils.js
@@ -29,8 +29,7 @@ module.exports.readConfig = function (configFile) {
 function getTestRoot(currentPath) {
   if (!currentPath) currentPath = '.'
   if (!path.isAbsolute(currentPath)) currentPath = path.join(process.cwd(), currentPath)
-  currentPath =
-    fs.lstatSync(currentPath).isDirectory() || !path.extname(currentPath) ? currentPath : path.dirname(currentPath)
+  currentPath = fs.lstatSync(currentPath).isDirectory() || !path.extname(currentPath) ? currentPath : path.dirname(currentPath)
   return currentPath
 }
 module.exports.getTestRoot = getTestRoot
@@ -71,7 +70,7 @@ function safeFileWrite(file, contents) {
 
 module.exports.safeFileWrite = safeFileWrite
 
-module.exports.captureStream = (stream) => {
+module.exports.captureStream = stream => {
   let oldStream
   let buffer = ''
 
@@ -79,7 +78,7 @@ module.exports.captureStream = (stream) => {
     startCapture() {
       buffer = ''
       oldStream = stream.write.bind(stream)
-      stream.write = (chunk) => (buffer += chunk)
+      stream.write = chunk => (buffer += chunk)
     },
     stopCapture() {
       if (oldStream !== undefined) stream.write = oldStream
@@ -88,7 +87,7 @@ module.exports.captureStream = (stream) => {
   }
 }
 
-module.exports.printError = (err) => {
+module.exports.printError = err => {
   output.print('')
   output.error(err.message)
   output.print('')
@@ -106,7 +105,7 @@ module.exports.createOutputDir = (config, testRoot) => {
   }
 }
 
-module.exports.findConfigFile = (testsPath) => {
+module.exports.findConfigFile = testsPath => {
   const extensions = ['js', 'ts']
   for (const ext of extensions) {
     const configFile = path.join(testsPath, `codecept.conf.${ext}`)

--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -13,8 +13,8 @@ module.exports = function (context) {
           fn = opts
           opts = {}
         }
-        opts.data = data.map((dataRow) => dataRow.data)
-        data.forEach((dataRow) => {
+        opts.data = data.map(dataRow => dataRow.data)
+        data.forEach(dataRow => {
           const dataTitle = replaceTitle(title, dataRow)
           if (dataRow.skip) {
             context.xScenario(dataTitle)
@@ -32,8 +32,8 @@ module.exports = function (context) {
             fn = opts
             opts = {}
           }
-          opts.data = data.map((dataRow) => dataRow.data)
-          data.forEach((dataRow) => {
+          opts.data = data.map(dataRow => dataRow.data)
+          data.forEach(dataRow => {
             const dataTitle = replaceTitle(title, dataRow)
             if (dataRow.skip) {
               context.xScenario(dataTitle)
@@ -51,8 +51,8 @@ module.exports = function (context) {
   context.xData = function (dataTable) {
     const data = detectDataType(dataTable)
     return {
-      Scenario: (title) => {
-        data.forEach((dataRow) => {
+      Scenario: title => {
+        data.forEach(dataRow => {
           const dataTitle = replaceTitle(title, dataRow)
           context.xScenario(dataTitle)
         })
@@ -69,10 +69,7 @@ function replaceTitle(title, dataRow) {
 
   // if `dataRow` is object and has own `toString()` method,
   // it should be printed
-  if (
-    Object.prototype.toString.call(dataRow.data) === Object().toString() &&
-    dataRow.data.toString() !== Object().toString()
-  ) {
+  if (Object.prototype.toString.call(dataRow.data) === Object().toString() && dataRow.data.toString() !== Object().toString()) {
     return `${title} | ${dataRow.data}`
   }
 
@@ -102,7 +99,7 @@ function detectDataType(dataTable) {
     return dataTable()
   }
   if (Array.isArray(dataTable)) {
-    return dataTable.map((item) => {
+    return dataTable.map(item => {
       if (isTableDataRow(item)) {
         return item
       }
@@ -117,10 +114,10 @@ function detectDataType(dataTable) {
 }
 
 function maskSecretInTitle(scenarios) {
-  scenarios.forEach((scenario) => {
+  scenarios.forEach(scenario => {
     const res = []
 
-    scenario.test.title.split(',').forEach((item) => {
+    scenario.test.title.split(',').forEach(item => {
       res.push(item.replace(/{"_secret":"(.*)"}/, '"*****"'))
     })
 

--- a/lib/data/dataScenarioConfig.js
+++ b/lib/data/dataScenarioConfig.js
@@ -10,7 +10,7 @@ class DataScenarioConfig {
    * @param {*} err
    */
   throws(err) {
-    this.scenarios.forEach((scenario) => scenario.throws(err))
+    this.scenarios.forEach(scenario => scenario.throws(err))
     return this
   }
 
@@ -21,7 +21,7 @@ class DataScenarioConfig {
    *
    */
   fails() {
-    this.scenarios.forEach((scenario) => scenario.fails())
+    this.scenarios.forEach(scenario => scenario.fails())
     return this
   }
 
@@ -31,7 +31,7 @@ class DataScenarioConfig {
    * @param {*} retries
    */
   retry(retries) {
-    this.scenarios.forEach((scenario) => scenario.retry(retries))
+    this.scenarios.forEach(scenario => scenario.retry(retries))
     return this
   }
 
@@ -40,7 +40,7 @@ class DataScenarioConfig {
    * @param {*} timeout
    */
   timeout(timeout) {
-    this.scenarios.forEach((scenario) => scenario.timeout(timeout))
+    this.scenarios.forEach(scenario => scenario.timeout(timeout))
     return this
   }
 
@@ -49,7 +49,7 @@ class DataScenarioConfig {
    * Helper name can be omitted and values will be applied to first helper.
    */
   config(helper, obj) {
-    this.scenarios.forEach((scenario) => scenario.config(helper, obj))
+    this.scenarios.forEach(scenario => scenario.config(helper, obj))
     return this
   }
 
@@ -58,7 +58,7 @@ class DataScenarioConfig {
    * @param {*} tagName
    */
   tag(tagName) {
-    this.scenarios.forEach((scenario) => scenario.tag(tagName))
+    this.scenarios.forEach(scenario => scenario.tag(tagName))
     return this
   }
 
@@ -67,7 +67,7 @@ class DataScenarioConfig {
    * @param {*} obj
    */
   inject(obj) {
-    this.scenarios.forEach((scenario) => scenario.inject(obj))
+    this.scenarios.forEach(scenario => scenario.inject(obj))
     return this
   }
 
@@ -76,7 +76,7 @@ class DataScenarioConfig {
    * @param {*} dependencies
    */
   injectDependencies(dependencies) {
-    this.scenarios.forEach((scenario) => scenario.injectDependencies(dependencies))
+    this.scenarios.forEach(scenario => scenario.injectDependencies(dependencies))
     return this
   }
 }

--- a/lib/data/dataTableArgument.js
+++ b/lib/data/dataTableArgument.js
@@ -5,8 +5,8 @@
 class DataTableArgument {
   /** @param {*} gherkinDataTable */
   constructor(gherkinDataTable) {
-    this.rawData = gherkinDataTable.rows.map((row) => {
-      return row.cells.map((cell) => {
+    this.rawData = gherkinDataTable.rows.map(row => {
+      return row.cells.map(cell => {
         return cell.value
       })
     })
@@ -34,7 +34,7 @@ class DataTableArgument {
   hashes() {
     const copy = this.raw()
     const header = copy.shift()
-    return copy.map((row) => {
+    return copy.map(row => {
       const r = {}
       row.forEach((cell, index) => (r[header[index]] = cell))
       return r
@@ -47,19 +47,19 @@ class DataTableArgument {
    */
   rowsHash() {
     const rows = this.raw()
-    const everyRowHasTwoColumns = rows.every((row) => row.length === 2)
+    const everyRowHasTwoColumns = rows.every(row => row.length === 2)
     if (!everyRowHasTwoColumns) {
       throw new Error('rowsHash can only be called on a data table where all rows have exactly two columns')
     }
     /** @type {Record<string, string>} */
     const result = {}
-    rows.forEach((x) => (result[x[0]] = x[1]))
+    rows.forEach(x => (result[x[0]] = x[1]))
     return result
   }
 
   /** Transposed the data */
   transpose() {
-    this.rawData = this.rawData[0].map((x, i) => this.rawData.map((y) => y[i]))
+    this.rawData = this.rawData[0].map((x, i) => this.rawData.map(y => y[i]))
   }
 }
 

--- a/lib/data/table.js
+++ b/lib/data/table.js
@@ -10,13 +10,10 @@ class DataTable {
 
   /** @param {Array<*>} array */
   add(array) {
-    if (array.length !== this.array.length)
-      throw new Error(
-        `There is too many elements in given data array. Please provide data in this format: ${this.array}`,
-      )
+    if (array.length !== this.array.length) throw new Error(`There is too many elements in given data array. Please provide data in this format: ${this.array}`)
     const tempObj = {}
     let arrayCounter = 0
-    this.array.forEach((elem) => {
+    this.array.forEach(elem => {
       tempObj[elem] = array[arrayCounter]
       tempObj.toString = () => JSON.stringify(tempObj)
       arrayCounter++
@@ -26,13 +23,10 @@ class DataTable {
 
   /** @param {Array<*>} array */
   xadd(array) {
-    if (array.length !== this.array.length)
-      throw new Error(
-        `There is too many elements in given data array. Please provide data in this format: ${this.array}`,
-      )
+    if (array.length !== this.array.length) throw new Error(`There is too many elements in given data array. Please provide data in this format: ${this.array}`)
     const tempObj = {}
     let arrayCounter = 0
-    this.array.forEach((elem) => {
+    this.array.forEach(elem => {
       tempObj[elem] = array[arrayCounter]
       tempObj.toString = () => JSON.stringify(tempObj)
       arrayCounter++
@@ -42,7 +36,7 @@ class DataTable {
 
   /** @param {Function} func */
   filter(func) {
-    return this.rows.filter((row) => func(row.data))
+    return this.rows.filter(row => func(row.data))
   }
 }
 

--- a/lib/helper/ApiDataFactory.js
+++ b/lib/helper/ApiDataFactory.js
@@ -217,7 +217,7 @@ class ApiDataFactory extends Helper {
     }
 
     this.created = {}
-    Object.keys(this.factories).forEach((f) => (this.created[f] = []))
+    Object.keys(this.factories).forEach(f => (this.created[f] = []))
   }
 
   static _checkRequirements() {
@@ -357,7 +357,7 @@ Current file error: ${err.message}`)
 
     request.baseURL = this.config.endpoint
 
-    return this.restHelper._executeRequest(request).then((resp) => {
+    return this.restHelper._executeRequest(request).then(resp => {
       const id = this._fetchId(resp.data, factory)
       this.created[factory].push(id)
       this.debugSection('Created', `Id: ${id}`)
@@ -391,10 +391,7 @@ Current file error: ${err.message}`)
     request.baseURL = this.config.endpoint
 
     if (request.url.match(/^undefined/)) {
-      return this.debugSection(
-        'Please configure the delete request in your ApiDataFactory helper',
-        "delete: () => ({ method: 'DELETE',  url: '/api/users' })",
-      )
+      return this.debugSection('Please configure the delete request in your ApiDataFactory helper', "delete: () => ({ method: 'DELETE',  url: '/api/users' })")
     }
 
     return this.restHelper._executeRequest(request).then(() => {

--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -185,9 +185,7 @@ class Appium extends Webdriver {
 
     webdriverio = require('webdriverio')
     if (!config.appiumV2) {
-      console.log(
-        'The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. Please migrating to Appium 2.x by adding appiumV2: true to your config.',
-      )
+      console.log('The Appium core team does not maintain Appium 1.x anymore since the 1st of January 2022. Please migrating to Appium 2.x by adding appiumV2: true to your config.')
       console.log('More info: https://bit.ly/appium-v2-migration')
       console.log('This Appium 1.x support will be removed in next major release.')
     }
@@ -234,20 +232,14 @@ class Appium extends Webdriver {
 
     config.baseUrl = config.url || config.baseUrl
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
-      config.capabilities =
-        this.appiumV2 === true ? this._convertAppiumV2Caps(config.desiredCapabilities) : config.desiredCapabilities
+      config.capabilities = this.appiumV2 === true ? this._convertAppiumV2Caps(config.desiredCapabilities) : config.desiredCapabilities
     }
 
     if (this.appiumV2) {
-      config.capabilities[`${vendorPrefix.appium}:deviceName`] =
-        config[`${vendorPrefix.appium}:device`] || config.capabilities[`${vendorPrefix.appium}:deviceName`]
-      config.capabilities[`${vendorPrefix.appium}:browserName`] =
-        config[`${vendorPrefix.appium}:browser`] || config.capabilities[`${vendorPrefix.appium}:browserName`]
-      config.capabilities[`${vendorPrefix.appium}:app`] =
-        config[`${vendorPrefix.appium}:app`] || config.capabilities[`${vendorPrefix.appium}:app`]
-      config.capabilities[`${vendorPrefix.appium}:tunnelIdentifier`] =
-        config[`${vendorPrefix.appium}:tunnelIdentifier`] ||
-        config.capabilities[`${vendorPrefix.appium}:tunnelIdentifier`] // Adding the code to connect to sauce labs via sauce tunnel
+      config.capabilities[`${vendorPrefix.appium}:deviceName`] = config[`${vendorPrefix.appium}:device`] || config.capabilities[`${vendorPrefix.appium}:deviceName`]
+      config.capabilities[`${vendorPrefix.appium}:browserName`] = config[`${vendorPrefix.appium}:browser`] || config.capabilities[`${vendorPrefix.appium}:browserName`]
+      config.capabilities[`${vendorPrefix.appium}:app`] = config[`${vendorPrefix.appium}:app`] || config.capabilities[`${vendorPrefix.appium}:app`]
+      config.capabilities[`${vendorPrefix.appium}:tunnelIdentifier`] = config[`${vendorPrefix.appium}:tunnelIdentifier`] || config.capabilities[`${vendorPrefix.appium}:tunnelIdentifier`] // Adding the code to connect to sauce labs via sauce tunnel
     } else {
       config.capabilities.deviceName = config.device || config.capabilities.deviceName
       config.capabilities.browserName = config.browser || config.capabilities.browserName
@@ -1304,14 +1296,14 @@ class Appium extends Webdriver {
           }
           return browser
             .$$(parseLocator.call(this, searchableLocator))
-            .then((els) => els.length && els[0].isDisplayed())
-            .then((res) => {
+            .then(els => els.length && els[0].isDisplayed())
+            .then(res => {
               if (res) {
                 return true
               }
               return this[direction](scrollLocator, offset, speed)
                 .getSource()
-                .then((source) => {
+                .then(source => {
                   if (source === currentSource) {
                     err = true
                   } else {
@@ -1324,12 +1316,9 @@ class Appium extends Webdriver {
         timeout * 1000,
         errorMsg,
       )
-      .catch((e) => {
+      .catch(e => {
         if (e.message.indexOf('timeout') && e.type !== 'NoSuchElement') {
-          throw new AssertionFailedError(
-            { customMessage: `Scroll to the end and element ${searchableLocator} was not found` },
-            '',
-          )
+          throw new AssertionFailedError({ customMessage: `Scroll to the end and element ${searchableLocator} was not found` }, '')
         } else {
           throw e
         }
@@ -1386,8 +1375,8 @@ class Appium extends Webdriver {
    */
   async pullFile(path, dest) {
     onlyForApps.call(this)
-    return this.browser.pullFile(path).then((res) =>
-      fs.writeFile(dest, Buffer.from(res, 'base64'), (err) => {
+    return this.browser.pullFile(path).then(res =>
+      fs.writeFile(dest, Buffer.from(res, 'base64'), err => {
         if (err) {
           return false
         }
@@ -1759,12 +1748,8 @@ function parseLocator(locator) {
   }
 
   locator = new Locator(locator, 'xpath')
-  if (locator.type === 'css' && !this.isWeb)
-    throw new Error(
-      'Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id',
-    )
-  if (locator.type === 'name' && !this.isWeb)
-    throw new Error("Can't locate element by name in Native context. Use either ID, class name or accessibility id")
+  if (locator.type === 'css' && !this.isWeb) throw new Error('Unable to use css locators in apps. Locator strategies for this request: xpath, id, class name or accessibility id')
+  if (locator.type === 'name' && !this.isWeb) throw new Error("Can't locate element by name in Native context. Use either ID, class name or accessibility id")
   if (locator.type === 'id' && !this.isWeb && this.platform === 'android') return `//*[@resource-id='${locator.value}']`
   return locator.simplify()
 }

--- a/lib/helper/FileSystem.js
+++ b/lib/helper/FileSystem.js
@@ -105,7 +105,7 @@ class FileSystem extends Helper {
    */
   seeFileNameMatching(text) {
     assert.ok(
-      this.grabFileNames().some((file) => file.includes(text)),
+      this.grabFileNames().some(file => file.includes(text)),
       `File name which contains ${text} not found in ${this.dir}`,
     )
   }
@@ -175,7 +175,7 @@ class FileSystem extends Helper {
    * ```
    */
   grabFileNames() {
-    return fs.readdirSync(this.dir).filter((item) => !fs.lstatSync(path.join(this.dir, item)).isDirectory())
+    return fs.readdirSync(this.dir).filter(item => !fs.lstatSync(path.join(this.dir, item)).isDirectory())
   }
 }
 
@@ -216,7 +216,7 @@ function isFileExists(file, timeout) {
       }
     })
 
-    fs.access(file, fs.constants.R_OK, (err) => {
+    fs.access(file, fs.constants.R_OK, err => {
       if (!err) {
         clearTimeout(timer)
         watcher.close()

--- a/lib/helper/GraphQLDataFactory.js
+++ b/lib/helper/GraphQLDataFactory.js
@@ -170,7 +170,7 @@ class GraphQLDataFactory extends Helper {
     this.factories = this.config.factories
 
     this.created = {}
-    Object.keys(this.factories).forEach((f) => (this.created[f] = []))
+    Object.keys(this.factories).forEach(f => (this.created[f] = []))
   }
 
   static _checkRequirements() {
@@ -278,7 +278,7 @@ class GraphQLDataFactory extends Helper {
    */
   _requestCreate(operation, variables) {
     const { query } = this.factories[operation]
-    return this.graphqlHelper.sendMutation(query, variables).then((response) => {
+    return this.graphqlHelper.sendMutation(query, variables).then(response => {
       const data = response.data.data[operation]
       this.created[operation].push(data)
       this.debugSection('Created', `record: ${data}`)
@@ -297,7 +297,7 @@ class GraphQLDataFactory extends Helper {
     const deleteOperation = this.factories[operation].revert(data)
     const { query, variables } = deleteOperation
 
-    return this.graphqlHelper.sendMutation(query, variables).then((response) => {
+    return this.graphqlHelper.sendMutation(query, variables).then(response => {
       const idx = this.created[operation].indexOf(data)
       this.debugSection('Deleted', `record: ${response.data.data}`)
       this.created[operation].splice(idx, 1)

--- a/lib/helper/JSONResponse.js
+++ b/lib/helper/JSONResponse.js
@@ -1,6 +1,6 @@
-const Helper = require('@codeceptjs/helper');
-const assert = require('assert');
-const joi = require('joi');
+const Helper = require('@codeceptjs/helper')
+const assert = require('assert')
+const joi = require('joi')
 
 /**
  * This helper allows performing assertions on JSON responses paired with following helpers:
@@ -60,33 +60,33 @@ const joi = require('joi');
  */
 class JSONResponse extends Helper {
   constructor(config = {}) {
-    super(config);
+    super(config)
     this.options = {
       requestHelper: 'REST',
-    };
-    this.options = { ...this.options, ...config };
+    }
+    this.options = { ...this.options, ...config }
   }
 
   _beforeSuite() {
-    this.response = null;
+    this.response = null
     if (!this.helpers[this.options.requestHelper]) {
-      throw new Error(`Error setting JSONResponse, helper ${this.options.requestHelper} is not enabled in config, helpers: ${Object.keys(this.helpers)}`);
+      throw new Error(`Error setting JSONResponse, helper ${this.options.requestHelper} is not enabled in config, helpers: ${Object.keys(this.helpers)}`)
     }
     // connect to REST helper
     this.helpers[this.options.requestHelper].config.onResponse = response => {
-      this.response = response;
-    };
+      this.response = response
+    }
   }
 
   _before() {
-    this.response = null;
+    this.response = null
   }
 
   static _checkRequirements() {
     try {
-      require('joi');
+      require('joi')
     } catch (e) {
-      return ['joi'];
+      return ['joi']
     }
   }
 
@@ -100,8 +100,8 @@ class JSONResponse extends Helper {
    * @param {number} code
    */
   seeResponseCodeIs(code) {
-    this._checkResponseReady();
-    assert.strictEqual(this.response.status, code, 'Response code is not the same as expected');
+    this._checkResponseReady()
+    assert.strictEqual(this.response.status, code, 'Response code is not the same as expected')
   }
 
   /**
@@ -114,32 +114,32 @@ class JSONResponse extends Helper {
    * @param {number} code
    */
   dontSeeResponseCodeIs(code) {
-    this._checkResponseReady();
-    assert.notStrictEqual(this.response.status, code);
+    this._checkResponseReady()
+    assert.notStrictEqual(this.response.status, code)
   }
 
   /**
    * Checks that the response code is 4xx
    */
   seeResponseCodeIsClientError() {
-    this._checkResponseReady();
-    assert(this.response.status >= 400 && this.response.status < 500);
+    this._checkResponseReady()
+    assert(this.response.status >= 400 && this.response.status < 500)
   }
 
   /**
    * Checks that the response code is 3xx
    */
   seeResponseCodeIsRedirection() {
-    this._checkResponseReady();
-    assert(this.response.status >= 300 && this.response.status < 400);
+    this._checkResponseReady()
+    assert(this.response.status >= 300 && this.response.status < 400)
   }
 
   /**
    * Checks that the response code is 5xx
    */
   seeResponseCodeIsServerError() {
-    this._checkResponseReady();
-    assert(this.response.status >= 500 && this.response.status < 600);
+    this._checkResponseReady()
+    assert(this.response.status >= 500 && this.response.status < 600)
   }
 
   /**
@@ -151,8 +151,8 @@ class JSONResponse extends Helper {
    * ```
    */
   seeResponseCodeIsSuccessful() {
-    this._checkResponseReady();
-    assert(this.response.status >= 200 && this.response.status < 300);
+    this._checkResponseReady()
+    assert(this.response.status >= 200 && this.response.status < 300)
   }
 
   /**
@@ -173,21 +173,21 @@ class JSONResponse extends Helper {
    * @param {object} json
    */
   seeResponseContainsJson(json = {}) {
-    this._checkResponseReady();
+    this._checkResponseReady()
     if (Array.isArray(this.response.data)) {
-      let found = false;
+      let found = false
       for (const el of this.response.data) {
         try {
-          this._assertContains(el, json);
-          found = true;
-          break;
+          this._assertContains(el, json)
+          found = true
+          break
         } catch (err) {
-          continue;
+          continue
         }
       }
-      assert(found, `No elements in array matched ${JSON.stringify(json)}`);
+      assert(found, `No elements in array matched ${JSON.stringify(json)}`)
     } else {
-      this._assertContains(this.response.data, json);
+      this._assertContains(this.response.data, json)
     }
   }
 
@@ -209,21 +209,21 @@ class JSONResponse extends Helper {
    * @param {object} json
    */
   dontSeeResponseContainsJson(json = {}) {
-    this._checkResponseReady();
+    this._checkResponseReady()
     if (Array.isArray(this.response.data)) {
       for (const data of this.response.data) {
         try {
-          this._assertContains(data, json);
-          assert.fail(`Found matching element: ${JSON.stringify(data)}`);
+          this._assertContains(data, json)
+          assert.fail(`Found matching element: ${JSON.stringify(data)}`)
         } catch (err) {
           // expected to fail
-          continue;
+          continue
         }
       }
     } else {
       try {
-        this._assertContains(this.response.data, json);
-        assert.fail('Response contains the JSON');
+        this._assertContains(this.response.data, json)
+        assert.fail('Response contains the JSON')
       } catch (err) {
         // expected to fail
       }
@@ -250,16 +250,16 @@ class JSONResponse extends Helper {
    * @param {array} keys
    */
   seeResponseContainsKeys(keys = []) {
-    this._checkResponseReady();
+    this._checkResponseReady()
     if (Array.isArray(this.response.data)) {
       for (const data of this.response.data) {
         for (const key of keys) {
-          assert(key in data, `Key "${key}" is not found in ${JSON.stringify(data)}`);
+          assert(key in data, `Key "${key}" is not found in ${JSON.stringify(data)}`)
         }
       }
     } else {
       for (const key of keys) {
-        assert(key in this.response.data, `Key "${key}" is not found in ${JSON.stringify(this.response.data)}`);
+        assert(key in this.response.data, `Key "${key}" is not found in ${JSON.stringify(this.response.data)}`)
       }
     }
   }
@@ -279,10 +279,10 @@ class JSONResponse extends Helper {
    * @param {function} fn
    */
   seeResponseValidByCallback(fn) {
-    this._checkResponseReady();
-    fn({ ...this.response, assert });
-    const body = fn.toString();
-    fn.toString = () => `${body.split('\n')[1]}...`;
+    this._checkResponseReady()
+    fn({ ...this.response, assert })
+    const body = fn.toString()
+    fn.toString = () => `${body.split('\n')[1]}...`
   }
 
   /**
@@ -296,8 +296,8 @@ class JSONResponse extends Helper {
    * @param {object} resp
    */
   seeResponseEquals(resp) {
-    this._checkResponseReady();
-    assert.deepStrictEqual(this.response.data, resp);
+    this._checkResponseReady()
+    assert.deepStrictEqual(this.response.data, resp)
   }
 
   /**
@@ -328,33 +328,33 @@ class JSONResponse extends Helper {
    * @param {any} fnOrSchema
    */
   seeResponseMatchesJsonSchema(fnOrSchema) {
-    this._checkResponseReady();
-    let schema = fnOrSchema;
+    this._checkResponseReady()
+    let schema = fnOrSchema
     if (typeof fnOrSchema === 'function') {
-      schema = fnOrSchema(joi);
-      const body = fnOrSchema.toString();
-      fnOrSchema.toString = () => `${body.split('\n')[1]}...`;
+      schema = fnOrSchema(joi)
+      const body = fnOrSchema.toString()
+      fnOrSchema.toString = () => `${body.split('\n')[1]}...`
     }
-    if (!schema) throw new Error('Empty Joi schema provided, see https://joi.dev/ for details');
-    if (!joi.isSchema(schema)) throw new Error('Invalid Joi schema provided, see https://joi.dev/ for details');
-    schema.toString = () => schema.describe();
-    joi.assert(this.response.data, schema);
+    if (!schema) throw new Error('Empty Joi schema provided, see https://joi.dev/ for details')
+    if (!joi.isSchema(schema)) throw new Error('Invalid Joi schema provided, see https://joi.dev/ for details')
+    schema.toString = () => schema.describe()
+    joi.assert(this.response.data, schema)
   }
 
   _checkResponseReady() {
-    if (!this.response) throw new Error('Response is not available');
+    if (!this.response) throw new Error('Response is not available')
   }
 
   _assertContains(actual, expected) {
     for (const key in expected) {
-      assert(key in actual, `Key "${key}" not found in ${JSON.stringify(actual)}`);
+      assert(key in actual, `Key "${key}" not found in ${JSON.stringify(actual)}`)
       if (typeof expected[key] === 'object' && expected[key] !== null) {
-        this._assertContains(actual[key], expected[key]);
+        this._assertContains(actual[key], expected[key])
       } else {
-        assert.deepStrictEqual(actual[key], expected[key], `Values for key "${key}" don't match`);
+        assert.deepStrictEqual(actual[key], expected[key], `Values for key "${key}" don't match`)
       }
     }
   }
 }
 
-module.exports = JSONResponse;
+module.exports = JSONResponse

--- a/lib/helper/Nightmare.js
+++ b/lib/helper/Nightmare.js
@@ -111,13 +111,7 @@ class Nightmare extends Helper {
       const by = Object.keys(locator)[0]
       const value = locator[by]
 
-      this.evaluate_now(
-        (by, locator, contextEl) => window.codeceptjs.findAndStoreElements(by, locator, contextEl),
-        done,
-        by,
-        value,
-        contextEl,
-      )
+      this.evaluate_now((by, locator, contextEl) => window.codeceptjs.findAndStoreElements(by, locator, contextEl), done, by, value, contextEl)
     })
 
     this.Nightmare.action('findElement', function (locator, contextEl, done) {
@@ -244,7 +238,7 @@ class Nightmare extends Helper {
                     nodeId: queryResult.nodeId,
                     files: pathsToUpload,
                   },
-                  (err) => {
+                  err => {
                     if (Object.keys(err).length > 0) {
                       parent.emit('log', 'problem setting input', err)
                       return done(err)
@@ -351,7 +345,7 @@ class Nightmare extends Helper {
     const outputFile = path.join(global.output_dir, fileName)
     this.debug(`HAR is saving to ${outputFile}`)
 
-    await this.browser.getHAR().then((har) => {
+    await this.browser.getHAR().then(har => {
       require('fs').writeFileSync(outputFile, JSON.stringify({ log: har }))
     })
   }
@@ -361,7 +355,7 @@ class Nightmare extends Helper {
   }
 
   async _stopBrowser() {
-    return this.browser.end().catch((error) => {
+    return this.browser.end().catch(error => {
       this.debugSection('Error on End', error)
     })
   }
@@ -445,7 +439,7 @@ class Nightmare extends Helper {
       // navigating to the same url will cause an error in nightmare, so don't do it
       return
     }
-    return this.browser.goto(url, headers).then((res) => {
+    return this.browser.goto(url, headers).then(res => {
       this.debugSection('URL', res.url)
       this.debugSection('Code', res.code)
       this.debugSection('Headers', JSON.stringify(res.headers))
@@ -535,7 +529,7 @@ class Nightmare extends Helper {
     locator = new Locator(locator, 'css')
     const num = await this.browser.evaluate(
       (by, locator) => {
-        return window.codeceptjs.findElements(by, locator).filter((e) => e.offsetWidth > 0 && e.offsetHeight > 0).length
+        return window.codeceptjs.findElements(by, locator).filter(e => e.offsetWidth > 0 && e.offsetHeight > 0).length
       },
       locator.type,
       locator.value,
@@ -551,7 +545,7 @@ class Nightmare extends Helper {
     locator = new Locator(locator, 'css')
     const num = await this.browser.evaluate(
       (by, locator) => {
-        return window.codeceptjs.findElements(by, locator).filter((e) => e.offsetWidth > 0 && e.offsetHeight > 0).length
+        return window.codeceptjs.findElements(by, locator).filter(e => e.offsetWidth > 0 && e.offsetHeight > 0).length
       },
       locator.type,
       locator.value,
@@ -598,9 +592,7 @@ class Nightmare extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator)
-    return equals(
-      `expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`,
-    ).assert(elements.length, num)
+    return equals(`expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`).assert(elements.length, num)
   }
 
   /**
@@ -608,10 +600,7 @@ class Nightmare extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator)
-    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(
-      res,
-      num,
-    )
+    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(res, num)
   }
 
   /**
@@ -622,7 +611,7 @@ class Nightmare extends Helper {
 
     const num = await this.browser.evaluate(
       (by, locator) => {
-        return window.codeceptjs.findElements(by, locator).filter((e) => e.offsetWidth > 0 && e.offsetHeight > 0).length
+        return window.codeceptjs.findElements(by, locator).filter(e => e.offsetWidth > 0 && e.offsetHeight > 0).length
       },
       locator.type,
       locator.value,
@@ -637,7 +626,7 @@ class Nightmare extends Helper {
   async click(locator, context = null) {
     const el = await findClickable.call(this, locator, context)
     assertElementExists(el, locator, 'Clickable')
-    return this.browser.evaluate((el) => window.codeceptjs.clickEl(el), el).wait(this.options.waitForAction)
+    return this.browser.evaluate(el => window.codeceptjs.clickEl(el), el).wait(this.options.waitForAction)
   }
 
   /**
@@ -646,7 +635,7 @@ class Nightmare extends Helper {
   async doubleClick(locator, context = null) {
     const el = await findClickable.call(this, locator, context)
     assertElementExists(el, locator, 'Clickable')
-    return this.browser.evaluate((el) => window.codeceptjs.doubleClickEl(el), el).wait(this.options.waitForAction)
+    return this.browser.evaluate(el => window.codeceptjs.doubleClickEl(el), el).wait(this.options.waitForAction)
   }
 
   /**
@@ -655,7 +644,7 @@ class Nightmare extends Helper {
   async rightClick(locator, context = null) {
     const el = await findClickable.call(this, locator, context)
     assertElementExists(el, locator, 'Clickable')
-    return this.browser.evaluate((el) => window.codeceptjs.rightClickEl(el), el).wait(this.options.waitForAction)
+    return this.browser.evaluate(el => window.codeceptjs.rightClickEl(el), el).wait(this.options.waitForAction)
   }
 
   /**
@@ -665,9 +654,7 @@ class Nightmare extends Helper {
     locator = new Locator(locator, 'css')
     const el = await this.browser.findElement(locator.toStrict())
     assertElementExists(el, locator)
-    return this.browser
-      .evaluate((el, x, y) => window.codeceptjs.hoverEl(el, x, y), el, offsetX, offsetY)
-      .wait(this.options.waitForAction) // wait for hover event to happen
+    return this.browser.evaluate((el, x, y) => window.codeceptjs.hoverEl(el, x, y), el, offsetX, offsetY).wait(this.options.waitForAction) // wait for hover event to happen
   }
 
   /**
@@ -676,7 +663,7 @@ class Nightmare extends Helper {
    * Wrapper for synchronous [evaluate](https://github.com/segmentio/nightmare#evaluatefn-arg1-arg2)
    */
   async executeScript(...args) {
-    return this.browser.evaluate.apply(this.browser, args).catch((err) => err) // Nightmare's first argument is error :(
+    return this.browser.evaluate.apply(this.browser, args).catch(err => err) // Nightmare's first argument is error :(
   }
 
   /**
@@ -686,7 +673,7 @@ class Nightmare extends Helper {
    * Unlike NightmareJS implementation calling `done` will return its first argument.
    */
   async executeAsyncScript(...args) {
-    return this.browser.evaluate.apply(this.browser, args).catch((err) => err) // Nightmare's first argument is error :(
+    return this.browser.evaluate.apply(this.browser, args).catch(err => err) // Nightmare's first argument is error :(
   }
 
   /**
@@ -705,7 +692,7 @@ class Nightmare extends Helper {
   async checkOption(field, context = null) {
     const els = await findCheckable.call(this, field, context)
     assertElementExists(els[0], field, 'Checkbox or radio')
-    return this.browser.evaluate((els) => window.codeceptjs.checkEl(els[0]), els).wait(this.options.waitForAction)
+    return this.browser.evaluate(els => window.codeceptjs.checkEl(els[0]), els).wait(this.options.waitForAction)
   }
 
   /**
@@ -714,7 +701,7 @@ class Nightmare extends Helper {
   async uncheckOption(field, context = null) {
     const els = await findCheckable.call(this, field, context)
     assertElementExists(els[0], field, 'Checkbox or radio')
-    return this.browser.evaluate((els) => window.codeceptjs.unCheckEl(els[0]), els).wait(this.options.waitForAction)
+    return this.browser.evaluate(els => window.codeceptjs.unCheckEl(els[0]), els).wait(this.options.waitForAction)
   }
 
   /**
@@ -826,7 +813,7 @@ class Nightmare extends Helper {
     locator = new Locator(locator, 'css')
     const els = await this.browser.findElements(locator.toStrict())
     const texts = []
-    const getText = (el) => window.codeceptjs.fetchElement(el).innerText
+    const getText = el => window.codeceptjs.fetchElement(el).innerText
     for (const el of els) {
       texts.push(await this.browser.evaluate(getText, el))
     }
@@ -855,7 +842,7 @@ class Nightmare extends Helper {
     locator = new Locator(locator, 'css')
     const els = await this.browser.findElements(locator.toStrict())
     const values = []
-    const getValues = (el) => window.codeceptjs.fetchElement(el).value
+    const getValues = el => window.codeceptjs.fetchElement(el).value
     for (const el of els) {
       values.push(await this.browser.evaluate(getValues, el))
     }
@@ -887,9 +874,7 @@ class Nightmare extends Helper {
 
     for (let index = 0; index < els.length; index++) {
       const el = els[index]
-      array.push(
-        await this.browser.evaluate((el, attr) => window.codeceptjs.fetchElement(el).getAttribute(attr), el, attr),
-      )
+      array.push(await this.browser.evaluate((el, attr) => window.codeceptjs.fetchElement(el).getAttribute(attr), el, attr))
     }
 
     return array
@@ -921,7 +906,7 @@ class Nightmare extends Helper {
 
     for (let index = 0; index < els.length; index++) {
       const el = els[index]
-      array.push(await this.browser.evaluate((el) => window.codeceptjs.fetchElement(el).innerHTML, el))
+      array.push(await this.browser.evaluate(el => window.codeceptjs.fetchElement(el).innerHTML, el))
     }
     this.debugSection('GrabHTML', array)
 
@@ -953,7 +938,7 @@ class Nightmare extends Helper {
 
     const getCssPropForElement = async (el, prop) => {
       return (
-        await this.browser.evaluate((el) => {
+        await this.browser.evaluate(el => {
           return window.getComputedStyle(window.codeceptjs.fetchElement(el))
         }, el)
       )[toCamelCase(prop)]
@@ -1083,7 +1068,7 @@ class Nightmare extends Helper {
    * {{> wait }}
    */
   async wait(sec) {
-    return new Promise((done) => {
+    return new Promise(done => {
       setTimeout(done, sec * 1000)
     })
   }
@@ -1106,7 +1091,7 @@ class Nightmare extends Helper {
         locator.value,
         text,
       )
-      .catch((err) => {
+      .catch(err => {
         if (err.message.indexOf('Cannot read property') > -1) {
           throw new Error(`element (${JSON.stringify(context)}) is not in DOM. Unable to wait text.`)
         } else if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
@@ -1132,7 +1117,7 @@ class Nightmare extends Helper {
         locator.type,
         locator.value,
       )
-      .catch((err) => {
+      .catch(err => {
         if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
           throw new Error(`element (${JSON.stringify(locator)}) still not visible on page after ${sec} sec`)
         } else throw err
@@ -1163,7 +1148,7 @@ class Nightmare extends Helper {
         locator.type,
         locator.value,
       )
-      .catch((err) => {
+      .catch(err => {
         if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
           throw new Error(`element (${JSON.stringify(locator)}) still visible after ${sec} sec`)
         } else throw err
@@ -1179,7 +1164,7 @@ class Nightmare extends Helper {
 
     return this.browser
       .wait((by, locator) => window.codeceptjs.findElement(by, locator) !== null, locator.type, locator.value)
-      .catch((err) => {
+      .catch(err => {
         if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
           throw new Error(`element (${JSON.stringify(locator)}) still not present on page after ${sec} sec`)
         } else throw err
@@ -1203,7 +1188,7 @@ class Nightmare extends Helper {
 
     return this.browser
       .wait((by, locator) => window.codeceptjs.findElement(by, locator) === null, locator.type, locator.value)
-      .catch((err) => {
+      .catch(err => {
         if (err.message && err.message.indexOf('.wait() timed out after') > -1) {
           throw new Error(`element (${JSON.stringify(locator)}) still on page after ${sec} sec`)
         } else throw err
@@ -1348,10 +1333,7 @@ class Nightmare extends Helper {
     return this.executeScript(function () {
       const body = document.body
       const html = document.documentElement
-      window.scrollTo(
-        0,
-        Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      )
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight))
     })
   }
 
@@ -1390,7 +1372,7 @@ async function proceedSee(assertType, text, context) {
 
   const texts = await this.browser.evaluate(
     (by, locator) => {
-      return window.codeceptjs.findElements(by, locator).map((el) => el.innerText)
+      return window.codeceptjs.findElements(by, locator).map(el => el.innerText)
     },
     locator.type,
     locator.value,
@@ -1402,8 +1384,8 @@ async function proceedSee(assertType, text, context) {
 async function proceedSeeInField(assertType, field, value) {
   const el = await findField.call(this, field)
   assertElementExists(el, field, 'Field')
-  const tag = await this.browser.evaluate((el) => window.codeceptjs.fetchElement(el).tagName, el)
-  const fieldVal = await this.browser.evaluate((el) => window.codeceptjs.fetchElement(el).value, el)
+  const tag = await this.browser.evaluate(el => window.codeceptjs.fetchElement(el).tagName, el)
+  const fieldVal = await this.browser.evaluate(el => window.codeceptjs.fetchElement(el).value, el)
   if (tag === 'select') {
     // locate option by values and check them
     const text = await this.browser.evaluate(
@@ -1421,8 +1403,8 @@ async function proceedSeeInField(assertType, field, value) {
 async function proceedIsChecked(assertType, option) {
   const els = await findCheckable.call(this, option)
   assertElementExists(els, option, 'Checkable')
-  const selected = await this.browser.evaluate((els) => {
-    return els.map((el) => window.codeceptjs.fetchElement(el).checked).reduce((prev, cur) => prev || cur)
+  const selected = await this.browser.evaluate(els => {
+    return els.map(el => window.codeceptjs.fetchElement(el).checked).reduce((prev, cur) => prev || cur)
   }, els)
   return truth(`checkable ${option}`, 'to be checked')[assertType](selected)
 }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1,17 +1,17 @@
-const path = require('path');
-const fs = require('fs');
+const path = require('path')
+const fs = require('fs')
 
-const Helper = require('@codeceptjs/helper');
-const { v4: uuidv4 } = require('uuid');
-const assert = require('assert');
-const promiseRetry = require('promise-retry');
-const Locator = require('../locator');
-const recorder = require('../recorder');
-const stringIncludes = require('../assert/include').includes;
-const { urlEquals } = require('../assert/equal');
-const { equals } = require('../assert/equal');
-const { empty } = require('../assert/empty');
-const { truth } = require('../assert/truth');
+const Helper = require('@codeceptjs/helper')
+const { v4: uuidv4 } = require('uuid')
+const assert = require('assert')
+const promiseRetry = require('promise-retry')
+const Locator = require('../locator')
+const recorder = require('../recorder')
+const stringIncludes = require('../assert/include').includes
+const { urlEquals } = require('../assert/equal')
+const { equals } = require('../assert/equal')
+const { empty } = require('../assert/empty')
+const { truth } = require('../assert/truth')
 const {
   xpathLocator,
   ucfirst,
@@ -24,28 +24,28 @@ const {
   clearString,
   requireWithFallback,
   normalizeSpacesInString,
-} = require('../utils');
-const { isColorProperty, convertColorToRGBA } = require('../colorUtils');
-const ElementNotFound = require('./errors/ElementNotFound');
-const RemoteBrowserConnectionRefused = require('./errors/RemoteBrowserConnectionRefused');
-const Popup = require('./extras/Popup');
-const Console = require('./extras/Console');
-const { findReact, findVue, findByPlaywrightLocator } = require('./extras/PlaywrightReactVueLocator');
+} = require('../utils')
+const { isColorProperty, convertColorToRGBA } = require('../colorUtils')
+const ElementNotFound = require('./errors/ElementNotFound')
+const RemoteBrowserConnectionRefused = require('./errors/RemoteBrowserConnectionRefused')
+const Popup = require('./extras/Popup')
+const Console = require('./extras/Console')
+const { findReact, findVue, findByPlaywrightLocator } = require('./extras/PlaywrightReactVueLocator')
 
-let playwright;
-let perfTiming;
-let defaultSelectorEnginesInitialized = false;
+let playwright
+let perfTiming
+let defaultSelectorEnginesInitialized = false
 
-const popupStore = new Popup();
-const consoleLogStore = new Console();
-const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron'];
+const popupStore = new Popup()
+const consoleLogStore = new Console()
+const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron']
 
-const { setRestartStrategy, restartsSession, restartsContext, restartsBrowser } = require('./extras/PlaywrightRestartOpts');
-const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine');
-const { seeElementError, dontSeeElementError, dontSeeElementInDOMError, seeElementInDOMError } = require('./errors/ElementAssertion');
-const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions');
+const { setRestartStrategy, restartsSession, restartsContext, restartsBrowser } = require('./extras/PlaywrightRestartOpts')
+const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine')
+const { seeElementError, dontSeeElementError, dontSeeElementInDOMError, seeElementInDOMError } = require('./errors/ElementAssertion')
+const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions')
 
-const pathSeparator = path.sep;
+const pathSeparator = path.sep
 
 /**
  * ## Configuration
@@ -94,7 +94,7 @@ const pathSeparator = path.sep;
  * @prop {object} [recordHar] - record HAR and will be saved to `output/har`. See more of [HAR options](https://playwright.dev/docs/api/class-browser#browser-new-context-option-record-har).
  * @prop {string} [testIdAttribute=data-testid] - locate elements based on the testIdAttribute. See more of [locate by test id](https://playwright.dev/docs/locators#locate-by-test-id).
  */
-const config = {};
+const config = {}
 
 /**
  * Uses [Playwright](https://github.com/microsoft/playwright) library to run tests inside:
@@ -316,34 +316,34 @@ const config = {};
  */
 class Playwright extends Helper {
   constructor(config) {
-    super(config);
+    super(config)
 
-    playwright = requireWithFallback('playwright', 'playwright-core');
+    playwright = requireWithFallback('playwright', 'playwright-core')
 
     // set defaults
-    this.isRemoteBrowser = false;
-    this.isRunning = false;
-    this.isAuthenticated = false;
-    this.sessionPages = {};
-    this.activeSessionName = '';
-    this.isElectron = false;
-    this.isCDPConnection = false;
-    this.electronSessions = [];
-    this.storageState = null;
+    this.isRemoteBrowser = false
+    this.isRunning = false
+    this.isAuthenticated = false
+    this.sessionPages = {}
+    this.activeSessionName = ''
+    this.isElectron = false
+    this.isCDPConnection = false
+    this.electronSessions = []
+    this.storageState = null
 
     // for network stuff
-    this.requests = [];
-    this.recording = false;
-    this.recordedAtLeastOnce = false;
+    this.requests = []
+    this.recording = false
+    this.recordedAtLeastOnce = false
 
     // for websocket messages
-    this.webSocketMessages = [];
-    this.recordingWebSocketMessages = false;
-    this.recordedWebSocketMessagesAtLeastOnce = false;
-    this.cdpSession = null;
+    this.webSocketMessages = []
+    this.recordingWebSocketMessages = false
+    this.recordedWebSocketMessagesAtLeastOnce = false
+    this.cdpSession = null
 
     // override defaults with config
-    this._setConfig(config);
+    this._setConfig(config)
   }
 
   _validateConfig(config) {
@@ -370,61 +370,61 @@ class Playwright extends Helper {
       use: { actionTimeout: 0 },
       ignoreHTTPSErrors: false, // Adding it here o that context can be set up to ignore the SSL errors,
       highlightElement: false,
-    };
-
-    process.env.testIdAttribute = 'data-testid';
-    config = Object.assign(defaults, config);
-
-    if (availableBrowsers.indexOf(config.browser) < 0) {
-      throw new Error(`Invalid config. Can't use browser "${config.browser}". Accepted values: ${availableBrowsers.join(', ')}`);
     }
 
-    return config;
+    process.env.testIdAttribute = 'data-testid'
+    config = Object.assign(defaults, config)
+
+    if (availableBrowsers.indexOf(config.browser) < 0) {
+      throw new Error(`Invalid config. Can't use browser "${config.browser}". Accepted values: ${availableBrowsers.join(', ')}`)
+    }
+
+    return config
   }
 
   _getOptionsForBrowser(config) {
     if (config[config.browser]) {
       if (config[config.browser].browserWSEndpoint && config[config.browser].browserWSEndpoint.wsEndpoint) {
-        config[config.browser].browserWSEndpoint = config[config.browser].browserWSEndpoint.wsEndpoint;
+        config[config.browser].browserWSEndpoint = config[config.browser].browserWSEndpoint.wsEndpoint
       }
       return {
         ...config[config.browser],
         wsEndpoint: config[config.browser].browserWSEndpoint,
-      };
+      }
     }
-    return {};
+    return {}
   }
 
   _setConfig(config) {
-    this.options = this._validateConfig(config);
-    setRestartStrategy(this.options);
+    this.options = this._validateConfig(config)
+    setRestartStrategy(this.options)
     this.playwrightOptions = {
       headless: !this.options.show,
       ...this._getOptionsForBrowser(config),
-    };
+    }
 
     if (this.options.channel && this.options.browser === 'chromium') {
-      this.playwrightOptions.channel = this.options.channel;
+      this.playwrightOptions.channel = this.options.channel
     }
 
     if (this.options.video) {
       // set the video resolution with window size
-      let size = parseWindowSize(this.options.windowSize);
+      let size = parseWindowSize(this.options.windowSize)
 
       // if the video resolution is passed, set the record resoultion with that resolution
       if (this.options.recordVideo && this.options.recordVideo.size) {
-        size = parseWindowSize(this.options.recordVideo.size);
+        size = parseWindowSize(this.options.recordVideo.size)
       }
-      this.options.recordVideo = { size };
+      this.options.recordVideo = { size }
     }
     if (this.options.recordVideo && !this.options.recordVideo.dir) {
-      this.options.recordVideo.dir = `${global.output_dir}/videos/`;
+      this.options.recordVideo.dir = `${global.output_dir}/videos/`
     }
-    this.isRemoteBrowser = !!this.playwrightOptions.browserWSEndpoint;
-    this.isElectron = this.options.browser === 'electron';
-    this.userDataDir = this.playwrightOptions.userDataDir ? `${this.playwrightOptions.userDataDir}_${Date.now().toString()}` : undefined;
-    this.isCDPConnection = this.playwrightOptions.cdpConnection;
-    popupStore.defaultAction = this.options.defaultPopupAction;
+    this.isRemoteBrowser = !!this.playwrightOptions.browserWSEndpoint
+    this.isElectron = this.options.browser === 'electron'
+    this.userDataDir = this.playwrightOptions.userDataDir ? `${this.playwrightOptions.userDataDir}_${Date.now().toString()}` : undefined
+    this.isCDPConnection = this.playwrightOptions.cdpConnection
+    popupStore.defaultAction = this.options.defaultPopupAction
   }
 
   static _config() {
@@ -447,216 +447,216 @@ class Playwright extends Helper {
         type: 'confirm',
         when: answers => answers.Playwright_browser !== 'electron',
       },
-    ];
+    ]
   }
 
   static _checkRequirements() {
     try {
-      requireWithFallback('playwright', 'playwright-core');
+      requireWithFallback('playwright', 'playwright-core')
     } catch (e) {
-      return ['playwright@^1.18'];
+      return ['playwright@^1.18']
     }
   }
 
   async _init() {
     // register an internal selector engine for reading value property of elements in a selector
-    if (defaultSelectorEnginesInitialized) return;
-    defaultSelectorEnginesInitialized = true;
+    if (defaultSelectorEnginesInitialized) return
+    defaultSelectorEnginesInitialized = true
     try {
-      await playwright.selectors.register('__value', createValueEngine);
-      await playwright.selectors.register('__disabled', createDisabledEngine);
-      if (process.env.testIdAttribute) await playwright.selectors.setTestIdAttribute(process.env.testIdAttribute);
+      await playwright.selectors.register('__value', createValueEngine)
+      await playwright.selectors.register('__disabled', createDisabledEngine)
+      if (process.env.testIdAttribute) await playwright.selectors.setTestIdAttribute(process.env.testIdAttribute)
     } catch (e) {
-      console.warn(e);
+      console.warn(e)
     }
   }
 
   _beforeSuite() {
     if ((restartsSession() || restartsContext()) && !this.options.manualStart && !this.isRunning) {
-      this.debugSection('Session', 'Starting singleton browser session');
-      return this._startBrowser();
+      this.debugSection('Session', 'Starting singleton browser session')
+      return this._startBrowser()
     }
   }
 
   async _before(test) {
-    this.currentRunningTest = test;
+    this.currentRunningTest = test
     recorder.retry({
       retries: process.env.FAILED_STEP_RETRIES || 3,
       when: err => {
         if (!err || typeof err.message !== 'string') {
-          return false;
+          return false
         }
         // ignore context errors
-        return err.message.includes('context');
+        return err.message.includes('context')
       },
-    });
+    })
 
-    if (restartsBrowser() && !this.options.manualStart) await this._startBrowser();
-    if (!this.isRunning && !this.options.manualStart) await this._startBrowser();
+    if (restartsBrowser() && !this.options.manualStart) await this._startBrowser()
+    if (!this.isRunning && !this.options.manualStart) await this._startBrowser()
 
-    this.isAuthenticated = false;
+    this.isAuthenticated = false
     if (this.isElectron) {
-      this.browserContext = this.browser.context();
+      this.browserContext = this.browser.context()
     } else if (this.playwrightOptions.userDataDir) {
-      this.browserContext = this.browser;
+      this.browserContext = this.browser
     } else {
       const contextOptions = {
         ignoreHTTPSErrors: this.options.ignoreHTTPSErrors,
         acceptDownloads: true,
         ...this.options.emulate,
-      };
+      }
       if (this.options.basicAuth) {
-        contextOptions.httpCredentials = this.options.basicAuth;
-        this.isAuthenticated = true;
+        contextOptions.httpCredentials = this.options.basicAuth
+        this.isAuthenticated = true
       }
-      if (this.options.bypassCSP) contextOptions.bypassCSP = this.options.bypassCSP;
-      if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
+      if (this.options.bypassCSP) contextOptions.bypassCSP = this.options.bypassCSP
+      if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo
       if (this.options.recordHar) {
-        const harExt = this.options.recordHar.content && this.options.recordHar.content === 'attach' ? 'zip' : 'har';
-        const fileName = `${`${global.output_dir}${path.sep}har${path.sep}${uuidv4()}_${clearString(this.currentRunningTest.title)}`.slice(0, 245)}.${harExt}`;
-        const dir = path.dirname(fileName);
-        if (!fileExists(dir)) fs.mkdirSync(dir);
-        this.options.recordHar.path = fileName;
-        this.currentRunningTest.artifacts.har = fileName;
-        contextOptions.recordHar = this.options.recordHar;
+        const harExt = this.options.recordHar.content && this.options.recordHar.content === 'attach' ? 'zip' : 'har'
+        const fileName = `${`${global.output_dir}${path.sep}har${path.sep}${uuidv4()}_${clearString(this.currentRunningTest.title)}`.slice(0, 245)}.${harExt}`
+        const dir = path.dirname(fileName)
+        if (!fileExists(dir)) fs.mkdirSync(dir)
+        this.options.recordHar.path = fileName
+        this.currentRunningTest.artifacts.har = fileName
+        contextOptions.recordHar = this.options.recordHar
       }
-      if (this.storageState) contextOptions.storageState = this.storageState;
-      if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent;
-      if (this.options.locale) contextOptions.locale = this.options.locale;
-      if (this.options.colorScheme) contextOptions.colorScheme = this.options.colorScheme;
-      this.contextOptions = contextOptions;
+      if (this.storageState) contextOptions.storageState = this.storageState
+      if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent
+      if (this.options.locale) contextOptions.locale = this.options.locale
+      if (this.options.colorScheme) contextOptions.colorScheme = this.options.colorScheme
+      this.contextOptions = contextOptions
       if (!this.browserContext || !restartsSession()) {
-        this.browserContext = await this.browser.newContext(this.contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
+        this.browserContext = await this.browser.newContext(this.contextOptions) // Adding the HTTPSError ignore in the context so that we can ignore those errors
       }
     }
 
-    let mainPage;
+    let mainPage
     if (this.isElectron) {
-      mainPage = await this.browser.firstWindow();
+      mainPage = await this.browser.firstWindow()
     } else {
       try {
-        const existingPages = await this.browserContext.pages();
-        mainPage = existingPages[0] || (await this.browserContext.newPage());
+        const existingPages = await this.browserContext.pages()
+        mainPage = existingPages[0] || (await this.browserContext.newPage())
       } catch (e) {
         if (this.playwrightOptions.userDataDir) {
-          this.browser = await playwright[this.options.browser].launchPersistentContext(this.userDataDir, this.playwrightOptions);
-          this.browserContext = this.browser;
-          const existingPages = await this.browserContext.pages();
-          mainPage = existingPages[0];
+          this.browser = await playwright[this.options.browser].launchPersistentContext(this.userDataDir, this.playwrightOptions)
+          this.browserContext = this.browser
+          const existingPages = await this.browserContext.pages()
+          mainPage = existingPages[0]
         }
       }
     }
-    await targetCreatedHandler.call(this, mainPage);
+    await targetCreatedHandler.call(this, mainPage)
 
-    await this._setPage(mainPage);
+    await this._setPage(mainPage)
 
-    if (this.options.trace) await this.browserContext.tracing.start({ screenshots: true, snapshots: true });
+    if (this.options.trace) await this.browserContext.tracing.start({ screenshots: true, snapshots: true })
 
-    return this.browser;
+    return this.browser
   }
 
   async _after() {
-    if (!this.isRunning) return;
+    if (!this.isRunning) return
 
     if (this.isElectron) {
-      this.browser.close();
-      this.electronSessions.forEach(session => session.close());
-      return;
+      this.browser.close()
+      this.electronSessions.forEach(session => session.close())
+      return
     }
 
     if (restartsSession()) {
-      return refreshContextSession.bind(this)();
+      return refreshContextSession.bind(this)()
     }
 
     if (restartsBrowser()) {
-      this.isRunning = false;
-      return this._stopBrowser();
+      this.isRunning = false
+      return this._stopBrowser()
     }
 
     // close other sessions
     try {
       if ((await this.browser)._type === 'Browser') {
-        const contexts = await this.browser.contexts();
-        const currentContext = contexts[0];
+        const contexts = await this.browser.contexts()
+        const currentContext = contexts[0]
         if (currentContext && (this.options.keepCookies || this.options.keepBrowserState)) {
-          this.storageState = await currentContext.storageState();
+          this.storageState = await currentContext.storageState()
         }
 
-        await Promise.all(contexts.map(c => c.close()));
+        await Promise.all(contexts.map(c => c.close()))
       }
     } catch (e) {
-      console.log(e);
+      console.log(e)
     }
 
     // await this.closeOtherTabs();
-    return this.browser;
+    return this.browser
   }
 
   _afterSuite() {}
 
   async _finishTest() {
-    if ((restartsSession() || restartsContext()) && this.isRunning) return this._stopBrowser();
+    if ((restartsSession() || restartsContext()) && this.isRunning) return this._stopBrowser()
   }
 
   _session() {
-    const defaultContext = this.browserContext;
+    const defaultContext = this.browserContext
     return {
       start: async (sessionName = '', config) => {
-        this.debugSection('New Context', config ? JSON.stringify(config) : 'opened');
-        this.activeSessionName = sessionName;
+        this.debugSection('New Context', config ? JSON.stringify(config) : 'opened')
+        this.activeSessionName = sessionName
 
-        let browserContext;
-        let page;
+        let browserContext
+        let page
         if (this.isElectron) {
-          const browser = await playwright._electron.launch(this.playwrightOptions);
-          this.electronSessions.push(browser);
-          browserContext = browser.context();
-          page = await browser.firstWindow();
+          const browser = await playwright._electron.launch(this.playwrightOptions)
+          this.electronSessions.push(browser)
+          browserContext = browser.context()
+          page = await browser.firstWindow()
         } else {
           try {
-            browserContext = await this.browser.newContext(Object.assign(this.contextOptions, config));
-            page = await browserContext.newPage();
+            browserContext = await this.browser.newContext(Object.assign(this.contextOptions, config))
+            page = await browserContext.newPage()
           } catch (e) {
             if (this.playwrightOptions.userDataDir) {
-              browserContext = await playwright[this.options.browser].launchPersistentContext(`${this.userDataDir}_${this.activeSessionName}`, this.playwrightOptions);
-              this.browser = browserContext;
-              page = await browserContext.pages()[0];
+              browserContext = await playwright[this.options.browser].launchPersistentContext(`${this.userDataDir}_${this.activeSessionName}`, this.playwrightOptions)
+              this.browser = browserContext
+              page = await browserContext.pages()[0]
             }
           }
         }
 
-        if (this.options.trace) await browserContext.tracing.start({ screenshots: true, snapshots: true });
-        await targetCreatedHandler.call(this, page);
-        await this._setPage(page);
+        if (this.options.trace) await browserContext.tracing.start({ screenshots: true, snapshots: true })
+        await targetCreatedHandler.call(this, page)
+        await this._setPage(page)
         // Create a new page inside context.
-        return browserContext;
+        return browserContext
       },
       stop: async () => {
         // is closed by _after
       },
       loadVars: async context => {
         if (context) {
-          this.browserContext = context;
-          const existingPages = await context.pages();
-          this.sessionPages[this.activeSessionName] = existingPages[0];
-          return this._setPage(this.sessionPages[this.activeSessionName]);
+          this.browserContext = context
+          const existingPages = await context.pages()
+          this.sessionPages[this.activeSessionName] = existingPages[0]
+          return this._setPage(this.sessionPages[this.activeSessionName])
         }
       },
       restoreVars: async session => {
-        this.withinLocator = null;
-        this.browserContext = defaultContext;
+        this.withinLocator = null
+        this.browserContext = defaultContext
 
         if (!session) {
-          this.activeSessionName = '';
+          this.activeSessionName = ''
         } else {
-          this.activeSessionName = session;
+          this.activeSessionName = session
         }
-        const existingPages = await this.browserContext.pages();
-        await this._setPage(existingPages[0]);
+        const existingPages = await this.browserContext.pages()
+        await this._setPage(existingPages[0])
 
-        return this._waitForAction();
+        return this._waitForAction()
       },
-    };
+    }
   }
 
   /**
@@ -677,7 +677,7 @@ class Playwright extends Helper {
    * @param {function} fn async function that executed with Playwright helper as arguments
    */
   usePlaywrightTo(description, fn) {
-    return this._useTo(...arguments);
+    return this._useTo(...arguments)
   }
 
   /**
@@ -691,7 +691,7 @@ class Playwright extends Helper {
    * ```
    */
   amAcceptingPopups() {
-    popupStore.actionType = 'accept';
+    popupStore.actionType = 'accept'
   }
 
   /**
@@ -700,7 +700,7 @@ class Playwright extends Helper {
    * libraries](http://jster.net/category/windows-modals-popups).
    */
   acceptPopup() {
-    popupStore.assertPopupActionType('accept');
+    popupStore.assertPopupActionType('accept')
   }
 
   /**
@@ -714,23 +714,23 @@ class Playwright extends Helper {
    * ```
    */
   amCancellingPopups() {
-    popupStore.actionType = 'cancel';
+    popupStore.actionType = 'cancel'
   }
 
   /**
    * Dismisses the active JavaScript popup, as created by window.alert|window.confirm|window.prompt.
    */
   cancelPopup() {
-    popupStore.assertPopupActionType('cancel');
+    popupStore.assertPopupActionType('cancel')
   }
 
   /**
    * {{> seeInPopup }}
    */
   async seeInPopup(text) {
-    popupStore.assertPopupVisible();
-    const popupText = await popupStore.popup.message();
-    stringIncludes('text in popup').assert(text, popupText);
+    popupStore.assertPopupVisible()
+    const popupText = await popupStore.popup.message()
+    stringIncludes('text in popup').assert(text, popupText)
   }
 
   /**
@@ -738,21 +738,21 @@ class Playwright extends Helper {
    * @param {object} page page to set
    */
   async _setPage(page) {
-    page = await page;
-    this._addPopupListener(page);
-    this.page = page;
-    if (!page) return;
-    this.browserContext.setDefaultTimeout(0);
-    page.setDefaultNavigationTimeout(this.options.getPageTimeout);
-    page.setDefaultTimeout(this.options.timeout);
+    page = await page
+    this._addPopupListener(page)
+    this.page = page
+    if (!page) return
+    this.browserContext.setDefaultTimeout(0)
+    page.setDefaultNavigationTimeout(this.options.getPageTimeout)
+    page.setDefaultTimeout(this.options.timeout)
 
     page.on('crash', async () => {
-      console.log('ERROR: Page has crashed, closing page!');
-      await page.close();
-    });
-    this.context = await this.page;
-    this.contextLocator = null;
-    await page.bringToFront();
+      console.log('ERROR: Page has crashed, closing page!')
+      await page.close()
+    })
+    this.context = await this.page
+    this.contextLocator = null
+    await page.bringToFront()
   }
 
   /**
@@ -764,33 +764,33 @@ class Playwright extends Helper {
    */
   _addPopupListener(page) {
     if (!page) {
-      return;
+      return
     }
-    page.removeAllListeners('dialog');
+    page.removeAllListeners('dialog')
     page.on('dialog', async dialog => {
-      popupStore.popup = dialog;
-      const action = popupStore.actionType || this.options.defaultPopupAction;
-      await this._waitForAction();
+      popupStore.popup = dialog
+      const action = popupStore.actionType || this.options.defaultPopupAction
+      await this._waitForAction()
 
       switch (action) {
         case 'accept':
-          return dialog.accept();
+          return dialog.accept()
 
         case 'cancel':
-          return dialog.dismiss();
+          return dialog.dismiss()
 
         default: {
-          throw new Error('Unknown popup action type. Only "accept" or "cancel" are accepted');
+          throw new Error('Unknown popup action type. Only "accept" or "cancel" are accepted')
         }
       }
-    });
+    })
   }
 
   /**
    * Gets page URL including hash.
    */
   async _getPageUrl() {
-    return this.executeScript(() => window.location.href);
+    return this.executeScript(() => window.location.href)
   }
 
   /**
@@ -803,45 +803,45 @@ class Playwright extends Helper {
    */
   async grabPopupText() {
     if (popupStore.popup) {
-      return popupStore.popup.message();
+      return popupStore.popup.message()
     }
-    return null;
+    return null
   }
 
   async _startBrowser() {
     if (this.isElectron) {
-      this.browser = await playwright._electron.launch(this.playwrightOptions);
+      this.browser = await playwright._electron.launch(this.playwrightOptions)
     } else if (this.isRemoteBrowser && this.isCDPConnection) {
       try {
-        this.browser = await playwright[this.options.browser].connectOverCDP(this.playwrightOptions);
+        this.browser = await playwright[this.options.browser].connectOverCDP(this.playwrightOptions)
       } catch (err) {
         if (err.toString().indexOf('ECONNREFUSED')) {
-          throw new RemoteBrowserConnectionRefused(err);
+          throw new RemoteBrowserConnectionRefused(err)
         }
-        throw err;
+        throw err
       }
     } else if (this.isRemoteBrowser) {
       try {
-        this.browser = await playwright[this.options.browser].connect(this.playwrightOptions);
+        this.browser = await playwright[this.options.browser].connect(this.playwrightOptions)
       } catch (err) {
         if (err.toString().indexOf('ECONNREFUSED')) {
-          throw new RemoteBrowserConnectionRefused(err);
+          throw new RemoteBrowserConnectionRefused(err)
         }
-        throw err;
+        throw err
       }
     } else if (this.playwrightOptions.userDataDir) {
-      this.browser = await playwright[this.options.browser].launchPersistentContext(this.userDataDir, this.playwrightOptions);
+      this.browser = await playwright[this.options.browser].launchPersistentContext(this.userDataDir, this.playwrightOptions)
     } else {
-      this.browser = await playwright[this.options.browser].launch(this.playwrightOptions);
+      this.browser = await playwright[this.options.browser].launch(this.playwrightOptions)
     }
 
     // works only for Chromium
     this.browser.on('targetchanged', target => {
-      this.debugSection('Url', target.url());
-    });
+      this.debugSection('Url', target.url())
+    })
 
-    this.isRunning = true;
-    return this.browser;
+    this.isRunning = true
+    return this.browser
   }
 
   /**
@@ -850,72 +850,72 @@ class Playwright extends Helper {
    * @param {object} [contextOptions] See https://playwright.dev/docs/api/class-browser#browser-new-context
    */
   async _createContextPage(contextOptions) {
-    this.browserContext = await this.browser.newContext(contextOptions);
-    const page = await this.browserContext.newPage();
-    targetCreatedHandler.call(this, page);
-    await this._setPage(page);
+    this.browserContext = await this.browser.newContext(contextOptions)
+    const page = await this.browserContext.newPage()
+    targetCreatedHandler.call(this, page)
+    await this._setPage(page)
   }
 
   _getType() {
-    return this.browser._type;
+    return this.browser._type
   }
 
   async _stopBrowser() {
-    this.withinLocator = null;
-    await this._setPage(null);
-    this.context = null;
-    this.frame = null;
-    popupStore.clear();
-    if (this.options.recordHar) await this.browserContext.close();
-    await this.browser.close();
+    this.withinLocator = null
+    await this._setPage(null)
+    this.context = null
+    this.frame = null
+    popupStore.clear()
+    if (this.options.recordHar) await this.browserContext.close()
+    await this.browser.close()
   }
 
   async _evaluateHandeInContext(...args) {
-    const context = await this._getContext();
-    return context.evaluateHandle(...args);
+    const context = await this._getContext()
+    return context.evaluateHandle(...args)
   }
 
   async _withinBegin(locator) {
     if (this.withinLocator) {
-      throw new Error("Can't start within block inside another within block");
+      throw new Error("Can't start within block inside another within block")
     }
 
-    const frame = isFrameLocator(locator);
+    const frame = isFrameLocator(locator)
 
     if (frame) {
       if (Array.isArray(frame)) {
-        await this.switchTo(null);
-        return frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve());
+        await this.switchTo(null)
+        return frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve())
       }
-      await this.switchTo(frame);
-      this.withinLocator = new Locator(frame);
-      return;
+      await this.switchTo(frame)
+      this.withinLocator = new Locator(frame)
+      return
     }
 
-    const el = await this._locateElement(locator);
-    assertElementExists(el, locator);
-    this.context = el;
-    this.contextLocator = locator;
+    const el = await this._locateElement(locator)
+    assertElementExists(el, locator)
+    this.context = el
+    this.contextLocator = locator
 
-    this.withinLocator = new Locator(locator);
+    this.withinLocator = new Locator(locator)
   }
 
   async _withinEnd() {
-    this.withinLocator = null;
-    this.context = await this.page;
-    this.contextLocator = null;
-    this.frame = null;
+    this.withinLocator = null
+    this.context = await this.page
+    this.contextLocator = null
+    this.frame = null
   }
 
   _extractDataFromPerformanceTiming(timing, ...dataNames) {
-    const navigationStart = timing.navigationStart;
+    const navigationStart = timing.navigationStart
 
-    const extractedData = {};
+    const extractedData = {}
     dataNames.forEach(name => {
-      extractedData[name] = timing[name] - navigationStart;
-    });
+      extractedData[name] = timing[name] - navigationStart
+    })
 
-    return extractedData;
+    return extractedData
   }
 
   /**
@@ -923,26 +923,26 @@ class Playwright extends Helper {
    */
   async amOnPage(url) {
     if (this.isElectron) {
-      throw new Error('Cannot open pages inside an Electron container');
+      throw new Error('Cannot open pages inside an Electron container')
     }
     if (!/^\w+\:(\/\/|.+)/.test(url)) {
-      url = this.options.url + (url.startsWith('/') ? url : `/${url}`);
+      url = this.options.url + (url.startsWith('/') ? url : `/${url}`)
     }
 
     if (this.options.basicAuth && this.isAuthenticated !== true) {
       if (url.includes(this.options.url)) {
-        await this.browserContext.setHTTPCredentials(this.options.basicAuth);
-        this.isAuthenticated = true;
+        await this.browserContext.setHTTPCredentials(this.options.basicAuth)
+        this.isAuthenticated = true
       }
     }
 
-    await this.page.goto(url, { waitUntil: this.options.waitForNavigation });
+    await this.page.goto(url, { waitUntil: this.options.waitForNavigation })
 
-    const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)));
+    const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)))
 
-    perfTiming = this._extractDataFromPerformanceTiming(performanceTiming, 'responseEnd', 'domInteractive', 'domContentLoadedEventEnd', 'loadEventEnd');
+    perfTiming = this._extractDataFromPerformanceTiming(performanceTiming, 'responseEnd', 'domInteractive', 'domContentLoadedEventEnd', 'loadEventEnd')
 
-    return this._waitForAction();
+    return this._waitForAction()
   }
 
   /**
@@ -963,11 +963,11 @@ class Playwright extends Helper {
    */
   async resizeWindow(width, height) {
     if (width === 'maximize') {
-      throw new Error("Playwright can't control windows, so it can't maximize it");
+      throw new Error("Playwright can't control windows, so it can't maximize it")
     }
 
-    await this.page.setViewportSize({ width, height });
-    return this._waitForAction();
+    await this.page.setViewportSize({ width, height })
+    return this._waitForAction()
   }
 
   /**
@@ -983,9 +983,9 @@ class Playwright extends Helper {
    */
   async setPlaywrightRequestHeaders(customHeaders) {
     if (!customHeaders) {
-      throw new Error('Cannot send empty headers.');
+      throw new Error('Cannot send empty headers.')
     }
-    return this.browserContext.setExtraHTTPHeaders(customHeaders);
+    return this.browserContext.setExtraHTTPHeaders(customHeaders)
   }
 
   /**
@@ -993,13 +993,13 @@ class Playwright extends Helper {
    *
    */
   async moveCursorTo(locator, offsetX = 0, offsetY = 0) {
-    const el = await this._locateElement(locator);
-    assertElementExists(el, locator);
+    const el = await this._locateElement(locator)
+    assertElementExists(el, locator)
 
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
-    const { x, y } = await clickablePoint(el);
-    await this.page.mouse.move(x + offsetX, y + offsetY);
-    return this._waitForAction();
+    const { x, y } = await clickablePoint(el)
+    await this.page.mouse.move(x + offsetX, y + offsetY)
+    return this._waitForAction()
   }
 
   /**
@@ -1007,11 +1007,11 @@ class Playwright extends Helper {
    *
    */
   async focus(locator, options = {}) {
-    const el = await this._locateElement(locator);
-    assertElementExists(el, locator, 'Element to focus');
+    const el = await this._locateElement(locator)
+    assertElementExists(el, locator, 'Element to focus')
 
-    await el.focus(options);
-    return this._waitForAction();
+    await el.focus(options)
+    return this._waitForAction()
   }
 
   /**
@@ -1019,11 +1019,11 @@ class Playwright extends Helper {
    *
    */
   async blur(locator, options = {}) {
-    const el = await this._locateElement(locator);
-    assertElementExists(el, locator, 'Element to blur');
+    const el = await this._locateElement(locator)
+    assertElementExists(el, locator, 'Element to blur')
 
-    await el.blur(options);
-    return this._waitForAction();
+    await el.blur(options)
+    return this._waitForAction()
   }
   /**
    * Return the checked status of given element.
@@ -1035,14 +1035,14 @@ class Playwright extends Helper {
    */
 
   async grabCheckedElementStatus(locator, options = {}) {
-    const supportedTypes = ['checkbox', 'radio'];
-    const el = await this._locateElement(locator);
-    const type = await el.getAttribute('type');
+    const supportedTypes = ['checkbox', 'radio']
+    const el = await this._locateElement(locator)
+    const type = await el.getAttribute('type')
 
     if (supportedTypes.includes(type)) {
-      return el.isChecked(options);
+      return el.isChecked(options)
     }
-    throw new Error(`Element is not a ${supportedTypes.join(' or ')} input`);
+    throw new Error(`Element is not a ${supportedTypes.join(' or ')} input`)
   }
   /**
    * Return the disabled status of given element.
@@ -1054,8 +1054,8 @@ class Playwright extends Helper {
    */
 
   async grabDisabledElementStatus(locator, options = {}) {
-    const el = await this._locateElement(locator);
-    return el.isDisabled(options);
+    const el = await this._locateElement(locator)
+    return el.isDisabled(options)
   }
 
   /**
@@ -1072,24 +1072,24 @@ class Playwright extends Helper {
    *
    */
   async dragAndDrop(srcElement, destElement, options) {
-    const src = new Locator(srcElement);
-    const dst = new Locator(destElement);
+    const src = new Locator(srcElement)
+    const dst = new Locator(destElement)
 
     if (options) {
-      return this.page.dragAndDrop(buildLocatorString(src), buildLocatorString(dst), options);
+      return this.page.dragAndDrop(buildLocatorString(src), buildLocatorString(dst), options)
     }
 
-    const _smallWaitInMs = 600;
-    await this.page.locator(buildLocatorString(src)).hover();
-    await this.page.mouse.down();
-    await this.page.waitForTimeout(_smallWaitInMs);
+    const _smallWaitInMs = 600
+    await this.page.locator(buildLocatorString(src)).hover()
+    await this.page.mouse.down()
+    await this.page.waitForTimeout(_smallWaitInMs)
 
-    const destElBox = await this.page.locator(buildLocatorString(dst)).boundingBox();
+    const destElBox = await this.page.locator(buildLocatorString(dst)).boundingBox()
 
-    await this.page.mouse.move(destElBox.x + destElBox.width / 2, destElBox.y + destElBox.height / 2);
-    await this.page.locator(buildLocatorString(dst)).hover({ position: { x: 10, y: 10 } });
-    await this.page.waitForTimeout(_smallWaitInMs);
-    await this.page.mouse.up();
+    await this.page.mouse.move(destElBox.x + destElBox.width / 2, destElBox.y + destElBox.height / 2)
+    await this.page.locator(buildLocatorString(dst)).hover({ position: { x: 10, y: 10 } })
+    await this.page.waitForTimeout(_smallWaitInMs)
+    await this.page.mouse.up()
   }
 
   /**
@@ -1107,16 +1107,16 @@ class Playwright extends Helper {
    * @param {object} [contextOptions] [Options for browser context](https://playwright.dev/docs/api/class-browser#browser-new-context) when starting new browser
    */
   async restartBrowser(contextOptions) {
-    await this._stopBrowser();
-    await this._startBrowser();
-    await this._createContextPage(contextOptions);
+    await this._stopBrowser()
+    await this._startBrowser()
+    await this._createContextPage(contextOptions)
   }
 
   /**
    * {{> refreshPage }}
    */
   async refreshPage() {
-    return this.page.reload({ timeout: this.options.getPageTimeout, waitUntil: this.options.waitForNavigation });
+    return this.page.reload({ timeout: this.options.getPageTimeout, waitUntil: this.options.waitForNavigation })
   }
 
   /**
@@ -1137,13 +1137,13 @@ class Playwright extends Helper {
    * @returns Promise<void>
    */
   async replayFromHar(harFilePath, opts) {
-    const file = path.join(global.codecept_dir, harFilePath);
+    const file = path.join(global.codecept_dir, harFilePath)
 
     if (!fileExists(file)) {
-      throw new Error(`File at ${file} cannot be found on local system`);
+      throw new Error(`File at ${file} cannot be found on local system`)
     }
 
-    await this.page.routeFromHAR(harFilePath, opts);
+    await this.page.routeFromHAR(harFilePath, opts)
   }
 
   /**
@@ -1151,8 +1151,8 @@ class Playwright extends Helper {
    */
   scrollPageToTop() {
     return this.executeScript(() => {
-      window.scrollTo(0, 0);
-    });
+      window.scrollTo(0, 0)
+    })
   }
 
   /**
@@ -1160,10 +1160,10 @@ class Playwright extends Helper {
    */
   async scrollPageToBottom() {
     return this.executeScript(() => {
-      const body = document.body;
-      const html = document.documentElement;
-      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight));
-    });
+      const body = document.body
+      const html = document.documentElement
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight))
+    })
   }
 
   /**
@@ -1171,32 +1171,32 @@ class Playwright extends Helper {
    */
   async scrollTo(locator, offsetX = 0, offsetY = 0) {
     if (typeof locator === 'number' && typeof offsetX === 'number') {
-      offsetY = offsetX;
-      offsetX = locator;
-      locator = null;
+      offsetY = offsetX
+      offsetX = locator
+      locator = null
     }
 
     if (locator) {
-      const el = await this._locateElement(locator);
-      assertElementExists(el, locator, 'Element');
-      await el.scrollIntoViewIfNeeded();
-      const elementCoordinates = await clickablePoint(el);
+      const el = await this._locateElement(locator)
+      assertElementExists(el, locator, 'Element')
+      await el.scrollIntoViewIfNeeded()
+      const elementCoordinates = await clickablePoint(el)
       await this.executeScript((offsetX, offsetY) => window.scrollBy(offsetX, offsetY), {
         offsetX: elementCoordinates.x + offsetX,
         offsetY: elementCoordinates.y + offsetY,
-      });
+      })
     } else {
-      await this.executeScript(({ offsetX, offsetY }) => window.scrollTo(offsetX, offsetY), { offsetX, offsetY });
+      await this.executeScript(({ offsetX, offsetY }) => window.scrollTo(offsetX, offsetY), { offsetX, offsetY })
     }
-    return this._waitForAction();
+    return this._waitForAction()
   }
 
   /**
    * {{> seeInTitle }}
    */
   async seeInTitle(text) {
-    const title = await this.page.title();
-    stringIncludes('web page title').assert(text, title);
+    const title = await this.page.title()
+    stringIncludes('web page title').assert(text, title)
   }
 
   /**
@@ -1207,33 +1207,33 @@ class Playwright extends Helper {
       return {
         x: window.pageXOffset,
         y: window.pageYOffset,
-      };
+      }
     }
 
-    return this.executeScript(getScrollPosition);
+    return this.executeScript(getScrollPosition)
   }
 
   /**
    * {{> seeTitleEquals }}
    */
   async seeTitleEquals(text) {
-    const title = await this.page.title();
-    return equals('web page title').assert(title, text);
+    const title = await this.page.title()
+    return equals('web page title').assert(title, text)
   }
 
   /**
    * {{> dontSeeInTitle }}
    */
   async dontSeeInTitle(text) {
-    const title = await this.page.title();
-    stringIncludes('web page title').negate(text, title);
+    const title = await this.page.title()
+    stringIncludes('web page title').negate(text, title)
   }
 
   /**
    * {{> grabTitle }}
    */
   async grabTitle() {
-    return this.page.title();
+    return this.page.title()
   }
 
   /**
@@ -1245,11 +1245,11 @@ class Playwright extends Helper {
    * ```
    */
   async _locate(locator) {
-    const context = await this._getContext();
+    const context = await this._getContext()
 
-    if (this.frame) return findElements(this.frame, locator);
+    if (this.frame) return findElements(this.frame, locator)
 
-    return findElements(context, locator);
+    return findElements(context, locator)
   }
 
   /**
@@ -1261,8 +1261,8 @@ class Playwright extends Helper {
    * ```
    */
   async _locateElement(locator) {
-    const context = await this._getContext();
-    return findElement(context, locator);
+    const context = await this._getContext()
+    return findElement(context, locator)
   }
 
   /**
@@ -1274,10 +1274,10 @@ class Playwright extends Helper {
    * ```
    */
   async _locateCheckable(locator, providedContext = null) {
-    const context = providedContext || (await this._getContext());
-    const els = await findCheckable.call(this, locator, context);
-    assertElementExists(els[0], locator, 'Checkbox or radio');
-    return els[0];
+    const context = providedContext || (await this._getContext())
+    const els = await findCheckable.call(this, locator, context)
+    assertElementExists(els[0], locator, 'Checkbox or radio')
+    return els[0]
   }
 
   /**
@@ -1288,8 +1288,8 @@ class Playwright extends Helper {
    * ```
    */
   async _locateClickable(locator) {
-    const context = await this._getContext();
-    return findClickable.call(this, context, locator);
+    const context = await this._getContext()
+    return findClickable.call(this, context, locator)
   }
 
   /**
@@ -1300,7 +1300,7 @@ class Playwright extends Helper {
    * ```
    */
   async _locateFields(locator) {
-    return findFields.call(this, locator);
+    return findFields.call(this, locator)
   }
 
   /**
@@ -1308,7 +1308,7 @@ class Playwright extends Helper {
    *
    */
   async grabWebElements(locator) {
-    return this._locate(locator);
+    return this._locate(locator)
   }
 
   /**
@@ -1316,7 +1316,7 @@ class Playwright extends Helper {
    *
    */
   async grabWebElement(locator) {
-    return this._locateElement(locator);
+    return this._locateElement(locator)
   }
 
   /**
@@ -1331,20 +1331,20 @@ class Playwright extends Helper {
    */
   async switchToNextTab(num = 1) {
     if (this.isElectron) {
-      throw new Error('Cannot switch tabs inside an Electron container');
+      throw new Error('Cannot switch tabs inside an Electron container')
     }
-    const pages = await this.browserContext.pages();
+    const pages = await this.browserContext.pages()
 
-    const index = pages.indexOf(this.page);
-    this.withinLocator = null;
-    const page = pages[index + num];
+    const index = pages.indexOf(this.page)
+    this.withinLocator = null
+    const page = pages[index + num]
 
     if (!page) {
-      throw new Error(`There is no ability to switch to next tab with offset ${num}`);
+      throw new Error(`There is no ability to switch to next tab with offset ${num}`)
     }
-    await targetCreatedHandler.call(this, page);
-    await this._setPage(page);
-    return this._waitForAction();
+    await targetCreatedHandler.call(this, page)
+    await this._setPage(page)
+    return this._waitForAction()
   }
 
   /**
@@ -1358,19 +1358,19 @@ class Playwright extends Helper {
    */
   async switchToPreviousTab(num = 1) {
     if (this.isElectron) {
-      throw new Error('Cannot switch tabs inside an Electron container');
+      throw new Error('Cannot switch tabs inside an Electron container')
     }
-    const pages = await this.browserContext.pages();
-    const index = pages.indexOf(this.page);
-    this.withinLocator = null;
-    const page = pages[index - num];
+    const pages = await this.browserContext.pages()
+    const index = pages.indexOf(this.page)
+    this.withinLocator = null
+    const page = pages[index - num]
 
     if (!page) {
-      throw new Error(`There is no ability to switch to previous tab with offset ${num}`);
+      throw new Error(`There is no ability to switch to previous tab with offset ${num}`)
     }
 
-    await this._setPage(page);
-    return this._waitForAction();
+    await this._setPage(page)
+    return this._waitForAction()
   }
 
   /**
@@ -1382,12 +1382,12 @@ class Playwright extends Helper {
    */
   async closeCurrentTab() {
     if (this.isElectron) {
-      throw new Error('Cannot close current tab inside an Electron container');
+      throw new Error('Cannot close current tab inside an Electron container')
     }
-    const oldPage = this.page;
-    await this.switchToPreviousTab();
-    await oldPage.close();
-    return this._waitForAction();
+    const oldPage = this.page
+    await this.switchToPreviousTab()
+    await oldPage.close()
+    return this._waitForAction()
   }
 
   /**
@@ -1398,13 +1398,13 @@ class Playwright extends Helper {
    * ```
    */
   async closeOtherTabs() {
-    const pages = await this.browserContext.pages();
-    const otherPages = pages.filter(page => page !== this.page);
+    const pages = await this.browserContext.pages()
+    const otherPages = pages.filter(page => page !== this.page)
     if (otherPages.length) {
-      this.debug(`Closing ${otherPages.length} tabs`);
-      return Promise.all(otherPages.map(p => p.close()));
+      this.debug(`Closing ${otherPages.length} tabs`)
+      return Promise.all(otherPages.map(p => p.close()))
     }
-    return Promise.resolve();
+    return Promise.resolve()
   }
 
   /**
@@ -1423,20 +1423,20 @@ class Playwright extends Helper {
    */
   async openNewTab(options) {
     if (this.isElectron) {
-      throw new Error('Cannot open new tabs inside an Electron container');
+      throw new Error('Cannot open new tabs inside an Electron container')
     }
-    const page = await this.browserContext.newPage(options);
-    await targetCreatedHandler.call(this, page);
-    await this._setPage(page);
-    return this._waitForAction();
+    const page = await this.browserContext.newPage(options)
+    await targetCreatedHandler.call(this, page)
+    await this._setPage(page)
+    return this._waitForAction()
   }
 
   /**
    * {{> grabNumberOfOpenTabs }}
    */
   async grabNumberOfOpenTabs() {
-    const pages = await this.browserContext.pages();
-    return pages.length;
+    const pages = await this.browserContext.pages()
+    return pages.length
   }
 
   /**
@@ -1444,12 +1444,12 @@ class Playwright extends Helper {
    *
    */
   async seeElement(locator) {
-    let els = await this._locate(locator);
-    els = await Promise.all(els.map(el => el.isVisible()));
+    let els = await this._locate(locator)
+    els = await Promise.all(els.map(el => el.isVisible()))
     try {
-      return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
+      return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
-      dontSeeElementError(locator);
+      dontSeeElementError(locator)
     }
   }
 
@@ -1458,12 +1458,12 @@ class Playwright extends Helper {
    *
    */
   async dontSeeElement(locator) {
-    let els = await this._locate(locator);
-    els = await Promise.all(els.map(el => el.isVisible()));
+    let els = await this._locate(locator)
+    els = await Promise.all(els.map(el => el.isVisible()))
     try {
-      return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
+      return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
-      seeElementError(locator);
+      seeElementError(locator)
     }
   }
 
@@ -1471,11 +1471,11 @@ class Playwright extends Helper {
    * {{> seeElementInDOM }}
    */
   async seeElementInDOM(locator) {
-    const els = await this._locate(locator);
+    const els = await this._locate(locator)
     try {
-      return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'));
+      return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
-      dontSeeElementInDOMError(locator);
+      dontSeeElementInDOMError(locator)
     }
   }
 
@@ -1483,11 +1483,11 @@ class Playwright extends Helper {
    * {{> dontSeeElementInDOM }}
    */
   async dontSeeElementInDOM(locator) {
-    const els = await this._locate(locator);
+    const els = await this._locate(locator)
     try {
-      return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'));
+      return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
-      seeElementInDOMError(locator);
+      seeElementInDOMError(locator)
     }
   }
 
@@ -1510,18 +1510,18 @@ class Playwright extends Helper {
    */
   async handleDownloads(fileName) {
     this.page.waitForEvent('download').then(async download => {
-      const filePath = await download.path();
-      fileName = fileName || `downloads/${path.basename(filePath)}`;
+      const filePath = await download.path()
+      fileName = fileName || `downloads/${path.basename(filePath)}`
 
-      const downloadPath = path.join(global.output_dir, fileName);
+      const downloadPath = path.join(global.output_dir, fileName)
       if (!fs.existsSync(path.dirname(downloadPath))) {
-        fs.mkdirSync(path.dirname(downloadPath), '0777');
+        fs.mkdirSync(path.dirname(downloadPath), '0777')
       }
-      fs.copyFileSync(filePath, downloadPath);
-      this.debug('Download completed');
-      this.debugSection('Downloaded From', await download.url());
-      this.debugSection('Downloaded To', downloadPath);
-    });
+      fs.copyFileSync(filePath, downloadPath)
+      this.debug('Download completed')
+      this.debugSection('Downloaded From', await download.url())
+      this.debugSection('Downloaded To', downloadPath)
+    })
   }
 
   /**
@@ -1541,37 +1541,37 @@ class Playwright extends Helper {
    *
    */
   async click(locator, context = null, options = {}) {
-    return proceedClick.call(this, locator, context, options);
+    return proceedClick.call(this, locator, context, options)
   }
 
   /**
    * Clicks link and waits for navigation (deprecated)
    */
   async clickLink(locator, context = null) {
-    console.log('clickLink deprecated: Playwright automatically waits for navigation to happen.');
-    console.log('Replace I.clickLink with I.click');
-    return this.click(locator, context);
+    console.log('clickLink deprecated: Playwright automatically waits for navigation to happen.')
+    console.log('Replace I.clickLink with I.click')
+    return this.click(locator, context)
   }
 
   /**
    * {{> forceClick }}
    */
   async forceClick(locator, context = null) {
-    return proceedClick.call(this, locator, context, { force: true });
+    return proceedClick.call(this, locator, context, { force: true })
   }
 
   /**
    * {{> doubleClick }}
    */
   async doubleClick(locator, context = null) {
-    return proceedClick.call(this, locator, context, { clickCount: 2 });
+    return proceedClick.call(this, locator, context, { clickCount: 2 })
   }
 
   /**
    * {{> rightClick }}
    */
   async rightClick(locator, context = null) {
-    return proceedClick.call(this, locator, context, { button: 'right' });
+    return proceedClick.call(this, locator, context, { button: 'right' })
   }
 
   /**
@@ -1590,9 +1590,9 @@ class Playwright extends Helper {
    *
    */
   async checkOption(field, context = null, options = { force: true }) {
-    const elm = await this._locateCheckable(field, context);
-    await elm.check(options);
-    return this._waitForAction();
+    const elm = await this._locateCheckable(field, context)
+    await elm.check(options)
+    return this._waitForAction()
   }
 
   /**
@@ -1610,41 +1610,41 @@ class Playwright extends Helper {
    * {{> uncheckOption }}
    */
   async uncheckOption(field, context = null, options = { force: true }) {
-    const elm = await this._locateCheckable(field, context);
-    await elm.uncheck(options);
-    return this._waitForAction();
+    const elm = await this._locateCheckable(field, context)
+    await elm.uncheck(options)
+    return this._waitForAction()
   }
 
   /**
    * {{> seeCheckboxIsChecked }}
    */
   async seeCheckboxIsChecked(field) {
-    return proceedIsChecked.call(this, 'assert', field);
+    return proceedIsChecked.call(this, 'assert', field)
   }
 
   /**
    * {{> dontSeeCheckboxIsChecked }}
    */
   async dontSeeCheckboxIsChecked(field) {
-    return proceedIsChecked.call(this, 'negate', field);
+    return proceedIsChecked.call(this, 'negate', field)
   }
 
   /**
    * {{> pressKeyDown }}
    */
   async pressKeyDown(key) {
-    key = getNormalizedKey.call(this, key);
-    await this.page.keyboard.down(key);
-    return this._waitForAction();
+    key = getNormalizedKey.call(this, key)
+    await this.page.keyboard.down(key)
+    return this._waitForAction()
   }
 
   /**
    * {{> pressKeyUp }}
    */
   async pressKeyUp(key) {
-    key = getNormalizedKey.call(this, key);
-    await this.page.keyboard.up(key);
-    return this._waitForAction();
+    key = getNormalizedKey.call(this, key)
+    await this.page.keyboard.up(key)
+    return this._waitForAction()
   }
 
   /**
@@ -1654,28 +1654,28 @@ class Playwright extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
-    const modifiers = [];
+    const modifiers = []
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k);
+        k = getNormalizedKey.call(this, k)
         if (isModifierKey(k)) {
-          modifiers.push(k);
+          modifiers.push(k)
         } else {
-          key = k;
-          break;
+          key = k
+          break
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key);
+      key = getNormalizedKey.call(this, key)
     }
     for (const modifier of modifiers) {
-      await this.page.keyboard.down(modifier);
+      await this.page.keyboard.down(modifier)
     }
-    await this.page.keyboard.press(key);
+    await this.page.keyboard.press(key)
     for (const modifier of modifiers) {
-      await this.page.keyboard.up(modifier);
+      await this.page.keyboard.up(modifier)
     }
-    return this._waitForAction();
+    return this._waitForAction()
   }
 
   /**
@@ -1683,13 +1683,13 @@ class Playwright extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
-      keys = keys.toString();
-      keys = keys.split('');
+      keys = keys.toString()
+      keys = keys.split('')
     }
 
     for (const key of keys) {
-      await this.page.keyboard.press(key);
-      if (delay) await this.wait(delay / 1000);
+      await this.page.keyboard.press(key)
+      if (delay) await this.wait(delay / 1000)
     }
   }
 
@@ -1698,17 +1698,17 @@ class Playwright extends Helper {
    *
    */
   async fillField(field, value) {
-    const els = await findFields.call(this, field);
-    assertElementExists(els, field, 'Field');
-    const el = els[0];
+    const els = await findFields.call(this, field)
+    assertElementExists(els, field, 'Field')
+    const el = els[0]
 
-    await el.clear();
+    await el.clear()
 
-    await highlightActiveElement.call(this, el);
+    await highlightActiveElement.call(this, el)
 
-    await el.type(value.toString(), { delay: this.options.pressKeyDelay });
+    await el.type(value.toString(), { delay: this.options.pressKeyDelay })
 
-    return this._waitForAction();
+    return this._waitForAction()
   }
 
   /**
@@ -1729,44 +1729,44 @@ class Playwright extends Helper {
    * @param {any} [options] [Additional options](https://playwright.dev/docs/api/class-locator#locator-clear) for available options object as 2nd argument.
    */
   async clearField(locator, options = {}) {
-    const els = await findFields.call(this, locator);
-    assertElementExists(els, locator, 'Field to clear');
+    const els = await findFields.call(this, locator)
+    assertElementExists(els, locator, 'Field to clear')
 
-    const el = els[0];
+    const el = els[0]
 
-    await highlightActiveElement.call(this, el);
+    await highlightActiveElement.call(this, el)
 
-    await el.clear();
+    await el.clear()
 
-    return this._waitForAction();
+    return this._waitForAction()
   }
 
   /**
    * {{> appendField }}
    */
   async appendField(field, value) {
-    const els = await findFields.call(this, field);
-    assertElementExists(els, field, 'Field');
-    await highlightActiveElement.call(this, els[0]);
-    await els[0].press('End');
-    await els[0].type(value.toString(), { delay: this.options.pressKeyDelay });
-    return this._waitForAction();
+    const els = await findFields.call(this, field)
+    assertElementExists(els, field, 'Field')
+    await highlightActiveElement.call(this, els[0])
+    await els[0].press('End')
+    await els[0].type(value.toString(), { delay: this.options.pressKeyDelay })
+    return this._waitForAction()
   }
 
   /**
    * {{> seeInField }}
    */
   async seeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString();
-    return proceedSeeInField.call(this, 'assert', field, _value);
+    const _value = typeof value === 'boolean' ? value : value.toString()
+    return proceedSeeInField.call(this, 'assert', field, _value)
   }
 
   /**
    * {{> dontSeeInField }}
    */
   async dontSeeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString();
-    return proceedSeeInField.call(this, 'negate', field, _value);
+    const _value = typeof value === 'boolean' ? value : value.toString()
+    return proceedSeeInField.call(this, 'negate', field, _value)
   }
 
   /**
@@ -1774,38 +1774,38 @@ class Playwright extends Helper {
    *
    */
   async attachFile(locator, pathToFile) {
-    const file = path.join(global.codecept_dir, pathToFile);
+    const file = path.join(global.codecept_dir, pathToFile)
 
     if (!fileExists(file)) {
-      throw new Error(`File at ${file} can not be found on local system`);
+      throw new Error(`File at ${file} can not be found on local system`)
     }
-    const els = await findFields.call(this, locator);
-    assertElementExists(els, locator, 'Field');
-    await els[0].setInputFiles(file);
-    return this._waitForAction();
+    const els = await findFields.call(this, locator)
+    assertElementExists(els, locator, 'Field')
+    await els[0].setInputFiles(file)
+    return this._waitForAction()
   }
 
   /**
    * {{> selectOption }}
    */
   async selectOption(select, option) {
-    const els = await findFields.call(this, select);
-    assertElementExists(els, select, 'Selectable field');
-    const el = els[0];
+    const els = await findFields.call(this, select)
+    assertElementExists(els, select, 'Selectable field')
+    const el = els[0]
 
-    await highlightActiveElement.call(this, el);
-    let optionToSelect = '';
+    await highlightActiveElement.call(this, el)
+    let optionToSelect = ''
 
     try {
-      optionToSelect = (await el.locator('option', { hasText: option }).textContent()).trim();
+      optionToSelect = (await el.locator('option', { hasText: option }).textContent()).trim()
     } catch (e) {
-      optionToSelect = option;
+      optionToSelect = option
     }
 
-    if (!Array.isArray(option)) option = [optionToSelect];
+    if (!Array.isArray(option)) option = [optionToSelect]
 
-    await el.selectOption(option);
-    return this._waitForAction();
+    await el.selectOption(option)
+    return this._waitForAction()
   }
 
   /**
@@ -1813,37 +1813,37 @@ class Playwright extends Helper {
    *
    */
   async grabNumberOfVisibleElements(locator) {
-    let els = await this._locate(locator);
-    els = await Promise.all(els.map(el => el.isVisible()));
-    return els.filter(v => v).length;
+    let els = await this._locate(locator)
+    els = await Promise.all(els.map(el => el.isVisible()))
+    return els.filter(v => v).length
   }
 
   /**
    * {{> seeInCurrentUrl }}
    */
   async seeInCurrentUrl(url) {
-    stringIncludes('url').assert(url, await this._getPageUrl());
+    stringIncludes('url').assert(url, await this._getPageUrl())
   }
 
   /**
    * {{> dontSeeInCurrentUrl }}
    */
   async dontSeeInCurrentUrl(url) {
-    stringIncludes('url').negate(url, await this._getPageUrl());
+    stringIncludes('url').negate(url, await this._getPageUrl())
   }
 
   /**
    * {{> seeCurrentUrlEquals }}
    */
   async seeCurrentUrlEquals(url) {
-    urlEquals(this.options.url).assert(url, await this._getPageUrl());
+    urlEquals(this.options.url).assert(url, await this._getPageUrl())
   }
 
   /**
    * {{> dontSeeCurrentUrlEquals }}
    */
   async dontSeeCurrentUrlEquals(url) {
-    urlEquals(this.options.url).negate(url, await this._getPageUrl());
+    urlEquals(this.options.url).negate(url, await this._getPageUrl())
   }
 
   /**
@@ -1852,14 +1852,14 @@ class Playwright extends Helper {
    *
    */
   async see(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context);
+    return proceedSee.call(this, 'assert', text, context)
   }
 
   /**
    * {{> seeTextEquals }}
    */
   async seeTextEquals(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context, true);
+    return proceedSee.call(this, 'assert', text, context, true)
   }
 
   /**
@@ -1868,14 +1868,14 @@ class Playwright extends Helper {
    *
    */
   async dontSee(text, context = null) {
-    return proceedSee.call(this, 'negate', text, context);
+    return proceedSee.call(this, 'negate', text, context)
   }
 
   /**
    * {{> grabSource }}
    */
   async grabSource() {
-    return this.page.content();
+    return this.page.content()
   }
 
   /**
@@ -1890,32 +1890,32 @@ class Playwright extends Helper {
    * @return {Promise<any[]>}
    */
   async grabBrowserLogs() {
-    const logs = consoleLogStore.entries;
-    consoleLogStore.clear();
-    return logs;
+    const logs = consoleLogStore.entries
+    consoleLogStore.clear()
+    return logs
   }
 
   /**
    * {{> grabCurrentUrl }}
    */
   async grabCurrentUrl() {
-    return this._getPageUrl();
+    return this._getPageUrl()
   }
 
   /**
    * {{> seeInSource }}
    */
   async seeInSource(text) {
-    const source = await this.page.content();
-    stringIncludes('HTML source of a page').assert(text, source);
+    const source = await this.page.content()
+    stringIncludes('HTML source of a page').assert(text, source)
   }
 
   /**
    * {{> dontSeeInSource }}
    */
   async dontSeeInSource(text) {
-    const source = await this.page.content();
-    stringIncludes('HTML source of a page').negate(text, source);
+    const source = await this.page.content()
+    stringIncludes('HTML source of a page').negate(text, source)
   }
 
   /**
@@ -1924,8 +1924,8 @@ class Playwright extends Helper {
    *
    */
   async seeNumberOfElements(locator, num) {
-    const elements = await this._locate(locator);
-    return equals(`expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
+    const elements = await this._locate(locator)
+    return equals(`expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`).assert(elements.length, num)
   }
 
   /**
@@ -1934,8 +1934,8 @@ class Playwright extends Helper {
    *
    */
   async seeNumberOfVisibleElements(locator, num) {
-    const res = await this.grabNumberOfVisibleElements(locator);
-    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(res, num);
+    const res = await this.grabNumberOfVisibleElements(locator)
+    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(res, num)
   }
 
   /**
@@ -1943,9 +1943,9 @@ class Playwright extends Helper {
    */
   async setCookie(cookie) {
     if (Array.isArray(cookie)) {
-      return this.browserContext.addCookies(cookie);
+      return this.browserContext.addCookies(cookie)
     }
-    return this.browserContext.addCookies([cookie]);
+    return this.browserContext.addCookies([cookie])
   }
 
   /**
@@ -1953,16 +1953,16 @@ class Playwright extends Helper {
    *
    */
   async seeCookie(name) {
-    const cookies = await this.browserContext.cookies();
-    empty(`cookie ${name} to be set`).negate(cookies.filter(c => c.name === name));
+    const cookies = await this.browserContext.cookies()
+    empty(`cookie ${name} to be set`).negate(cookies.filter(c => c.name === name))
   }
 
   /**
    * {{> dontSeeCookie }}
    */
   async dontSeeCookie(name) {
-    const cookies = await this.browserContext.cookies();
-    empty(`cookie ${name} not to be set`).assert(cookies.filter(c => c.name === name));
+    const cookies = await this.browserContext.cookies()
+    empty(`cookie ${name} not to be set`).assert(cookies.filter(c => c.name === name))
   }
 
   /**
@@ -1971,10 +1971,10 @@ class Playwright extends Helper {
    * {{> grabCookie }}
    */
   async grabCookie(name) {
-    const cookies = await this.browserContext.cookies();
-    if (!name) return cookies;
-    const cookie = cookies.filter(c => c.name === name);
-    if (cookie[0]) return cookie[0];
+    const cookies = await this.browserContext.cookies()
+    if (!name) return cookies
+    const cookie = cookies.filter(c => c.name === name)
+    if (cookie[0]) return cookie[0]
   }
 
   /**
@@ -1983,8 +1983,8 @@ class Playwright extends Helper {
   async clearCookie() {
     // Playwright currently doesn't support to delete a certain cookie
     // https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md#async-method-browsercontextclearcookies
-    if (!this.browserContext) return;
-    return this.browserContext.clearCookies();
+    if (!this.browserContext) return
+    return this.browserContext.clearCookies()
   }
 
   /**
@@ -2014,9 +2014,9 @@ class Playwright extends Helper {
   async executeScript(fn, arg) {
     if (this.context && this.context.constructor.name === 'FrameLocator') {
       // switching to iframe context
-      return this.context.locator(':root').evaluate(fn, arg);
+      return this.context.locator(':root').evaluate(fn, arg)
     }
-    return this.page.evaluate.apply(this.page, [fn, arg]);
+    return this.page.evaluate.apply(this.page, [fn, arg])
   }
 
   /**
@@ -2025,14 +2025,14 @@ class Playwright extends Helper {
    * @param {*} locator
    */
   _contextLocator(locator) {
-    locator = buildLocatorString(new Locator(locator, 'css'));
+    locator = buildLocatorString(new Locator(locator, 'css'))
 
     if (this.contextLocator) {
-      const contextLocator = buildLocatorString(new Locator(this.contextLocator, 'css'));
-      locator = `${contextLocator} >> ${locator}`;
+      const contextLocator = buildLocatorString(new Locator(this.contextLocator, 'css'))
+      locator = `${contextLocator} >> ${locator}`
     }
 
-    return locator;
+    return locator
   }
 
   /**
@@ -2040,11 +2040,11 @@ class Playwright extends Helper {
    *
    */
   async grabTextFrom(locator) {
-    locator = this._contextLocator(locator);
-    const text = await this.page.textContent(locator);
-    assertElementExists(text, locator);
-    this.debugSection('Text', text);
-    return text;
+    locator = this._contextLocator(locator)
+    const text = await this.page.textContent(locator)
+    assertElementExists(text, locator)
+    this.debugSection('Text', text)
+    return text
   }
 
   /**
@@ -2052,51 +2052,51 @@ class Playwright extends Helper {
    *
    */
   async grabTextFromAll(locator) {
-    const els = await this._locate(locator);
-    const texts = [];
+    const els = await this._locate(locator)
+    const texts = []
     for (const el of els) {
-      texts.push(await el.innerText());
+      texts.push(await el.innerText())
     }
-    this.debug(`Matched ${els.length} elements`);
-    return texts;
+    this.debug(`Matched ${els.length} elements`)
+    return texts
   }
 
   /**
    * {{> grabValueFrom }}
    */
   async grabValueFrom(locator) {
-    const values = await this.grabValueFromAll(locator);
-    assertElementExists(values, locator);
-    this.debugSection('Value', values[0]);
-    return values[0];
+    const values = await this.grabValueFromAll(locator)
+    assertElementExists(values, locator)
+    this.debugSection('Value', values[0])
+    return values[0]
   }
 
   /**
    * {{> grabValueFromAll }}
    */
   async grabValueFromAll(locator) {
-    const els = await findFields.call(this, locator);
-    this.debug(`Matched ${els.length} elements`);
-    return Promise.all(els.map(el => el.inputValue()));
+    const els = await findFields.call(this, locator)
+    this.debug(`Matched ${els.length} elements`)
+    return Promise.all(els.map(el => el.inputValue()))
   }
 
   /**
    * {{> grabHTMLFrom }}
    */
   async grabHTMLFrom(locator) {
-    const html = await this.grabHTMLFromAll(locator);
-    assertElementExists(html, locator);
-    this.debugSection('HTML', html[0]);
-    return html[0];
+    const html = await this.grabHTMLFromAll(locator)
+    assertElementExists(html, locator)
+    this.debugSection('HTML', html[0])
+    return html[0]
   }
 
   /**
    * {{> grabHTMLFromAll }}
    */
   async grabHTMLFromAll(locator) {
-    const els = await this._locate(locator);
-    this.debug(`Matched ${els.length} elements`);
-    return Promise.all(els.map(el => el.innerHTML()));
+    const els = await this._locate(locator)
+    this.debug(`Matched ${els.length} elements`)
+    return Promise.all(els.map(el => el.innerHTML()))
   }
 
   /**
@@ -2104,10 +2104,10 @@ class Playwright extends Helper {
    *
    */
   async grabCssPropertyFrom(locator, cssProperty) {
-    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty);
-    assertElementExists(cssValues, locator);
-    this.debugSection('CSS', cssValues[0]);
-    return cssValues[0];
+    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty)
+    assertElementExists(cssValues, locator)
+    this.debugSection('CSS', cssValues[0])
+    return cssValues[0]
   }
 
   /**
@@ -2115,11 +2115,11 @@ class Playwright extends Helper {
    *
    */
   async grabCssPropertyFromAll(locator, cssProperty) {
-    const els = await this._locate(locator);
-    this.debug(`Matched ${els.length} elements`);
-    const cssValues = await Promise.all(els.map(el => el.evaluate((el, cssProperty) => getComputedStyle(el).getPropertyValue(cssProperty), cssProperty)));
+    const els = await this._locate(locator)
+    this.debug(`Matched ${els.length} elements`)
+    const cssValues = await Promise.all(els.map(el => el.evaluate((el, cssProperty) => getComputedStyle(el).getPropertyValue(cssProperty), cssProperty)))
 
-    return cssValues;
+    return cssValues
   }
 
   /**
@@ -2127,35 +2127,35 @@ class Playwright extends Helper {
    *
    */
   async seeCssPropertiesOnElements(locator, cssProperties) {
-    const res = await this._locate(locator);
-    assertElementExists(res, locator);
+    const res = await this._locate(locator)
+    assertElementExists(res, locator)
 
-    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties);
-    const elemAmount = res.length;
-    let props = [];
+    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties)
+    const elemAmount = res.length
+    let props = []
 
     for (const element of res) {
       for (const prop of Object.keys(cssProperties)) {
-        const cssProp = await this.grabCssPropertyFrom(locator, prop);
+        const cssProp = await this.grabCssPropertyFrom(locator, prop)
         if (isColorProperty(prop)) {
-          props.push(convertColorToRGBA(cssProp));
+          props.push(convertColorToRGBA(cssProp))
         } else {
-          props.push(cssProp);
+          props.push(cssProp)
         }
       }
     }
 
-    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key]);
-    if (!Array.isArray(props)) props = [props];
-    let chunked = chunkArray(props, values.length);
+    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key])
+    if (!Array.isArray(props)) props = [props]
+    let chunked = chunkArray(props, values.length)
     chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // eslint-disable-next-line eqeqeq
-        if (val[i] != values[i]) return false;
+        if (val[i] != values[i]) return false
       }
-      return true;
-    });
-    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
+      return true
+    })
+    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount)
   }
 
   /**
@@ -2163,30 +2163,30 @@ class Playwright extends Helper {
    *
    */
   async seeAttributesOnElements(locator, attributes) {
-    const res = await this._locate(locator);
-    assertElementExists(res, locator);
+    const res = await this._locate(locator)
+    assertElementExists(res, locator)
 
-    const elemAmount = res.length;
-    const commands = [];
+    const elemAmount = res.length
+    const commands = []
     res.forEach(el => {
       Object.keys(attributes).forEach(prop => {
-        commands.push(el.evaluate((el, attr) => el[attr] || el.getAttribute(attr), prop));
-      });
-    });
-    let attrs = await Promise.all(commands);
-    const values = Object.keys(attributes).map(key => attributes[key]);
-    if (!Array.isArray(attrs)) attrs = [attrs];
-    let chunked = chunkArray(attrs, values.length);
+        commands.push(el.evaluate((el, attr) => el[attr] || el.getAttribute(attr), prop))
+      })
+    })
+    let attrs = await Promise.all(commands)
+    const values = Object.keys(attributes).map(key => attributes[key])
+    if (!Array.isArray(attrs)) attrs = [attrs]
+    let chunked = chunkArray(attrs, values.length)
     chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // the attribute could be a boolean
-        if (typeof val[i] === 'boolean') return val[i] === values[i];
+        if (typeof val[i] === 'boolean') return val[i] === values[i]
         // if the attribute doesn't exist, returns false as well
-        if (!val[i] || !val[i].includes(values[i])) return false;
+        if (!val[i] || !val[i].includes(values[i])) return false
       }
-      return true;
-    });
-    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
+      return true
+    })
+    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount)
   }
 
   /**
@@ -2194,21 +2194,21 @@ class Playwright extends Helper {
    *
    */
   async dragSlider(locator, offsetX = 0) {
-    const src = await this._locateElement(locator);
-    assertElementExists(src, locator, 'Slider Element');
+    const src = await this._locateElement(locator)
+    assertElementExists(src, locator, 'Slider Element')
 
     // Note: Using clickablePoint private api because the .BoundingBox does not take into account iframe offsets!
-    const sliderSource = await clickablePoint(src);
+    const sliderSource = await clickablePoint(src)
 
     // Drag start point
-    await this.page.mouse.move(sliderSource.x, sliderSource.y, { steps: 5 });
-    await this.page.mouse.down();
+    await this.page.mouse.move(sliderSource.x, sliderSource.y, { steps: 5 })
+    await this.page.mouse.down()
 
     // Drag destination
-    await this.page.mouse.move(sliderSource.x + offsetX, sliderSource.y, { steps: 5 });
-    await this.page.mouse.up();
+    await this.page.mouse.move(sliderSource.x + offsetX, sliderSource.y, { steps: 5 })
+    await this.page.mouse.up()
 
-    return this._waitForAction();
+    return this._waitForAction()
   }
 
   /**
@@ -2216,10 +2216,10 @@ class Playwright extends Helper {
    *
    */
   async grabAttributeFrom(locator, attr) {
-    const attrs = await this.grabAttributeFromAll(locator, attr);
-    assertElementExists(attrs, locator);
-    this.debugSection('Attribute', attrs[0]);
-    return attrs[0];
+    const attrs = await this.grabAttributeFromAll(locator, attr)
+    assertElementExists(attrs, locator)
+    this.debugSection('Attribute', attrs[0])
+    return attrs[0]
   }
 
   /**
@@ -2227,15 +2227,15 @@ class Playwright extends Helper {
    *
    */
   async grabAttributeFromAll(locator, attr) {
-    const els = await this._locate(locator);
-    this.debug(`Matched ${els.length} elements`);
-    const array = [];
+    const els = await this._locate(locator)
+    this.debug(`Matched ${els.length} elements`)
+    const array = []
 
     for (let index = 0; index < els.length; index++) {
-      array.push(await els[index].getAttribute(attr));
+      array.push(await els[index].getAttribute(attr))
     }
 
-    return array;
+    return array
   }
 
   /**
@@ -2243,43 +2243,43 @@ class Playwright extends Helper {
    *
    */
   async saveElementScreenshot(locator, fileName) {
-    const outputFile = screenshotOutputFolder(fileName);
+    const outputFile = screenshotOutputFolder(fileName)
 
-    const res = await this._locateElement(locator);
-    assertElementExists(res, locator);
-    const elem = res;
-    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`);
-    return elem.screenshot({ path: outputFile, type: 'png' });
+    const res = await this._locateElement(locator)
+    assertElementExists(res, locator)
+    const elem = res
+    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`)
+    return elem.screenshot({ path: outputFile, type: 'png' })
   }
 
   /**
    * {{> saveScreenshot }}
    */
   async saveScreenshot(fileName, fullPage) {
-    const fullPageOption = fullPage || this.options.fullPageScreenshots;
-    let outputFile = screenshotOutputFolder(fileName);
+    const fullPageOption = fullPage || this.options.fullPageScreenshots
+    let outputFile = screenshotOutputFolder(fileName)
 
-    this.debug(`Screenshot is saving to ${outputFile}`);
+    this.debug(`Screenshot is saving to ${outputFile}`)
 
     await this.page.screenshot({
       path: outputFile,
       fullPage: fullPageOption,
       type: 'png',
-    });
+    })
 
     if (this.activeSessionName) {
       for (const sessionName in this.sessionPages) {
-        const activeSessionPage = this.sessionPages[sessionName];
-        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
+        const activeSessionPage = this.sessionPages[sessionName]
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`)
 
-        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`)
 
         if (activeSessionPage) {
           await activeSessionPage.screenshot({
             path: outputFile,
             fullPage: fullPageOption,
             type: 'png',
-          });
+          })
         }
       }
     }
@@ -2303,21 +2303,21 @@ class Playwright extends Helper {
    * @returns {Promise<object>} response
    */
   async makeApiRequest(method, url, options) {
-    method = method.toLowerCase();
-    const allowedMethods = ['get', 'post', 'patch', 'head', 'fetch', 'delete'];
+    method = method.toLowerCase()
+    const allowedMethods = ['get', 'post', 'patch', 'head', 'fetch', 'delete']
     if (!allowedMethods.includes(method)) {
-      throw new Error(`Method ${method} is not allowed, use the one from a list ${allowedMethods} or switch to using REST helper`);
+      throw new Error(`Method ${method} is not allowed, use the one from a list ${allowedMethods} or switch to using REST helper`)
     }
 
     if (url.startsWith('/')) {
       // local url
-      url = this.options.url + url;
-      this.debugSection('URL', url);
+      url = this.options.url + url
+      this.debugSection('URL', url)
     }
 
-    const response = await this.page.request[method](url, options);
-    this.debugSection('Status', response.status());
-    this.debugSection('Response', await response.text());
+    const response = await this.page.request[method](url, options)
+    this.debugSection('Status', response.status())
+    this.debugSection('Response', await response.text())
 
     // hook to allow JSON response handle this
     if (this.config.onResponse) {
@@ -2326,71 +2326,71 @@ class Playwright extends Helper {
         status: response.status(),
         statusText: response.statusText(),
         headers: response.headers(),
-      };
-      this.config.onResponse(axiosResponse);
+      }
+      this.config.onResponse(axiosResponse)
     }
 
-    return response;
+    return response
   }
 
   async _failed(test) {
-    await this._withinEnd();
+    await this._withinEnd()
 
     if (!test.artifacts) {
-      test.artifacts = {};
+      test.artifacts = {}
     }
 
     if (this.options.recordVideo && this.page && this.page.video()) {
-      test.artifacts.video = saveVideoForPage(this.page, `${test.title}.failed`);
+      test.artifacts.video = saveVideoForPage(this.page, `${test.title}.failed`)
       for (const sessionName in this.sessionPages) {
-        test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.failed`);
+        test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.failed`)
       }
     }
 
     if (this.options.trace) {
-      test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.failed`);
+      test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.failed`)
       for (const sessionName in this.sessionPages) {
-        if (!this.sessionPages[sessionName].context) continue;
-        test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.failed`);
+        if (!this.sessionPages[sessionName].context) continue
+        test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.failed`)
       }
     }
 
     if (this.options.recordHar) {
-      test.artifacts.har = this.currentRunningTest.artifacts.har;
+      test.artifacts.har = this.currentRunningTest.artifacts.har
     }
   }
 
   async _passed(test) {
     if (this.options.recordVideo && this.page && this.page.video()) {
       if (this.options.keepVideoForPassedTests) {
-        test.artifacts.video = saveVideoForPage(this.page, `${test.title}.passed`);
+        test.artifacts.video = saveVideoForPage(this.page, `${test.title}.passed`)
         for (const sessionName of Object.keys(this.sessionPages)) {
-          test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.passed`);
+          test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.passed`)
         }
       } else {
         this.page
           .video()
           .delete()
-          .catch(e => {});
+          .catch(e => {})
       }
     }
 
     if (this.options.trace) {
       if (this.options.keepTraceForPassedTests) {
         if (this.options.trace) {
-          test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.passed`);
+          test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.passed`)
           for (const sessionName in this.sessionPages) {
-            if (!this.sessionPages[sessionName].context) continue;
-            test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.passed`);
+            if (!this.sessionPages[sessionName].context) continue
+            test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.passed`)
           }
         }
       } else {
-        await this.browserContext.tracing.stop();
+        await this.browserContext.tracing.stop()
       }
     }
 
     if (this.options.recordHar) {
-      test.artifacts.har = this.currentRunningTest.artifacts.har;
+      test.artifacts.har = this.currentRunningTest.artifacts.har
     }
   }
 
@@ -2399,89 +2399,89 @@ class Playwright extends Helper {
    */
   async wait(sec) {
     return new Promise(done => {
-      setTimeout(done, sec * 1000);
-    });
+      setTimeout(done, sec * 1000)
+    })
   }
 
   /**
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
 
-    let waiter;
-    const context = await this._getContext();
+    let waiter
+    const context = await this._getContext()
     if (!locator.isXPath()) {
       const valueFn = function ([locator]) {
-        return Array.from(document.querySelectorAll(locator)).filter(el => !el.disabled).length > 0;
-      };
-      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout });
+        return Array.from(document.querySelectorAll(locator)).filter(el => !el.disabled).length > 0
+      }
+      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout })
     } else {
       const enabledFn = function ([locator, $XPath]) {
-        eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).filter(el => !el.disabled).length > 0;
-      };
-      waiter = context.waitForFunction(enabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
+        eval($XPath) // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => !el.disabled).length > 0
+      }
+      waiter = context.waitForFunction(enabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout })
     }
     return waiter.catch(err => {
-      throw new Error(`element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`);
-    });
+      throw new Error(`element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`)
+    })
   }
 
   /**
    * {{> waitForDisabled }}
    */
   async waitForDisabled(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
 
-    let waiter;
-    const context = await this._getContext();
+    let waiter
+    const context = await this._getContext()
     if (!locator.isXPath()) {
       const valueFn = function ([locator]) {
-        return Array.from(document.querySelectorAll(locator)).filter(el => el.disabled).length > 0;
-      };
-      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout });
+        return Array.from(document.querySelectorAll(locator)).filter(el => el.disabled).length > 0
+      }
+      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout })
     } else {
       const disabledFn = function ([locator, $XPath]) {
-        eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).filter(el => el.disabled).length > 0;
-      };
-      waiter = context.waitForFunction(disabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
+        eval($XPath) // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => el.disabled).length > 0
+      }
+      waiter = context.waitForFunction(disabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout })
     }
     return waiter.catch(err => {
-      throw new Error(`element (${locator.toString()}) is still enabled after ${waitTimeout / 1000} sec\n${err.message}`);
-    });
+      throw new Error(`element (${locator.toString()}) is still enabled after ${waitTimeout / 1000} sec\n${err.message}`)
+    })
   }
 
   /**
    * {{> waitForValue }}
    */
   async waitForValue(field, value, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    const locator = new Locator(field, 'css');
-    const matcher = await this.context;
-    let waiter;
-    const context = await this._getContext();
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    const locator = new Locator(field, 'css')
+    const matcher = await this.context
+    let waiter
+    const context = await this._getContext()
     if (!locator.isXPath()) {
       const valueFn = function ([locator, value]) {
-        return Array.from(document.querySelectorAll(locator)).filter(el => (el.value || '').indexOf(value) !== -1).length > 0;
-      };
-      waiter = context.waitForFunction(valueFn, [locator.value, value], { timeout: waitTimeout });
+        return Array.from(document.querySelectorAll(locator)).filter(el => (el.value || '').indexOf(value) !== -1).length > 0
+      }
+      waiter = context.waitForFunction(valueFn, [locator.value, value], { timeout: waitTimeout })
     } else {
       const valueFn = function ([locator, $XPath, value]) {
-        eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).filter(el => (el.value || '').indexOf(value) !== -1).length > 0;
-      };
+        eval($XPath) // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => (el.value || '').indexOf(value) !== -1).length > 0
+      }
       waiter = context.waitForFunction(valueFn, [locator.value, $XPath.toString(), value], {
         timeout: waitTimeout,
-      });
+      })
     }
     return waiter.catch(err => {
-      const loc = locator.toString();
-      throw new Error(`element (${loc}) is not in DOM or there is no element(${loc}) with value "${value}" after ${waitTimeout / 1000} sec\n${err.message}`);
-    });
+      const loc = locator.toString()
+      throw new Error(`element (${loc}) is not in DOM or there is no element(${loc}) with value "${value}" after ${waitTimeout / 1000} sec\n${err.message}`)
+    })
   }
 
   /**
@@ -2489,40 +2489,40 @@ class Playwright extends Helper {
    *
    */
   async waitNumberOfVisibleElements(locator, num, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
 
-    let waiter;
-    const context = await this._getContext();
+    let waiter
+    const context = await this._getContext()
     if (locator.isCSS()) {
       const visibleFn = function ([locator, num]) {
-        const els = document.querySelectorAll(locator);
+        const els = document.querySelectorAll(locator)
         if (!els || els.length === 0) {
-          return false;
+          return false
         }
-        return Array.prototype.filter.call(els, el => el.offsetParent !== null).length === num;
-      };
-      waiter = context.waitForFunction(visibleFn, [locator.value, num], { timeout: waitTimeout });
+        return Array.prototype.filter.call(els, el => el.offsetParent !== null).length === num
+      }
+      waiter = context.waitForFunction(visibleFn, [locator.value, num], { timeout: waitTimeout })
     } else {
       const visibleFn = function ([locator, $XPath, num]) {
-        eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).filter(el => el.offsetParent !== null).length === num;
-      };
+        eval($XPath) // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => el.offsetParent !== null).length === num
+      }
       waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString(), num], {
         timeout: waitTimeout,
-      });
+      })
     }
     return waiter.catch(err => {
-      throw new Error(`The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`);
-    });
+      throw new Error(`The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`)
+    })
   }
 
   /**
    * {{> waitForClickable }}
    */
   async waitForClickable(locator, waitTimeout) {
-    console.log('I.waitForClickable is DEPRECATED: This is no longer needed, Playwright automatically waits for element to be clickable');
-    console.log('Remove usage of this function');
+    console.log('I.waitForClickable is DEPRECATED: This is no longer needed, Playwright automatically waits for element to be clickable')
+    console.log('Remove usage of this function')
   }
 
   /**
@@ -2530,14 +2530,14 @@ class Playwright extends Helper {
    *
    */
   async waitForElement(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
 
-    const context = await this._getContext();
+    const context = await this._getContext()
     try {
-      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'attached' });
+      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'attached' })
     } catch (e) {
-      throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${e.message}`);
+      throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${e.message}`)
     }
   }
 
@@ -2547,28 +2547,28 @@ class Playwright extends Helper {
    * {{> waitForVisible }}
    */
   async waitForVisible(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
-    const context = await this._getContext();
-    let count = 0;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
+    const context = await this._getContext()
+    let count = 0
 
     // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
-    let waiter;
+    let waiter
     if (this.frame) {
       do {
-        waiter = await this.frame.locator(buildLocatorString(locator)).first().isVisible();
-        await this.wait(1);
-        count += 1000;
-        if (waiter) break;
-      } while (count <= waitTimeout);
+        waiter = await this.frame.locator(buildLocatorString(locator)).first().isVisible()
+        await this.wait(1)
+        count += 1000
+        if (waiter) break
+      } while (count <= waitTimeout)
 
-      if (!waiter) throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec.`);
+      if (!waiter) throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec.`)
     }
 
     try {
-      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'visible' });
+      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'visible' })
     } catch (e) {
-      throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${e.message}`);
+      throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${e.message}`)
     }
   }
 
@@ -2576,29 +2576,29 @@ class Playwright extends Helper {
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
-    const context = await this._getContext();
-    let waiter;
-    let count = 0;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
+    const context = await this._getContext()
+    let waiter
+    let count = 0
 
     // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
     if (this.frame) {
       do {
-        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden();
-        await this.wait(1);
-        count += 1000;
-        if (waiter) break;
-      } while (count <= waitTimeout);
+        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden()
+        await this.wait(1)
+        count += 1000
+        if (waiter) break
+      } while (count <= waitTimeout)
 
-      if (!waiter) throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec.`);
-      return;
+      if (!waiter) throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec.`)
+      return
     }
 
     try {
-      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'hidden' });
+      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'hidden' })
     } catch (e) {
-      throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${e.message}`);
+      throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${e.message}`)
     }
   }
 
@@ -2606,23 +2606,23 @@ class Playwright extends Helper {
    * {{> waitToHide }}
    */
   async waitToHide(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
-    const context = await this._getContext();
-    let waiter;
-    let count = 0;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
+    const context = await this._getContext()
+    let waiter
+    let count = 0
 
     // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
     if (this.frame) {
       do {
-        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden();
-        await this.wait(1);
-        count += 1000;
-        if (waiter) break;
-      } while (count <= waitTimeout);
+        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden()
+        await this.wait(1)
+        count += 1000
+        if (waiter) break
+      } while (count <= waitTimeout)
 
-      if (!waiter) throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec.`);
-      return;
+      if (!waiter) throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec.`)
+      return
     }
 
     return context
@@ -2630,110 +2630,110 @@ class Playwright extends Helper {
       .first()
       .waitFor({ timeout: waitTimeout, state: 'hidden' })
       .catch(err => {
-        throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`);
-      });
+        throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`)
+      })
   }
 
   /**
    * {{> waitForNumberOfTabs }}
    */
   async waitForNumberOfTabs(expectedTabs, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    let currentTabs;
-    let count = 0;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    let currentTabs
+    let count = 0
 
     do {
-      currentTabs = await this.grabNumberOfOpenTabs();
-      await this.wait(1);
-      count += 1000;
-      if (currentTabs >= expectedTabs) return;
-    } while (count <= waitTimeout);
+      currentTabs = await this.grabNumberOfOpenTabs()
+      await this.wait(1)
+      count += 1000
+      if (currentTabs >= expectedTabs) return
+    } while (count <= waitTimeout)
 
-    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`)
   }
 
   async _getContext() {
     if ((this.context && this.context.constructor.name === 'FrameLocator') || this.context) {
-      return this.context;
+      return this.context
     }
-    return this.page;
+    return this.page
   }
 
   /**
    * {{> waitInUrl }}
    */
   async waitInUrl(urlPart, sec = null) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
     return this.page
       .waitForFunction(
         urlPart => {
-          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
-          return currUrl.indexOf(urlPart) > -1;
+          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
+          return currUrl.indexOf(urlPart) > -1
         },
         urlPart,
         { timeout: waitTimeout },
       )
       .catch(async e => {
-        const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
+        const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
         if (/Timeout/i.test(e.message)) {
-          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`);
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
         } else {
-          throw e;
+          throw e
         }
-      });
+      })
   }
 
   /**
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
-    const baseUrl = this.options.url;
+    const baseUrl = this.options.url
     if (urlPart.indexOf('http') < 0) {
-      urlPart = baseUrl + urlPart;
+      urlPart = baseUrl + urlPart
     }
 
     return this.page
       .waitForFunction(
         urlPart => {
-          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
-          return currUrl.indexOf(urlPart) > -1;
+          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
+          return currUrl.indexOf(urlPart) > -1
         },
         urlPart,
         { timeout: waitTimeout },
       )
       .catch(async e => {
-        const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
+        const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
         if (/Timeout/i.test(e.message)) {
-          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`);
+          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
         } else {
-          throw e;
+          throw e
         }
-      });
+      })
   }
 
   /**
    * {{> waitForText }}
    */
   async waitForText(text, sec = null, context = null) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    const errorMessage = `Text "${text}" was not found on page after ${waitTimeout / 1000} sec.`;
-    let waiter;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    const errorMessage = `Text "${text}" was not found on page after ${waitTimeout / 1000} sec.`
+    let waiter
 
-    const contextObject = await this._getContext();
+    const contextObject = await this._getContext()
 
     if (context) {
-      const locator = new Locator(context, 'css');
+      const locator = new Locator(context, 'css')
       if (!locator.isXPath()) {
         try {
           await contextObject
             .locator(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> text=${text}`)
             .first()
-            .waitFor({ timeout: waitTimeout, state: 'visible' });
+            .waitFor({ timeout: waitTimeout, state: 'visible' })
         } catch (e) {
-          throw new Error(`${errorMessage}\n${e.message}`);
+          throw new Error(`${errorMessage}\n${e.message}`)
         }
       }
 
@@ -2741,34 +2741,34 @@ class Playwright extends Helper {
         try {
           await contextObject.waitForFunction(
             ([locator, text, $XPath]) => {
-              eval($XPath); // eslint-disable-line no-eval
-              const el = $XPath(null, locator);
-              if (!el.length) return false;
-              return el[0].innerText.indexOf(text) > -1;
+              eval($XPath) // eslint-disable-line no-eval
+              const el = $XPath(null, locator)
+              if (!el.length) return false
+              return el[0].innerText.indexOf(text) > -1
             },
             [locator.value, text, $XPath.toString()],
             { timeout: waitTimeout },
-          );
+          )
         } catch (e) {
-          throw new Error(`${errorMessage}\n${e.message}`);
+          throw new Error(`${errorMessage}\n${e.message}`)
         }
       }
     } else {
       // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
 
-      const _contextObject = this.frame ? this.frame : contextObject;
-      let count = 0;
+      const _contextObject = this.frame ? this.frame : contextObject
+      let count = 0
       do {
         waiter = await _contextObject
           .locator(`:has-text(${JSON.stringify(text)})`)
           .first()
-          .isVisible();
-        if (waiter) break;
-        await this.wait(1);
-        count += 1000;
-      } while (count <= waitTimeout);
+          .isVisible()
+        if (waiter) break
+        await this.wait(1)
+        count += 1000
+      } while (count <= waitTimeout)
 
-      if (!waiter) throw new Error(`${errorMessage}`);
+      if (!waiter) throw new Error(`${errorMessage}`)
     }
   }
 
@@ -2784,8 +2784,8 @@ class Playwright extends Helper {
    * @param {?number} [sec=null] seconds to wait
    */
   async waitForRequest(urlOrPredicate, sec = null) {
-    const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    return this.page.waitForRequest(urlOrPredicate, { timeout });
+    const timeout = sec ? sec * 1000 : this.options.waitForTimeout
+    return this.page.waitForRequest(urlOrPredicate, { timeout })
   }
 
   /**
@@ -2800,8 +2800,8 @@ class Playwright extends Helper {
    * @param {?number} [sec=null] number of seconds to wait
    */
   async waitForResponse(urlOrPredicate, sec = null) {
-    const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    return this.page.waitForResponse(urlOrPredicate, { timeout });
+    const timeout = sec ? sec * 1000 : this.options.waitForTimeout
+    return this.page.waitForResponse(urlOrPredicate, { timeout })
   }
 
   /**
@@ -2811,51 +2811,51 @@ class Playwright extends Helper {
     if (Number.isInteger(locator)) {
       // Select by frame index of current context
 
-      let childFrames = null;
+      let childFrames = null
       if (this.context && typeof this.context.childFrames === 'function') {
-        childFrames = this.context.childFrames();
+        childFrames = this.context.childFrames()
       } else {
-        childFrames = this.page.mainFrame().childFrames();
+        childFrames = this.page.mainFrame().childFrames()
       }
 
       if (locator >= 0 && locator < childFrames.length) {
-        this.context = await this.page.frameLocator('iframe').nth(locator);
-        this.contextLocator = locator;
+        this.context = await this.page.frameLocator('iframe').nth(locator)
+        this.contextLocator = locator
       } else {
-        throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath');
+        throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath')
       }
-      return;
+      return
     }
 
     if (!locator) {
-      this.context = this.page;
-      this.contextLocator = null;
-      this.frame = null;
-      return;
+      this.context = this.page
+      this.contextLocator = null
+      this.frame = null
+      return
     }
 
     // iframe by selector
-    locator = buildLocatorString(new Locator(locator, 'css'));
-    const frame = await this._locateElement(locator);
+    locator = buildLocatorString(new Locator(locator, 'css'))
+    const frame = await this._locateElement(locator)
 
     if (!frame) {
-      throw new Error(`Frame ${JSON.stringify(locator)} was not found by text|CSS|XPath`);
+      throw new Error(`Frame ${JSON.stringify(locator)} was not found by text|CSS|XPath`)
     }
 
     if (this.frame) {
-      this.frame = await this.frame.frameLocator(locator);
+      this.frame = await this.frame.frameLocator(locator)
     } else {
-      this.frame = await this.page.frameLocator(locator);
+      this.frame = await this.page.frameLocator(locator)
     }
 
-    const contentFrame = this.frame;
+    const contentFrame = this.frame
 
     if (contentFrame) {
-      this.context = contentFrame;
-      this.contextLocator = null;
+      this.context = contentFrame
+      this.contextLocator = null
     } else {
-      this.context = this.page.frame(this.page.frames()[1].name());
-      this.contextLocator = locator;
+      this.context = this.page.frame(this.page.frames()[1].name())
+      this.contextLocator = locator
     }
   }
 
@@ -2863,17 +2863,17 @@ class Playwright extends Helper {
    * {{> waitForFunction }}
    */
   async waitForFunction(fn, argsOrSec = null, sec = null) {
-    let args = [];
+    let args = []
     if (argsOrSec) {
       if (Array.isArray(argsOrSec)) {
-        args = argsOrSec;
+        args = argsOrSec
       } else if (typeof argsOrSec === 'number') {
-        sec = argsOrSec;
+        sec = argsOrSec
       }
     }
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    const context = await this._getContext();
-    return context.waitForFunction(fn, args, { timeout: waitTimeout });
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    const context = await this._getContext()
+    return context.waitForFunction(fn, args, { timeout: waitTimeout })
   }
 
   /**
@@ -2885,13 +2885,13 @@ class Playwright extends Helper {
    */
   async waitForNavigation(options = {}) {
     console.log(`waitForNavigation deprecated:
-    * This method is inherently racy, please use 'waitForURL' instead.`);
+    * This method is inherently racy, please use 'waitForURL' instead.`)
     options = {
       timeout: this.options.getPageTimeout,
       waitUntil: this.options.waitForNavigation,
       ...options,
-    };
-    return this.page.waitForNavigation(options);
+    }
+    return this.page.waitForNavigation(options)
   }
 
   /**
@@ -2907,44 +2907,44 @@ class Playwright extends Helper {
       timeout: this.options.getPageTimeout,
       waitUntil: this.options.waitForNavigation,
       ...options,
-    };
-    return this.page.waitForURL(url, options);
+    }
+    return this.page.waitForURL(url, options)
   }
 
   async waitUntilExists(locator, sec) {
     console.log(`waitUntilExists deprecated:
     * use 'waitForElement' to wait for element to be attached
-    * use 'waitForDetached to wait for element to be removed'`);
-    return this.waitForDetached(locator, sec);
+    * use 'waitForDetached to wait for element to be removed'`)
+    return this.waitForDetached(locator, sec)
   }
 
   /**
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    locator = new Locator(locator, 'css');
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    locator = new Locator(locator, 'css')
 
-    let waiter;
-    const context = await this._getContext();
+    let waiter
+    const context = await this._getContext()
     if (!locator.isXPath()) {
       try {
         await context
           .locator(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`)
           .first()
-          .waitFor({ timeout: waitTimeout, state: 'detached' });
+          .waitFor({ timeout: waitTimeout, state: 'detached' })
       } catch (e) {
-        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${e.message}`);
+        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${e.message}`)
       }
     } else {
       const visibleFn = function ([locator, $XPath]) {
-        eval($XPath); // eslint-disable-line no-eval
-        return $XPath(null, locator).length === 0;
-      };
-      waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
+        eval($XPath) // eslint-disable-line no-eval
+        return $XPath(null, locator).length === 0
+      }
+      waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString()], { timeout: waitTimeout })
       return waiter.catch(err => {
-        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${err.message}`);
-      });
+        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${err.message}`)
+      })
     }
   }
 
@@ -2953,56 +2953,56 @@ class Playwright extends Helper {
    */
   async waitForCookie(name, sec) {
     // by default, we will retry 3 times
-    let retries = 3;
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    let retries = 3
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
     if (sec) {
-      retries = sec;
+      retries = sec
     } else {
-      retries = Math.ceil(waitTimeout / 1000) - 1;
+      retries = Math.ceil(waitTimeout / 1000) - 1
     }
 
     return promiseRetry(
       async (retry, number) => {
         const _grabCookie = async name => {
-          const cookies = await this.browserContext.cookies();
-          const cookie = cookies.filter(c => c.name === name);
-          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`);
-        };
+          const cookies = await this.browserContext.cookies()
+          const cookie = cookies.filter(c => c.name === name)
+          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`)
+        }
 
-        this.debugSection('Wait for cookie: ', name);
-        if (number > 1) this.debugSection('Retrying... Attempt #', number);
+        this.debugSection('Wait for cookie: ', name)
+        if (number > 1) this.debugSection('Retrying... Attempt #', number)
 
         try {
-          await _grabCookie(name);
+          await _grabCookie(name)
         } catch (e) {
-          retry(e);
+          retry(e)
         }
       },
       { retries, maxTimeout: 1000 },
-    );
+    )
   }
 
   async _waitForAction() {
-    return this.wait(this.options.waitForAction / 1000);
+    return this.wait(this.options.waitForAction / 1000)
   }
 
   /**
    * {{> grabDataFromPerformanceTiming }}
    */
   async grabDataFromPerformanceTiming() {
-    return perfTiming;
+    return perfTiming
   }
 
   /**
    * {{> grabElementBoundingRect }}
    */
   async grabElementBoundingRect(locator, prop) {
-    const el = await this._locateElement(locator);
-    assertElementExists(el, locator);
-    const rect = await el.boundingBox();
-    if (prop) return rect[prop];
-    return rect;
+    const el = await this._locateElement(locator)
+    assertElementExists(el, locator)
+    const rect = await el.boundingBox()
+    if (prop) return rect[prop]
+    return rect
   }
 
   /**
@@ -3017,7 +3017,7 @@ class Playwright extends Helper {
    * @param {function} [handler] a function to process request
    */
   async mockRoute(url, handler) {
-    return this.browserContext.route(...arguments);
+    return this.browserContext.route(...arguments)
   }
 
   /**
@@ -3033,7 +3033,7 @@ class Playwright extends Helper {
    * @param {function} [handler] a function to process request
    */
   async stopMockingRoute(url, handler) {
-    return this.browserContext.unroute(...arguments);
+    return this.browserContext.unroute(...arguments)
   }
 
   /**
@@ -3041,9 +3041,9 @@ class Playwright extends Helper {
    *
    */
   startRecordingTraffic() {
-    this.flushNetworkTraffics();
-    this.recording = true;
-    this.recordedAtLeastOnce = true;
+    this.flushNetworkTraffics()
+    this.recording = true
+    this.recordedAtLeastOnce = true
 
     this.page.on('requestfinished', async request => {
       const information = {
@@ -3052,16 +3052,16 @@ class Playwright extends Helper {
         requestHeaders: request.headers(),
         requestPostData: request.postData(),
         response: request.response(),
-      };
-
-      this.debugSection('REQUEST: ', JSON.stringify(information));
-
-      if (typeof information.requestPostData === 'object') {
-        information.requestPostData = JSON.parse(information.requestPostData);
       }
 
-      this.requests.push(information);
-    });
+      this.debugSection('REQUEST: ', JSON.stringify(information))
+
+      if (typeof information.requestPostData === 'object') {
+        information.requestPostData = JSON.parse(information.requestPostData)
+      }
+
+      this.requests.push(information)
+    })
   }
 
   /**
@@ -3089,16 +3089,16 @@ class Playwright extends Helper {
           route
             .abort()
             // Sometimes it happens that browser has been closed in the meantime. It is ok to ignore error then.
-            .catch(e => {});
-        });
-      });
+            .catch(e => {})
+        })
+      })
     } else {
       this.page.route(urls, route => {
         route
           .abort()
           // Sometimes it happens that browser has been closed in the meantime. It is ok to ignore error then.
-          .catch(e => {});
-      });
+          .catch(e => {})
+      })
     }
   }
 
@@ -3120,10 +3120,10 @@ class Playwright extends Helper {
    */
   mockTraffic(urls, responseString, contentType = 'application/json') {
     // Required to mock cross-domain requests
-    const headers = { 'access-control-allow-origin': '*' };
+    const headers = { 'access-control-allow-origin': '*' }
 
     if (typeof urls === 'string') {
-      urls = [urls];
+      urls = [urls]
     }
 
     urls.forEach(url => {
@@ -3131,15 +3131,15 @@ class Playwright extends Helper {
         if (this.page.isClosed()) {
           // Sometimes it happens that browser has been closed in the meantime.
           // In this case we just don't fulfill to prevent error in test scenario.
-          return;
+          return
         }
         route.fulfill({
           contentType,
           headers,
           body: responseString,
-        });
-      });
-    });
+        })
+      })
+    })
   }
 
   /**
@@ -3147,7 +3147,7 @@ class Playwright extends Helper {
    * {{> flushNetworkTraffics }}
    */
   flushNetworkTraffics() {
-    flushNetworkTraffics.call(this);
+    flushNetworkTraffics.call(this)
   }
 
   /**
@@ -3155,7 +3155,7 @@ class Playwright extends Helper {
    * {{> stopRecordingTraffic }}
    */
   stopRecordingTraffic() {
-    stopRecordingTraffic.call(this);
+    stopRecordingTraffic.call(this)
   }
 
   /**
@@ -3173,21 +3173,21 @@ class Playwright extends Helper {
    */
   grabTrafficUrl(urlMatch) {
     if (!this.recordedAtLeastOnce) {
-      throw new Error('Failure in test automation. You use "I.grabTrafficUrl", but "I.startRecordingTraffic" was never called before.');
+      throw new Error('Failure in test automation. You use "I.grabTrafficUrl", but "I.startRecordingTraffic" was never called before.')
     }
 
     for (const i in this.requests) {
       // eslint-disable-next-line no-prototype-builtins
       if (this.requests.hasOwnProperty(i)) {
-        const request = this.requests[i];
+        const request = this.requests[i]
 
         if (request.url && request.url.match(new RegExp(urlMatch))) {
-          return request.url;
+          return request.url
         }
       }
     }
 
-    assert.fail(`Method "getTrafficUrl" failed: No request found in traffic that matches ${urlMatch}`);
+    assert.fail(`Method "getTrafficUrl" failed: No request found in traffic that matches ${urlMatch}`)
   }
 
   /**
@@ -3195,7 +3195,7 @@ class Playwright extends Helper {
    * {{> grabRecordedNetworkTraffics }}
    */
   async grabRecordedNetworkTraffics() {
-    return grabRecordedNetworkTraffics.call(this);
+    return grabRecordedNetworkTraffics.call(this)
   }
 
   /**
@@ -3203,7 +3203,7 @@ class Playwright extends Helper {
    * {{> seeTraffic }}
    */
   async seeTraffic({ name, url, parameters, requestPostData, timeout = 10 }) {
-    await seeTraffic.call(this, ...arguments);
+    await seeTraffic.call(this, ...arguments)
   }
 
   /**
@@ -3212,42 +3212,42 @@ class Playwright extends Helper {
    *
    */
   dontSeeTraffic({ name, url }) {
-    dontSeeTraffic.call(this, ...arguments);
+    dontSeeTraffic.call(this, ...arguments)
   }
 
   /**
    * {{> startRecordingWebSocketMessages }}
    */
   async startRecordingWebSocketMessages() {
-    this.flushWebSocketMessages();
-    this.recordingWebSocketMessages = true;
-    this.recordedWebSocketMessagesAtLeastOnce = true;
+    this.flushWebSocketMessages()
+    this.recordingWebSocketMessages = true
+    this.recordedWebSocketMessagesAtLeastOnce = true
 
-    this.cdpSession = await this.getNewCDPSession();
-    await this.cdpSession.send('Network.enable');
-    await this.cdpSession.send('Page.enable');
+    this.cdpSession = await this.getNewCDPSession()
+    await this.cdpSession.send('Network.enable')
+    await this.cdpSession.send('Page.enable')
 
     this.cdpSession.on('Network.webSocketFrameReceived', payload => {
-      this._logWebsocketMessages(this._getWebSocketLog('RECEIVED', payload));
-    });
+      this._logWebsocketMessages(this._getWebSocketLog('RECEIVED', payload))
+    })
 
     this.cdpSession.on('Network.webSocketFrameSent', payload => {
-      this._logWebsocketMessages(this._getWebSocketLog('SENT', payload));
-    });
+      this._logWebsocketMessages(this._getWebSocketLog('SENT', payload))
+    })
 
     this.cdpSession.on('Network.webSocketFrameError', payload => {
-      this._logWebsocketMessages(this._getWebSocketLog('ERROR', payload));
-    });
+      this._logWebsocketMessages(this._getWebSocketLog('ERROR', payload))
+    })
   }
 
   /**
    * {{> stopRecordingWebSocketMessages }}
    */
   async stopRecordingWebSocketMessages() {
-    await this.cdpSession.send('Network.disable');
-    await this.cdpSession.send('Page.disable');
-    this.page.removeAllListeners('Network');
-    this.recordingWebSocketMessages = false;
+    await this.cdpSession.send('Network.disable')
+    await this.cdpSession.send('Page.disable')
+    this.page.removeAllListeners('Network')
+    this.recordingWebSocketMessages = false
   }
 
   /**
@@ -3259,17 +3259,17 @@ class Playwright extends Helper {
   grabWebSocketMessages() {
     if (!this.recordingWebSocketMessages) {
       if (!this.recordedWebSocketMessagesAtLeastOnce) {
-        throw new Error('Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.');
+        throw new Error('Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.')
       }
     }
-    return this.webSocketMessages;
+    return this.webSocketMessages
   }
 
   /**
    * Resets all recorded WS messages.
    */
   flushWebSocketMessages() {
-    this.webSocketMessages = [];
+    this.webSocketMessages = []
   }
 
   /**
@@ -3327,344 +3327,344 @@ class Playwright extends Helper {
    * @return {Promise<Array<Object>>}
    */
   async grabMetrics() {
-    const client = await this.page.context().newCDPSession(this.page);
-    await client.send('Performance.enable');
-    const perfMetricObject = await client.send('Performance.getMetrics');
-    return perfMetricObject?.metrics;
+    const client = await this.page.context().newCDPSession(this.page)
+    await client.send('Performance.enable')
+    const perfMetricObject = await client.send('Performance.getMetrics')
+    return perfMetricObject?.metrics
   }
 
   _getWebSocketMessage(payload) {
     if (payload.errorMessage) {
-      return payload.errorMessage;
+      return payload.errorMessage
     }
 
-    return payload.response.payloadData;
+    return payload.response.payloadData
   }
 
   _getWebSocketLog(prefix, payload) {
-    return `${prefix} ID: ${payload.requestId} TIMESTAMP: ${payload.timestamp} (${new Date().toISOString()})\n\n${this._getWebSocketMessage(payload)}\n\n`;
+    return `${prefix} ID: ${payload.requestId} TIMESTAMP: ${payload.timestamp} (${new Date().toISOString()})\n\n${this._getWebSocketMessage(payload)}\n\n`
   }
 
   async getNewCDPSession() {
-    return this.page.context().newCDPSession(this.page);
+    return this.page.context().newCDPSession(this.page)
   }
 
   _logWebsocketMessages(message) {
-    this.webSocketMessages.push(message);
+    this.webSocketMessages.push(message)
   }
 }
 
-module.exports = Playwright;
+module.exports = Playwright
 
 function buildLocatorString(locator) {
   if (locator.isCustom()) {
-    return `${locator.type}=${locator.value}`;
+    return `${locator.type}=${locator.value}`
   }
   if (locator.isXPath()) {
-    return `xpath=${locator.value}`;
+    return `xpath=${locator.value}`
   }
-  return locator.simplify();
+  return locator.simplify()
 }
 
 async function findElements(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator);
-  if (locator.vue) return findVue(matcher, locator);
-  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator);
-  locator = new Locator(locator, 'css');
+  if (locator.react) return findReact(matcher, locator)
+  if (locator.vue) return findVue(matcher, locator)
+  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator)
+  locator = new Locator(locator, 'css')
 
-  return matcher.locator(buildLocatorString(locator)).all();
+  return matcher.locator(buildLocatorString(locator)).all()
 }
 
 async function findElement(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator);
-  if (locator.vue) return findVue(matcher, locator);
-  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator);
-  locator = new Locator(locator, 'css');
+  if (locator.react) return findReact(matcher, locator)
+  if (locator.vue) return findVue(matcher, locator)
+  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator)
+  locator = new Locator(locator, 'css')
 
-  return matcher.locator(buildLocatorString(locator)).first();
+  return matcher.locator(buildLocatorString(locator)).first()
 }
 
 async function getVisibleElements(elements) {
-  const visibleElements = [];
+  const visibleElements = []
   for (const element of elements) {
     if (await element.isVisible()) {
-      visibleElements.push(element);
+      visibleElements.push(element)
     }
   }
   if (visibleElements.length === 0) {
-    return elements;
+    return elements
   }
-  return visibleElements;
+  return visibleElements
 }
 
 async function proceedClick(locator, context = null, options = {}) {
-  let matcher = await this._getContext();
+  let matcher = await this._getContext()
   if (context) {
-    const els = await this._locate(context);
-    assertElementExists(els, context);
-    matcher = els[0];
+    const els = await this._locate(context)
+    assertElementExists(els, context)
+    matcher = els[0]
   }
-  const els = await findClickable.call(this, matcher, locator);
+  const els = await findClickable.call(this, matcher, locator)
   if (context) {
-    assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`);
+    assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`)
   } else {
-    assertElementExists(els, locator, 'Clickable element');
+    assertElementExists(els, locator, 'Clickable element')
   }
 
-  await highlightActiveElement.call(this, els[0]);
+  await highlightActiveElement.call(this, els[0])
 
   /*
     using the force true options itself but instead dispatching a click
   */
   if (options.force) {
-    await els[0].dispatchEvent('click');
+    await els[0].dispatchEvent('click')
   } else {
-    const element = els.length > 1 ? (await getVisibleElements(els))[0] : els[0];
-    await element.click(options);
+    const element = els.length > 1 ? (await getVisibleElements(els))[0] : els[0]
+    await element.click(options)
   }
-  const promises = [];
+  const promises = []
   if (options.waitForNavigation) {
-    promises.push(this.waitForURL(/.*/, { waitUntil: options.waitForNavigation }));
+    promises.push(this.waitForURL(/.*/, { waitUntil: options.waitForNavigation }))
   }
-  promises.push(this._waitForAction());
+  promises.push(this._waitForAction())
 
-  return Promise.all(promises);
+  return Promise.all(promises)
 }
 
 async function findClickable(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator);
-  if (locator.vue) return findVue(matcher, locator);
-  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator);
+  if (locator.react) return findReact(matcher, locator)
+  if (locator.vue) return findVue(matcher, locator)
+  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator)
 
-  locator = new Locator(locator);
-  if (!locator.isFuzzy()) return findElements.call(this, matcher, locator);
+  locator = new Locator(locator)
+  if (!locator.isFuzzy()) return findElements.call(this, matcher, locator)
 
-  let els;
-  const literal = xpathLocator.literal(locator.value);
+  let els
+  const literal = xpathLocator.literal(locator.value)
 
-  els = await findElements.call(this, matcher, Locator.clickable.narrow(literal));
-  if (els.length) return els;
+  els = await findElements.call(this, matcher, Locator.clickable.narrow(literal))
+  if (els.length) return els
 
-  els = await findElements.call(this, matcher, Locator.clickable.wide(literal));
-  if (els.length) return els;
+  els = await findElements.call(this, matcher, Locator.clickable.wide(literal))
+  if (els.length) return els
 
   try {
-    els = await findElements.call(this, matcher, Locator.clickable.self(literal));
-    if (els.length) return els;
+    els = await findElements.call(this, matcher, Locator.clickable.self(literal))
+    if (els.length) return els
   } catch (err) {
     // Do nothing
   }
 
-  return findElements.call(this, matcher, locator.value); // by css or xpath
+  return findElements.call(this, matcher, locator.value) // by css or xpath
 }
 
 async function proceedSee(assertType, text, context, strict = false) {
-  let description;
-  let allText;
+  let description
+  let allText
 
   if (!context) {
-    const el = await this.context;
+    const el = await this.context
 
-    allText = el.constructor.name !== 'Locator' ? [await el.locator('body').innerText()] : [await el.innerText()];
+    allText = el.constructor.name !== 'Locator' ? [await el.locator('body').innerText()] : [await el.innerText()]
 
-    description = 'web application';
+    description = 'web application'
   } else {
-    const locator = new Locator(context, 'css');
-    description = `element ${locator.toString()}`;
-    const els = await this._locate(locator);
-    assertElementExists(els, locator.toString());
-    allText = await Promise.all(els.map(el => el.innerText()));
+    const locator = new Locator(context, 'css')
+    description = `element ${locator.toString()}`
+    const els = await this._locate(locator)
+    assertElementExists(els, locator.toString())
+    allText = await Promise.all(els.map(el => el.innerText()))
   }
 
   if (strict) {
-    return allText.map(elText => equals(description)[assertType](text, elText));
+    return allText.map(elText => equals(description)[assertType](text, elText))
   }
-  return stringIncludes(description)[assertType](normalizeSpacesInString(text), normalizeSpacesInString(allText.join(' | ')));
+  return stringIncludes(description)[assertType](normalizeSpacesInString(text), normalizeSpacesInString(allText.join(' | ')))
 }
 
 async function findCheckable(locator, context) {
-  let contextEl = await this.context;
+  let contextEl = await this.context
   if (typeof context === 'string') {
-    contextEl = await findElements.call(this, contextEl, new Locator(context, 'css').simplify());
-    contextEl = contextEl[0];
+    contextEl = await findElements.call(this, contextEl, new Locator(context, 'css').simplify())
+    contextEl = contextEl[0]
   }
 
-  const matchedLocator = new Locator(locator);
+  const matchedLocator = new Locator(locator)
   if (!matchedLocator.isFuzzy()) {
-    return findElements.call(this, contextEl, matchedLocator.simplify());
+    return findElements.call(this, contextEl, matchedLocator.simplify())
   }
 
-  const literal = xpathLocator.literal(locator);
-  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal));
+  const literal = xpathLocator.literal(locator)
+  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal))
   if (els.length) {
-    return els;
+    return els
   }
-  els = await findElements.call(this, contextEl, Locator.checkable.byName(literal));
+  els = await findElements.call(this, contextEl, Locator.checkable.byName(literal))
   if (els.length) {
-    return els;
+    return els
   }
-  return findElements.call(this, contextEl, locator);
+  return findElements.call(this, contextEl, locator)
 }
 
 async function proceedIsChecked(assertType, option) {
-  let els = await findCheckable.call(this, option);
-  assertElementExists(els, option, 'Checkable');
-  els = await Promise.all(els.map(el => el.isChecked()));
-  const selected = els.reduce((prev, cur) => prev || cur);
-  return truth(`checkable ${option}`, 'to be checked')[assertType](selected);
+  let els = await findCheckable.call(this, option)
+  assertElementExists(els, option, 'Checkable')
+  els = await Promise.all(els.map(el => el.isChecked()))
+  const selected = els.reduce((prev, cur) => prev || cur)
+  return truth(`checkable ${option}`, 'to be checked')[assertType](selected)
 }
 
 async function findFields(locator) {
-  const matchedLocator = new Locator(locator);
+  const matchedLocator = new Locator(locator)
   if (!matchedLocator.isFuzzy()) {
-    return this._locate(matchedLocator);
+    return this._locate(matchedLocator)
   }
-  const literal = xpathLocator.literal(locator);
+  const literal = xpathLocator.literal(locator)
 
-  let els = await this._locate({ xpath: Locator.field.labelEquals(literal) });
+  let els = await this._locate({ xpath: Locator.field.labelEquals(literal) })
   if (els.length) {
-    return els;
+    return els
   }
 
-  els = await this._locate({ xpath: Locator.field.labelContains(literal) });
+  els = await this._locate({ xpath: Locator.field.labelContains(literal) })
   if (els.length) {
-    return els;
+    return els
   }
-  els = await this._locate({ xpath: Locator.field.byName(literal) });
+  els = await this._locate({ xpath: Locator.field.byName(literal) })
   if (els.length) {
-    return els;
+    return els
   }
-  return this._locate({ css: locator });
+  return this._locate({ css: locator })
 }
 
 async function proceedSeeInField(assertType, field, value) {
-  const els = await findFields.call(this, field);
-  assertElementExists(els, field, 'Field');
-  const el = els[0];
-  const tag = await el.evaluate(e => e.tagName);
-  const fieldType = await el.getAttribute('type');
+  const els = await findFields.call(this, field)
+  assertElementExists(els, field, 'Field')
+  const el = els[0]
+  const tag = await el.evaluate(e => e.tagName)
+  const fieldType = await el.getAttribute('type')
 
   const proceedMultiple = async elements => {
-    const fields = Array.isArray(elements) ? elements : [elements];
+    const fields = Array.isArray(elements) ? elements : [elements]
 
-    const elementValues = [];
+    const elementValues = []
     for (const element of fields) {
-      elementValues.push(await element.inputValue());
+      elementValues.push(await element.inputValue())
     }
 
     if (typeof value === 'boolean') {
-      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!elementValues.length);
+      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!elementValues.length)
     } else {
       if (assertType === 'assert') {
-        equals(`select option by ${field}`)[assertType](true, elementValues.length > 0);
+        equals(`select option by ${field}`)[assertType](true, elementValues.length > 0)
       }
-      elementValues.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val));
+      elementValues.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val))
     }
-  };
+  }
 
   if (tag === 'SELECT') {
     if (await el.getAttribute('multiple')) {
-      const selectedOptions = await el.all('option:checked');
-      if (!selectedOptions.length) return null;
+      const selectedOptions = await el.all('option:checked')
+      if (!selectedOptions.length) return null
 
-      const options = await filterFieldsByValue(selectedOptions, value, true);
-      return proceedMultiple(options);
+      const options = await filterFieldsByValue(selectedOptions, value, true)
+      return proceedMultiple(options)
     }
 
-    return el.inputValue();
+    return el.inputValue()
   }
 
   if (tag === 'INPUT') {
     if (fieldType === 'checkbox' || fieldType === 'radio') {
       if (typeof value === 'boolean') {
         // Filter by values
-        const options = await filterFieldsBySelectionState(els, true);
-        return proceedMultiple(options);
+        const options = await filterFieldsBySelectionState(els, true)
+        return proceedMultiple(options)
       }
 
-      const options = await filterFieldsByValue(els, value, true);
-      return proceedMultiple(options);
+      const options = await filterFieldsByValue(els, value, true)
+      return proceedMultiple(options)
     }
-    return proceedMultiple(els[0]);
+    return proceedMultiple(els[0])
   }
 
-  let fieldVal;
+  let fieldVal
 
   try {
-    fieldVal = await el.inputValue();
+    fieldVal = await el.inputValue()
   } catch (e) {
     if (e.message.includes('Error: Node is not an <input>, <textarea> or <select> element')) {
-      fieldVal = await el.innerText();
+      fieldVal = await el.innerText()
     }
   }
 
-  return stringIncludes(`fields by ${field}`)[assertType](value, fieldVal);
+  return stringIncludes(`fields by ${field}`)[assertType](value, fieldVal)
 }
 
 async function filterFieldsByValue(elements, value, onlySelected) {
-  const matches = [];
+  const matches = []
   for (const element of elements) {
-    const val = await element.getAttribute('value');
-    let isSelected = true;
+    const val = await element.getAttribute('value')
+    let isSelected = true
     if (onlySelected) {
-      isSelected = await elementSelected(element);
+      isSelected = await elementSelected(element)
     }
     if ((value == null || val.indexOf(value) > -1) && isSelected) {
-      matches.push(element);
+      matches.push(element)
     }
   }
-  return matches;
+  return matches
 }
 
 async function filterFieldsBySelectionState(elements, state) {
-  const matches = [];
+  const matches = []
   for (const element of elements) {
-    const isSelected = await elementSelected(element);
+    const isSelected = await elementSelected(element)
     if (isSelected === state) {
-      matches.push(element);
+      matches.push(element)
     }
   }
-  return matches;
+  return matches
 }
 
 async function elementSelected(element) {
-  const type = await element.getAttribute('type');
+  const type = await element.getAttribute('type')
 
   if (type === 'checkbox' || type === 'radio') {
-    return element.isChecked();
+    return element.isChecked()
   }
-  return element.getAttribute('selected');
+  return element.getAttribute('selected')
 }
 
 function isFrameLocator(locator) {
-  locator = new Locator(locator);
+  locator = new Locator(locator)
   if (locator.isFrame()) {
-    return locator.value;
+    return locator.value
   }
-  return false;
+  return false
 }
 
 function assertElementExists(res, locator, prefix, suffix) {
   // if element text is an empty string, just exit this check
-  if (typeof res === 'string' && res === '') return;
+  if (typeof res === 'string' && res === '') return
   if (!res || res.length === 0) {
-    throw new ElementNotFound(locator, prefix, suffix);
+    throw new ElementNotFound(locator, prefix, suffix)
   }
 }
 
 function $XPath(element, selector) {
-  const found = document.evaluate(selector, element || document.body, null, 5, null);
-  const res = [];
-  let current = null;
+  const found = document.evaluate(selector, element || document.body, null, 5, null)
+  const res = []
+  let current = null
   while ((current = found.iterateNext())) {
-    res.push(current);
+    res.push(current)
   }
-  return res;
+  return res
 }
 
 async function targetCreatedHandler(page) {
-  if (!page) return;
-  this.withinLocator = null;
+  if (!page) return
+  this.withinLocator = null
   page.on('load', () => {
     page
       .$('body')
@@ -3672,48 +3672,48 @@ async function targetCreatedHandler(page) {
       .then(async () => {
         if (this.context && this.context._type === 'Frame') {
           // we are inside iframe?
-          const frameEl = await this.context.frameElement();
-          this.context = await frameEl.contentFrame();
-          this.contextLocator = null;
-          return;
+          const frameEl = await this.context.frameElement()
+          this.context = await frameEl.contentFrame()
+          this.contextLocator = null
+          return
         }
         // if context element was in iframe - keep it
         // if (await this.context.ownerFrame()) return;
-        this.context = page;
-        this.contextLocator = null;
-      });
-  });
+        this.context = page
+        this.contextLocator = null
+      })
+  })
   page.on('console', msg => {
     if (!consoleLogStore.includes(msg) && this.options.ignoreLog && !this.options.ignoreLog.includes(msg.type())) {
-      this.debugSection(`Browser:${ucfirst(msg.type())}`, ((msg.text && msg.text()) || msg._text || '') + msg.args().join(' '));
+      this.debugSection(`Browser:${ucfirst(msg.type())}`, ((msg.text && msg.text()) || msg._text || '') + msg.args().join(' '))
     }
-    consoleLogStore.add(msg);
-  });
+    consoleLogStore.add(msg)
+  })
 
   if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && this._getType() === 'Browser') {
     try {
-      await page.setViewportSize(parseWindowSize(this.options.windowSize));
+      await page.setViewportSize(parseWindowSize(this.options.windowSize))
     } catch (err) {
-      this.debug('Target can be already closed, ignoring...');
+      this.debug('Target can be already closed, ignoring...')
     }
   }
 }
 
 function parseWindowSize(windowSize) {
-  if (!windowSize) return { width: 800, height: 600 };
+  if (!windowSize) return { width: 800, height: 600 }
 
   if (windowSize.width && windowSize.height) {
-    return { width: parseInt(windowSize.width, 10), height: parseInt(windowSize.height, 10) };
+    return { width: parseInt(windowSize.width, 10), height: parseInt(windowSize.height, 10) }
   }
 
-  const dimensions = windowSize.split('x');
+  const dimensions = windowSize.split('x')
   if (dimensions.length < 2 || windowSize === 'maximize') {
-    console.log('Invalid window size, setting window to default values');
-    return { width: 800, height: 600 }; // invalid size
+    console.log('Invalid window size, setting window to default values')
+    return { width: 800, height: 600 } // invalid size
   }
-  const width = parseInt(dimensions[0], 10);
-  const height = parseInt(dimensions[1], 10);
-  return { width, height };
+  const width = parseInt(dimensions[0], 10)
+  const height = parseInt(dimensions[1], 10)
+  return { width, height }
 }
 
 // List of key values to key definitions
@@ -3766,90 +3766,90 @@ const keyDefinitionMap = {
   '\\': 'Backslash',
   ']': 'BracketRight',
   "'": 'Quote',
-};
+}
 
 function getNormalizedKey(key) {
-  const normalizedKey = getNormalizedKeyAttributeValue(key);
+  const normalizedKey = getNormalizedKeyAttributeValue(key)
   if (key !== normalizedKey) {
-    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
+    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`)
   }
   // Use key definition to ensure correct key is displayed when Shift modifier is active
   if (Object.prototype.hasOwnProperty.call(keyDefinitionMap, normalizedKey)) {
-    return keyDefinitionMap[normalizedKey];
+    return keyDefinitionMap[normalizedKey]
   }
-  return normalizedKey;
+  return normalizedKey
 }
 
 async function clickablePoint(el) {
-  const rect = await el.boundingBox();
-  if (!rect) throw new ElementNotFound(el);
-  const { x, y, width, height } = rect;
-  return { x: x + width / 2, y: y + height / 2 };
+  const rect = await el.boundingBox()
+  if (!rect) throw new ElementNotFound(el)
+  const { x, y, width, height } = rect
+  return { x: x + width / 2, y: y + height / 2 }
 }
 
 async function refreshContextSession() {
   // close other sessions
   try {
-    const contexts = await this.browser.contexts();
-    contexts.shift();
+    const contexts = await this.browser.contexts()
+    contexts.shift()
 
-    await Promise.all(contexts.map(c => c.close()));
+    await Promise.all(contexts.map(c => c.close()))
   } catch (e) {
-    console.log(e);
+    console.log(e)
   }
 
   if (this.page) {
-    const existingPages = await this.browserContext.pages();
-    await this._setPage(existingPages[0]);
+    const existingPages = await this.browserContext.pages()
+    await this._setPage(existingPages[0])
   }
 
-  if (this.options.keepBrowserState) return;
+  if (this.options.keepBrowserState) return
 
   if (!this.options.keepCookies) {
-    this.debugSection('Session', 'cleaning cookies and localStorage');
-    await this.clearCookie();
+    this.debugSection('Session', 'cleaning cookies and localStorage')
+    await this.clearCookie()
   }
-  const currentUrl = await this.grabCurrentUrl();
+  const currentUrl = await this.grabCurrentUrl()
 
   if (currentUrl.startsWith('http')) {
     await this.executeScript('localStorage.clear();').catch(err => {
-      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
-    });
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
+    })
     await this.executeScript('sessionStorage.clear();').catch(err => {
-      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
-    });
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
+    })
   }
 }
 
 function saveVideoForPage(page, name) {
-  if (!page.video()) return null;
-  const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`;
+  if (!page.video()) return null
+  const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`
   page
     .video()
     .saveAs(fileName)
     .then(() => {
-      if (!page) return;
+      if (!page) return
       page
         .video()
         .delete()
-        .catch(() => {});
-    });
-  return fileName;
+        .catch(() => {})
+    })
+  return fileName
 }
 async function saveTraceForContext(context, name) {
-  if (!context) return;
-  if (!context.tracing) return;
-  const fileName = `${`${global.output_dir}${pathSeparator}trace${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.zip`;
-  await context.tracing.stop({ path: fileName });
-  return fileName;
+  if (!context) return
+  if (!context.tracing) return
+  const fileName = `${`${global.output_dir}${pathSeparator}trace${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.zip`
+  await context.tracing.stop({ path: fileName })
+  return fileName
 }
 
 async function highlightActiveElement(element) {
   if (this.options.highlightElement && global.debugMode) {
     await element.evaluate(el => {
-      const prevStyle = el.style.boxShadow;
-      el.style.boxShadow = '0px 0px 4px 3px rgba(255, 0, 0, 0.7)';
-      setTimeout(() => (el.style.boxShadow = prevStyle), 2000);
-    });
+      const prevStyle = el.style.boxShadow
+      el.style.boxShadow = '0px 0px 4px 3px rgba(255, 0, 0, 0.7)'
+      setTimeout(() => (el.style.boxShadow = prevStyle), 2000)
+    })
   }
 }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1,17 +1,17 @@
-const path = require('path')
-const fs = require('fs')
+const path = require('path');
+const fs = require('fs');
 
-const Helper = require('@codeceptjs/helper')
-const { v4: uuidv4 } = require('uuid')
-const assert = require('assert')
-const promiseRetry = require('promise-retry')
-const Locator = require('../locator')
-const recorder = require('../recorder')
-const stringIncludes = require('../assert/include').includes
-const { urlEquals } = require('../assert/equal')
-const { equals } = require('../assert/equal')
-const { empty } = require('../assert/empty')
-const { truth } = require('../assert/truth')
+const Helper = require('@codeceptjs/helper');
+const { v4: uuidv4 } = require('uuid');
+const assert = require('assert');
+const promiseRetry = require('promise-retry');
+const Locator = require('../locator');
+const recorder = require('../recorder');
+const stringIncludes = require('../assert/include').includes;
+const { urlEquals } = require('../assert/equal');
+const { equals } = require('../assert/equal');
+const { empty } = require('../assert/empty');
+const { truth } = require('../assert/truth');
 const {
   xpathLocator,
   ucfirst,
@@ -24,44 +24,28 @@ const {
   clearString,
   requireWithFallback,
   normalizeSpacesInString,
-} = require('../utils')
-const { isColorProperty, convertColorToRGBA } = require('../colorUtils')
-const ElementNotFound = require('./errors/ElementNotFound')
-const RemoteBrowserConnectionRefused = require('./errors/RemoteBrowserConnectionRefused')
-const Popup = require('./extras/Popup')
-const Console = require('./extras/Console')
-const { findReact, findVue, findByPlaywrightLocator } = require('./extras/PlaywrightReactVueLocator')
+} = require('../utils');
+const { isColorProperty, convertColorToRGBA } = require('../colorUtils');
+const ElementNotFound = require('./errors/ElementNotFound');
+const RemoteBrowserConnectionRefused = require('./errors/RemoteBrowserConnectionRefused');
+const Popup = require('./extras/Popup');
+const Console = require('./extras/Console');
+const { findReact, findVue, findByPlaywrightLocator } = require('./extras/PlaywrightReactVueLocator');
 
-let playwright
-let perfTiming
-let defaultSelectorEnginesInitialized = false
+let playwright;
+let perfTiming;
+let defaultSelectorEnginesInitialized = false;
 
-const popupStore = new Popup()
-const consoleLogStore = new Console()
-const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron']
+const popupStore = new Popup();
+const consoleLogStore = new Console();
+const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron'];
 
-const {
-  setRestartStrategy,
-  restartsSession,
-  restartsContext,
-  restartsBrowser,
-} = require('./extras/PlaywrightRestartOpts')
-const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine')
-const {
-  seeElementError,
-  dontSeeElementError,
-  dontSeeElementInDOMError,
-  seeElementInDOMError,
-} = require('./errors/ElementAssertion')
-const {
-  dontSeeTraffic,
-  seeTraffic,
-  grabRecordedNetworkTraffics,
-  stopRecordingTraffic,
-  flushNetworkTraffics,
-} = require('./network/actions')
+const { setRestartStrategy, restartsSession, restartsContext, restartsBrowser } = require('./extras/PlaywrightRestartOpts');
+const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine');
+const { seeElementError, dontSeeElementError, dontSeeElementInDOMError, seeElementInDOMError } = require('./errors/ElementAssertion');
+const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions');
 
-const pathSeparator = path.sep
+const pathSeparator = path.sep;
 
 /**
  * ## Configuration
@@ -110,7 +94,7 @@ const pathSeparator = path.sep
  * @prop {object} [recordHar] - record HAR and will be saved to `output/har`. See more of [HAR options](https://playwright.dev/docs/api/class-browser#browser-new-context-option-record-har).
  * @prop {string} [testIdAttribute=data-testid] - locate elements based on the testIdAttribute. See more of [locate by test id](https://playwright.dev/docs/locators#locate-by-test-id).
  */
-const config = {}
+const config = {};
 
 /**
  * Uses [Playwright](https://github.com/microsoft/playwright) library to run tests inside:
@@ -332,34 +316,34 @@ const config = {}
  */
 class Playwright extends Helper {
   constructor(config) {
-    super(config)
+    super(config);
 
-    playwright = requireWithFallback('playwright', 'playwright-core')
+    playwright = requireWithFallback('playwright', 'playwright-core');
 
     // set defaults
-    this.isRemoteBrowser = false
-    this.isRunning = false
-    this.isAuthenticated = false
-    this.sessionPages = {}
-    this.activeSessionName = ''
-    this.isElectron = false
-    this.isCDPConnection = false
-    this.electronSessions = []
-    this.storageState = null
+    this.isRemoteBrowser = false;
+    this.isRunning = false;
+    this.isAuthenticated = false;
+    this.sessionPages = {};
+    this.activeSessionName = '';
+    this.isElectron = false;
+    this.isCDPConnection = false;
+    this.electronSessions = [];
+    this.storageState = null;
 
     // for network stuff
-    this.requests = []
-    this.recording = false
-    this.recordedAtLeastOnce = false
+    this.requests = [];
+    this.recording = false;
+    this.recordedAtLeastOnce = false;
 
     // for websocket messages
-    this.webSocketMessages = []
-    this.recordingWebSocketMessages = false
-    this.recordedWebSocketMessagesAtLeastOnce = false
-    this.cdpSession = null
+    this.webSocketMessages = [];
+    this.recordingWebSocketMessages = false;
+    this.recordedWebSocketMessagesAtLeastOnce = false;
+    this.cdpSession = null;
 
     // override defaults with config
-    this._setConfig(config)
+    this._setConfig(config);
   }
 
   _validateConfig(config) {
@@ -386,65 +370,61 @@ class Playwright extends Helper {
       use: { actionTimeout: 0 },
       ignoreHTTPSErrors: false, // Adding it here o that context can be set up to ignore the SSL errors,
       highlightElement: false,
-    }
+    };
 
-    process.env.testIdAttribute = 'data-testid'
-    config = Object.assign(defaults, config)
+    process.env.testIdAttribute = 'data-testid';
+    config = Object.assign(defaults, config);
 
     if (availableBrowsers.indexOf(config.browser) < 0) {
-      throw new Error(
-        `Invalid config. Can't use browser "${config.browser}". Accepted values: ${availableBrowsers.join(', ')}`,
-      )
+      throw new Error(`Invalid config. Can't use browser "${config.browser}". Accepted values: ${availableBrowsers.join(', ')}`);
     }
 
-    return config
+    return config;
   }
 
   _getOptionsForBrowser(config) {
     if (config[config.browser]) {
       if (config[config.browser].browserWSEndpoint && config[config.browser].browserWSEndpoint.wsEndpoint) {
-        config[config.browser].browserWSEndpoint = config[config.browser].browserWSEndpoint.wsEndpoint
+        config[config.browser].browserWSEndpoint = config[config.browser].browserWSEndpoint.wsEndpoint;
       }
       return {
         ...config[config.browser],
         wsEndpoint: config[config.browser].browserWSEndpoint,
-      }
+      };
     }
-    return {}
+    return {};
   }
 
   _setConfig(config) {
-    this.options = this._validateConfig(config)
-    setRestartStrategy(this.options)
+    this.options = this._validateConfig(config);
+    setRestartStrategy(this.options);
     this.playwrightOptions = {
       headless: !this.options.show,
       ...this._getOptionsForBrowser(config),
-    }
+    };
 
     if (this.options.channel && this.options.browser === 'chromium') {
-      this.playwrightOptions.channel = this.options.channel
+      this.playwrightOptions.channel = this.options.channel;
     }
 
     if (this.options.video) {
       // set the video resolution with window size
-      let size = parseWindowSize(this.options.windowSize)
+      let size = parseWindowSize(this.options.windowSize);
 
       // if the video resolution is passed, set the record resoultion with that resolution
       if (this.options.recordVideo && this.options.recordVideo.size) {
-        size = parseWindowSize(this.options.recordVideo.size)
+        size = parseWindowSize(this.options.recordVideo.size);
       }
-      this.options.recordVideo = { size }
+      this.options.recordVideo = { size };
     }
     if (this.options.recordVideo && !this.options.recordVideo.dir) {
-      this.options.recordVideo.dir = `${global.output_dir}/videos/`
+      this.options.recordVideo.dir = `${global.output_dir}/videos/`;
     }
-    this.isRemoteBrowser = !!this.playwrightOptions.browserWSEndpoint
-    this.isElectron = this.options.browser === 'electron'
-    this.userDataDir = this.playwrightOptions.userDataDir
-      ? `${this.playwrightOptions.userDataDir}_${Date.now().toString()}`
-      : undefined
-    this.isCDPConnection = this.playwrightOptions.cdpConnection
-    popupStore.defaultAction = this.options.defaultPopupAction
+    this.isRemoteBrowser = !!this.playwrightOptions.browserWSEndpoint;
+    this.isElectron = this.options.browser === 'electron';
+    this.userDataDir = this.playwrightOptions.userDataDir ? `${this.playwrightOptions.userDataDir}_${Date.now().toString()}` : undefined;
+    this.isCDPConnection = this.playwrightOptions.cdpConnection;
+    popupStore.defaultAction = this.options.defaultPopupAction;
   }
 
   static _config() {
@@ -458,231 +438,225 @@ class Playwright extends Helper {
         name: 'url',
         message: 'Base url of site to be tested',
         default: 'http://localhost',
-        when: (answers) => answers.Playwright_browser !== 'electron',
+        when: answers => answers.Playwright_browser !== 'electron',
       },
       {
         name: 'show',
         message: 'Show browser window',
         default: true,
         type: 'confirm',
-        when: (answers) => answers.Playwright_browser !== 'electron',
+        when: answers => answers.Playwright_browser !== 'electron',
       },
-    ]
+    ];
   }
 
   static _checkRequirements() {
     try {
-      requireWithFallback('playwright', 'playwright-core')
+      requireWithFallback('playwright', 'playwright-core');
     } catch (e) {
-      return ['playwright@^1.18']
+      return ['playwright@^1.18'];
     }
   }
 
   async _init() {
     // register an internal selector engine for reading value property of elements in a selector
-    if (defaultSelectorEnginesInitialized) return
-    defaultSelectorEnginesInitialized = true
+    if (defaultSelectorEnginesInitialized) return;
+    defaultSelectorEnginesInitialized = true;
     try {
-      await playwright.selectors.register('__value', createValueEngine)
-      await playwright.selectors.register('__disabled', createDisabledEngine)
-      if (process.env.testIdAttribute) await playwright.selectors.setTestIdAttribute(process.env.testIdAttribute)
+      await playwright.selectors.register('__value', createValueEngine);
+      await playwright.selectors.register('__disabled', createDisabledEngine);
+      if (process.env.testIdAttribute) await playwright.selectors.setTestIdAttribute(process.env.testIdAttribute);
     } catch (e) {
-      console.warn(e)
+      console.warn(e);
     }
   }
 
   _beforeSuite() {
     if ((restartsSession() || restartsContext()) && !this.options.manualStart && !this.isRunning) {
-      this.debugSection('Session', 'Starting singleton browser session')
-      return this._startBrowser()
+      this.debugSection('Session', 'Starting singleton browser session');
+      return this._startBrowser();
     }
   }
 
   async _before(test) {
-    this.currentRunningTest = test
+    this.currentRunningTest = test;
     recorder.retry({
       retries: process.env.FAILED_STEP_RETRIES || 3,
-      when: (err) => {
+      when: err => {
         if (!err || typeof err.message !== 'string') {
-          return false
+          return false;
         }
         // ignore context errors
-        return err.message.includes('context')
+        return err.message.includes('context');
       },
-    })
+    });
 
-    if (restartsBrowser() && !this.options.manualStart) await this._startBrowser()
-    if (!this.isRunning && !this.options.manualStart) await this._startBrowser()
+    if (restartsBrowser() && !this.options.manualStart) await this._startBrowser();
+    if (!this.isRunning && !this.options.manualStart) await this._startBrowser();
 
-    this.isAuthenticated = false
+    this.isAuthenticated = false;
     if (this.isElectron) {
-      this.browserContext = this.browser.context()
+      this.browserContext = this.browser.context();
     } else if (this.playwrightOptions.userDataDir) {
-      this.browserContext = this.browser
+      this.browserContext = this.browser;
     } else {
       const contextOptions = {
         ignoreHTTPSErrors: this.options.ignoreHTTPSErrors,
         acceptDownloads: true,
         ...this.options.emulate,
-      }
+      };
       if (this.options.basicAuth) {
-        contextOptions.httpCredentials = this.options.basicAuth
-        this.isAuthenticated = true
+        contextOptions.httpCredentials = this.options.basicAuth;
+        this.isAuthenticated = true;
       }
-      if (this.options.bypassCSP) contextOptions.bypassCSP = this.options.bypassCSP
-      if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo
+      if (this.options.bypassCSP) contextOptions.bypassCSP = this.options.bypassCSP;
+      if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
       if (this.options.recordHar) {
-        const harExt = this.options.recordHar.content && this.options.recordHar.content === 'attach' ? 'zip' : 'har'
-        const fileName = `${`${global.output_dir}${path.sep}har${path.sep}${uuidv4()}_${clearString(this.currentRunningTest.title)}`.slice(0, 245)}.${harExt}`
-        const dir = path.dirname(fileName)
-        if (!fileExists(dir)) fs.mkdirSync(dir)
-        this.options.recordHar.path = fileName
-        this.currentRunningTest.artifacts.har = fileName
-        contextOptions.recordHar = this.options.recordHar
+        const harExt = this.options.recordHar.content && this.options.recordHar.content === 'attach' ? 'zip' : 'har';
+        const fileName = `${`${global.output_dir}${path.sep}har${path.sep}${uuidv4()}_${clearString(this.currentRunningTest.title)}`.slice(0, 245)}.${harExt}`;
+        const dir = path.dirname(fileName);
+        if (!fileExists(dir)) fs.mkdirSync(dir);
+        this.options.recordHar.path = fileName;
+        this.currentRunningTest.artifacts.har = fileName;
+        contextOptions.recordHar = this.options.recordHar;
       }
-      if (this.storageState) contextOptions.storageState = this.storageState
-      if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent
-      if (this.options.locale) contextOptions.locale = this.options.locale
-      if (this.options.colorScheme) contextOptions.colorScheme = this.options.colorScheme
-      this.contextOptions = contextOptions
+      if (this.storageState) contextOptions.storageState = this.storageState;
+      if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent;
+      if (this.options.locale) contextOptions.locale = this.options.locale;
+      if (this.options.colorScheme) contextOptions.colorScheme = this.options.colorScheme;
+      this.contextOptions = contextOptions;
       if (!this.browserContext || !restartsSession()) {
-        this.browserContext = await this.browser.newContext(this.contextOptions) // Adding the HTTPSError ignore in the context so that we can ignore those errors
+        this.browserContext = await this.browser.newContext(this.contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
       }
     }
 
-    let mainPage
+    let mainPage;
     if (this.isElectron) {
-      mainPage = await this.browser.firstWindow()
+      mainPage = await this.browser.firstWindow();
     } else {
       try {
-        const existingPages = await this.browserContext.pages()
-        mainPage = existingPages[0] || (await this.browserContext.newPage())
+        const existingPages = await this.browserContext.pages();
+        mainPage = existingPages[0] || (await this.browserContext.newPage());
       } catch (e) {
         if (this.playwrightOptions.userDataDir) {
-          this.browser = await playwright[this.options.browser].launchPersistentContext(
-            this.userDataDir,
-            this.playwrightOptions,
-          )
-          this.browserContext = this.browser
-          const existingPages = await this.browserContext.pages()
-          mainPage = existingPages[0]
+          this.browser = await playwright[this.options.browser].launchPersistentContext(this.userDataDir, this.playwrightOptions);
+          this.browserContext = this.browser;
+          const existingPages = await this.browserContext.pages();
+          mainPage = existingPages[0];
         }
       }
     }
-    await targetCreatedHandler.call(this, mainPage)
+    await targetCreatedHandler.call(this, mainPage);
 
-    await this._setPage(mainPage)
+    await this._setPage(mainPage);
 
-    if (this.options.trace) await this.browserContext.tracing.start({ screenshots: true, snapshots: true })
+    if (this.options.trace) await this.browserContext.tracing.start({ screenshots: true, snapshots: true });
 
-    return this.browser
+    return this.browser;
   }
 
   async _after() {
-    if (!this.isRunning) return
+    if (!this.isRunning) return;
 
     if (this.isElectron) {
-      this.browser.close()
-      this.electronSessions.forEach((session) => session.close())
-      return
+      this.browser.close();
+      this.electronSessions.forEach(session => session.close());
+      return;
     }
 
     if (restartsSession()) {
-      return refreshContextSession.bind(this)()
+      return refreshContextSession.bind(this)();
     }
 
     if (restartsBrowser()) {
-      this.isRunning = false
-      return this._stopBrowser()
+      this.isRunning = false;
+      return this._stopBrowser();
     }
 
     // close other sessions
     try {
       if ((await this.browser)._type === 'Browser') {
-        const contexts = await this.browser.contexts()
-        const currentContext = contexts[0]
+        const contexts = await this.browser.contexts();
+        const currentContext = contexts[0];
         if (currentContext && (this.options.keepCookies || this.options.keepBrowserState)) {
-          this.storageState = await currentContext.storageState()
+          this.storageState = await currentContext.storageState();
         }
 
-        await Promise.all(contexts.map((c) => c.close()))
+        await Promise.all(contexts.map(c => c.close()));
       }
     } catch (e) {
-      console.log(e)
+      console.log(e);
     }
 
     // await this.closeOtherTabs();
-    return this.browser
+    return this.browser;
   }
 
   _afterSuite() {}
 
   async _finishTest() {
-    if ((restartsSession() || restartsContext()) && this.isRunning) return this._stopBrowser()
+    if ((restartsSession() || restartsContext()) && this.isRunning) return this._stopBrowser();
   }
 
   _session() {
-    const defaultContext = this.browserContext
+    const defaultContext = this.browserContext;
     return {
       start: async (sessionName = '', config) => {
-        this.debugSection('New Context', config ? JSON.stringify(config) : 'opened')
-        this.activeSessionName = sessionName
+        this.debugSection('New Context', config ? JSON.stringify(config) : 'opened');
+        this.activeSessionName = sessionName;
 
-        let browserContext
-        let page
+        let browserContext;
+        let page;
         if (this.isElectron) {
-          const browser = await playwright._electron.launch(this.playwrightOptions)
-          this.electronSessions.push(browser)
-          browserContext = browser.context()
-          page = await browser.firstWindow()
+          const browser = await playwright._electron.launch(this.playwrightOptions);
+          this.electronSessions.push(browser);
+          browserContext = browser.context();
+          page = await browser.firstWindow();
         } else {
           try {
-            browserContext = await this.browser.newContext(Object.assign(this.contextOptions, config))
-            page = await browserContext.newPage()
+            browserContext = await this.browser.newContext(Object.assign(this.contextOptions, config));
+            page = await browserContext.newPage();
           } catch (e) {
             if (this.playwrightOptions.userDataDir) {
-              browserContext = await playwright[this.options.browser].launchPersistentContext(
-                `${this.userDataDir}_${this.activeSessionName}`,
-                this.playwrightOptions,
-              )
-              this.browser = browserContext
-              page = await browserContext.pages()[0]
+              browserContext = await playwright[this.options.browser].launchPersistentContext(`${this.userDataDir}_${this.activeSessionName}`, this.playwrightOptions);
+              this.browser = browserContext;
+              page = await browserContext.pages()[0];
             }
           }
         }
 
-        if (this.options.trace) await browserContext.tracing.start({ screenshots: true, snapshots: true })
-        await targetCreatedHandler.call(this, page)
-        await this._setPage(page)
+        if (this.options.trace) await browserContext.tracing.start({ screenshots: true, snapshots: true });
+        await targetCreatedHandler.call(this, page);
+        await this._setPage(page);
         // Create a new page inside context.
-        return browserContext
+        return browserContext;
       },
       stop: async () => {
         // is closed by _after
       },
-      loadVars: async (context) => {
+      loadVars: async context => {
         if (context) {
-          this.browserContext = context
-          const existingPages = await context.pages()
-          this.sessionPages[this.activeSessionName] = existingPages[0]
-          return this._setPage(this.sessionPages[this.activeSessionName])
+          this.browserContext = context;
+          const existingPages = await context.pages();
+          this.sessionPages[this.activeSessionName] = existingPages[0];
+          return this._setPage(this.sessionPages[this.activeSessionName]);
         }
       },
-      restoreVars: async (session) => {
-        this.withinLocator = null
-        this.browserContext = defaultContext
+      restoreVars: async session => {
+        this.withinLocator = null;
+        this.browserContext = defaultContext;
 
         if (!session) {
-          this.activeSessionName = ''
+          this.activeSessionName = '';
         } else {
-          this.activeSessionName = session
+          this.activeSessionName = session;
         }
-        const existingPages = await this.browserContext.pages()
-        await this._setPage(existingPages[0])
+        const existingPages = await this.browserContext.pages();
+        await this._setPage(existingPages[0]);
 
-        return this._waitForAction()
+        return this._waitForAction();
       },
-    }
+    };
   }
 
   /**
@@ -703,7 +677,7 @@ class Playwright extends Helper {
    * @param {function} fn async function that executed with Playwright helper as arguments
    */
   usePlaywrightTo(description, fn) {
-    return this._useTo(...arguments)
+    return this._useTo(...arguments);
   }
 
   /**
@@ -717,7 +691,7 @@ class Playwright extends Helper {
    * ```
    */
   amAcceptingPopups() {
-    popupStore.actionType = 'accept'
+    popupStore.actionType = 'accept';
   }
 
   /**
@@ -726,7 +700,7 @@ class Playwright extends Helper {
    * libraries](http://jster.net/category/windows-modals-popups).
    */
   acceptPopup() {
-    popupStore.assertPopupActionType('accept')
+    popupStore.assertPopupActionType('accept');
   }
 
   /**
@@ -740,23 +714,23 @@ class Playwright extends Helper {
    * ```
    */
   amCancellingPopups() {
-    popupStore.actionType = 'cancel'
+    popupStore.actionType = 'cancel';
   }
 
   /**
    * Dismisses the active JavaScript popup, as created by window.alert|window.confirm|window.prompt.
    */
   cancelPopup() {
-    popupStore.assertPopupActionType('cancel')
+    popupStore.assertPopupActionType('cancel');
   }
 
   /**
    * {{> seeInPopup }}
    */
   async seeInPopup(text) {
-    popupStore.assertPopupVisible()
-    const popupText = await popupStore.popup.message()
-    stringIncludes('text in popup').assert(text, popupText)
+    popupStore.assertPopupVisible();
+    const popupText = await popupStore.popup.message();
+    stringIncludes('text in popup').assert(text, popupText);
   }
 
   /**
@@ -764,21 +738,21 @@ class Playwright extends Helper {
    * @param {object} page page to set
    */
   async _setPage(page) {
-    page = await page
-    this._addPopupListener(page)
-    this.page = page
-    if (!page) return
-    this.browserContext.setDefaultTimeout(0)
-    page.setDefaultNavigationTimeout(this.options.getPageTimeout)
-    page.setDefaultTimeout(this.options.timeout)
+    page = await page;
+    this._addPopupListener(page);
+    this.page = page;
+    if (!page) return;
+    this.browserContext.setDefaultTimeout(0);
+    page.setDefaultNavigationTimeout(this.options.getPageTimeout);
+    page.setDefaultTimeout(this.options.timeout);
 
     page.on('crash', async () => {
-      console.log('ERROR: Page has crashed, closing page!')
-      await page.close()
-    })
-    this.context = await this.page
-    this.contextLocator = null
-    await page.bringToFront()
+      console.log('ERROR: Page has crashed, closing page!');
+      await page.close();
+    });
+    this.context = await this.page;
+    this.contextLocator = null;
+    await page.bringToFront();
   }
 
   /**
@@ -790,33 +764,33 @@ class Playwright extends Helper {
    */
   _addPopupListener(page) {
     if (!page) {
-      return
+      return;
     }
-    page.removeAllListeners('dialog')
-    page.on('dialog', async (dialog) => {
-      popupStore.popup = dialog
-      const action = popupStore.actionType || this.options.defaultPopupAction
-      await this._waitForAction()
+    page.removeAllListeners('dialog');
+    page.on('dialog', async dialog => {
+      popupStore.popup = dialog;
+      const action = popupStore.actionType || this.options.defaultPopupAction;
+      await this._waitForAction();
 
       switch (action) {
         case 'accept':
-          return dialog.accept()
+          return dialog.accept();
 
         case 'cancel':
-          return dialog.dismiss()
+          return dialog.dismiss();
 
         default: {
-          throw new Error('Unknown popup action type. Only "accept" or "cancel" are accepted')
+          throw new Error('Unknown popup action type. Only "accept" or "cancel" are accepted');
         }
       }
-    })
+    });
   }
 
   /**
    * Gets page URL including hash.
    */
   async _getPageUrl() {
-    return this.executeScript(() => window.location.href)
+    return this.executeScript(() => window.location.href);
   }
 
   /**
@@ -829,48 +803,45 @@ class Playwright extends Helper {
    */
   async grabPopupText() {
     if (popupStore.popup) {
-      return popupStore.popup.message()
+      return popupStore.popup.message();
     }
-    return null
+    return null;
   }
 
   async _startBrowser() {
     if (this.isElectron) {
-      this.browser = await playwright._electron.launch(this.playwrightOptions)
+      this.browser = await playwright._electron.launch(this.playwrightOptions);
     } else if (this.isRemoteBrowser && this.isCDPConnection) {
       try {
-        this.browser = await playwright[this.options.browser].connectOverCDP(this.playwrightOptions)
+        this.browser = await playwright[this.options.browser].connectOverCDP(this.playwrightOptions);
       } catch (err) {
         if (err.toString().indexOf('ECONNREFUSED')) {
-          throw new RemoteBrowserConnectionRefused(err)
+          throw new RemoteBrowserConnectionRefused(err);
         }
-        throw err
+        throw err;
       }
     } else if (this.isRemoteBrowser) {
       try {
-        this.browser = await playwright[this.options.browser].connect(this.playwrightOptions)
+        this.browser = await playwright[this.options.browser].connect(this.playwrightOptions);
       } catch (err) {
         if (err.toString().indexOf('ECONNREFUSED')) {
-          throw new RemoteBrowserConnectionRefused(err)
+          throw new RemoteBrowserConnectionRefused(err);
         }
-        throw err
+        throw err;
       }
     } else if (this.playwrightOptions.userDataDir) {
-      this.browser = await playwright[this.options.browser].launchPersistentContext(
-        this.userDataDir,
-        this.playwrightOptions,
-      )
+      this.browser = await playwright[this.options.browser].launchPersistentContext(this.userDataDir, this.playwrightOptions);
     } else {
-      this.browser = await playwright[this.options.browser].launch(this.playwrightOptions)
+      this.browser = await playwright[this.options.browser].launch(this.playwrightOptions);
     }
 
     // works only for Chromium
-    this.browser.on('targetchanged', (target) => {
-      this.debugSection('Url', target.url())
-    })
+    this.browser.on('targetchanged', target => {
+      this.debugSection('Url', target.url());
+    });
 
-    this.isRunning = true
-    return this.browser
+    this.isRunning = true;
+    return this.browser;
   }
 
   /**
@@ -879,72 +850,72 @@ class Playwright extends Helper {
    * @param {object} [contextOptions] See https://playwright.dev/docs/api/class-browser#browser-new-context
    */
   async _createContextPage(contextOptions) {
-    this.browserContext = await this.browser.newContext(contextOptions)
-    const page = await this.browserContext.newPage()
-    targetCreatedHandler.call(this, page)
-    await this._setPage(page)
+    this.browserContext = await this.browser.newContext(contextOptions);
+    const page = await this.browserContext.newPage();
+    targetCreatedHandler.call(this, page);
+    await this._setPage(page);
   }
 
   _getType() {
-    return this.browser._type
+    return this.browser._type;
   }
 
   async _stopBrowser() {
-    this.withinLocator = null
-    await this._setPage(null)
-    this.context = null
-    this.frame = null
-    popupStore.clear()
-    if (this.options.recordHar) await this.browserContext.close()
-    await this.browser.close()
+    this.withinLocator = null;
+    await this._setPage(null);
+    this.context = null;
+    this.frame = null;
+    popupStore.clear();
+    if (this.options.recordHar) await this.browserContext.close();
+    await this.browser.close();
   }
 
   async _evaluateHandeInContext(...args) {
-    const context = await this._getContext()
-    return context.evaluateHandle(...args)
+    const context = await this._getContext();
+    return context.evaluateHandle(...args);
   }
 
   async _withinBegin(locator) {
     if (this.withinLocator) {
-      throw new Error("Can't start within block inside another within block")
+      throw new Error("Can't start within block inside another within block");
     }
 
-    const frame = isFrameLocator(locator)
+    const frame = isFrameLocator(locator);
 
     if (frame) {
       if (Array.isArray(frame)) {
-        await this.switchTo(null)
-        return frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve())
+        await this.switchTo(null);
+        return frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve());
       }
-      await this.switchTo(frame)
-      this.withinLocator = new Locator(frame)
-      return
+      await this.switchTo(frame);
+      this.withinLocator = new Locator(frame);
+      return;
     }
 
-    const el = await this._locateElement(locator)
-    assertElementExists(el, locator)
-    this.context = el
-    this.contextLocator = locator
+    const el = await this._locateElement(locator);
+    assertElementExists(el, locator);
+    this.context = el;
+    this.contextLocator = locator;
 
-    this.withinLocator = new Locator(locator)
+    this.withinLocator = new Locator(locator);
   }
 
   async _withinEnd() {
-    this.withinLocator = null
-    this.context = await this.page
-    this.contextLocator = null
-    this.frame = null
+    this.withinLocator = null;
+    this.context = await this.page;
+    this.contextLocator = null;
+    this.frame = null;
   }
 
   _extractDataFromPerformanceTiming(timing, ...dataNames) {
-    const navigationStart = timing.navigationStart
+    const navigationStart = timing.navigationStart;
 
-    const extractedData = {}
-    dataNames.forEach((name) => {
-      extractedData[name] = timing[name] - navigationStart
-    })
+    const extractedData = {};
+    dataNames.forEach(name => {
+      extractedData[name] = timing[name] - navigationStart;
+    });
 
-    return extractedData
+    return extractedData;
   }
 
   /**
@@ -952,32 +923,26 @@ class Playwright extends Helper {
    */
   async amOnPage(url) {
     if (this.isElectron) {
-      throw new Error('Cannot open pages inside an Electron container')
+      throw new Error('Cannot open pages inside an Electron container');
     }
     if (!/^\w+\:(\/\/|.+)/.test(url)) {
-      url = this.options.url + (url.startsWith('/') ? url : `/${url}`)
+      url = this.options.url + (url.startsWith('/') ? url : `/${url}`);
     }
 
     if (this.options.basicAuth && this.isAuthenticated !== true) {
       if (url.includes(this.options.url)) {
-        await this.browserContext.setHTTPCredentials(this.options.basicAuth)
-        this.isAuthenticated = true
+        await this.browserContext.setHTTPCredentials(this.options.basicAuth);
+        this.isAuthenticated = true;
       }
     }
 
-    await this.page.goto(url, { waitUntil: this.options.waitForNavigation })
+    await this.page.goto(url, { waitUntil: this.options.waitForNavigation });
 
-    const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)))
+    const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)));
 
-    perfTiming = this._extractDataFromPerformanceTiming(
-      performanceTiming,
-      'responseEnd',
-      'domInteractive',
-      'domContentLoadedEventEnd',
-      'loadEventEnd',
-    )
+    perfTiming = this._extractDataFromPerformanceTiming(performanceTiming, 'responseEnd', 'domInteractive', 'domContentLoadedEventEnd', 'loadEventEnd');
 
-    return this._waitForAction()
+    return this._waitForAction();
   }
 
   /**
@@ -998,11 +963,11 @@ class Playwright extends Helper {
    */
   async resizeWindow(width, height) {
     if (width === 'maximize') {
-      throw new Error("Playwright can't control windows, so it can't maximize it")
+      throw new Error("Playwright can't control windows, so it can't maximize it");
     }
 
-    await this.page.setViewportSize({ width, height })
-    return this._waitForAction()
+    await this.page.setViewportSize({ width, height });
+    return this._waitForAction();
   }
 
   /**
@@ -1018,9 +983,9 @@ class Playwright extends Helper {
    */
   async setPlaywrightRequestHeaders(customHeaders) {
     if (!customHeaders) {
-      throw new Error('Cannot send empty headers.')
+      throw new Error('Cannot send empty headers.');
     }
-    return this.browserContext.setExtraHTTPHeaders(customHeaders)
+    return this.browserContext.setExtraHTTPHeaders(customHeaders);
   }
 
   /**
@@ -1028,13 +993,13 @@ class Playwright extends Helper {
    *
    */
   async moveCursorTo(locator, offsetX = 0, offsetY = 0) {
-    const el = await this._locateElement(locator)
-    assertElementExists(el, locator)
+    const el = await this._locateElement(locator);
+    assertElementExists(el, locator);
 
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
-    const { x, y } = await clickablePoint(el)
-    await this.page.mouse.move(x + offsetX, y + offsetY)
-    return this._waitForAction()
+    const { x, y } = await clickablePoint(el);
+    await this.page.mouse.move(x + offsetX, y + offsetY);
+    return this._waitForAction();
   }
 
   /**
@@ -1042,11 +1007,11 @@ class Playwright extends Helper {
    *
    */
   async focus(locator, options = {}) {
-    const el = await this._locateElement(locator)
-    assertElementExists(el, locator, 'Element to focus')
+    const el = await this._locateElement(locator);
+    assertElementExists(el, locator, 'Element to focus');
 
-    await el.focus(options)
-    return this._waitForAction()
+    await el.focus(options);
+    return this._waitForAction();
   }
 
   /**
@@ -1054,11 +1019,11 @@ class Playwright extends Helper {
    *
    */
   async blur(locator, options = {}) {
-    const el = await this._locateElement(locator)
-    assertElementExists(el, locator, 'Element to blur')
+    const el = await this._locateElement(locator);
+    assertElementExists(el, locator, 'Element to blur');
 
-    await el.blur(options)
-    return this._waitForAction()
+    await el.blur(options);
+    return this._waitForAction();
   }
   /**
    * Return the checked status of given element.
@@ -1070,14 +1035,14 @@ class Playwright extends Helper {
    */
 
   async grabCheckedElementStatus(locator, options = {}) {
-    const supportedTypes = ['checkbox', 'radio']
-    const el = await this._locateElement(locator)
-    const type = await el.getAttribute('type')
+    const supportedTypes = ['checkbox', 'radio'];
+    const el = await this._locateElement(locator);
+    const type = await el.getAttribute('type');
 
     if (supportedTypes.includes(type)) {
-      return el.isChecked(options)
+      return el.isChecked(options);
     }
-    throw new Error(`Element is not a ${supportedTypes.join(' or ')} input`)
+    throw new Error(`Element is not a ${supportedTypes.join(' or ')} input`);
   }
   /**
    * Return the disabled status of given element.
@@ -1089,8 +1054,8 @@ class Playwright extends Helper {
    */
 
   async grabDisabledElementStatus(locator, options = {}) {
-    const el = await this._locateElement(locator)
-    return el.isDisabled(options)
+    const el = await this._locateElement(locator);
+    return el.isDisabled(options);
   }
 
   /**
@@ -1107,24 +1072,24 @@ class Playwright extends Helper {
    *
    */
   async dragAndDrop(srcElement, destElement, options) {
-    const src = new Locator(srcElement)
-    const dst = new Locator(destElement)
+    const src = new Locator(srcElement);
+    const dst = new Locator(destElement);
 
     if (options) {
-      return this.page.dragAndDrop(buildLocatorString(src), buildLocatorString(dst), options)
+      return this.page.dragAndDrop(buildLocatorString(src), buildLocatorString(dst), options);
     }
 
-    const _smallWaitInMs = 600
-    await this.page.locator(buildLocatorString(src)).hover()
-    await this.page.mouse.down()
-    await this.page.waitForTimeout(_smallWaitInMs)
+    const _smallWaitInMs = 600;
+    await this.page.locator(buildLocatorString(src)).hover();
+    await this.page.mouse.down();
+    await this.page.waitForTimeout(_smallWaitInMs);
 
-    const destElBox = await this.page.locator(buildLocatorString(dst)).boundingBox()
+    const destElBox = await this.page.locator(buildLocatorString(dst)).boundingBox();
 
-    await this.page.mouse.move(destElBox.x + destElBox.width / 2, destElBox.y + destElBox.height / 2)
-    await this.page.locator(buildLocatorString(dst)).hover({ position: { x: 10, y: 10 } })
-    await this.page.waitForTimeout(_smallWaitInMs)
-    await this.page.mouse.up()
+    await this.page.mouse.move(destElBox.x + destElBox.width / 2, destElBox.y + destElBox.height / 2);
+    await this.page.locator(buildLocatorString(dst)).hover({ position: { x: 10, y: 10 } });
+    await this.page.waitForTimeout(_smallWaitInMs);
+    await this.page.mouse.up();
   }
 
   /**
@@ -1142,16 +1107,16 @@ class Playwright extends Helper {
    * @param {object} [contextOptions] [Options for browser context](https://playwright.dev/docs/api/class-browser#browser-new-context) when starting new browser
    */
   async restartBrowser(contextOptions) {
-    await this._stopBrowser()
-    await this._startBrowser()
-    await this._createContextPage(contextOptions)
+    await this._stopBrowser();
+    await this._startBrowser();
+    await this._createContextPage(contextOptions);
   }
 
   /**
    * {{> refreshPage }}
    */
   async refreshPage() {
-    return this.page.reload({ timeout: this.options.getPageTimeout, waitUntil: this.options.waitForNavigation })
+    return this.page.reload({ timeout: this.options.getPageTimeout, waitUntil: this.options.waitForNavigation });
   }
 
   /**
@@ -1172,13 +1137,13 @@ class Playwright extends Helper {
    * @returns Promise<void>
    */
   async replayFromHar(harFilePath, opts) {
-    const file = path.join(global.codecept_dir, harFilePath)
+    const file = path.join(global.codecept_dir, harFilePath);
 
     if (!fileExists(file)) {
-      throw new Error(`File at ${file} cannot be found on local system`)
+      throw new Error(`File at ${file} cannot be found on local system`);
     }
 
-    await this.page.routeFromHAR(harFilePath, opts)
+    await this.page.routeFromHAR(harFilePath, opts);
   }
 
   /**
@@ -1186,8 +1151,8 @@ class Playwright extends Helper {
    */
   scrollPageToTop() {
     return this.executeScript(() => {
-      window.scrollTo(0, 0)
-    })
+      window.scrollTo(0, 0);
+    });
   }
 
   /**
@@ -1195,13 +1160,10 @@ class Playwright extends Helper {
    */
   async scrollPageToBottom() {
     return this.executeScript(() => {
-      const body = document.body
-      const html = document.documentElement
-      window.scrollTo(
-        0,
-        Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      )
-    })
+      const body = document.body;
+      const html = document.documentElement;
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight));
+    });
   }
 
   /**
@@ -1209,32 +1171,32 @@ class Playwright extends Helper {
    */
   async scrollTo(locator, offsetX = 0, offsetY = 0) {
     if (typeof locator === 'number' && typeof offsetX === 'number') {
-      offsetY = offsetX
-      offsetX = locator
-      locator = null
+      offsetY = offsetX;
+      offsetX = locator;
+      locator = null;
     }
 
     if (locator) {
-      const el = await this._locateElement(locator)
-      assertElementExists(el, locator, 'Element')
-      await el.scrollIntoViewIfNeeded()
-      const elementCoordinates = await clickablePoint(el)
+      const el = await this._locateElement(locator);
+      assertElementExists(el, locator, 'Element');
+      await el.scrollIntoViewIfNeeded();
+      const elementCoordinates = await clickablePoint(el);
       await this.executeScript((offsetX, offsetY) => window.scrollBy(offsetX, offsetY), {
         offsetX: elementCoordinates.x + offsetX,
         offsetY: elementCoordinates.y + offsetY,
-      })
+      });
     } else {
-      await this.executeScript(({ offsetX, offsetY }) => window.scrollTo(offsetX, offsetY), { offsetX, offsetY })
+      await this.executeScript(({ offsetX, offsetY }) => window.scrollTo(offsetX, offsetY), { offsetX, offsetY });
     }
-    return this._waitForAction()
+    return this._waitForAction();
   }
 
   /**
    * {{> seeInTitle }}
    */
   async seeInTitle(text) {
-    const title = await this.page.title()
-    stringIncludes('web page title').assert(text, title)
+    const title = await this.page.title();
+    stringIncludes('web page title').assert(text, title);
   }
 
   /**
@@ -1245,33 +1207,33 @@ class Playwright extends Helper {
       return {
         x: window.pageXOffset,
         y: window.pageYOffset,
-      }
+      };
     }
 
-    return this.executeScript(getScrollPosition)
+    return this.executeScript(getScrollPosition);
   }
 
   /**
    * {{> seeTitleEquals }}
    */
   async seeTitleEquals(text) {
-    const title = await this.page.title()
-    return equals('web page title').assert(title, text)
+    const title = await this.page.title();
+    return equals('web page title').assert(title, text);
   }
 
   /**
    * {{> dontSeeInTitle }}
    */
   async dontSeeInTitle(text) {
-    const title = await this.page.title()
-    stringIncludes('web page title').negate(text, title)
+    const title = await this.page.title();
+    stringIncludes('web page title').negate(text, title);
   }
 
   /**
    * {{> grabTitle }}
    */
   async grabTitle() {
-    return this.page.title()
+    return this.page.title();
   }
 
   /**
@@ -1283,11 +1245,11 @@ class Playwright extends Helper {
    * ```
    */
   async _locate(locator) {
-    const context = await this._getContext()
+    const context = await this._getContext();
 
-    if (this.frame) return findElements(this.frame, locator)
+    if (this.frame) return findElements(this.frame, locator);
 
-    return findElements(context, locator)
+    return findElements(context, locator);
   }
 
   /**
@@ -1299,8 +1261,8 @@ class Playwright extends Helper {
    * ```
    */
   async _locateElement(locator) {
-    const context = await this._getContext()
-    return findElement(context, locator)
+    const context = await this._getContext();
+    return findElement(context, locator);
   }
 
   /**
@@ -1312,10 +1274,10 @@ class Playwright extends Helper {
    * ```
    */
   async _locateCheckable(locator, providedContext = null) {
-    const context = providedContext || (await this._getContext())
-    const els = await findCheckable.call(this, locator, context)
-    assertElementExists(els[0], locator, 'Checkbox or radio')
-    return els[0]
+    const context = providedContext || (await this._getContext());
+    const els = await findCheckable.call(this, locator, context);
+    assertElementExists(els[0], locator, 'Checkbox or radio');
+    return els[0];
   }
 
   /**
@@ -1326,8 +1288,8 @@ class Playwright extends Helper {
    * ```
    */
   async _locateClickable(locator) {
-    const context = await this._getContext()
-    return findClickable.call(this, context, locator)
+    const context = await this._getContext();
+    return findClickable.call(this, context, locator);
   }
 
   /**
@@ -1338,7 +1300,7 @@ class Playwright extends Helper {
    * ```
    */
   async _locateFields(locator) {
-    return findFields.call(this, locator)
+    return findFields.call(this, locator);
   }
 
   /**
@@ -1346,7 +1308,7 @@ class Playwright extends Helper {
    *
    */
   async grabWebElements(locator) {
-    return this._locate(locator)
+    return this._locate(locator);
   }
 
   /**
@@ -1354,7 +1316,7 @@ class Playwright extends Helper {
    *
    */
   async grabWebElement(locator) {
-    return this._locateElement(locator)
+    return this._locateElement(locator);
   }
 
   /**
@@ -1369,20 +1331,20 @@ class Playwright extends Helper {
    */
   async switchToNextTab(num = 1) {
     if (this.isElectron) {
-      throw new Error('Cannot switch tabs inside an Electron container')
+      throw new Error('Cannot switch tabs inside an Electron container');
     }
-    const pages = await this.browserContext.pages()
+    const pages = await this.browserContext.pages();
 
-    const index = pages.indexOf(this.page)
-    this.withinLocator = null
-    const page = pages[index + num]
+    const index = pages.indexOf(this.page);
+    this.withinLocator = null;
+    const page = pages[index + num];
 
     if (!page) {
-      throw new Error(`There is no ability to switch to next tab with offset ${num}`)
+      throw new Error(`There is no ability to switch to next tab with offset ${num}`);
     }
-    await targetCreatedHandler.call(this, page)
-    await this._setPage(page)
-    return this._waitForAction()
+    await targetCreatedHandler.call(this, page);
+    await this._setPage(page);
+    return this._waitForAction();
   }
 
   /**
@@ -1396,19 +1358,19 @@ class Playwright extends Helper {
    */
   async switchToPreviousTab(num = 1) {
     if (this.isElectron) {
-      throw new Error('Cannot switch tabs inside an Electron container')
+      throw new Error('Cannot switch tabs inside an Electron container');
     }
-    const pages = await this.browserContext.pages()
-    const index = pages.indexOf(this.page)
-    this.withinLocator = null
-    const page = pages[index - num]
+    const pages = await this.browserContext.pages();
+    const index = pages.indexOf(this.page);
+    this.withinLocator = null;
+    const page = pages[index - num];
 
     if (!page) {
-      throw new Error(`There is no ability to switch to previous tab with offset ${num}`)
+      throw new Error(`There is no ability to switch to previous tab with offset ${num}`);
     }
 
-    await this._setPage(page)
-    return this._waitForAction()
+    await this._setPage(page);
+    return this._waitForAction();
   }
 
   /**
@@ -1420,12 +1382,12 @@ class Playwright extends Helper {
    */
   async closeCurrentTab() {
     if (this.isElectron) {
-      throw new Error('Cannot close current tab inside an Electron container')
+      throw new Error('Cannot close current tab inside an Electron container');
     }
-    const oldPage = this.page
-    await this.switchToPreviousTab()
-    await oldPage.close()
-    return this._waitForAction()
+    const oldPage = this.page;
+    await this.switchToPreviousTab();
+    await oldPage.close();
+    return this._waitForAction();
   }
 
   /**
@@ -1436,13 +1398,13 @@ class Playwright extends Helper {
    * ```
    */
   async closeOtherTabs() {
-    const pages = await this.browserContext.pages()
-    const otherPages = pages.filter((page) => page !== this.page)
+    const pages = await this.browserContext.pages();
+    const otherPages = pages.filter(page => page !== this.page);
     if (otherPages.length) {
-      this.debug(`Closing ${otherPages.length} tabs`)
-      return Promise.all(otherPages.map((p) => p.close()))
+      this.debug(`Closing ${otherPages.length} tabs`);
+      return Promise.all(otherPages.map(p => p.close()));
     }
-    return Promise.resolve()
+    return Promise.resolve();
   }
 
   /**
@@ -1461,20 +1423,20 @@ class Playwright extends Helper {
    */
   async openNewTab(options) {
     if (this.isElectron) {
-      throw new Error('Cannot open new tabs inside an Electron container')
+      throw new Error('Cannot open new tabs inside an Electron container');
     }
-    const page = await this.browserContext.newPage(options)
-    await targetCreatedHandler.call(this, page)
-    await this._setPage(page)
-    return this._waitForAction()
+    const page = await this.browserContext.newPage(options);
+    await targetCreatedHandler.call(this, page);
+    await this._setPage(page);
+    return this._waitForAction();
   }
 
   /**
    * {{> grabNumberOfOpenTabs }}
    */
   async grabNumberOfOpenTabs() {
-    const pages = await this.browserContext.pages()
-    return pages.length
+    const pages = await this.browserContext.pages();
+    return pages.length;
   }
 
   /**
@@ -1482,12 +1444,12 @@ class Playwright extends Helper {
    *
    */
   async seeElement(locator) {
-    let els = await this._locate(locator)
-    els = await Promise.all(els.map((el) => el.isVisible()))
+    let els = await this._locate(locator);
+    els = await Promise.all(els.map(el => el.isVisible()));
     try {
-      return empty('visible elements').negate(els.filter((v) => v).fill('ELEMENT'))
+      return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'));
     } catch (e) {
-      dontSeeElementError(locator)
+      dontSeeElementError(locator);
     }
   }
 
@@ -1496,12 +1458,12 @@ class Playwright extends Helper {
    *
    */
   async dontSeeElement(locator) {
-    let els = await this._locate(locator)
-    els = await Promise.all(els.map((el) => el.isVisible()))
+    let els = await this._locate(locator);
+    els = await Promise.all(els.map(el => el.isVisible()));
     try {
-      return empty('visible elements').assert(els.filter((v) => v).fill('ELEMENT'))
+      return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'));
     } catch (e) {
-      seeElementError(locator)
+      seeElementError(locator);
     }
   }
 
@@ -1509,11 +1471,11 @@ class Playwright extends Helper {
    * {{> seeElementInDOM }}
    */
   async seeElementInDOM(locator) {
-    const els = await this._locate(locator)
+    const els = await this._locate(locator);
     try {
-      return empty('elements on page').negate(els.filter((v) => v).fill('ELEMENT'))
+      return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'));
     } catch (e) {
-      dontSeeElementInDOMError(locator)
+      dontSeeElementInDOMError(locator);
     }
   }
 
@@ -1521,11 +1483,11 @@ class Playwright extends Helper {
    * {{> dontSeeElementInDOM }}
    */
   async dontSeeElementInDOM(locator) {
-    const els = await this._locate(locator)
+    const els = await this._locate(locator);
     try {
-      return empty('elements on a page').assert(els.filter((v) => v).fill('ELEMENT'))
+      return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'));
     } catch (e) {
-      seeElementInDOMError(locator)
+      seeElementInDOMError(locator);
     }
   }
 
@@ -1547,19 +1509,19 @@ class Playwright extends Helper {
    * @return {Promise<void>}
    */
   async handleDownloads(fileName) {
-    this.page.waitForEvent('download').then(async (download) => {
-      const filePath = await download.path()
-      fileName = fileName || `downloads/${path.basename(filePath)}`
+    this.page.waitForEvent('download').then(async download => {
+      const filePath = await download.path();
+      fileName = fileName || `downloads/${path.basename(filePath)}`;
 
-      const downloadPath = path.join(global.output_dir, fileName)
+      const downloadPath = path.join(global.output_dir, fileName);
       if (!fs.existsSync(path.dirname(downloadPath))) {
-        fs.mkdirSync(path.dirname(downloadPath), '0777')
+        fs.mkdirSync(path.dirname(downloadPath), '0777');
       }
-      fs.copyFileSync(filePath, downloadPath)
-      this.debug('Download completed')
-      this.debugSection('Downloaded From', await download.url())
-      this.debugSection('Downloaded To', downloadPath)
-    })
+      fs.copyFileSync(filePath, downloadPath);
+      this.debug('Download completed');
+      this.debugSection('Downloaded From', await download.url());
+      this.debugSection('Downloaded To', downloadPath);
+    });
   }
 
   /**
@@ -1579,37 +1541,37 @@ class Playwright extends Helper {
    *
    */
   async click(locator, context = null, options = {}) {
-    return proceedClick.call(this, locator, context, options)
+    return proceedClick.call(this, locator, context, options);
   }
 
   /**
    * Clicks link and waits for navigation (deprecated)
    */
   async clickLink(locator, context = null) {
-    console.log('clickLink deprecated: Playwright automatically waits for navigation to happen.')
-    console.log('Replace I.clickLink with I.click')
-    return this.click(locator, context)
+    console.log('clickLink deprecated: Playwright automatically waits for navigation to happen.');
+    console.log('Replace I.clickLink with I.click');
+    return this.click(locator, context);
   }
 
   /**
    * {{> forceClick }}
    */
   async forceClick(locator, context = null) {
-    return proceedClick.call(this, locator, context, { force: true })
+    return proceedClick.call(this, locator, context, { force: true });
   }
 
   /**
    * {{> doubleClick }}
    */
   async doubleClick(locator, context = null) {
-    return proceedClick.call(this, locator, context, { clickCount: 2 })
+    return proceedClick.call(this, locator, context, { clickCount: 2 });
   }
 
   /**
    * {{> rightClick }}
    */
   async rightClick(locator, context = null) {
-    return proceedClick.call(this, locator, context, { button: 'right' })
+    return proceedClick.call(this, locator, context, { button: 'right' });
   }
 
   /**
@@ -1628,9 +1590,9 @@ class Playwright extends Helper {
    *
    */
   async checkOption(field, context = null, options = { force: true }) {
-    const elm = await this._locateCheckable(field, context)
-    await elm.check(options)
-    return this._waitForAction()
+    const elm = await this._locateCheckable(field, context);
+    await elm.check(options);
+    return this._waitForAction();
   }
 
   /**
@@ -1648,41 +1610,41 @@ class Playwright extends Helper {
    * {{> uncheckOption }}
    */
   async uncheckOption(field, context = null, options = { force: true }) {
-    const elm = await this._locateCheckable(field, context)
-    await elm.uncheck(options)
-    return this._waitForAction()
+    const elm = await this._locateCheckable(field, context);
+    await elm.uncheck(options);
+    return this._waitForAction();
   }
 
   /**
    * {{> seeCheckboxIsChecked }}
    */
   async seeCheckboxIsChecked(field) {
-    return proceedIsChecked.call(this, 'assert', field)
+    return proceedIsChecked.call(this, 'assert', field);
   }
 
   /**
    * {{> dontSeeCheckboxIsChecked }}
    */
   async dontSeeCheckboxIsChecked(field) {
-    return proceedIsChecked.call(this, 'negate', field)
+    return proceedIsChecked.call(this, 'negate', field);
   }
 
   /**
    * {{> pressKeyDown }}
    */
   async pressKeyDown(key) {
-    key = getNormalizedKey.call(this, key)
-    await this.page.keyboard.down(key)
-    return this._waitForAction()
+    key = getNormalizedKey.call(this, key);
+    await this.page.keyboard.down(key);
+    return this._waitForAction();
   }
 
   /**
    * {{> pressKeyUp }}
    */
   async pressKeyUp(key) {
-    key = getNormalizedKey.call(this, key)
-    await this.page.keyboard.up(key)
-    return this._waitForAction()
+    key = getNormalizedKey.call(this, key);
+    await this.page.keyboard.up(key);
+    return this._waitForAction();
   }
 
   /**
@@ -1692,28 +1654,28 @@ class Playwright extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
-    const modifiers = []
+    const modifiers = [];
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k)
+        k = getNormalizedKey.call(this, k);
         if (isModifierKey(k)) {
-          modifiers.push(k)
+          modifiers.push(k);
         } else {
-          key = k
-          break
+          key = k;
+          break;
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key)
+      key = getNormalizedKey.call(this, key);
     }
     for (const modifier of modifiers) {
-      await this.page.keyboard.down(modifier)
+      await this.page.keyboard.down(modifier);
     }
-    await this.page.keyboard.press(key)
+    await this.page.keyboard.press(key);
     for (const modifier of modifiers) {
-      await this.page.keyboard.up(modifier)
+      await this.page.keyboard.up(modifier);
     }
-    return this._waitForAction()
+    return this._waitForAction();
   }
 
   /**
@@ -1721,13 +1683,13 @@ class Playwright extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
-      keys = keys.toString()
-      keys = keys.split('')
+      keys = keys.toString();
+      keys = keys.split('');
     }
 
     for (const key of keys) {
-      await this.page.keyboard.press(key)
-      if (delay) await this.wait(delay / 1000)
+      await this.page.keyboard.press(key);
+      if (delay) await this.wait(delay / 1000);
     }
   }
 
@@ -1736,17 +1698,17 @@ class Playwright extends Helper {
    *
    */
   async fillField(field, value) {
-    const els = await findFields.call(this, field)
-    assertElementExists(els, field, 'Field')
-    const el = els[0]
+    const els = await findFields.call(this, field);
+    assertElementExists(els, field, 'Field');
+    const el = els[0];
 
-    await el.clear()
+    await el.clear();
 
-    await highlightActiveElement.call(this, el)
+    await highlightActiveElement.call(this, el);
 
-    await el.type(value.toString(), { delay: this.options.pressKeyDelay })
+    await el.type(value.toString(), { delay: this.options.pressKeyDelay });
 
-    return this._waitForAction()
+    return this._waitForAction();
   }
 
   /**
@@ -1767,44 +1729,44 @@ class Playwright extends Helper {
    * @param {any} [options] [Additional options](https://playwright.dev/docs/api/class-locator#locator-clear) for available options object as 2nd argument.
    */
   async clearField(locator, options = {}) {
-    const els = await findFields.call(this, locator)
-    assertElementExists(els, locator, 'Field to clear')
+    const els = await findFields.call(this, locator);
+    assertElementExists(els, locator, 'Field to clear');
 
-    const el = els[0]
+    const el = els[0];
 
-    await highlightActiveElement.call(this, el)
+    await highlightActiveElement.call(this, el);
 
-    await el.clear()
+    await el.clear();
 
-    return this._waitForAction()
+    return this._waitForAction();
   }
 
   /**
    * {{> appendField }}
    */
   async appendField(field, value) {
-    const els = await findFields.call(this, field)
-    assertElementExists(els, field, 'Field')
-    await highlightActiveElement.call(this, els[0])
-    await els[0].press('End')
-    await els[0].type(value.toString(), { delay: this.options.pressKeyDelay })
-    return this._waitForAction()
+    const els = await findFields.call(this, field);
+    assertElementExists(els, field, 'Field');
+    await highlightActiveElement.call(this, els[0]);
+    await els[0].press('End');
+    await els[0].type(value.toString(), { delay: this.options.pressKeyDelay });
+    return this._waitForAction();
   }
 
   /**
    * {{> seeInField }}
    */
   async seeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString()
-    return proceedSeeInField.call(this, 'assert', field, _value)
+    const _value = typeof value === 'boolean' ? value : value.toString();
+    return proceedSeeInField.call(this, 'assert', field, _value);
   }
 
   /**
    * {{> dontSeeInField }}
    */
   async dontSeeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString()
-    return proceedSeeInField.call(this, 'negate', field, _value)
+    const _value = typeof value === 'boolean' ? value : value.toString();
+    return proceedSeeInField.call(this, 'negate', field, _value);
   }
 
   /**
@@ -1812,38 +1774,38 @@ class Playwright extends Helper {
    *
    */
   async attachFile(locator, pathToFile) {
-    const file = path.join(global.codecept_dir, pathToFile)
+    const file = path.join(global.codecept_dir, pathToFile);
 
     if (!fileExists(file)) {
-      throw new Error(`File at ${file} can not be found on local system`)
+      throw new Error(`File at ${file} can not be found on local system`);
     }
-    const els = await findFields.call(this, locator)
-    assertElementExists(els, locator, 'Field')
-    await els[0].setInputFiles(file)
-    return this._waitForAction()
+    const els = await findFields.call(this, locator);
+    assertElementExists(els, locator, 'Field');
+    await els[0].setInputFiles(file);
+    return this._waitForAction();
   }
 
   /**
    * {{> selectOption }}
    */
   async selectOption(select, option) {
-    const els = await findFields.call(this, select)
-    assertElementExists(els, select, 'Selectable field')
-    const el = els[0]
+    const els = await findFields.call(this, select);
+    assertElementExists(els, select, 'Selectable field');
+    const el = els[0];
 
-    await highlightActiveElement.call(this, el)
-    let optionToSelect = ''
+    await highlightActiveElement.call(this, el);
+    let optionToSelect = '';
 
     try {
-      optionToSelect = (await el.locator('option', { hasText: option }).textContent()).trim()
+      optionToSelect = (await el.locator('option', { hasText: option }).textContent()).trim();
     } catch (e) {
-      optionToSelect = option
+      optionToSelect = option;
     }
 
-    if (!Array.isArray(option)) option = [optionToSelect]
+    if (!Array.isArray(option)) option = [optionToSelect];
 
-    await el.selectOption(option)
-    return this._waitForAction()
+    await el.selectOption(option);
+    return this._waitForAction();
   }
 
   /**
@@ -1851,37 +1813,37 @@ class Playwright extends Helper {
    *
    */
   async grabNumberOfVisibleElements(locator) {
-    let els = await this._locate(locator)
-    els = await Promise.all(els.map((el) => el.isVisible()))
-    return els.filter((v) => v).length
+    let els = await this._locate(locator);
+    els = await Promise.all(els.map(el => el.isVisible()));
+    return els.filter(v => v).length;
   }
 
   /**
    * {{> seeInCurrentUrl }}
    */
   async seeInCurrentUrl(url) {
-    stringIncludes('url').assert(url, await this._getPageUrl())
+    stringIncludes('url').assert(url, await this._getPageUrl());
   }
 
   /**
    * {{> dontSeeInCurrentUrl }}
    */
   async dontSeeInCurrentUrl(url) {
-    stringIncludes('url').negate(url, await this._getPageUrl())
+    stringIncludes('url').negate(url, await this._getPageUrl());
   }
 
   /**
    * {{> seeCurrentUrlEquals }}
    */
   async seeCurrentUrlEquals(url) {
-    urlEquals(this.options.url).assert(url, await this._getPageUrl())
+    urlEquals(this.options.url).assert(url, await this._getPageUrl());
   }
 
   /**
    * {{> dontSeeCurrentUrlEquals }}
    */
   async dontSeeCurrentUrlEquals(url) {
-    urlEquals(this.options.url).negate(url, await this._getPageUrl())
+    urlEquals(this.options.url).negate(url, await this._getPageUrl());
   }
 
   /**
@@ -1890,14 +1852,14 @@ class Playwright extends Helper {
    *
    */
   async see(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context)
+    return proceedSee.call(this, 'assert', text, context);
   }
 
   /**
    * {{> seeTextEquals }}
    */
   async seeTextEquals(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context, true)
+    return proceedSee.call(this, 'assert', text, context, true);
   }
 
   /**
@@ -1906,14 +1868,14 @@ class Playwright extends Helper {
    *
    */
   async dontSee(text, context = null) {
-    return proceedSee.call(this, 'negate', text, context)
+    return proceedSee.call(this, 'negate', text, context);
   }
 
   /**
    * {{> grabSource }}
    */
   async grabSource() {
-    return this.page.content()
+    return this.page.content();
   }
 
   /**
@@ -1928,32 +1890,32 @@ class Playwright extends Helper {
    * @return {Promise<any[]>}
    */
   async grabBrowserLogs() {
-    const logs = consoleLogStore.entries
-    consoleLogStore.clear()
-    return logs
+    const logs = consoleLogStore.entries;
+    consoleLogStore.clear();
+    return logs;
   }
 
   /**
    * {{> grabCurrentUrl }}
    */
   async grabCurrentUrl() {
-    return this._getPageUrl()
+    return this._getPageUrl();
   }
 
   /**
    * {{> seeInSource }}
    */
   async seeInSource(text) {
-    const source = await this.page.content()
-    stringIncludes('HTML source of a page').assert(text, source)
+    const source = await this.page.content();
+    stringIncludes('HTML source of a page').assert(text, source);
   }
 
   /**
    * {{> dontSeeInSource }}
    */
   async dontSeeInSource(text) {
-    const source = await this.page.content()
-    stringIncludes('HTML source of a page').negate(text, source)
+    const source = await this.page.content();
+    stringIncludes('HTML source of a page').negate(text, source);
   }
 
   /**
@@ -1962,10 +1924,8 @@ class Playwright extends Helper {
    *
    */
   async seeNumberOfElements(locator, num) {
-    const elements = await this._locate(locator)
-    return equals(
-      `expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`,
-    ).assert(elements.length, num)
+    const elements = await this._locate(locator);
+    return equals(`expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`).assert(elements.length, num);
   }
 
   /**
@@ -1974,11 +1934,8 @@ class Playwright extends Helper {
    *
    */
   async seeNumberOfVisibleElements(locator, num) {
-    const res = await this.grabNumberOfVisibleElements(locator)
-    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(
-      res,
-      num,
-    )
+    const res = await this.grabNumberOfVisibleElements(locator);
+    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(res, num);
   }
 
   /**
@@ -1986,9 +1943,9 @@ class Playwright extends Helper {
    */
   async setCookie(cookie) {
     if (Array.isArray(cookie)) {
-      return this.browserContext.addCookies(cookie)
+      return this.browserContext.addCookies(cookie);
     }
-    return this.browserContext.addCookies([cookie])
+    return this.browserContext.addCookies([cookie]);
   }
 
   /**
@@ -1996,16 +1953,16 @@ class Playwright extends Helper {
    *
    */
   async seeCookie(name) {
-    const cookies = await this.browserContext.cookies()
-    empty(`cookie ${name} to be set`).negate(cookies.filter((c) => c.name === name))
+    const cookies = await this.browserContext.cookies();
+    empty(`cookie ${name} to be set`).negate(cookies.filter(c => c.name === name));
   }
 
   /**
    * {{> dontSeeCookie }}
    */
   async dontSeeCookie(name) {
-    const cookies = await this.browserContext.cookies()
-    empty(`cookie ${name} not to be set`).assert(cookies.filter((c) => c.name === name))
+    const cookies = await this.browserContext.cookies();
+    empty(`cookie ${name} not to be set`).assert(cookies.filter(c => c.name === name));
   }
 
   /**
@@ -2014,10 +1971,10 @@ class Playwright extends Helper {
    * {{> grabCookie }}
    */
   async grabCookie(name) {
-    const cookies = await this.browserContext.cookies()
-    if (!name) return cookies
-    const cookie = cookies.filter((c) => c.name === name)
-    if (cookie[0]) return cookie[0]
+    const cookies = await this.browserContext.cookies();
+    if (!name) return cookies;
+    const cookie = cookies.filter(c => c.name === name);
+    if (cookie[0]) return cookie[0];
   }
 
   /**
@@ -2026,8 +1983,8 @@ class Playwright extends Helper {
   async clearCookie() {
     // Playwright currently doesn't support to delete a certain cookie
     // https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md#async-method-browsercontextclearcookies
-    if (!this.browserContext) return
-    return this.browserContext.clearCookies()
+    if (!this.browserContext) return;
+    return this.browserContext.clearCookies();
   }
 
   /**
@@ -2057,9 +2014,9 @@ class Playwright extends Helper {
   async executeScript(fn, arg) {
     if (this.context && this.context.constructor.name === 'FrameLocator') {
       // switching to iframe context
-      return this.context.locator(':root').evaluate(fn, arg)
+      return this.context.locator(':root').evaluate(fn, arg);
     }
-    return this.page.evaluate.apply(this.page, [fn, arg])
+    return this.page.evaluate.apply(this.page, [fn, arg]);
   }
 
   /**
@@ -2068,14 +2025,14 @@ class Playwright extends Helper {
    * @param {*} locator
    */
   _contextLocator(locator) {
-    locator = buildLocatorString(new Locator(locator, 'css'))
+    locator = buildLocatorString(new Locator(locator, 'css'));
 
     if (this.contextLocator) {
-      const contextLocator = buildLocatorString(new Locator(this.contextLocator, 'css'))
-      locator = `${contextLocator} >> ${locator}`
+      const contextLocator = buildLocatorString(new Locator(this.contextLocator, 'css'));
+      locator = `${contextLocator} >> ${locator}`;
     }
 
-    return locator
+    return locator;
   }
 
   /**
@@ -2083,11 +2040,11 @@ class Playwright extends Helper {
    *
    */
   async grabTextFrom(locator) {
-    locator = this._contextLocator(locator)
-    const text = await this.page.textContent(locator)
-    assertElementExists(text, locator)
-    this.debugSection('Text', text)
-    return text
+    locator = this._contextLocator(locator);
+    const text = await this.page.textContent(locator);
+    assertElementExists(text, locator);
+    this.debugSection('Text', text);
+    return text;
   }
 
   /**
@@ -2095,51 +2052,51 @@ class Playwright extends Helper {
    *
    */
   async grabTextFromAll(locator) {
-    const els = await this._locate(locator)
-    const texts = []
+    const els = await this._locate(locator);
+    const texts = [];
     for (const el of els) {
-      texts.push(await await el.innerText())
+      texts.push(await await el.innerText());
     }
-    this.debug(`Matched ${els.length} elements`)
-    return texts
+    this.debug(`Matched ${els.length} elements`);
+    return texts;
   }
 
   /**
    * {{> grabValueFrom }}
    */
   async grabValueFrom(locator) {
-    const values = await this.grabValueFromAll(locator)
-    assertElementExists(values, locator)
-    this.debugSection('Value', values[0])
-    return values[0]
+    const values = await this.grabValueFromAll(locator);
+    assertElementExists(values, locator);
+    this.debugSection('Value', values[0]);
+    return values[0];
   }
 
   /**
    * {{> grabValueFromAll }}
    */
   async grabValueFromAll(locator) {
-    const els = await findFields.call(this, locator)
-    this.debug(`Matched ${els.length} elements`)
-    return Promise.all(els.map((el) => el.inputValue()))
+    const els = await findFields.call(this, locator);
+    this.debug(`Matched ${els.length} elements`);
+    return Promise.all(els.map(el => el.inputValue()));
   }
 
   /**
    * {{> grabHTMLFrom }}
    */
   async grabHTMLFrom(locator) {
-    const html = await this.grabHTMLFromAll(locator)
-    assertElementExists(html, locator)
-    this.debugSection('HTML', html[0])
-    return html[0]
+    const html = await this.grabHTMLFromAll(locator);
+    assertElementExists(html, locator);
+    this.debugSection('HTML', html[0]);
+    return html[0];
   }
 
   /**
    * {{> grabHTMLFromAll }}
    */
   async grabHTMLFromAll(locator) {
-    const els = await this._locate(locator)
-    this.debug(`Matched ${els.length} elements`)
-    return Promise.all(els.map((el) => el.innerHTML()))
+    const els = await this._locate(locator);
+    this.debug(`Matched ${els.length} elements`);
+    return Promise.all(els.map(el => el.innerHTML()));
   }
 
   /**
@@ -2147,10 +2104,10 @@ class Playwright extends Helper {
    *
    */
   async grabCssPropertyFrom(locator, cssProperty) {
-    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty)
-    assertElementExists(cssValues, locator)
-    this.debugSection('CSS', cssValues[0])
-    return cssValues[0]
+    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty);
+    assertElementExists(cssValues, locator);
+    this.debugSection('CSS', cssValues[0]);
+    return cssValues[0];
   }
 
   /**
@@ -2158,15 +2115,11 @@ class Playwright extends Helper {
    *
    */
   async grabCssPropertyFromAll(locator, cssProperty) {
-    const els = await this._locate(locator)
-    this.debug(`Matched ${els.length} elements`)
-    const cssValues = await Promise.all(
-      els.map((el) =>
-        el.evaluate((el, cssProperty) => getComputedStyle(el).getPropertyValue(cssProperty), cssProperty),
-      ),
-    )
+    const els = await this._locate(locator);
+    this.debug(`Matched ${els.length} elements`);
+    const cssValues = await Promise.all(els.map(el => el.evaluate((el, cssProperty) => getComputedStyle(el).getPropertyValue(cssProperty), cssProperty)));
 
-    return cssValues
+    return cssValues;
   }
 
   /**
@@ -2174,37 +2127,35 @@ class Playwright extends Helper {
    *
    */
   async seeCssPropertiesOnElements(locator, cssProperties) {
-    const res = await this._locate(locator)
-    assertElementExists(res, locator)
+    const res = await this._locate(locator);
+    assertElementExists(res, locator);
 
-    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties)
-    const elemAmount = res.length
-    let props = []
+    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties);
+    const elemAmount = res.length;
+    let props = [];
 
     for (const element of res) {
       for (const prop of Object.keys(cssProperties)) {
-        const cssProp = await this.grabCssPropertyFrom(locator, prop)
+        const cssProp = await this.grabCssPropertyFrom(locator, prop);
         if (isColorProperty(prop)) {
-          props.push(convertColorToRGBA(cssProp))
+          props.push(convertColorToRGBA(cssProp));
         } else {
-          props.push(cssProp)
+          props.push(cssProp);
         }
       }
     }
 
-    const values = Object.keys(cssPropertiesCamelCase).map((key) => cssPropertiesCamelCase[key])
-    if (!Array.isArray(props)) props = [props]
-    let chunked = chunkArray(props, values.length)
-    chunked = chunked.filter((val) => {
+    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key]);
+    if (!Array.isArray(props)) props = [props];
+    let chunked = chunkArray(props, values.length);
+    chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // eslint-disable-next-line eqeqeq
-        if (val[i] != values[i]) return false
+        if (val[i] != values[i]) return false;
       }
-      return true
-    })
-    return equals(
-      `all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`,
-    ).assert(chunked.length, elemAmount)
+      return true;
+    });
+    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -2212,33 +2163,30 @@ class Playwright extends Helper {
    *
    */
   async seeAttributesOnElements(locator, attributes) {
-    const res = await this._locate(locator)
-    assertElementExists(res, locator)
+    const res = await this._locate(locator);
+    assertElementExists(res, locator);
 
-    const elemAmount = res.length
-    const commands = []
-    res.forEach((el) => {
-      Object.keys(attributes).forEach((prop) => {
-        commands.push(el.evaluate((el, attr) => el[attr] || el.getAttribute(attr), prop))
-      })
-    })
-    let attrs = await Promise.all(commands)
-    const values = Object.keys(attributes).map((key) => attributes[key])
-    if (!Array.isArray(attrs)) attrs = [attrs]
-    let chunked = chunkArray(attrs, values.length)
-    chunked = chunked.filter((val) => {
+    const elemAmount = res.length;
+    const commands = [];
+    res.forEach(el => {
+      Object.keys(attributes).forEach(prop => {
+        commands.push(el.evaluate((el, attr) => el[attr] || el.getAttribute(attr), prop));
+      });
+    });
+    let attrs = await Promise.all(commands);
+    const values = Object.keys(attributes).map(key => attributes[key]);
+    if (!Array.isArray(attrs)) attrs = [attrs];
+    let chunked = chunkArray(attrs, values.length);
+    chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // the attribute could be a boolean
-        if (typeof val[i] === 'boolean') return val[i] === values[i]
+        if (typeof val[i] === 'boolean') return val[i] === values[i];
         // if the attribute doesn't exist, returns false as well
-        if (!val[i] || !val[i].includes(values[i])) return false
+        if (!val[i] || !val[i].includes(values[i])) return false;
       }
-      return true
-    })
-    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(
-      chunked.length,
-      elemAmount,
-    )
+      return true;
+    });
+    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(chunked.length, elemAmount);
   }
 
   /**
@@ -2246,21 +2194,21 @@ class Playwright extends Helper {
    *
    */
   async dragSlider(locator, offsetX = 0) {
-    const src = await this._locateElement(locator)
-    assertElementExists(src, locator, 'Slider Element')
+    const src = await this._locateElement(locator);
+    assertElementExists(src, locator, 'Slider Element');
 
     // Note: Using clickablePoint private api because the .BoundingBox does not take into account iframe offsets!
-    const sliderSource = await clickablePoint(src)
+    const sliderSource = await clickablePoint(src);
 
     // Drag start point
-    await this.page.mouse.move(sliderSource.x, sliderSource.y, { steps: 5 })
-    await this.page.mouse.down()
+    await this.page.mouse.move(sliderSource.x, sliderSource.y, { steps: 5 });
+    await this.page.mouse.down();
 
     // Drag destination
-    await this.page.mouse.move(sliderSource.x + offsetX, sliderSource.y, { steps: 5 })
-    await this.page.mouse.up()
+    await this.page.mouse.move(sliderSource.x + offsetX, sliderSource.y, { steps: 5 });
+    await this.page.mouse.up();
 
-    return this._waitForAction()
+    return this._waitForAction();
   }
 
   /**
@@ -2268,10 +2216,10 @@ class Playwright extends Helper {
    *
    */
   async grabAttributeFrom(locator, attr) {
-    const attrs = await this.grabAttributeFromAll(locator, attr)
-    assertElementExists(attrs, locator)
-    this.debugSection('Attribute', attrs[0])
-    return attrs[0]
+    const attrs = await this.grabAttributeFromAll(locator, attr);
+    assertElementExists(attrs, locator);
+    this.debugSection('Attribute', attrs[0]);
+    return attrs[0];
   }
 
   /**
@@ -2279,15 +2227,15 @@ class Playwright extends Helper {
    *
    */
   async grabAttributeFromAll(locator, attr) {
-    const els = await this._locate(locator)
-    this.debug(`Matched ${els.length} elements`)
-    const array = []
+    const els = await this._locate(locator);
+    this.debug(`Matched ${els.length} elements`);
+    const array = [];
 
     for (let index = 0; index < els.length; index++) {
-      array.push(await els[index].getAttribute(attr))
+      array.push(await els[index].getAttribute(attr));
     }
 
-    return array
+    return array;
   }
 
   /**
@@ -2295,43 +2243,43 @@ class Playwright extends Helper {
    *
    */
   async saveElementScreenshot(locator, fileName) {
-    const outputFile = screenshotOutputFolder(fileName)
+    const outputFile = screenshotOutputFolder(fileName);
 
-    const res = await this._locateElement(locator)
-    assertElementExists(res, locator)
-    const elem = res
-    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`)
-    return elem.screenshot({ path: outputFile, type: 'png' })
+    const res = await this._locateElement(locator);
+    assertElementExists(res, locator);
+    const elem = res;
+    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`);
+    return elem.screenshot({ path: outputFile, type: 'png' });
   }
 
   /**
    * {{> saveScreenshot }}
    */
   async saveScreenshot(fileName, fullPage) {
-    const fullPageOption = fullPage || this.options.fullPageScreenshots
-    let outputFile = screenshotOutputFolder(fileName)
+    const fullPageOption = fullPage || this.options.fullPageScreenshots;
+    let outputFile = screenshotOutputFolder(fileName);
 
-    this.debug(`Screenshot is saving to ${outputFile}`)
+    this.debug(`Screenshot is saving to ${outputFile}`);
 
     await this.page.screenshot({
       path: outputFile,
       fullPage: fullPageOption,
       type: 'png',
-    })
+    });
 
     if (this.activeSessionName) {
       for (const sessionName in this.sessionPages) {
-        const activeSessionPage = this.sessionPages[sessionName]
-        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`)
+        const activeSessionPage = this.sessionPages[sessionName];
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
 
-        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`)
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
 
         if (activeSessionPage) {
           await activeSessionPage.screenshot({
             path: outputFile,
             fullPage: fullPageOption,
             type: 'png',
-          })
+          });
         }
       }
     }
@@ -2355,23 +2303,21 @@ class Playwright extends Helper {
    * @returns {Promise<object>} response
    */
   async makeApiRequest(method, url, options) {
-    method = method.toLowerCase()
-    const allowedMethods = ['get', 'post', 'patch', 'head', 'fetch', 'delete']
+    method = method.toLowerCase();
+    const allowedMethods = ['get', 'post', 'patch', 'head', 'fetch', 'delete'];
     if (!allowedMethods.includes(method)) {
-      throw new Error(
-        `Method ${method} is not allowed, use the one from a list ${allowedMethods} or switch to using REST helper`,
-      )
+      throw new Error(`Method ${method} is not allowed, use the one from a list ${allowedMethods} or switch to using REST helper`);
     }
 
     if (url.startsWith('/')) {
       // local url
-      url = this.options.url + url
-      this.debugSection('URL', url)
+      url = this.options.url + url;
+      this.debugSection('URL', url);
     }
 
-    const response = await this.page.request[method](url, options)
-    this.debugSection('Status', response.status())
-    this.debugSection('Response', await response.text())
+    const response = await this.page.request[method](url, options);
+    this.debugSection('Status', response.status());
+    this.debugSection('Response', await response.text());
 
     // hook to allow JSON response handle this
     if (this.config.onResponse) {
@@ -2380,83 +2326,71 @@ class Playwright extends Helper {
         status: response.status(),
         statusText: response.statusText(),
         headers: response.headers(),
-      }
-      this.config.onResponse(axiosResponse)
+      };
+      this.config.onResponse(axiosResponse);
     }
 
-    return response
+    return response;
   }
 
   async _failed(test) {
-    await this._withinEnd()
+    await this._withinEnd();
 
     if (!test.artifacts) {
-      test.artifacts = {}
+      test.artifacts = {};
     }
 
     if (this.options.recordVideo && this.page && this.page.video()) {
-      test.artifacts.video = saveVideoForPage(this.page, `${test.title}.failed`)
+      test.artifacts.video = saveVideoForPage(this.page, `${test.title}.failed`);
       for (const sessionName in this.sessionPages) {
-        test.artifacts[`video_${sessionName}`] = saveVideoForPage(
-          this.sessionPages[sessionName],
-          `${test.title}_${sessionName}.failed`,
-        )
+        test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.failed`);
       }
     }
 
     if (this.options.trace) {
-      test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.failed`)
+      test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.failed`);
       for (const sessionName in this.sessionPages) {
-        if (!this.sessionPages[sessionName].context) continue
-        test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(
-          this.sessionPages[sessionName].context,
-          `${test.title}_${sessionName}.failed`,
-        )
+        if (!this.sessionPages[sessionName].context) continue;
+        test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.failed`);
       }
     }
 
     if (this.options.recordHar) {
-      test.artifacts.har = this.currentRunningTest.artifacts.har
+      test.artifacts.har = this.currentRunningTest.artifacts.har;
     }
   }
 
   async _passed(test) {
     if (this.options.recordVideo && this.page && this.page.video()) {
       if (this.options.keepVideoForPassedTests) {
-        test.artifacts.video = saveVideoForPage(this.page, `${test.title}.passed`)
+        test.artifacts.video = saveVideoForPage(this.page, `${test.title}.passed`);
         for (const sessionName of Object.keys(this.sessionPages)) {
-          test.artifacts[`video_${sessionName}`] = saveVideoForPage(
-            this.sessionPages[sessionName],
-            `${test.title}_${sessionName}.passed`,
-          )
+          test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.passed`);
         }
       } else {
         this.page
           .video()
           .delete()
-          .catch((e) => {})
+          .catch(e => {});
       }
     }
 
     if (this.options.trace) {
       if (this.options.keepTraceForPassedTests) {
         if (this.options.trace) {
-          test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.passed`)
+          test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.passed`);
           for (const sessionName in this.sessionPages) {
-            if (!this.sessionPages[sessionName].context) continue
-            test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(
-              this.sessionPages[sessionName].context,
-              `${test.title}_${sessionName}.passed`,
-            )
+            if (!this.sessionPages[sessionName].context) continue;
+            test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.passed`);
           }
         }
       } else {
-        await this.browserContext.tracing.stop()
+        await this.browserContext.tracing.stop();
       }
     }
 
     if (this.options.recordHar) {
-      test.artifacts.har = this.currentRunningTest.artifacts.har
+      test.artifacts.har = this.currentRunningTest.artifacts.har;
     }
   }
 
@@ -2464,99 +2398,90 @@ class Playwright extends Helper {
    * {{> wait }}
    */
   async wait(sec) {
-    return new Promise((done) => {
-      setTimeout(done, sec * 1000)
-    })
+    return new Promise(done => {
+      setTimeout(done, sec * 1000);
+    });
   }
 
   /**
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
 
-    let waiter
-    const context = await this._getContext()
+    let waiter;
+    const context = await this._getContext();
     if (!locator.isXPath()) {
       const valueFn = function ([locator]) {
-        return Array.from(document.querySelectorAll(locator)).filter((el) => !el.disabled).length > 0
-      }
-      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout })
+        return Array.from(document.querySelectorAll(locator)).filter(el => !el.disabled).length > 0;
+      };
+      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout });
     } else {
       const enabledFn = function ([locator, $XPath]) {
-        eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => !el.disabled).length > 0
-      }
-      waiter = context.waitForFunction(enabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout })
+        eval($XPath); // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => !el.disabled).length > 0;
+      };
+      waiter = context.waitForFunction(enabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
-    })
+    return waiter.catch(err => {
+      throw new Error(`element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`);
+    });
   }
 
   /**
    * {{> waitForDisabled }}
    */
   async waitForDisabled(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
 
-    let waiter
-    const context = await this._getContext()
+    let waiter;
+    const context = await this._getContext();
     if (!locator.isXPath()) {
       const valueFn = function ([locator]) {
-        return Array.from(document.querySelectorAll(locator)).filter((el) => el.disabled).length > 0
-      }
-      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout })
+        return Array.from(document.querySelectorAll(locator)).filter(el => el.disabled).length > 0;
+      };
+      waiter = context.waitForFunction(valueFn, [locator.value], { timeout: waitTimeout });
     } else {
       const disabledFn = function ([locator, $XPath]) {
-        eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => el.disabled).length > 0
-      }
-      waiter = context.waitForFunction(disabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout })
+        eval($XPath); // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => el.disabled).length > 0;
+      };
+      waiter = context.waitForFunction(disabledFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `element (${locator.toString()}) is still enabled after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
-    })
+    return waiter.catch(err => {
+      throw new Error(`element (${locator.toString()}) is still enabled after ${waitTimeout / 1000} sec\n${err.message}`);
+    });
   }
 
   /**
    * {{> waitForValue }}
    */
   async waitForValue(field, value, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    const locator = new Locator(field, 'css')
-    const matcher = await this.context
-    let waiter
-    const context = await this._getContext()
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const locator = new Locator(field, 'css');
+    const matcher = await this.context;
+    let waiter;
+    const context = await this._getContext();
     if (!locator.isXPath()) {
       const valueFn = function ([locator, value]) {
-        return (
-          Array.from(document.querySelectorAll(locator)).filter((el) => (el.value || '').indexOf(value) !== -1).length >
-          0
-        )
-      }
-      waiter = context.waitForFunction(valueFn, [locator.value, value], { timeout: waitTimeout })
+        return Array.from(document.querySelectorAll(locator)).filter(el => (el.value || '').indexOf(value) !== -1).length > 0;
+      };
+      waiter = context.waitForFunction(valueFn, [locator.value, value], { timeout: waitTimeout });
     } else {
       const valueFn = function ([locator, $XPath, value]) {
-        eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => (el.value || '').indexOf(value) !== -1).length > 0
-      }
+        eval($XPath); // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => (el.value || '').indexOf(value) !== -1).length > 0;
+      };
       waiter = context.waitForFunction(valueFn, [locator.value, $XPath.toString(), value], {
         timeout: waitTimeout,
-      })
+      });
     }
-    return waiter.catch((err) => {
-      const loc = locator.toString()
-      throw new Error(
-        `element (${loc}) is not in DOM or there is no element(${loc}) with value "${value}" after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
-    })
+    return waiter.catch(err => {
+      const loc = locator.toString();
+      throw new Error(`element (${loc}) is not in DOM or there is no element(${loc}) with value "${value}" after ${waitTimeout / 1000} sec\n${err.message}`);
+    });
   }
 
   /**
@@ -2564,44 +2489,40 @@ class Playwright extends Helper {
    *
    */
   async waitNumberOfVisibleElements(locator, num, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
 
-    let waiter
-    const context = await this._getContext()
+    let waiter;
+    const context = await this._getContext();
     if (locator.isCSS()) {
       const visibleFn = function ([locator, num]) {
-        const els = document.querySelectorAll(locator)
+        const els = document.querySelectorAll(locator);
         if (!els || els.length === 0) {
-          return false
+          return false;
         }
-        return Array.prototype.filter.call(els, (el) => el.offsetParent !== null).length === num
-      }
-      waiter = context.waitForFunction(visibleFn, [locator.value, num], { timeout: waitTimeout })
+        return Array.prototype.filter.call(els, el => el.offsetParent !== null).length === num;
+      };
+      waiter = context.waitForFunction(visibleFn, [locator.value, num], { timeout: waitTimeout });
     } else {
       const visibleFn = function ([locator, $XPath, num]) {
-        eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => el.offsetParent !== null).length === num
-      }
+        eval($XPath); // eslint-disable-line no-eval
+        return $XPath(null, locator).filter(el => el.offsetParent !== null).length === num;
+      };
       waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString(), num], {
         timeout: waitTimeout,
-      })
+      });
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
-    })
+    return waiter.catch(err => {
+      throw new Error(`The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`);
+    });
   }
 
   /**
    * {{> waitForClickable }}
    */
   async waitForClickable(locator, waitTimeout) {
-    console.log(
-      'I.waitForClickable is DEPRECATED: This is no longer needed, Playwright automatically waits for element to be clickable',
-    )
-    console.log('Remove usage of this function')
+    console.log('I.waitForClickable is DEPRECATED: This is no longer needed, Playwright automatically waits for element to be clickable');
+    console.log('Remove usage of this function');
   }
 
   /**
@@ -2609,16 +2530,14 @@ class Playwright extends Helper {
    *
    */
   async waitForElement(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
 
-    const context = await this._getContext()
+    const context = await this._getContext();
     try {
-      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'attached' })
+      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'attached' });
     } catch (e) {
-      throw new Error(
-        `element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${e.message}`,
-      )
+      throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${e.message}`);
     }
   }
 
@@ -2628,28 +2547,28 @@ class Playwright extends Helper {
    * {{> waitForVisible }}
    */
   async waitForVisible(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
-    const context = await this._getContext()
-    let count = 0
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
+    const context = await this._getContext();
+    let count = 0;
 
     // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
-    let waiter
+    let waiter;
     if (this.frame) {
       do {
-        waiter = await this.frame.locator(buildLocatorString(locator)).first().isVisible()
-        await this.wait(1)
-        count += 1000
-        if (waiter) break
-      } while (count <= waitTimeout)
+        waiter = await this.frame.locator(buildLocatorString(locator)).first().isVisible();
+        await this.wait(1);
+        count += 1000;
+        if (waiter) break;
+      } while (count <= waitTimeout);
 
-      if (!waiter) throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec.`)
+      if (!waiter) throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec.`);
     }
 
     try {
-      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'visible' })
+      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'visible' });
     } catch (e) {
-      throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${e.message}`)
+      throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${e.message}`);
     }
   }
 
@@ -2657,29 +2576,29 @@ class Playwright extends Helper {
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
-    const context = await this._getContext()
-    let waiter
-    let count = 0
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
+    const context = await this._getContext();
+    let waiter;
+    let count = 0;
 
     // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
     if (this.frame) {
       do {
-        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden()
-        await this.wait(1)
-        count += 1000
-        if (waiter) break
-      } while (count <= waitTimeout)
+        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden();
+        await this.wait(1);
+        count += 1000;
+        if (waiter) break;
+      } while (count <= waitTimeout);
 
-      if (!waiter) throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec.`)
-      return
+      if (!waiter) throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec.`);
+      return;
     }
 
     try {
-      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'hidden' })
+      await context.locator(buildLocatorString(locator)).first().waitFor({ timeout: waitTimeout, state: 'hidden' });
     } catch (e) {
-      throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${e.message}`)
+      throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${e.message}`);
     }
   }
 
@@ -2687,136 +2606,134 @@ class Playwright extends Helper {
    * {{> waitToHide }}
    */
   async waitToHide(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
-    const context = await this._getContext()
-    let waiter
-    let count = 0
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
+    const context = await this._getContext();
+    let waiter;
+    let count = 0;
 
     // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
     if (this.frame) {
       do {
-        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden()
-        await this.wait(1)
-        count += 1000
-        if (waiter) break
-      } while (count <= waitTimeout)
+        waiter = await this.frame.locator(buildLocatorString(locator)).first().isHidden();
+        await this.wait(1);
+        count += 1000;
+        if (waiter) break;
+      } while (count <= waitTimeout);
 
-      if (!waiter) throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec.`)
-      return
+      if (!waiter) throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec.`);
+      return;
     }
 
     return context
       .locator(buildLocatorString(locator))
       .first()
       .waitFor({ timeout: waitTimeout, state: 'hidden' })
-      .catch((err) => {
-        throw new Error(
-          `element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`,
-        )
-      })
+      .catch(err => {
+        throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`);
+      });
   }
 
   /**
    * {{> waitForNumberOfTabs }}
    */
   async waitForNumberOfTabs(expectedTabs, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    let currentTabs
-    let count = 0
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    let currentTabs;
+    let count = 0;
 
     do {
-      currentTabs = await this.grabNumberOfOpenTabs()
-      await this.wait(1)
-      count += 1000
-      if (currentTabs >= expectedTabs) return
-    } while (count <= waitTimeout)
+      currentTabs = await this.grabNumberOfOpenTabs();
+      await this.wait(1);
+      count += 1000;
+      if (currentTabs >= expectedTabs) return;
+    } while (count <= waitTimeout);
 
-    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`)
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
   }
 
   async _getContext() {
     if ((this.context && this.context.constructor.name === 'FrameLocator') || this.context) {
-      return this.context
+      return this.context;
     }
-    return this.page
+    return this.page;
   }
 
   /**
    * {{> waitInUrl }}
    */
   async waitInUrl(urlPart, sec = null) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
 
     return this.page
       .waitForFunction(
-        (urlPart) => {
-          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
-          return currUrl.indexOf(urlPart) > -1
+        urlPart => {
+          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
+          return currUrl.indexOf(urlPart) > -1;
         },
         urlPart,
         { timeout: waitTimeout },
       )
-      .catch(async (e) => {
-        const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
+      .catch(async e => {
+        const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
         if (/Timeout/i.test(e.message)) {
-          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`);
         } else {
-          throw e
+          throw e;
         }
-      })
+      });
   }
 
   /**
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
 
-    const baseUrl = this.options.url
+    const baseUrl = this.options.url;
     if (urlPart.indexOf('http') < 0) {
-      urlPart = baseUrl + urlPart
+      urlPart = baseUrl + urlPart;
     }
 
     return this.page
       .waitForFunction(
-        (urlPart) => {
-          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
-          return currUrl.indexOf(urlPart) > -1
+        urlPart => {
+          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)));
+          return currUrl.indexOf(urlPart) > -1;
         },
         urlPart,
         { timeout: waitTimeout },
       )
-      .catch(async (e) => {
-        const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
+      .catch(async e => {
+        const currUrl = await this._getPageUrl(); // Required because the waitForFunction can't return data.
         if (/Timeout/i.test(e.message)) {
-          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`);
         } else {
-          throw e
+          throw e;
         }
-      })
+      });
   }
 
   /**
    * {{> waitForText }}
    */
   async waitForText(text, sec = null, context = null) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    const errorMessage = `Text "${text}" was not found on page after ${waitTimeout / 1000} sec.`
-    let waiter
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const errorMessage = `Text "${text}" was not found on page after ${waitTimeout / 1000} sec.`;
+    let waiter;
 
-    const contextObject = await this._getContext()
+    const contextObject = await this._getContext();
 
     if (context) {
-      const locator = new Locator(context, 'css')
+      const locator = new Locator(context, 'css');
       if (!locator.isXPath()) {
         try {
           await contextObject
             .locator(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()} >> text=${text}`)
             .first()
-            .waitFor({ timeout: waitTimeout, state: 'visible' })
+            .waitFor({ timeout: waitTimeout, state: 'visible' });
         } catch (e) {
-          throw new Error(`${errorMessage}\n${e.message}`)
+          throw new Error(`${errorMessage}\n${e.message}`);
         }
       }
 
@@ -2824,34 +2741,34 @@ class Playwright extends Helper {
         try {
           await contextObject.waitForFunction(
             ([locator, text, $XPath]) => {
-              eval($XPath) // eslint-disable-line no-eval
-              const el = $XPath(null, locator)
-              if (!el.length) return false
-              return el[0].innerText.indexOf(text) > -1
+              eval($XPath); // eslint-disable-line no-eval
+              const el = $XPath(null, locator);
+              if (!el.length) return false;
+              return el[0].innerText.indexOf(text) > -1;
             },
             [locator.value, text, $XPath.toString()],
             { timeout: waitTimeout },
-          )
+          );
         } catch (e) {
-          throw new Error(`${errorMessage}\n${e.message}`)
+          throw new Error(`${errorMessage}\n${e.message}`);
         }
       }
     } else {
       // we have this as https://github.com/microsoft/playwright/issues/26829 is not yet implemented
 
-      const _contextObject = this.frame ? this.frame : contextObject
-      let count = 0
+      const _contextObject = this.frame ? this.frame : contextObject;
+      let count = 0;
       do {
         waiter = await _contextObject
           .locator(`:has-text(${JSON.stringify(text)})`)
           .first()
-          .isVisible()
-        if (waiter) break
-        await this.wait(1)
-        count += 1000
-      } while (count <= waitTimeout)
+          .isVisible();
+        if (waiter) break;
+        await this.wait(1);
+        count += 1000;
+      } while (count <= waitTimeout);
 
-      if (!waiter) throw new Error(`${errorMessage}`)
+      if (!waiter) throw new Error(`${errorMessage}`);
     }
   }
 
@@ -2867,8 +2784,8 @@ class Playwright extends Helper {
    * @param {?number} [sec=null] seconds to wait
    */
   async waitForRequest(urlOrPredicate, sec = null) {
-    const timeout = sec ? sec * 1000 : this.options.waitForTimeout
-    return this.page.waitForRequest(urlOrPredicate, { timeout })
+    const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    return this.page.waitForRequest(urlOrPredicate, { timeout });
   }
 
   /**
@@ -2883,8 +2800,8 @@ class Playwright extends Helper {
    * @param {?number} [sec=null] number of seconds to wait
    */
   async waitForResponse(urlOrPredicate, sec = null) {
-    const timeout = sec ? sec * 1000 : this.options.waitForTimeout
-    return this.page.waitForResponse(urlOrPredicate, { timeout })
+    const timeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    return this.page.waitForResponse(urlOrPredicate, { timeout });
   }
 
   /**
@@ -2894,51 +2811,51 @@ class Playwright extends Helper {
     if (Number.isInteger(locator)) {
       // Select by frame index of current context
 
-      let childFrames = null
+      let childFrames = null;
       if (this.context && typeof this.context.childFrames === 'function') {
-        childFrames = this.context.childFrames()
+        childFrames = this.context.childFrames();
       } else {
-        childFrames = this.page.mainFrame().childFrames()
+        childFrames = this.page.mainFrame().childFrames();
       }
 
       if (locator >= 0 && locator < childFrames.length) {
-        this.context = await this.page.frameLocator('iframe').nth(locator)
-        this.contextLocator = locator
+        this.context = await this.page.frameLocator('iframe').nth(locator);
+        this.contextLocator = locator;
       } else {
-        throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath')
+        throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath');
       }
-      return
+      return;
     }
 
     if (!locator) {
-      this.context = this.page
-      this.contextLocator = null
-      this.frame = null
-      return
+      this.context = this.page;
+      this.contextLocator = null;
+      this.frame = null;
+      return;
     }
 
     // iframe by selector
-    locator = buildLocatorString(new Locator(locator, 'css'))
-    const frame = await this._locateElement(locator)
+    locator = buildLocatorString(new Locator(locator, 'css'));
+    const frame = await this._locateElement(locator);
 
     if (!frame) {
-      throw new Error(`Frame ${JSON.stringify(locator)} was not found by text|CSS|XPath`)
+      throw new Error(`Frame ${JSON.stringify(locator)} was not found by text|CSS|XPath`);
     }
 
     if (this.frame) {
-      this.frame = await this.frame.frameLocator(locator)
+      this.frame = await this.frame.frameLocator(locator);
     } else {
-      this.frame = await this.page.frameLocator(locator)
+      this.frame = await this.page.frameLocator(locator);
     }
 
-    const contentFrame = this.frame
+    const contentFrame = this.frame;
 
     if (contentFrame) {
-      this.context = contentFrame
-      this.contextLocator = null
+      this.context = contentFrame;
+      this.contextLocator = null;
     } else {
-      this.context = this.page.frame(this.page.frames()[1].name())
-      this.contextLocator = locator
+      this.context = this.page.frame(this.page.frames()[1].name());
+      this.contextLocator = locator;
     }
   }
 
@@ -2946,17 +2863,17 @@ class Playwright extends Helper {
    * {{> waitForFunction }}
    */
   async waitForFunction(fn, argsOrSec = null, sec = null) {
-    let args = []
+    let args = [];
     if (argsOrSec) {
       if (Array.isArray(argsOrSec)) {
-        args = argsOrSec
+        args = argsOrSec;
       } else if (typeof argsOrSec === 'number') {
-        sec = argsOrSec
+        sec = argsOrSec;
       }
     }
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    const context = await this._getContext()
-    return context.waitForFunction(fn, args, { timeout: waitTimeout })
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    const context = await this._getContext();
+    return context.waitForFunction(fn, args, { timeout: waitTimeout });
   }
 
   /**
@@ -2968,13 +2885,13 @@ class Playwright extends Helper {
    */
   async waitForNavigation(options = {}) {
     console.log(`waitForNavigation deprecated:
-    * This method is inherently racy, please use 'waitForURL' instead.`)
+    * This method is inherently racy, please use 'waitForURL' instead.`);
     options = {
       timeout: this.options.getPageTimeout,
       waitUntil: this.options.waitForNavigation,
       ...options,
-    }
-    return this.page.waitForNavigation(options)
+    };
+    return this.page.waitForNavigation(options);
   }
 
   /**
@@ -2990,44 +2907,44 @@ class Playwright extends Helper {
       timeout: this.options.getPageTimeout,
       waitUntil: this.options.waitForNavigation,
       ...options,
-    }
-    return this.page.waitForURL(url, options)
+    };
+    return this.page.waitForURL(url, options);
   }
 
   async waitUntilExists(locator, sec) {
     console.log(`waitUntilExists deprecated:
     * use 'waitForElement' to wait for element to be attached
-    * use 'waitForDetached to wait for element to be removed'`)
-    return this.waitForDetached(locator, sec)
+    * use 'waitForDetached to wait for element to be removed'`);
+    return this.waitForDetached(locator, sec);
   }
 
   /**
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    locator = new Locator(locator, 'css')
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
+    locator = new Locator(locator, 'css');
 
-    let waiter
-    const context = await this._getContext()
+    let waiter;
+    const context = await this._getContext();
     if (!locator.isXPath()) {
       try {
         await context
           .locator(`${locator.isCustom() ? `${locator.type}=${locator.value}` : locator.simplify()}`)
           .first()
-          .waitFor({ timeout: waitTimeout, state: 'detached' })
+          .waitFor({ timeout: waitTimeout, state: 'detached' });
       } catch (e) {
-        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${e.message}`)
+        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${e.message}`);
       }
     } else {
       const visibleFn = function ([locator, $XPath]) {
-        eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).length === 0
-      }
-      waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString()], { timeout: waitTimeout })
-      return waiter.catch((err) => {
-        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${err.message}`)
-      })
+        eval($XPath); // eslint-disable-line no-eval
+        return $XPath(null, locator).length === 0;
+      };
+      waiter = context.waitForFunction(visibleFn, [locator.value, $XPath.toString()], { timeout: waitTimeout });
+      return waiter.catch(err => {
+        throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${err.message}`);
+      });
     }
   }
 
@@ -3036,56 +2953,56 @@ class Playwright extends Helper {
    */
   async waitForCookie(name, sec) {
     // by default, we will retry 3 times
-    let retries = 3
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
+    let retries = 3;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
 
     if (sec) {
-      retries = sec
+      retries = sec;
     } else {
-      retries = Math.ceil(waitTimeout / 1000) - 1
+      retries = Math.ceil(waitTimeout / 1000) - 1;
     }
 
     return promiseRetry(
       async (retry, number) => {
-        const _grabCookie = async (name) => {
-          const cookies = await this.browserContext.cookies()
-          const cookie = cookies.filter((c) => c.name === name)
-          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`)
-        }
+        const _grabCookie = async name => {
+          const cookies = await this.browserContext.cookies();
+          const cookie = cookies.filter(c => c.name === name);
+          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`);
+        };
 
-        this.debugSection('Wait for cookie: ', name)
-        if (number > 1) this.debugSection('Retrying... Attempt #', number)
+        this.debugSection('Wait for cookie: ', name);
+        if (number > 1) this.debugSection('Retrying... Attempt #', number);
 
         try {
-          await _grabCookie(name)
+          await _grabCookie(name);
         } catch (e) {
-          retry(e)
+          retry(e);
         }
       },
       { retries, maxTimeout: 1000 },
-    )
+    );
   }
 
   async _waitForAction() {
-    return this.wait(this.options.waitForAction / 1000)
+    return this.wait(this.options.waitForAction / 1000);
   }
 
   /**
    * {{> grabDataFromPerformanceTiming }}
    */
   async grabDataFromPerformanceTiming() {
-    return perfTiming
+    return perfTiming;
   }
 
   /**
    * {{> grabElementBoundingRect }}
    */
   async grabElementBoundingRect(locator, prop) {
-    const el = await this._locateElement(locator)
-    assertElementExists(el, locator)
-    const rect = await el.boundingBox()
-    if (prop) return rect[prop]
-    return rect
+    const el = await this._locateElement(locator);
+    assertElementExists(el, locator);
+    const rect = await el.boundingBox();
+    if (prop) return rect[prop];
+    return rect;
   }
 
   /**
@@ -3100,7 +3017,7 @@ class Playwright extends Helper {
    * @param {function} [handler] a function to process request
    */
   async mockRoute(url, handler) {
-    return this.browserContext.route(...arguments)
+    return this.browserContext.route(...arguments);
   }
 
   /**
@@ -3116,7 +3033,7 @@ class Playwright extends Helper {
    * @param {function} [handler] a function to process request
    */
   async stopMockingRoute(url, handler) {
-    return this.browserContext.unroute(...arguments)
+    return this.browserContext.unroute(...arguments);
   }
 
   /**
@@ -3124,27 +3041,27 @@ class Playwright extends Helper {
    *
    */
   startRecordingTraffic() {
-    this.flushNetworkTraffics()
-    this.recording = true
-    this.recordedAtLeastOnce = true
+    this.flushNetworkTraffics();
+    this.recording = true;
+    this.recordedAtLeastOnce = true;
 
-    this.page.on('requestfinished', async (request) => {
+    this.page.on('requestfinished', async request => {
       const information = {
         url: request.url(),
         method: request.method(),
         requestHeaders: request.headers(),
         requestPostData: request.postData(),
         response: request.response(),
-      }
+      };
 
-      this.debugSection('REQUEST: ', JSON.stringify(information))
+      this.debugSection('REQUEST: ', JSON.stringify(information));
 
       if (typeof information.requestPostData === 'object') {
-        information.requestPostData = JSON.parse(information.requestPostData)
+        information.requestPostData = JSON.parse(information.requestPostData);
       }
 
-      this.requests.push(information)
-    })
+      this.requests.push(information);
+    });
   }
 
   /**
@@ -3167,21 +3084,21 @@ class Playwright extends Helper {
    */
   blockTraffic(urls) {
     if (Array.isArray(urls)) {
-      urls.forEach((url) => {
-        this.page.route(url, (route) => {
+      urls.forEach(url => {
+        this.page.route(url, route => {
           route
             .abort()
             // Sometimes it happens that browser has been closed in the meantime. It is ok to ignore error then.
-            .catch((e) => {})
-        })
-      })
+            .catch(e => {});
+        });
+      });
     } else {
-      this.page.route(urls, (route) => {
+      this.page.route(urls, route => {
         route
           .abort()
           // Sometimes it happens that browser has been closed in the meantime. It is ok to ignore error then.
-          .catch((e) => {})
-      })
+          .catch(e => {});
+      });
     }
   }
 
@@ -3203,26 +3120,26 @@ class Playwright extends Helper {
    */
   mockTraffic(urls, responseString, contentType = 'application/json') {
     // Required to mock cross-domain requests
-    const headers = { 'access-control-allow-origin': '*' }
+    const headers = { 'access-control-allow-origin': '*' };
 
     if (typeof urls === 'string') {
-      urls = [urls]
+      urls = [urls];
     }
 
-    urls.forEach((url) => {
-      this.page.route(url, (route) => {
+    urls.forEach(url => {
+      this.page.route(url, route => {
         if (this.page.isClosed()) {
           // Sometimes it happens that browser has been closed in the meantime.
           // In this case we just don't fulfill to prevent error in test scenario.
-          return
+          return;
         }
         route.fulfill({
           contentType,
           headers,
           body: responseString,
-        })
-      })
-    })
+        });
+      });
+    });
   }
 
   /**
@@ -3230,7 +3147,7 @@ class Playwright extends Helper {
    * {{> flushNetworkTraffics }}
    */
   flushNetworkTraffics() {
-    flushNetworkTraffics.call(this)
+    flushNetworkTraffics.call(this);
   }
 
   /**
@@ -3238,7 +3155,7 @@ class Playwright extends Helper {
    * {{> stopRecordingTraffic }}
    */
   stopRecordingTraffic() {
-    stopRecordingTraffic.call(this)
+    stopRecordingTraffic.call(this);
   }
 
   /**
@@ -3256,23 +3173,21 @@ class Playwright extends Helper {
    */
   grabTrafficUrl(urlMatch) {
     if (!this.recordedAtLeastOnce) {
-      throw new Error(
-        'Failure in test automation. You use "I.grabTrafficUrl", but "I.startRecordingTraffic" was never called before.',
-      )
+      throw new Error('Failure in test automation. You use "I.grabTrafficUrl", but "I.startRecordingTraffic" was never called before.');
     }
 
     for (const i in this.requests) {
       // eslint-disable-next-line no-prototype-builtins
       if (this.requests.hasOwnProperty(i)) {
-        const request = this.requests[i]
+        const request = this.requests[i];
 
         if (request.url && request.url.match(new RegExp(urlMatch))) {
-          return request.url
+          return request.url;
         }
       }
     }
 
-    assert.fail(`Method "getTrafficUrl" failed: No request found in traffic that matches ${urlMatch}`)
+    assert.fail(`Method "getTrafficUrl" failed: No request found in traffic that matches ${urlMatch}`);
   }
 
   /**
@@ -3280,7 +3195,7 @@ class Playwright extends Helper {
    * {{> grabRecordedNetworkTraffics }}
    */
   async grabRecordedNetworkTraffics() {
-    return grabRecordedNetworkTraffics.call(this)
+    return grabRecordedNetworkTraffics.call(this);
   }
 
   /**
@@ -3288,7 +3203,7 @@ class Playwright extends Helper {
    * {{> seeTraffic }}
    */
   async seeTraffic({ name, url, parameters, requestPostData, timeout = 10 }) {
-    await seeTraffic.call(this, ...arguments)
+    await seeTraffic.call(this, ...arguments);
   }
 
   /**
@@ -3297,42 +3212,42 @@ class Playwright extends Helper {
    *
    */
   dontSeeTraffic({ name, url }) {
-    dontSeeTraffic.call(this, ...arguments)
+    dontSeeTraffic.call(this, ...arguments);
   }
 
   /**
    * {{> startRecordingWebSocketMessages }}
    */
   async startRecordingWebSocketMessages() {
-    this.flushWebSocketMessages()
-    this.recordingWebSocketMessages = true
-    this.recordedWebSocketMessagesAtLeastOnce = true
+    this.flushWebSocketMessages();
+    this.recordingWebSocketMessages = true;
+    this.recordedWebSocketMessagesAtLeastOnce = true;
 
-    this.cdpSession = await this.getNewCDPSession()
-    await this.cdpSession.send('Network.enable')
-    await this.cdpSession.send('Page.enable')
+    this.cdpSession = await this.getNewCDPSession();
+    await this.cdpSession.send('Network.enable');
+    await this.cdpSession.send('Page.enable');
 
-    this.cdpSession.on('Network.webSocketFrameReceived', (payload) => {
-      this._logWebsocketMessages(this._getWebSocketLog('RECEIVED', payload))
-    })
+    this.cdpSession.on('Network.webSocketFrameReceived', payload => {
+      this._logWebsocketMessages(this._getWebSocketLog('RECEIVED', payload));
+    });
 
-    this.cdpSession.on('Network.webSocketFrameSent', (payload) => {
-      this._logWebsocketMessages(this._getWebSocketLog('SENT', payload))
-    })
+    this.cdpSession.on('Network.webSocketFrameSent', payload => {
+      this._logWebsocketMessages(this._getWebSocketLog('SENT', payload));
+    });
 
-    this.cdpSession.on('Network.webSocketFrameError', (payload) => {
-      this._logWebsocketMessages(this._getWebSocketLog('ERROR', payload))
-    })
+    this.cdpSession.on('Network.webSocketFrameError', payload => {
+      this._logWebsocketMessages(this._getWebSocketLog('ERROR', payload));
+    });
   }
 
   /**
    * {{> stopRecordingWebSocketMessages }}
    */
   async stopRecordingWebSocketMessages() {
-    await this.cdpSession.send('Network.disable')
-    await this.cdpSession.send('Page.disable')
-    this.page.removeAllListeners('Network')
-    this.recordingWebSocketMessages = false
+    await this.cdpSession.send('Network.disable');
+    await this.cdpSession.send('Page.disable');
+    this.page.removeAllListeners('Network');
+    this.recordingWebSocketMessages = false;
   }
 
   /**
@@ -3344,19 +3259,17 @@ class Playwright extends Helper {
   grabWebSocketMessages() {
     if (!this.recordingWebSocketMessages) {
       if (!this.recordedWebSocketMessagesAtLeastOnce) {
-        throw new Error(
-          'Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.',
-        )
+        throw new Error('Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.');
       }
     }
-    return this.webSocketMessages
+    return this.webSocketMessages;
   }
 
   /**
    * Resets all recorded WS messages.
    */
   flushWebSocketMessages() {
-    this.webSocketMessages = []
+    this.webSocketMessages = [];
   }
 
   /**
@@ -3414,350 +3327,344 @@ class Playwright extends Helper {
    * @return {Promise<Array<Object>>}
    */
   async grabMetrics() {
-    const client = await this.page.context().newCDPSession(this.page)
-    await client.send('Performance.enable')
-    const perfMetricObject = await client.send('Performance.getMetrics')
-    return perfMetricObject?.metrics
+    const client = await this.page.context().newCDPSession(this.page);
+    await client.send('Performance.enable');
+    const perfMetricObject = await client.send('Performance.getMetrics');
+    return perfMetricObject?.metrics;
   }
 
   _getWebSocketMessage(payload) {
     if (payload.errorMessage) {
-      return payload.errorMessage
+      return payload.errorMessage;
     }
 
-    return payload.response.payloadData
+    return payload.response.payloadData;
   }
 
   _getWebSocketLog(prefix, payload) {
-    return `${prefix} ID: ${payload.requestId} TIMESTAMP: ${payload.timestamp} (${new Date().toISOString()})\n\n${this._getWebSocketMessage(payload)}\n\n`
+    return `${prefix} ID: ${payload.requestId} TIMESTAMP: ${payload.timestamp} (${new Date().toISOString()})\n\n${this._getWebSocketMessage(payload)}\n\n`;
   }
 
   async getNewCDPSession() {
-    return this.page.context().newCDPSession(this.page)
+    return this.page.context().newCDPSession(this.page);
   }
 
   _logWebsocketMessages(message) {
-    this.webSocketMessages.push(message)
+    this.webSocketMessages.push(message);
   }
 }
 
-module.exports = Playwright
+module.exports = Playwright;
 
 function buildLocatorString(locator) {
   if (locator.isCustom()) {
-    return `${locator.type}=${locator.value}`
+    return `${locator.type}=${locator.value}`;
   }
   if (locator.isXPath()) {
-    return `xpath=${locator.value}`
+    return `xpath=${locator.value}`;
   }
-  return locator.simplify()
+  return locator.simplify();
 }
 
 async function findElements(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator)
-  if (locator.vue) return findVue(matcher, locator)
-  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator)
-  locator = new Locator(locator, 'css')
+  if (locator.react) return findReact(matcher, locator);
+  if (locator.vue) return findVue(matcher, locator);
+  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator);
+  locator = new Locator(locator, 'css');
 
-  return matcher.locator(buildLocatorString(locator)).all()
+  return matcher.locator(buildLocatorString(locator)).all();
 }
 
 async function findElement(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator)
-  if (locator.vue) return findVue(matcher, locator)
-  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator)
-  locator = new Locator(locator, 'css')
+  if (locator.react) return findReact(matcher, locator);
+  if (locator.vue) return findVue(matcher, locator);
+  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator);
+  locator = new Locator(locator, 'css');
 
-  return matcher.locator(buildLocatorString(locator)).first()
+  return matcher.locator(buildLocatorString(locator)).first();
 }
 
 async function getVisibleElements(elements) {
-  const visibleElements = []
+  const visibleElements = [];
   for (const element of elements) {
     if (await element.isVisible()) {
-      visibleElements.push(element)
+      visibleElements.push(element);
     }
   }
   if (visibleElements.length === 0) {
-    return elements
+    return elements;
   }
-  return visibleElements
+  return visibleElements;
 }
 
 async function proceedClick(locator, context = null, options = {}) {
-  let matcher = await this._getContext()
+  let matcher = await this._getContext();
   if (context) {
-    const els = await this._locate(context)
-    assertElementExists(els, context)
-    matcher = els[0]
+    const els = await this._locate(context);
+    assertElementExists(els, context);
+    matcher = els[0];
   }
-  const els = await findClickable.call(this, matcher, locator)
+  const els = await findClickable.call(this, matcher, locator);
   if (context) {
-    assertElementExists(
-      els,
-      locator,
-      'Clickable element',
-      `was not found inside element ${new Locator(context).toString()}`,
-    )
+    assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`);
   } else {
-    assertElementExists(els, locator, 'Clickable element')
+    assertElementExists(els, locator, 'Clickable element');
   }
 
-  await highlightActiveElement.call(this, els[0])
+  await highlightActiveElement.call(this, els[0]);
 
   /*
     using the force true options itself but instead dispatching a click
   */
   if (options.force) {
-    await els[0].dispatchEvent('click')
+    await els[0].dispatchEvent('click');
   } else {
-    const element = els.length > 1 ? (await getVisibleElements(els))[0] : els[0]
-    await element.click(options)
+    const element = els.length > 1 ? (await getVisibleElements(els))[0] : els[0];
+    await element.click(options);
   }
-  const promises = []
+  const promises = [];
   if (options.waitForNavigation) {
-    promises.push(this.waitForURL(/.*/, { waitUntil: options.waitForNavigation }))
+    promises.push(this.waitForURL(/.*/, { waitUntil: options.waitForNavigation }));
   }
-  promises.push(this._waitForAction())
+  promises.push(this._waitForAction());
 
-  return Promise.all(promises)
+  return Promise.all(promises);
 }
 
 async function findClickable(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator)
-  if (locator.vue) return findVue(matcher, locator)
-  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator)
+  if (locator.react) return findReact(matcher, locator);
+  if (locator.vue) return findVue(matcher, locator);
+  if (locator.pw) return findByPlaywrightLocator.call(this, matcher, locator);
 
-  locator = new Locator(locator)
-  if (!locator.isFuzzy()) return findElements.call(this, matcher, locator)
+  locator = new Locator(locator);
+  if (!locator.isFuzzy()) return findElements.call(this, matcher, locator);
 
-  let els
-  const literal = xpathLocator.literal(locator.value)
+  let els;
+  const literal = xpathLocator.literal(locator.value);
 
-  els = await findElements.call(this, matcher, Locator.clickable.narrow(literal))
-  if (els.length) return els
+  els = await findElements.call(this, matcher, Locator.clickable.narrow(literal));
+  if (els.length) return els;
 
-  els = await findElements.call(this, matcher, Locator.clickable.wide(literal))
-  if (els.length) return els
+  els = await findElements.call(this, matcher, Locator.clickable.wide(literal));
+  if (els.length) return els;
 
   try {
-    els = await findElements.call(this, matcher, Locator.clickable.self(literal))
-    if (els.length) return els
+    els = await findElements.call(this, matcher, Locator.clickable.self(literal));
+    if (els.length) return els;
   } catch (err) {
     // Do nothing
   }
 
-  return findElements.call(this, matcher, locator.value) // by css or xpath
+  return findElements.call(this, matcher, locator.value); // by css or xpath
 }
 
 async function proceedSee(assertType, text, context, strict = false) {
-  let description
-  let allText
+  let description;
+  let allText;
 
   if (!context) {
-    const el = await this.context
+    const el = await this.context;
 
-    allText = el.constructor.name !== 'Locator' ? [await el.locator('body').innerText()] : [await el.innerText()]
+    allText = el.constructor.name !== 'Locator' ? [await el.locator('body').innerText()] : [await el.innerText()];
 
-    description = 'web application'
+    description = 'web application';
   } else {
-    const locator = new Locator(context, 'css')
-    description = `element ${locator.toString()}`
-    const els = await this._locate(locator)
-    assertElementExists(els, locator.toString())
-    allText = await Promise.all(els.map((el) => el.innerText()))
+    const locator = new Locator(context, 'css');
+    description = `element ${locator.toString()}`;
+    const els = await this._locate(locator);
+    assertElementExists(els, locator.toString());
+    allText = await Promise.all(els.map(el => el.innerText()));
   }
 
   if (strict) {
-    return allText.map((elText) => equals(description)[assertType](text, elText))
+    return allText.map(elText => equals(description)[assertType](text, elText));
   }
-  return stringIncludes(description)[assertType](
-    normalizeSpacesInString(text),
-    normalizeSpacesInString(allText.join(' | ')),
-  )
+  return stringIncludes(description)[assertType](normalizeSpacesInString(text), normalizeSpacesInString(allText.join(' | ')));
 }
 
 async function findCheckable(locator, context) {
-  let contextEl = await this.context
+  let contextEl = await this.context;
   if (typeof context === 'string') {
-    contextEl = await findElements.call(this, contextEl, new Locator(context, 'css').simplify())
-    contextEl = contextEl[0]
+    contextEl = await findElements.call(this, contextEl, new Locator(context, 'css').simplify());
+    contextEl = contextEl[0];
   }
 
-  const matchedLocator = new Locator(locator)
+  const matchedLocator = new Locator(locator);
   if (!matchedLocator.isFuzzy()) {
-    return findElements.call(this, contextEl, matchedLocator.simplify())
+    return findElements.call(this, contextEl, matchedLocator.simplify());
   }
 
-  const literal = xpathLocator.literal(locator)
-  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal))
+  const literal = xpathLocator.literal(locator);
+  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal));
   if (els.length) {
-    return els
+    return els;
   }
-  els = await findElements.call(this, contextEl, Locator.checkable.byName(literal))
+  els = await findElements.call(this, contextEl, Locator.checkable.byName(literal));
   if (els.length) {
-    return els
+    return els;
   }
-  return findElements.call(this, contextEl, locator)
+  return findElements.call(this, contextEl, locator);
 }
 
 async function proceedIsChecked(assertType, option) {
-  let els = await findCheckable.call(this, option)
-  assertElementExists(els, option, 'Checkable')
-  els = await Promise.all(els.map((el) => el.isChecked()))
-  const selected = els.reduce((prev, cur) => prev || cur)
-  return truth(`checkable ${option}`, 'to be checked')[assertType](selected)
+  let els = await findCheckable.call(this, option);
+  assertElementExists(els, option, 'Checkable');
+  els = await Promise.all(els.map(el => el.isChecked()));
+  const selected = els.reduce((prev, cur) => prev || cur);
+  return truth(`checkable ${option}`, 'to be checked')[assertType](selected);
 }
 
 async function findFields(locator) {
-  const matchedLocator = new Locator(locator)
+  const matchedLocator = new Locator(locator);
   if (!matchedLocator.isFuzzy()) {
-    return this._locate(matchedLocator)
+    return this._locate(matchedLocator);
   }
-  const literal = xpathLocator.literal(locator)
+  const literal = xpathLocator.literal(locator);
 
-  let els = await this._locate({ xpath: Locator.field.labelEquals(literal) })
+  let els = await this._locate({ xpath: Locator.field.labelEquals(literal) });
   if (els.length) {
-    return els
+    return els;
   }
 
-  els = await this._locate({ xpath: Locator.field.labelContains(literal) })
+  els = await this._locate({ xpath: Locator.field.labelContains(literal) });
   if (els.length) {
-    return els
+    return els;
   }
-  els = await this._locate({ xpath: Locator.field.byName(literal) })
+  els = await this._locate({ xpath: Locator.field.byName(literal) });
   if (els.length) {
-    return els
+    return els;
   }
-  return this._locate({ css: locator })
+  return this._locate({ css: locator });
 }
 
 async function proceedSeeInField(assertType, field, value) {
-  const els = await findFields.call(this, field)
-  assertElementExists(els, field, 'Field')
-  const el = els[0]
-  const tag = await el.evaluate((e) => e.tagName)
-  const fieldType = await el.getAttribute('type')
+  const els = await findFields.call(this, field);
+  assertElementExists(els, field, 'Field');
+  const el = els[0];
+  const tag = await el.evaluate(e => e.tagName);
+  const fieldType = await el.getAttribute('type');
 
-  const proceedMultiple = async (elements) => {
-    const fields = Array.isArray(elements) ? elements : [elements]
+  const proceedMultiple = async elements => {
+    const fields = Array.isArray(elements) ? elements : [elements];
 
-    const elementValues = []
+    const elementValues = [];
     for (const element of fields) {
-      elementValues.push(await element.inputValue())
+      elementValues.push(await element.inputValue());
     }
 
     if (typeof value === 'boolean') {
-      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!elementValues.length)
+      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!elementValues.length);
     } else {
       if (assertType === 'assert') {
-        equals(`select option by ${field}`)[assertType](true, elementValues.length > 0)
+        equals(`select option by ${field}`)[assertType](true, elementValues.length > 0);
       }
-      elementValues.forEach((val) => stringIncludes(`fields by ${field}`)[assertType](value, val))
+      elementValues.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val));
     }
-  }
+  };
 
   if (tag === 'SELECT') {
     if (await el.getAttribute('multiple')) {
-      const selectedOptions = await el.all('option:checked')
-      if (!selectedOptions.length) return null
+      const selectedOptions = await el.all('option:checked');
+      if (!selectedOptions.length) return null;
 
-      const options = await filterFieldsByValue(selectedOptions, value, true)
-      return proceedMultiple(options)
+      const options = await filterFieldsByValue(selectedOptions, value, true);
+      return proceedMultiple(options);
     }
 
-    return el.inputValue()
+    return el.inputValue();
   }
 
   if (tag === 'INPUT') {
     if (fieldType === 'checkbox' || fieldType === 'radio') {
       if (typeof value === 'boolean') {
         // Filter by values
-        const options = await filterFieldsBySelectionState(els, true)
-        return proceedMultiple(options)
+        const options = await filterFieldsBySelectionState(els, true);
+        return proceedMultiple(options);
       }
 
-      const options = await filterFieldsByValue(els, value, true)
-      return proceedMultiple(options)
+      const options = await filterFieldsByValue(els, value, true);
+      return proceedMultiple(options);
     }
-    return proceedMultiple(els[0])
+    return proceedMultiple(els[0]);
   }
 
-  let fieldVal
+  let fieldVal;
 
   try {
-    fieldVal = await el.inputValue()
+    fieldVal = await el.inputValue();
   } catch (e) {
     if (e.message.includes('Error: Node is not an <input>, <textarea> or <select> element')) {
-      fieldVal = await el.innerText()
+      fieldVal = await el.innerText();
     }
   }
 
-  return stringIncludes(`fields by ${field}`)[assertType](value, fieldVal)
+  return stringIncludes(`fields by ${field}`)[assertType](value, fieldVal);
 }
 
 async function filterFieldsByValue(elements, value, onlySelected) {
-  const matches = []
+  const matches = [];
   for (const element of elements) {
-    const val = await element.getAttribute('value')
-    let isSelected = true
+    const val = await element.getAttribute('value');
+    let isSelected = true;
     if (onlySelected) {
-      isSelected = await elementSelected(element)
+      isSelected = await elementSelected(element);
     }
     if ((value == null || val.indexOf(value) > -1) && isSelected) {
-      matches.push(element)
+      matches.push(element);
     }
   }
-  return matches
+  return matches;
 }
 
 async function filterFieldsBySelectionState(elements, state) {
-  const matches = []
+  const matches = [];
   for (const element of elements) {
-    const isSelected = await elementSelected(element)
+    const isSelected = await elementSelected(element);
     if (isSelected === state) {
-      matches.push(element)
+      matches.push(element);
     }
   }
-  return matches
+  return matches;
 }
 
 async function elementSelected(element) {
-  const type = await element.getAttribute('type')
+  const type = await element.getAttribute('type');
 
   if (type === 'checkbox' || type === 'radio') {
-    return element.isChecked()
+    return element.isChecked();
   }
-  return element.getAttribute('selected')
+  return element.getAttribute('selected');
 }
 
 function isFrameLocator(locator) {
-  locator = new Locator(locator)
+  locator = new Locator(locator);
   if (locator.isFrame()) {
-    return locator.value
+    return locator.value;
   }
-  return false
+  return false;
 }
 
 function assertElementExists(res, locator, prefix, suffix) {
+  // if element text is an empty string, just exit this check
+  if (typeof res === 'string' && res === '') return;
   if (!res || res.length === 0) {
-    throw new ElementNotFound(locator, prefix, suffix)
+    throw new ElementNotFound(locator, prefix, suffix);
   }
 }
 
 function $XPath(element, selector) {
-  const found = document.evaluate(selector, element || document.body, null, 5, null)
-  const res = []
-  let current = null
+  const found = document.evaluate(selector, element || document.body, null, 5, null);
+  const res = [];
+  let current = null;
   while ((current = found.iterateNext())) {
-    res.push(current)
+    res.push(current);
   }
-  return res
+  return res;
 }
 
 async function targetCreatedHandler(page) {
-  if (!page) return
-  this.withinLocator = null
+  if (!page) return;
+  this.withinLocator = null;
   page.on('load', () => {
     page
       .$('body')
@@ -3765,51 +3672,48 @@ async function targetCreatedHandler(page) {
       .then(async () => {
         if (this.context && this.context._type === 'Frame') {
           // we are inside iframe?
-          const frameEl = await this.context.frameElement()
-          this.context = await frameEl.contentFrame()
-          this.contextLocator = null
-          return
+          const frameEl = await this.context.frameElement();
+          this.context = await frameEl.contentFrame();
+          this.contextLocator = null;
+          return;
         }
         // if context element was in iframe - keep it
         // if (await this.context.ownerFrame()) return;
-        this.context = page
-        this.contextLocator = null
-      })
-  })
-  page.on('console', (msg) => {
+        this.context = page;
+        this.contextLocator = null;
+      });
+  });
+  page.on('console', msg => {
     if (!consoleLogStore.includes(msg) && this.options.ignoreLog && !this.options.ignoreLog.includes(msg.type())) {
-      this.debugSection(
-        `Browser:${ucfirst(msg.type())}`,
-        ((msg.text && msg.text()) || msg._text || '') + msg.args().join(' '),
-      )
+      this.debugSection(`Browser:${ucfirst(msg.type())}`, ((msg.text && msg.text()) || msg._text || '') + msg.args().join(' '));
     }
-    consoleLogStore.add(msg)
-  })
+    consoleLogStore.add(msg);
+  });
 
   if (this.options.windowSize && this.options.windowSize.indexOf('x') > 0 && this._getType() === 'Browser') {
     try {
-      await page.setViewportSize(parseWindowSize(this.options.windowSize))
+      await page.setViewportSize(parseWindowSize(this.options.windowSize));
     } catch (err) {
-      this.debug('Target can be already closed, ignoring...')
+      this.debug('Target can be already closed, ignoring...');
     }
   }
 }
 
 function parseWindowSize(windowSize) {
-  if (!windowSize) return { width: 800, height: 600 }
+  if (!windowSize) return { width: 800, height: 600 };
 
   if (windowSize.width && windowSize.height) {
-    return { width: parseInt(windowSize.width, 10), height: parseInt(windowSize.height, 10) }
+    return { width: parseInt(windowSize.width, 10), height: parseInt(windowSize.height, 10) };
   }
 
-  const dimensions = windowSize.split('x')
+  const dimensions = windowSize.split('x');
   if (dimensions.length < 2 || windowSize === 'maximize') {
-    console.log('Invalid window size, setting window to default values')
-    return { width: 800, height: 600 } // invalid size
+    console.log('Invalid window size, setting window to default values');
+    return { width: 800, height: 600 }; // invalid size
   }
-  const width = parseInt(dimensions[0], 10)
-  const height = parseInt(dimensions[1], 10)
-  return { width, height }
+  const width = parseInt(dimensions[0], 10);
+  const height = parseInt(dimensions[1], 10);
+  return { width, height };
 }
 
 // List of key values to key definitions
@@ -3862,90 +3766,90 @@ const keyDefinitionMap = {
   '\\': 'Backslash',
   ']': 'BracketRight',
   "'": 'Quote',
-}
+};
 
 function getNormalizedKey(key) {
-  const normalizedKey = getNormalizedKeyAttributeValue(key)
+  const normalizedKey = getNormalizedKeyAttributeValue(key);
   if (key !== normalizedKey) {
-    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`)
+    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
   }
   // Use key definition to ensure correct key is displayed when Shift modifier is active
   if (Object.prototype.hasOwnProperty.call(keyDefinitionMap, normalizedKey)) {
-    return keyDefinitionMap[normalizedKey]
+    return keyDefinitionMap[normalizedKey];
   }
-  return normalizedKey
+  return normalizedKey;
 }
 
 async function clickablePoint(el) {
-  const rect = await el.boundingBox()
-  if (!rect) throw new ElementNotFound(el)
-  const { x, y, width, height } = rect
-  return { x: x + width / 2, y: y + height / 2 }
+  const rect = await el.boundingBox();
+  if (!rect) throw new ElementNotFound(el);
+  const { x, y, width, height } = rect;
+  return { x: x + width / 2, y: y + height / 2 };
 }
 
 async function refreshContextSession() {
   // close other sessions
   try {
-    const contexts = await this.browser.contexts()
-    contexts.shift()
+    const contexts = await this.browser.contexts();
+    contexts.shift();
 
-    await Promise.all(contexts.map((c) => c.close()))
+    await Promise.all(contexts.map(c => c.close()));
   } catch (e) {
-    console.log(e)
+    console.log(e);
   }
 
   if (this.page) {
-    const existingPages = await this.browserContext.pages()
-    await this._setPage(existingPages[0])
+    const existingPages = await this.browserContext.pages();
+    await this._setPage(existingPages[0]);
   }
 
-  if (this.options.keepBrowserState) return
+  if (this.options.keepBrowserState) return;
 
   if (!this.options.keepCookies) {
-    this.debugSection('Session', 'cleaning cookies and localStorage')
-    await this.clearCookie()
+    this.debugSection('Session', 'cleaning cookies and localStorage');
+    await this.clearCookie();
   }
-  const currentUrl = await this.grabCurrentUrl()
+  const currentUrl = await this.grabCurrentUrl();
 
   if (currentUrl.startsWith('http')) {
-    await this.executeScript('localStorage.clear();').catch((err) => {
-      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
-    })
-    await this.executeScript('sessionStorage.clear();').catch((err) => {
-      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
-    })
+    await this.executeScript('localStorage.clear();').catch(err => {
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
+    });
+    await this.executeScript('sessionStorage.clear();').catch(err => {
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
+    });
   }
 }
 
 function saveVideoForPage(page, name) {
-  if (!page.video()) return null
-  const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`
+  if (!page.video()) return null;
+  const fileName = `${`${global.output_dir}${pathSeparator}videos${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.webm`;
   page
     .video()
     .saveAs(fileName)
     .then(() => {
-      if (!page) return
+      if (!page) return;
       page
         .video()
         .delete()
-        .catch(() => {})
-    })
-  return fileName
+        .catch(() => {});
+    });
+  return fileName;
 }
 async function saveTraceForContext(context, name) {
-  if (!context) return
-  if (!context.tracing) return
-  const fileName = `${`${global.output_dir}${pathSeparator}trace${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.zip`
-  await context.tracing.stop({ path: fileName })
-  return fileName
+  if (!context) return;
+  if (!context.tracing) return;
+  const fileName = `${`${global.output_dir}${pathSeparator}trace${pathSeparator}${uuidv4()}_${clearString(name)}`.slice(0, 245)}.zip`;
+  await context.tracing.stop({ path: fileName });
+  return fileName;
 }
 
 async function highlightActiveElement(element) {
   if (this.options.highlightElement && global.debugMode) {
-    await element.evaluate((el) => {
-      const prevStyle = el.style.boxShadow
-      el.style.boxShadow = '0px 0px 4px 3px rgba(255, 0, 0, 0.7)'
-      setTimeout(() => (el.style.boxShadow = prevStyle), 2000)
-    })
+    await element.evaluate(el => {
+      const prevStyle = el.style.boxShadow;
+      el.style.boxShadow = '0px 0px 4px 3px rgba(255, 0, 0, 0.7)';
+      setTimeout(() => (el.style.boxShadow = prevStyle), 2000);
+    });
   }
 }

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -117,9 +117,7 @@ class Protractor extends Helper {
     this.isRunning = false
     this._setConfig(config)
 
-    console.log(
-      'Protractor helper is deprecated as well as Protractor itself.\nThis helper will be removed in next major release',
-    )
+    console.log('Protractor helper is deprecated as well as Protractor itself.\nThis helper will be removed in next major release')
   }
 
   _validateConfig(config) {
@@ -152,7 +150,7 @@ class Protractor extends Helper {
   }
 
   async _init() {
-    process.on('unhandledRejection', (reason) => {
+    process.on('unhandledRejection', reason => {
       if (reason.message.indexOf('ECONNREFUSED') > 0) {
         this.browser = null
       }
@@ -288,9 +286,7 @@ class Protractor extends Helper {
     if (frame) {
       if (Array.isArray(frame)) {
         withinStore.frame = frame.join('>')
-        return this.switchTo(null).then(() =>
-          frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve()),
-        )
+        return this.switchTo(null).then(() => frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve()))
       }
       withinStore.frame = frame
       return this.switchTo(locator)
@@ -300,8 +296,8 @@ class Protractor extends Helper {
     const context = await global.element(guessLocator(locator) || global.by.css(locator))
     if (!context) throw new ElementNotFound(locator)
 
-    this.browser.findElement = (l) => (l ? context.element(l).getWebElement() : context.getWebElement())
-    this.browser.findElements = (l) => context.all(l).getWebElements()
+    this.browser.findElement = l => (l ? context.element(l).getWebElement() : context.getWebElement())
+    this.browser.findElements = l => context.all(l).getWebElements()
     return context
   }
 
@@ -320,7 +316,7 @@ class Protractor extends Helper {
   _session() {
     const defaultSession = this.browser
     return {
-      start: async (opts) => {
+      start: async opts => {
         opts = this._validateConfig(Object.assign(this.options, opts))
         this.debugSection('New Browser', JSON.stringify(opts))
         const runner = new Runner(opts)
@@ -331,10 +327,10 @@ class Protractor extends Helper {
         await browser.manage().window().setSize(parseInt(res[0], 10), parseInt(res[1], 10))
         return browser.ready
       },
-      stop: async (browser) => {
+      stop: async browser => {
         return browser.close()
       },
-      loadVars: async (browser) => {
+      loadVars: async browser => {
         if (isWithin()) throw new Error("Can't start session inside within block")
         this.browser = browser
         loadGlobals(this.browser)
@@ -573,7 +569,7 @@ class Protractor extends Helper {
       if (!els.length) {
         els = await field.findElements(global.by.xpath(Locator.select.byValue(opt)))
       }
-      els.forEach((el) => promises.push(el.click()))
+      els.forEach(el => promises.push(el.click()))
     }
 
     return Promise.all(promises)
@@ -740,7 +736,7 @@ class Protractor extends Helper {
     const els = await this._locate(locator)
 
     const html = await Promise.all(
-      els.map((el) => {
+      els.map(el => {
         return this.browser.executeScript('return arguments[0].innerHTML;', el)
       }),
     )
@@ -766,7 +762,7 @@ class Protractor extends Helper {
    */
   async grabValueFromAll(locator) {
     const els = await findFields(this.browser, locator)
-    const values = await Promise.all(els.map((el) => el.getAttribute('value')))
+    const values = await Promise.all(els.map(el => el.getAttribute('value')))
 
     return values
   }
@@ -789,7 +785,7 @@ class Protractor extends Helper {
    */
   async grabCssPropertyFromAll(locator, cssProperty) {
     const els = await this._locate(locator, true)
-    const values = await Promise.all(els.map((el) => el.getCssValue(cssProperty)))
+    const values = await Promise.all(els.map(el => el.getCssValue(cssProperty)))
 
     return values
   }
@@ -839,7 +835,7 @@ class Protractor extends Helper {
    * {{> seeInTitle }}
    */
   async seeInTitle(text) {
-    return this.browser.getTitle().then((title) => stringIncludes('web page title').assert(text, title))
+    return this.browser.getTitle().then(title => stringIncludes('web page title').assert(text, title))
   }
 
   /**
@@ -854,14 +850,14 @@ class Protractor extends Helper {
    * {{> dontSeeInTitle }}
    */
   async dontSeeInTitle(text) {
-    return this.browser.getTitle().then((title) => stringIncludes('web page title').negate(text, title))
+    return this.browser.getTitle().then(title => stringIncludes('web page title').negate(text, title))
   }
 
   /**
    * {{> grabTitle }}
    */
   async grabTitle() {
-    return this.browser.getTitle().then((title) => {
+    return this.browser.getTitle().then(title => {
       this.debugSection('Title', title)
       return title
     })
@@ -872,8 +868,8 @@ class Protractor extends Helper {
    */
   async seeElement(locator) {
     let els = await this._locate(locator, true)
-    els = await Promise.all(els.map((el) => el.isDisplayed()))
-    return empty('elements').negate(els.filter((v) => v).fill('ELEMENT'))
+    els = await Promise.all(els.map(el => el.isDisplayed()))
+    return empty('elements').negate(els.filter(v => v).fill('ELEMENT'))
   }
 
   /**
@@ -881,33 +877,29 @@ class Protractor extends Helper {
    */
   async dontSeeElement(locator) {
     let els = await this._locate(locator, false)
-    els = await Promise.all(els.map((el) => el.isDisplayed()))
-    return empty('elements').assert(els.filter((v) => v).fill('ELEMENT'))
+    els = await Promise.all(els.map(el => el.isDisplayed()))
+    return empty('elements').assert(els.filter(v => v).fill('ELEMENT'))
   }
 
   /**
    * {{> seeElementInDOM }}
    */
   async seeElementInDOM(locator) {
-    return this.browser
-      .findElements(guessLocator(locator) || global.by.css(locator))
-      .then((els) => empty('elements').negate(els.fill('ELEMENT')))
+    return this.browser.findElements(guessLocator(locator) || global.by.css(locator)).then(els => empty('elements').negate(els.fill('ELEMENT')))
   }
 
   /**
    * {{> dontSeeElementInDOM }}
    */
   async dontSeeElementInDOM(locator) {
-    return this.browser
-      .findElements(guessLocator(locator) || global.by.css(locator))
-      .then((els) => empty('elements').assert(els.fill('ELEMENT')))
+    return this.browser.findElements(guessLocator(locator) || global.by.css(locator)).then(els => empty('elements').assert(els.fill('ELEMENT')))
   }
 
   /**
    * {{> seeInSource }}
    */
   async seeInSource(text) {
-    return this.browser.getPageSource().then((source) => stringIncludes('HTML source of a page').assert(text, source))
+    return this.browser.getPageSource().then(source => stringIncludes('HTML source of a page').assert(text, source))
   }
 
   /**
@@ -921,7 +913,7 @@ class Protractor extends Helper {
    * {{> dontSeeInSource }}
    */
   async dontSeeInSource(text) {
-    return this.browser.getPageSource().then((source) => stringIncludes('HTML source of a page').negate(text, source))
+    return this.browser.getPageSource().then(source => stringIncludes('HTML source of a page').negate(text, source))
   }
 
   /**
@@ -929,9 +921,7 @@ class Protractor extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator)
-    return equals(
-      `expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`,
-    ).assert(elements.length, num)
+    return equals(`expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`).assert(elements.length, num)
   }
 
   /**
@@ -939,10 +929,7 @@ class Protractor extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator)
-    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(
-      res,
-      num,
-    )
+    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(res, num)
   }
 
   /**
@@ -950,7 +937,7 @@ class Protractor extends Helper {
    */
   async grabNumberOfVisibleElements(locator) {
     let els = await this._locate(locator)
-    els = await Promise.all(els.map((el) => el.isDisplayed()))
+    els = await Promise.all(els.map(el => el.isDisplayed()))
     return els.length
   }
 
@@ -964,11 +951,11 @@ class Protractor extends Helper {
     const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties)
 
     const attributeNames = Object.keys(cssPropertiesCamelCase)
-    const expectedValues = attributeNames.map((name) => cssPropertiesCamelCase[name])
+    const expectedValues = attributeNames.map(name => cssPropertiesCamelCase[name])
     const missingAttributes = []
 
     for (const el of els) {
-      const attributeValues = await Promise.all(attributeNames.map((attr) => el.getCssValue(attr)))
+      const attributeValues = await Promise.all(attributeNames.map(attr => el.getCssValue(attr)))
 
       const missing = attributeValues.filter((actual, i) => {
         const prop = attributeNames[i]
@@ -982,9 +969,7 @@ class Protractor extends Helper {
         missingAttributes.push(...missing)
       }
     }
-    return equals(
-      `all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`,
-    ).assert(missingAttributes.length, 0)
+    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(missingAttributes.length, 0)
   }
 
   /**
@@ -995,11 +980,11 @@ class Protractor extends Helper {
     assertElementExists(els, locator)
 
     const attributeNames = Object.keys(attributes)
-    const expectedValues = attributeNames.map((name) => attributes[name])
+    const expectedValues = attributeNames.map(name => attributes[name])
     const missingAttributes = []
 
     for (const el of els) {
-      const attributeValues = await Promise.all(attributeNames.map((attr) => el.getAttribute(attr)))
+      const attributeValues = await Promise.all(attributeNames.map(attr => el.getAttribute(attr)))
       const missing = attributeValues.filter((actual, i) => {
         if (expectedValues[i] instanceof RegExp) {
           return expectedValues[i].test(actual)
@@ -1011,10 +996,7 @@ class Protractor extends Helper {
       }
     }
 
-    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(
-      missingAttributes.length,
-      0,
-    )
+    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(missingAttributes.length, 0)
   }
 
   /**
@@ -1036,28 +1018,28 @@ class Protractor extends Helper {
    * {{> seeInCurrentUrl }}
    */
   async seeInCurrentUrl(url) {
-    return this.browser.getCurrentUrl().then((currentUrl) => stringIncludes('url').assert(url, currentUrl))
+    return this.browser.getCurrentUrl().then(currentUrl => stringIncludes('url').assert(url, currentUrl))
   }
 
   /**
    * {{> dontSeeInCurrentUrl }}
    */
   async dontSeeInCurrentUrl(url) {
-    return this.browser.getCurrentUrl().then((currentUrl) => stringIncludes('url').negate(url, currentUrl))
+    return this.browser.getCurrentUrl().then(currentUrl => stringIncludes('url').negate(url, currentUrl))
   }
 
   /**
    * {{> seeCurrentUrlEquals }}
    */
   async seeCurrentUrlEquals(url) {
-    return this.browser.getCurrentUrl().then((currentUrl) => urlEquals(this.options.url).assert(url, currentUrl))
+    return this.browser.getCurrentUrl().then(currentUrl => urlEquals(this.options.url).assert(url, currentUrl))
   }
 
   /**
    * {{> dontSeeCurrentUrlEquals }}
    */
   async dontSeeCurrentUrlEquals(url) {
-    return this.browser.getCurrentUrl().then((currentUrl) => urlEquals(this.options.url).negate(url, currentUrl))
+    return this.browser.getCurrentUrl().then(currentUrl => urlEquals(this.options.url).negate(url, currentUrl))
   }
 
   /**
@@ -1072,7 +1054,7 @@ class Protractor extends Helper {
       const stream = fs.createWriteStream(outputFile)
       stream.write(Buffer.from(png, 'base64'))
       stream.end()
-      return new Promise((resolve) => stream.on('finish', resolve)) // eslint-disable-line no-promise-executor-return
+      return new Promise(resolve => stream.on('finish', resolve)) // eslint-disable-line no-promise-executor-return
     }
 
     const res = await this._locate(locator)
@@ -1095,7 +1077,7 @@ class Protractor extends Helper {
       const stream = fs.createWriteStream(outputFile)
       stream.write(Buffer.from(png, 'base64'))
       stream.end()
-      return new Promise((resolve) => stream.on('finish', resolve)) // eslint-disable-line no-promise-executor-return
+      return new Promise(resolve => stream.on('finish', resolve)) // eslint-disable-line no-promise-executor-return
     }
 
     if (!fullPage) {
@@ -1134,7 +1116,7 @@ class Protractor extends Helper {
     return this.browser
       .manage()
       .getCookie(name)
-      .then((res) => truth(`cookie ${name}`, 'to be set').assert(res))
+      .then(res => truth(`cookie ${name}`, 'to be set').assert(res))
   }
 
   /**
@@ -1144,7 +1126,7 @@ class Protractor extends Helper {
     return this.browser
       .manage()
       .getCookie(name)
-      .then((res) => truth(`cookie ${name}`, 'to be set').negate(res))
+      .then(res => truth(`cookie ${name}`, 'to be set').negate(res))
   }
 
   /**
@@ -1242,11 +1224,11 @@ class Protractor extends Helper {
 
     const handles = await client.getAllWindowHandles()
     const currentHandle = await client.getWindowHandle()
-    const otherHandles = handles.filter((handle) => handle !== currentHandle)
+    const otherHandles = handles.filter(handle => handle !== currentHandle)
 
     if (!otherHandles || !otherHandles.length) return
     let p = Promise.resolve()
-    otherHandles.forEach((handle) => {
+    otherHandles.forEach(handle => {
       p = p.then(() =>
         client
           .switchTo()
@@ -1393,7 +1375,7 @@ class Protractor extends Helper {
   async waitForDetached(locator, sec = null) {
     const aSec = sec || this.options.waitForTimeoutInSeconds
     const el = global.element(guessLocator(locator) || global.by.css(locator))
-    return this.browser.wait(EC.not(EC.presenceOf(el)), aSec * 1000).catch((err) => {
+    return this.browser.wait(EC.not(EC.presenceOf(el)), aSec * 1000).catch(err => {
       if (err.message && err.message.indexOf('Wait timed out after') > -1) {
         throw new Error(`element (${JSON.stringify(locator)}) still on page after ${sec} sec`)
       } else throw err
@@ -1453,9 +1435,9 @@ class Protractor extends Helper {
       return function () {
         return global.element
           .all(loc)
-          .filter((el) => el.isDisplayed())
+          .filter(el => el.isDisplayed())
           .count()
-          .then((count) => count === expectedCount)
+          .then(count => count === expectedCount)
       }
     }
 
@@ -1485,22 +1467,20 @@ class Protractor extends Helper {
   async waitForValue(field, value, sec = null) {
     const aSec = sec || this.options.waitForTimeoutInSeconds
 
-    const valueToBeInElementValue = (loc) => {
+    const valueToBeInElementValue = loc => {
       return async () => {
         const els = await findFields(this.browser, loc)
 
         if (!els) {
           return false
         }
-        const values = await Promise.all(els.map((el) => el.getAttribute('value')))
-        return values.filter((part) => part.indexOf(value) >= 0).length > 0
+        const values = await Promise.all(els.map(el => el.getAttribute('value')))
+        return values.filter(part => part.indexOf(value) >= 0).length > 0
       }
     }
 
     return this.browser.wait(valueToBeInElementValue(field, value), aSec * 1000).catch(() => {
-      throw Error(
-        `element (${field}) is not in DOM or there is no element(${field}) with value "${value}" after ${aSec} sec`,
-      )
+      throw Error(`element (${field}) is not in DOM or there is no element(${field}) with value "${value}" after ${aSec} sec`)
     })
   }
 
@@ -1528,7 +1508,7 @@ class Protractor extends Helper {
     const aSec = sec || this.options.waitForTimeoutInSeconds
     const waitTimeout = aSec * 1000
 
-    return this.browser.wait(EC.urlContains(urlPart), waitTimeout).catch(async (e) => {
+    return this.browser.wait(EC.urlContains(urlPart), waitTimeout).catch(async e => {
       const currUrl = await this.browser.getCurrentUrl()
       if (/wait timed out after/i.test(e.message)) {
         throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
@@ -1549,7 +1529,7 @@ class Protractor extends Helper {
       urlPart = baseUrl + urlPart
     }
 
-    return this.browser.wait(EC.urlIs(urlPart), waitTimeout).catch(async (e) => {
+    return this.browser.wait(EC.urlIs(urlPart), waitTimeout).catch(async e => {
       const currUrl = await this.browser.getCurrentUrl()
       if (/wait timed out after/i.test(e.message)) {
         throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
@@ -1645,10 +1625,7 @@ class Protractor extends Helper {
     return this.executeScript(function () {
       const body = document.body
       const html = document.documentElement
-      window.scrollTo(
-        0,
-        Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      )
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight))
     })
   }
 
@@ -1778,7 +1755,7 @@ async function proceedSee(assertType, text, context) {
   const els = await this._smartWait(() => this.browser.findElements(locator), enableSmartWait)
   const promises = []
   let source = ''
-  els.forEach((el) => promises.push(el.getText().then((elText) => (source += `| ${elText}`))))
+  els.forEach(el => promises.push(el.getText().then(elText => (source += `| ${elText}`))))
   await Promise.all(promises)
   return stringIncludes(description)[assertType](text, source)
 }
@@ -1803,7 +1780,7 @@ async function proceedIsChecked(assertType, option) {
   const els = await findCheckable(this.browser, option)
   assertElementExists(els, option, 'Option')
   const elsSelected = []
-  els.forEach((el) => elsSelected.push(el.isSelected()))
+  els.forEach(el => elsSelected.push(el.isSelected()))
   const values = await Promise.all(elsSelected)
   const selected = values.reduce((prev, cur) => prev || cur)
   return truth(`checkable ${option}`, 'to be checked')[assertType](selected)

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -36,19 +36,8 @@ const Popup = require('./extras/Popup')
 const Console = require('./extras/Console')
 const { highlightElement } = require('./scripts/highlightElement')
 const { blurElement } = require('./scripts/blurElement')
-const {
-  dontSeeElementError,
-  seeElementError,
-  dontSeeElementInDOMError,
-  seeElementInDOMError,
-} = require('./errors/ElementAssertion')
-const {
-  dontSeeTraffic,
-  seeTraffic,
-  grabRecordedNetworkTraffics,
-  stopRecordingTraffic,
-  flushNetworkTraffics,
-} = require('./network/actions')
+const { dontSeeElementError, seeElementError, dontSeeElementInDOMError, seeElementInDOMError } = require('./errors/ElementAssertion')
+const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions')
 
 let puppeteer
 let perfTiming
@@ -271,9 +260,7 @@ class Puppeteer extends Helper {
   }
 
   _getOptions(config) {
-    return config.browser === 'firefox'
-      ? Object.assign(this.options.firefox, { product: 'firefox' })
-      : this.options.chrome
+    return config.browser === 'firefox' ? Object.assign(this.options.firefox, { product: 'firefox' }) : this.options.chrome
   }
 
   _setConfig(config) {
@@ -326,7 +313,7 @@ class Puppeteer extends Helper {
     this.currentRunningTest = test
     recorder.retry({
       retries: process.env.FAILED_STEP_RETRIES || 3,
-      when: (err) => {
+      when: err => {
         if (!err || typeof err.message !== 'string') {
           return false
         }
@@ -346,7 +333,7 @@ class Puppeteer extends Helper {
     const contexts = this.browser.browserContexts()
     const defaultCtx = contexts.shift()
 
-    await Promise.all(contexts.map((c) => c.close()))
+    await Promise.all(contexts.map(c => c.close()))
 
     if (this.options.restart) {
       this.isRunning = false
@@ -355,7 +342,7 @@ class Puppeteer extends Helper {
 
     // ensure this.page is from default context
     if (this.page) {
-      const existingPages = defaultCtx.targets().filter((t) => t.type() === 'page')
+      const existingPages = defaultCtx.targets().filter(t => t.type() === 'page')
       await this._setPage(await existingPages[0].page())
     }
 
@@ -368,10 +355,10 @@ class Puppeteer extends Helper {
     const currentUrl = await this.grabCurrentUrl()
 
     if (currentUrl.startsWith('http')) {
-      await this.executeScript('localStorage.clear();').catch((err) => {
+      await this.executeScript('localStorage.clear();').catch(err => {
         if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
       })
-      await this.executeScript('sessionStorage.clear();').catch((err) => {
+      await this.executeScript('sessionStorage.clear();').catch(err => {
         if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
       })
     }
@@ -400,12 +387,12 @@ class Puppeteer extends Helper {
       stop: async () => {
         // is closed by _after
       },
-      loadVars: async (context) => {
-        const existingPages = context.targets().filter((t) => t.type() === 'page')
+      loadVars: async context => {
+        const existingPages = context.targets().filter(t => t.type() === 'page')
         this.sessionPages[this.activeSessionName] = await existingPages[0].page()
         return this._setPage(this.sessionPages[this.activeSessionName])
       },
-      restoreVars: async (session) => {
+      restoreVars: async session => {
         this.withinLocator = null
 
         if (!session) {
@@ -414,7 +401,7 @@ class Puppeteer extends Helper {
           this.activeSessionName = session
         }
         const defaultCtx = this.browser.defaultBrowserContext()
-        const existingPages = defaultCtx.targets().filter((t) => t.type() === 'page')
+        const existingPages = defaultCtx.targets().filter(t => t.type() === 'page')
         await this._setPage(await existingPages[0].page())
 
         return this._waitForAction()
@@ -517,7 +504,7 @@ class Puppeteer extends Helper {
     if (!page) {
       return
     }
-    page.on('error', async (error) => {
+    page.on('error', async error => {
       console.error('Puppeteer page error', error)
     })
   }
@@ -533,7 +520,7 @@ class Puppeteer extends Helper {
     if (!page) {
       return
     }
-    page.on('dialog', async (dialog) => {
+    page.on('dialog', async dialog => {
       popupStore.popup = dialog
       const action = popupStore.actionType || this.options.defaultPopupAction
       await this._waitForAction()
@@ -588,15 +575,15 @@ class Puppeteer extends Helper {
       this.browser = await puppeteer.launch(this.puppeteerOptions)
     }
 
-    this.browser.on('targetcreated', (target) =>
+    this.browser.on('targetcreated', target =>
       target
         .page()
-        .then((page) => targetCreatedHandler.call(this, page))
-        .catch((e) => {
+        .then(page => targetCreatedHandler.call(this, page))
+        .catch(e => {
           console.error('Puppeteer page error', e)
         }),
     )
-    this.browser.on('targetchanged', (target) => {
+    this.browser.on('targetchanged', target => {
       this.debugSection('Url', target.url())
     })
 
@@ -639,9 +626,7 @@ class Puppeteer extends Helper {
 
     if (frame) {
       if (Array.isArray(frame)) {
-        return this.switchTo(null).then(() =>
-          frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve()),
-        )
+        return this.switchTo(null).then(() => frame.reduce((p, frameLocator) => p.then(() => this.switchTo(frameLocator)), Promise.resolve()))
       }
       await this.switchTo(frame)
       this.withinLocator = new Locator(frame)
@@ -664,7 +649,7 @@ class Puppeteer extends Helper {
     const navigationStart = timing.navigationStart
 
     const extractedData = {}
-    dataNames.forEach((name) => {
+    dataNames.forEach(name => {
       extractedData[name] = timing[name] - navigationStart
     })
 
@@ -698,13 +683,7 @@ class Puppeteer extends Helper {
 
     const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)))
 
-    perfTiming = this._extractDataFromPerformanceTiming(
-      performanceTiming,
-      'responseEnd',
-      'domInteractive',
-      'domContentLoadedEventEnd',
-      'loadEventEnd',
-    )
+    perfTiming = this._extractDataFromPerformanceTiming(performanceTiming, 'responseEnd', 'domInteractive', 'domContentLoadedEventEnd', 'loadEventEnd')
 
     return this._waitForAction()
   }
@@ -815,10 +794,7 @@ class Puppeteer extends Helper {
     return this.executeScript(() => {
       const body = document.body
       const html = document.documentElement
-      window.scrollTo(
-        0,
-        Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      )
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight))
     })
   }
 
@@ -836,13 +812,9 @@ class Puppeteer extends Helper {
       const els = await this._locate(locator)
       assertElementExists(els, locator, 'Element')
       const el = els[0]
-      await el.evaluate((el) => el.scrollIntoView())
+      await el.evaluate(el => el.scrollIntoView())
       const elementCoordinates = await getClickablePoint(els[0])
-      await this.executeScript(
-        (x, y) => window.scrollBy(x, y),
-        elementCoordinates.x + offsetX,
-        elementCoordinates.y + offsetY,
-      )
+      await this.executeScript((x, y) => window.scrollBy(x, y), elementCoordinates.x + offsetX, elementCoordinates.y + offsetY)
     } else {
       await this.executeScript((x, y) => window.scrollTo(x, y), offsetX, offsetY)
     }
@@ -1025,10 +997,10 @@ class Puppeteer extends Helper {
    */
   async closeOtherTabs() {
     const pages = await this.browser.pages()
-    const otherPages = pages.filter((page) => page !== this.page)
+    const otherPages = pages.filter(page => page !== this.page)
 
     let p = Promise.resolve()
-    otherPages.forEach((page) => {
+    otherPages.forEach(page => {
       p = p.then(() => page.close())
     })
     await p
@@ -1061,19 +1033,11 @@ class Puppeteer extends Helper {
    */
   async seeElement(locator) {
     let els = await this._locate(locator)
-    els = (await Promise.all(els.map((el) => el.boundingBox() && el))).filter((v) => v)
+    els = (await Promise.all(els.map(el => el.boundingBox() && el))).filter(v => v)
     // Puppeteer visibility was ignored? | Remove when Puppeteer is fixed
-    els = await Promise.all(
-      els.map(
-        async (el) =>
-          (await el.evaluate(
-            (node) =>
-              window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none',
-          )) && el,
-      ),
-    )
+    els = await Promise.all(els.map(async el => (await el.evaluate(node => window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none')) && el))
     try {
-      return empty('visible elements').negate(els.filter((v) => v).fill('ELEMENT'))
+      return empty('visible elements').negate(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
       dontSeeElementError(locator)
     }
@@ -1085,19 +1049,11 @@ class Puppeteer extends Helper {
    */
   async dontSeeElement(locator) {
     let els = await this._locate(locator)
-    els = (await Promise.all(els.map((el) => el.boundingBox() && el))).filter((v) => v)
+    els = (await Promise.all(els.map(el => el.boundingBox() && el))).filter(v => v)
     // Puppeteer visibility was ignored? | Remove when Puppeteer is fixed
-    els = await Promise.all(
-      els.map(
-        async (el) =>
-          (await el.evaluate(
-            (node) =>
-              window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none',
-          )) && el,
-      ),
-    )
+    els = await Promise.all(els.map(async el => (await el.evaluate(node => window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none')) && el))
     try {
-      return empty('visible elements').assert(els.filter((v) => v).fill('ELEMENT'))
+      return empty('visible elements').assert(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
       seeElementError(locator)
     }
@@ -1109,7 +1065,7 @@ class Puppeteer extends Helper {
   async seeElementInDOM(locator) {
     const els = await this._locate(locator)
     try {
-      return empty('elements on page').negate(els.filter((v) => v).fill('ELEMENT'))
+      return empty('elements on page').negate(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
       dontSeeElementInDOMError(locator)
     }
@@ -1121,7 +1077,7 @@ class Puppeteer extends Helper {
   async dontSeeElementInDOM(locator) {
     const els = await this._locate(locator)
     try {
-      return empty('elements on a page').assert(els.filter((v) => v).fill('ELEMENT'))
+      return empty('elements on a page').assert(els.filter(v => v).fill('ELEMENT'))
     } catch (e) {
       seeElementInDOMError(locator)
     }
@@ -1151,17 +1107,12 @@ class Puppeteer extends Helper {
 
     const els = await findClickable.call(this, matcher, locator)
     if (context) {
-      assertElementExists(
-        els,
-        locator,
-        'Clickable element',
-        `was not found inside element ${new Locator(context).toString()}`,
-      )
+      assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`)
     } else {
       assertElementExists(els, locator, 'Clickable element')
     }
     const elem = els[0]
-    return this.executeScript((el) => {
+    return this.executeScript(el => {
       if (document.activeElement instanceof HTMLElement) {
         document.activeElement.blur()
       }
@@ -1220,8 +1171,8 @@ class Puppeteer extends Helper {
     let fileName
     await this.page.setRequestInterception(true)
 
-    const xRequest = await new Promise((resolve) => {
-      this.page.on('request', (request) => {
+    const xRequest = await new Promise(resolve => {
+      this.page.on('request', request => {
         console.log('rq', request, customName)
         const grabbedFileName = request.url().split('/')[request.url().split('/').length - 1]
         const fileExtension = request.url().split('/')[request.url().split('/').length - 1].split('.')[1]
@@ -1248,7 +1199,7 @@ class Puppeteer extends Helper {
     }
 
     const cookies = await this.page.cookies()
-    options.headers.Cookie = cookies.map((ck) => `${ck.name}=${ck.value}`).join(';')
+    options.headers.Cookie = cookies.map(ck => `${ck.name}=${ck.value}`).join(';')
 
     const response = await axios({
       method: options.method,
@@ -1302,7 +1253,7 @@ class Puppeteer extends Helper {
    */
   async checkOption(field, context = null) {
     const elm = await this._locateCheckable(field, context)
-    const curentlyChecked = await elm.getProperty('checked').then((checkedProperty) => checkedProperty.jsonValue())
+    const curentlyChecked = await elm.getProperty('checked').then(checkedProperty => checkedProperty.jsonValue())
     // Only check if NOT currently checked
     if (!curentlyChecked) {
       await elm.click()
@@ -1315,7 +1266,7 @@ class Puppeteer extends Helper {
    */
   async uncheckOption(field, context = null) {
     const elm = await this._locateCheckable(field, context)
-    const curentlyChecked = await elm.getProperty('checked').then((checkedProperty) => checkedProperty.jsonValue())
+    const curentlyChecked = await elm.getProperty('checked').then(checkedProperty => checkedProperty.jsonValue())
     // Only uncheck if currently checked
     if (curentlyChecked) {
       await elm.click()
@@ -1408,12 +1359,12 @@ class Puppeteer extends Helper {
     const els = await findVisibleFields.call(this, field)
     assertElementExists(els, field, 'Field')
     const el = els[0]
-    const tag = await el.getProperty('tagName').then((el) => el.jsonValue())
-    const editable = await el.getProperty('contenteditable').then((el) => el.jsonValue())
+    const tag = await el.getProperty('tagName').then(el => el.jsonValue())
+    const editable = await el.getProperty('contenteditable').then(el => el.jsonValue())
     if (tag === 'INPUT' || tag === 'TEXTAREA') {
-      await this._evaluateHandeInContext((el) => (el.value = ''), el)
+      await this._evaluateHandeInContext(el => (el.value = ''), el)
     } else if (editable) {
-      await this._evaluateHandeInContext((el) => (el.innerHTML = ''), el)
+      await this._evaluateHandeInContext(el => (el.innerHTML = ''), el)
     }
 
     highlightActiveElement.call(this, el, await this._getContext())
@@ -1483,7 +1434,7 @@ class Puppeteer extends Helper {
     const els = await findVisibleFields.call(this, select)
     assertElementExists(els, select, 'Selectable field')
     const el = els[0]
-    if ((await el.getProperty('tagName').then((t) => t.jsonValue())) !== 'SELECT') {
+    if ((await el.getProperty('tagName').then(t => t.jsonValue())) !== 'SELECT') {
       throw new Error('Element is not <select>')
     }
     highlightActiveElement.call(this, els[0], await this._getContext())
@@ -1493,15 +1444,15 @@ class Puppeteer extends Helper {
       const opt = xpathLocator.literal(option[key])
       let optEl = await findElements.call(this, el, { xpath: Locator.select.byVisibleText(opt) })
       if (optEl.length) {
-        this._evaluateHandeInContext((el) => (el.selected = true), optEl[0])
+        this._evaluateHandeInContext(el => (el.selected = true), optEl[0])
         continue
       }
       optEl = await findElements.call(this, el, { xpath: Locator.select.byValue(opt) })
       if (optEl.length) {
-        this._evaluateHandeInContext((el) => (el.selected = true), optEl[0])
+        this._evaluateHandeInContext(el => (el.selected = true), optEl[0])
       }
     }
-    await this._evaluateHandeInContext((element) => {
+    await this._evaluateHandeInContext(element => {
       element.dispatchEvent(new Event('input', { bubbles: true }))
       element.dispatchEvent(new Event('change', { bubbles: true }))
     }, el)
@@ -1515,19 +1466,11 @@ class Puppeteer extends Helper {
    */
   async grabNumberOfVisibleElements(locator) {
     let els = await this._locate(locator)
-    els = (await Promise.all(els.map((el) => el.boundingBox() && el))).filter((v) => v)
+    els = (await Promise.all(els.map(el => el.boundingBox() && el))).filter(v => v)
     // Puppeteer visibility was ignored? | Remove when Puppeteer is fixed
-    els = await Promise.all(
-      els.map(
-        async (el) =>
-          (await el.evaluate(
-            (node) =>
-              window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none',
-          )) && el,
-      ),
-    )
+    els = await Promise.all(els.map(async el => (await el.evaluate(node => window.getComputedStyle(node).visibility !== 'hidden' && window.getComputedStyle(node).display !== 'none')) && el))
 
-    return els.filter((v) => v).length
+    return els.filter(v => v).length
   }
 
   /**
@@ -1635,9 +1578,7 @@ class Puppeteer extends Helper {
    */
   async seeNumberOfElements(locator, num) {
     const elements = await this._locate(locator)
-    return equals(
-      `expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`,
-    ).assert(elements.length, num)
+    return equals(`expected number of elements (${new Locator(locator)}) is ${num}, but found ${elements.length}`).assert(elements.length, num)
   }
 
   /**
@@ -1647,10 +1588,7 @@ class Puppeteer extends Helper {
    */
   async seeNumberOfVisibleElements(locator, num) {
     const res = await this.grabNumberOfVisibleElements(locator)
-    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(
-      res,
-      num,
-    )
+    return equals(`expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`).assert(res, num)
   }
 
   /**
@@ -1669,7 +1607,7 @@ class Puppeteer extends Helper {
    */
   async seeCookie(name) {
     const cookies = await this.page.cookies()
-    empty(`cookie ${name} to be set`).negate(cookies.filter((c) => c.name === name))
+    empty(`cookie ${name} to be set`).negate(cookies.filter(c => c.name === name))
   }
 
   /**
@@ -1677,7 +1615,7 @@ class Puppeteer extends Helper {
    */
   async dontSeeCookie(name) {
     const cookies = await this.page.cookies()
-    empty(`cookie ${name} not to be set`).assert(cookies.filter((c) => c.name === name))
+    empty(`cookie ${name} not to be set`).assert(cookies.filter(c => c.name === name))
   }
 
   /**
@@ -1688,7 +1626,7 @@ class Puppeteer extends Helper {
   async grabCookie(name) {
     const cookies = await this.page.cookies()
     if (!name) return cookies
-    const cookie = cookies.filter((c) => c.name === name)
+    const cookie = cookies.filter(c => c.name === name)
     if (cookie[0]) return cookie[0]
   }
 
@@ -1708,9 +1646,9 @@ class Puppeteer extends Helper {
 
     return promiseRetry(
       async (retry, number) => {
-        const _grabCookie = async (name) => {
+        const _grabCookie = async name => {
           const cookies = await this.page.cookies()
-          const cookie = cookies.filter((c) => c.name === name)
+          const cookie = cookies.filter(c => c.name === name)
           if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`)
         }
 
@@ -1735,7 +1673,7 @@ class Puppeteer extends Helper {
     if (!name) {
       return this.page.deleteCookie.apply(this.page, cookies)
     }
-    const cookie = cookies.filter((c) => c.name === name)
+    const cookie = cookies.filter(c => c.name === name)
     if (!cookie[0]) return
     return this.page.deleteCookie(cookie[0])
   }
@@ -1761,7 +1699,7 @@ class Puppeteer extends Helper {
     const asyncFn = function () {
       const args = Array.from(arguments)
       const fn = eval(`(${args.shift()})`) // eslint-disable-line no-eval
-      return new Promise((done) => {
+      return new Promise(done => {
         args.push(done)
         fn.apply(null, args)
       })
@@ -1828,7 +1766,7 @@ class Puppeteer extends Helper {
    */
   async grabHTMLFromAll(locator) {
     const els = await this._locate(locator)
-    const values = await Promise.all(els.map((el) => el.evaluate((element) => element.innerHTML, el)))
+    const values = await Promise.all(els.map(el => el.evaluate(element => element.innerHTML, el)))
     return values
   }
 
@@ -1851,10 +1789,8 @@ class Puppeteer extends Helper {
    */
   async grabCssPropertyFromAll(locator, cssProperty) {
     const els = await this._locate(locator)
-    const res = await Promise.all(
-      els.map((el) => el.evaluate((el) => JSON.parse(JSON.stringify(getComputedStyle(el))), el)),
-    )
-    const cssValues = res.map((props) => props[toCamelCase(cssProperty)])
+    const res = await Promise.all(els.map(el => el.evaluate(el => JSON.parse(JSON.stringify(getComputedStyle(el))), el)))
+    const cssValues = res.map(props => props[toCamelCase(cssProperty)])
 
     return cssValues
   }
@@ -1897,19 +1833,17 @@ class Puppeteer extends Helper {
       }
     }
 
-    const values = Object.keys(cssPropertiesCamelCase).map((key) => cssPropertiesCamelCase[key])
+    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key])
     if (!Array.isArray(props)) props = [props]
     let chunked = chunkArray(props, values.length)
-    chunked = chunked.filter((val) => {
+    chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // eslint-disable-next-line eqeqeq
         if (val[i] != values[i]) return false
       }
       return true
     })
-    return equals(
-      `all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`,
-    ).assert(chunked.length, elemAmount)
+    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount)
   }
 
   /**
@@ -1922,7 +1856,7 @@ class Puppeteer extends Helper {
 
     const expectedAttributes = Object.entries(attributes)
 
-    const valuesPromises = elements.map(async (element) => {
+    const valuesPromises = elements.map(async element => {
       const elementAttributes = {}
       await Promise.all(
         expectedAttributes.map(async ([attribute, expectedValue]) => {
@@ -1935,7 +1869,7 @@ class Puppeteer extends Helper {
 
     const actualAttributes = await Promise.all(valuesPromises)
 
-    const matchingElements = actualAttributes.filter((attrs) =>
+    const matchingElements = actualAttributes.filter(attrs =>
       expectedAttributes.every(([attribute, expectedValue]) => {
         const actualValue = attrs[attribute]
         if (!actualValue) return false
@@ -1947,10 +1881,7 @@ class Puppeteer extends Helper {
     const elementsCount = elements.length
     const matchingCount = matchingElements.length
 
-    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(
-      matchingCount,
-      elementsCount,
-    )
+    return equals(`all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`).assert(matchingCount, elementsCount)
   }
 
   /**
@@ -2080,7 +2011,7 @@ class Puppeteer extends Helper {
    * {{> wait }}
    */
   async wait(sec) {
-    return new Promise((done) => {
+    return new Promise(done => {
       setTimeout(done, sec * 1000)
     })
   }
@@ -2100,20 +2031,18 @@ class Puppeteer extends Helper {
         if (!els || els.length === 0) {
           return false
         }
-        return Array.prototype.filter.call(els, (el) => !el.disabled).length > 0
+        return Array.prototype.filter.call(els, el => !el.disabled).length > 0
       }
       waiter = context.waitForFunction(enabledFn, { timeout: waitTimeout }, locator.value)
     } else {
       const enabledFn = function (locator, $XPath) {
         eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => !el.disabled).length > 0
+        return $XPath(null, locator).filter(el => !el.disabled).length > 0
       }
       waiter = context.waitForFunction(enabledFn, { timeout: waitTimeout }, locator.value, $XPath.toString())
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
+    return waiter.catch(err => {
+      throw new Error(`element (${locator.toString()}) still not enabled after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
 
@@ -2132,21 +2061,19 @@ class Puppeteer extends Helper {
         if (!els || els.length === 0) {
           return false
         }
-        return Array.prototype.filter.call(els, (el) => (el.value.toString() || '').indexOf(value) !== -1).length > 0
+        return Array.prototype.filter.call(els, el => (el.value.toString() || '').indexOf(value) !== -1).length > 0
       }
       waiter = context.waitForFunction(valueFn, { timeout: waitTimeout }, locator.value, value)
     } else {
       const valueFn = function (locator, $XPath, value) {
         eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => (el.value || '').indexOf(value) !== -1).length > 0
+        return $XPath(null, locator).filter(el => (el.value || '').indexOf(value) !== -1).length > 0
       }
       waiter = context.waitForFunction(valueFn, { timeout: waitTimeout }, locator.value, $XPath.toString(), value)
     }
-    return waiter.catch((err) => {
+    return waiter.catch(err => {
       const loc = locator.toString()
-      throw new Error(
-        `element (${loc}) is not in DOM or there is no element(${loc}) with value "${value}" after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
+      throw new Error(`element (${loc}) is not in DOM or there is no element(${loc}) with value "${value}" after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
 
@@ -2165,20 +2092,18 @@ class Puppeteer extends Helper {
         if (!els || els.length === 0) {
           return false
         }
-        return Array.prototype.filter.call(els, (el) => el.offsetParent !== null).length === num
+        return Array.prototype.filter.call(els, el => el.offsetParent !== null).length === num
       }
       waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, num)
     } else {
       const visibleFn = function (locator, $XPath, num) {
         eval($XPath) // eslint-disable-line no-eval
-        return $XPath(null, locator).filter((el) => el.offsetParent !== null).length === num
+        return $XPath(null, locator).filter(el => el.offsetParent !== null).length === num
       }
       waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, $XPath.toString(), num)
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
+    return waiter.catch(err => {
+      throw new Error(`The number of elements (${locator.toString()}) is not ${num} after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
 
@@ -2189,11 +2114,9 @@ class Puppeteer extends Helper {
     const els = await this._locate(locator)
     assertElementExists(els, locator)
 
-    return this.waitForFunction(isElementClickable, [els[0]], waitTimeout).catch(async (e) => {
+    return this.waitForFunction(isElementClickable, [els[0]], waitTimeout).catch(async e => {
       if (/Waiting failed/i.test(e.message) || /failed: timeout/i.test(e.message)) {
-        throw new Error(
-          `element ${new Locator(locator).toString()} still not clickable after ${waitTimeout || this.options.waitForTimeout / 1000} sec`,
-        )
+        throw new Error(`element ${new Locator(locator).toString()} still not clickable after ${waitTimeout || this.options.waitForTimeout / 1000} sec`)
       } else {
         throw e
       }
@@ -2215,10 +2138,8 @@ class Puppeteer extends Helper {
     } else {
       waiter = _waitForElement.call(this, locator, { timeout: waitTimeout })
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
+    return waiter.catch(err => {
+      throw new Error(`element (${locator.toString()}) still not present on page after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
 
@@ -2238,10 +2159,8 @@ class Puppeteer extends Helper {
     } else {
       waiter = _waitForElement.call(this, locator, { timeout: waitTimeout, visible: true })
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
+    return waiter.catch(err => {
+      throw new Error(`element (${locator.toString()}) still not visible after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
 
@@ -2259,7 +2178,7 @@ class Puppeteer extends Helper {
     } else {
       waiter = _waitForElement.call(this, locator, { timeout: waitTimeout, hidden: true })
     }
-    return waiter.catch((err) => {
+    return waiter.catch(err => {
       throw new Error(`element (${locator.toString()}) still visible after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
@@ -2277,10 +2196,8 @@ class Puppeteer extends Helper {
     } else {
       waiter = _waitForElement.call(this, locator, { timeout: waitTimeout, hidden: true })
     }
-    return waiter.catch((err) => {
-      throw new Error(
-        `element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`,
-      )
+    return waiter.catch(err => {
+      throw new Error(`element (${locator.toString()}) still not hidden after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
 
@@ -2317,14 +2234,14 @@ class Puppeteer extends Helper {
 
     return this.page
       .waitForFunction(
-        (urlPart) => {
+        urlPart => {
           const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
           return currUrl.indexOf(urlPart) > -1
         },
         { timeout: waitTimeout },
         urlPart,
       )
-      .catch(async (e) => {
+      .catch(async e => {
         const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
         if (/Waiting failed:/i.test(e.message) || /failed: timeout/i.test(e.message)) {
           throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
@@ -2347,14 +2264,14 @@ class Puppeteer extends Helper {
 
     return this.page
       .waitForFunction(
-        (urlPart) => {
+        urlPart => {
           const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
           return currUrl.indexOf(urlPart) > -1
         },
         { timeout: waitTimeout },
         urlPart,
       )
-      .catch(async (e) => {
+      .catch(async e => {
         const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
         if (/Waiting failed/i.test(e.message) || /failed: timeout/i.test(e.message)) {
           throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
@@ -2403,14 +2320,10 @@ class Puppeteer extends Helper {
         )
       }
     } else {
-      waiter = contextObject.waitForFunction(
-        (text) => document.body && document.body.innerText.indexOf(text) > -1,
-        { timeout: waitTimeout },
-        text,
-      )
+      waiter = contextObject.waitForFunction(text => document.body && document.body.innerText.indexOf(text) > -1, { timeout: waitTimeout }, text)
     }
 
-    return waiter.catch((err) => {
+    return waiter.catch(err => {
       throw new Error(`Text "${text}" was not found on page after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
@@ -2548,7 +2461,7 @@ class Puppeteer extends Helper {
       }
       waiter = context.waitForFunction(visibleFn, { timeout: waitTimeout }, locator.value, $XPath.toString())
     }
-    return waiter.catch((err) => {
+    return waiter.catch(err => {
       throw new Error(`element (${locator.toString()}) still on page after ${waitTimeout / 1000} sec\n${err.message}`)
     })
   }
@@ -2589,7 +2502,7 @@ class Puppeteer extends Helper {
   async mockRoute(url, handler) {
     await this.page.setRequestInterception(true)
 
-    this.page.on('request', (interceptedRequest) => {
+    this.page.on('request', interceptedRequest => {
       if (interceptedRequest.url().match(url)) {
         // @ts-ignore
         handler(interceptedRequest)
@@ -2614,7 +2527,7 @@ class Puppeteer extends Helper {
     this.page.off('request')
 
     // Resume normal request handling for the given URL
-    this.page.on('request', (interceptedRequest) => {
+    this.page.on('request', interceptedRequest => {
       if (interceptedRequest.url().includes(url)) {
         interceptedRequest.continue()
       } else {
@@ -2650,7 +2563,7 @@ class Puppeteer extends Helper {
 
     await this.page.setRequestInterception(true)
 
-    this.page.on('request', (request) => {
+    this.page.on('request', request => {
       const information = {
         url: request.url(),
         method: request.method(),
@@ -2711,15 +2624,15 @@ class Puppeteer extends Helper {
     await this.cdpSession.send('Network.enable')
     await this.cdpSession.send('Page.enable')
 
-    this.cdpSession.on('Network.webSocketFrameReceived', (payload) => {
+    this.cdpSession.on('Network.webSocketFrameReceived', payload => {
       this._logWebsocketMessages(this._getWebSocketLog('RECEIVED', payload))
     })
 
-    this.cdpSession.on('Network.webSocketFrameSent', (payload) => {
+    this.cdpSession.on('Network.webSocketFrameSent', payload => {
       this._logWebsocketMessages(this._getWebSocketLog('SENT', payload))
     })
 
-    this.cdpSession.on('Network.webSocketFrameError', (payload) => {
+    this.cdpSession.on('Network.webSocketFrameError', payload => {
       this._logWebsocketMessages(this._getWebSocketLog('ERROR', payload))
     })
   }
@@ -2743,9 +2656,7 @@ class Puppeteer extends Helper {
   grabWebSocketMessages() {
     if (!this.recordingWebSocketMessages) {
       if (!this.recordedWebSocketMessagesAtLeastOnce) {
-        throw new Error(
-          'Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.',
-        )
+        throw new Error('Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.')
       }
     }
     return this.webSocketMessages
@@ -2797,12 +2708,7 @@ async function proceedClick(locator, context = null, options = {}) {
   }
   const els = await findClickable.call(this, matcher, locator)
   if (context) {
-    assertElementExists(
-      els,
-      locator,
-      'Clickable element',
-      `was not found inside element ${new Locator(context).toString()}`,
-    )
+    assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`)
   } else {
     assertElementExists(els, locator, 'Clickable element')
   }
@@ -2854,23 +2760,20 @@ async function proceedSee(assertType, text, context, strict = false) {
       el = await this.context.$('body')
     }
 
-    allText = [await el.getProperty('innerText').then((p) => p.jsonValue())]
+    allText = [await el.getProperty('innerText').then(p => p.jsonValue())]
     description = 'web application'
   } else {
     const locator = new Locator(context, 'css')
     description = `element ${locator.toString()}`
     const els = await this._locate(locator)
     assertElementExists(els, locator.toString())
-    allText = await Promise.all(els.map((el) => el.getProperty('innerText').then((p) => p.jsonValue())))
+    allText = await Promise.all(els.map(el => el.getProperty('innerText').then(p => p.jsonValue())))
   }
 
   if (strict) {
-    return allText.map((elText) => equals(description)[assertType](text, elText))
+    return allText.map(elText => equals(description)[assertType](text, elText))
   }
-  return stringIncludes(description)[assertType](
-    normalizeSpacesInString(text),
-    normalizeSpacesInString(allText.join(' | ')),
-  )
+  return stringIncludes(description)[assertType](normalizeSpacesInString(text), normalizeSpacesInString(allText.join(' | ')))
 }
 
 async function findCheckable(locator, context) {
@@ -2900,15 +2803,15 @@ async function findCheckable(locator, context) {
 async function proceedIsChecked(assertType, option) {
   let els = await findCheckable.call(this, option)
   assertElementExists(els, option, 'Checkable')
-  els = await Promise.all(els.map((el) => el.getProperty('checked')))
-  els = await Promise.all(els.map((el) => el.jsonValue()))
+  els = await Promise.all(els.map(el => el.getProperty('checked')))
+  els = await Promise.all(els.map(el => el.jsonValue()))
   const selected = els.reduce((prev, cur) => prev || cur)
   return truth(`checkable ${option}`, 'to be checked')[assertType](selected)
 }
 
 async function findVisibleFields(locator) {
   const els = await findFields.call(this, locator)
-  const visible = await Promise.all(els.map((el) => el.boundingBox()))
+  const visible = await Promise.all(els.map(el => el.boundingBox()))
   return els.filter((el, index) => visible[index])
 }
 
@@ -2961,15 +2864,15 @@ async function proceedSeeInField(assertType, field, value) {
   const els = await findVisibleFields.call(this, field)
   assertElementExists(els, field, 'Field')
   const el = els[0]
-  const tag = await el.getProperty('tagName').then((el) => el.jsonValue())
-  const fieldType = await el.getProperty('type').then((el) => el.jsonValue())
+  const tag = await el.getProperty('tagName').then(el => el.jsonValue())
+  const fieldType = await el.getProperty('type').then(el => el.jsonValue())
 
-  const proceedMultiple = async (elements) => {
+  const proceedMultiple = async elements => {
     const fields = Array.isArray(elements) ? elements : [elements]
 
     const elementValues = []
     for (const element of fields) {
-      elementValues.push(await element.getProperty('value').then((el) => el.jsonValue()))
+      elementValues.push(await element.getProperty('value').then(el => el.jsonValue()))
     }
 
     if (typeof value === 'boolean') {
@@ -2978,7 +2881,7 @@ async function proceedSeeInField(assertType, field, value) {
       if (assertType === 'assert') {
         equals(`select option by ${field}`)[assertType](true, elementValues.length > 0)
       }
-      elementValues.forEach((val) => stringIncludes(`fields by ${field}`)[assertType](value, val))
+      elementValues.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val))
     }
   }
 
@@ -3006,14 +2909,14 @@ async function proceedSeeInField(assertType, field, value) {
     }
     return proceedMultiple(els[0])
   }
-  const fieldVal = await el.getProperty('value').then((el) => el.jsonValue())
+  const fieldVal = await el.getProperty('value').then(el => el.jsonValue())
   return stringIncludes(`fields by ${field}`)[assertType](value, fieldVal)
 }
 
 async function filterFieldsByValue(elements, value, onlySelected) {
   const matches = []
   for (const element of elements) {
-    const val = await element.getProperty('value').then((el) => el.jsonValue())
+    const val = await element.getProperty('value').then(el => el.jsonValue())
     let isSelected = true
     if (onlySelected) {
       isSelected = await elementSelected(element)
@@ -3037,12 +2940,12 @@ async function filterFieldsBySelectionState(elements, state) {
 }
 
 async function elementSelected(element) {
-  const type = await element.getProperty('type').then((el) => el.jsonValue())
+  const type = await element.getProperty('type').then(el => el.jsonValue())
 
   if (type === 'checkbox' || type === 'radio') {
-    return element.getProperty('checked').then((el) => el.jsonValue())
+    return element.getProperty('checked').then(el => el.jsonValue())
   }
-  return element.getProperty('selected').then((el) => el.jsonValue())
+  return element.getProperty('selected').then(el => el.jsonValue())
 }
 
 function isFrameLocator(locator) {
@@ -3077,9 +2980,9 @@ async function targetCreatedHandler(page) {
     page
       .$('body')
       .catch(() => null)
-      .then((context) => (this.context = context))
+      .then(context => (this.context = context))
   })
-  page.on('console', (msg) => {
+  page.on('console', msg => {
     this.debugSection(`Browser:${ucfirst(msg.type())}`, (msg._text || '') + msg.args().join(' '))
     consoleLogStore.add(msg)
   })
@@ -3186,7 +3089,7 @@ async function findReactElements(locator, props = {}, state = {}) {
 
   await this.page.evaluate(() => window.resq.waitToLoadReact())
   const arrayHandle = await this.page.evaluateHandle(
-    (obj) => {
+    obj => {
       const { selector, props, state } = obj
       let elements = window.resq.resq$$(selector)
       if (Object.keys(props).length) {
@@ -3205,7 +3108,7 @@ async function findReactElements(locator, props = {}, state = {}) {
       // [[div, div], [div, div]] => [div, div, div, div]
       let nodes = []
 
-      elements.forEach((element) => {
+      elements.forEach(element => {
         let { node, isFragment } = element
 
         if (!node) {

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -205,10 +205,7 @@ class REST extends Helper {
 
     if (request.data instanceof Secret) {
       _debugRequest.data = '*****'
-      request.data =
-        typeof request.data === 'object' && !(request.data instanceof Secret)
-          ? { ...request.data.toString() }
-          : request.data.toString()
+      request.data = typeof request.data === 'object' && !(request.data instanceof Secret) ? { ...request.data.toString() } : request.data.toString()
     }
 
     if (typeof request.data === 'string') {
@@ -221,9 +218,7 @@ class REST extends Helper {
       await this.config.onRequest(request)
     }
 
-    this.options.prettyPrintJson
-      ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest)))
-      : this.debugSection('Request', JSON.stringify(_debugRequest))
+    this.options.prettyPrintJson ? this.debugSection('Request', beautify(JSON.stringify(_debugRequest))) : this.debugSection('Request', JSON.stringify(_debugRequest))
 
     if (this.options.printCurl) {
       this.debugSection('CURL Request', curlize(request))
@@ -240,9 +235,7 @@ class REST extends Helper {
     if (this.config.onResponse) {
       await this.config.onResponse(response)
     }
-    this.options.prettyPrintJson
-      ? this.debugSection('Response', beautify(JSON.stringify(response.data)))
-      : this.debugSection('Response', JSON.stringify(response.data))
+    this.options.prettyPrintJson ? this.debugSection('Response', beautify(JSON.stringify(response.data))) : this.debugSection('Response', JSON.stringify(response.data))
     return response
   }
 
@@ -437,13 +430,8 @@ class REST extends Helper {
 module.exports = REST
 
 function curlize(request) {
-  if (request.data?.constructor.name.toLowerCase() === 'formdata')
-    return 'cURL is not printed as the request body is not a JSON'
-  let curl =
-    `curl --location --request ${request.method ? request.method.toUpperCase() : 'GET'} ${request.baseURL} `.replace(
-      "'",
-      '',
-    )
+  if (request.data?.constructor.name.toLowerCase() === 'formdata') return 'cURL is not printed as the request body is not a JSON'
+  let curl = `curl --location --request ${request.method ? request.method.toUpperCase() : 'GET'} ${request.baseURL} `.replace("'", '')
 
   if (request.headers) {
     Object.entries(request.headers).forEach(([key, value]) => {

--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -21,9 +21,8 @@ const Locator = require('../locator')
 /**
  * Client Functions
  */
-const getPageUrl = (t) => ClientFunction(() => document.location.href).with({ boundTestRun: t })
-const getHtmlSource = (t) =>
-  ClientFunction(() => document.getElementsByTagName('html')[0].innerHTML).with({ boundTestRun: t })
+const getPageUrl = t => ClientFunction(() => document.location.href).with({ boundTestRun: t })
+const getHtmlSource = t => ClientFunction(() => document.getElementsByTagName('html')[0].innerHTML).with({ boundTestRun: t })
 
 /**
  * Uses [TestCafe](https://github.com/DevExpress/testcafe) library to run cross-browser tests.
@@ -187,7 +186,7 @@ class TestCafe extends Helper {
         assertionTimeout: this.options.waitForTimeout,
         takeScreenshotsOnFails: true,
       })
-      .catch((err) => {
+      .catch(err => {
         this.debugSection('_before', `Error ${err.toString()}`)
         this.isRunning = false
         this.testcafe.close()
@@ -208,7 +207,7 @@ class TestCafe extends Helper {
           skipJsErrors: true,
           skipUncaughtErrors: true,
         })
-        .catch((err) => {
+        .catch(err => {
           this.debugSection('_before', `Error ${err.toString()}`)
           this.isRunning = false
           this.testcafe.close()
@@ -260,7 +259,7 @@ class TestCafe extends Helper {
       await this.clearCookie()
 
       // TODO IMHO that should only happen when
-      await this.executeScript(() => localStorage.clear()).catch((err) => {
+      await this.executeScript(() => localStorage.clear()).catch(err => {
         if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
       })
     }
@@ -394,9 +393,7 @@ class TestCafe extends Helper {
   async waitForVisible(locator, sec) {
     const timeout = sec ? sec * 1000 : undefined
 
-    return (await findElements.call(this, this.context, locator))
-      .with({ visibilityCheck: true, timeout })()
-      .catch(mapError)
+    return (await findElements.call(this, this.context, locator)).with({ visibilityCheck: true, timeout })().catch(mapError)
   }
 
   /**
@@ -634,10 +631,7 @@ class TestCafe extends Helper {
       els = (await findElements.call(this, this.context, 'body')).withText(text)
     }
 
-    return this.t
-      .expect(els.filterVisible().count)
-      .eql(0, `Element with text "${text}" can still be seen`)
-      .catch(mapError)
+    return this.t.expect(els.filterVisible().count).eql(0, `Element with text "${text}" can still be seen`).catch(mapError)
   }
 
   /**
@@ -789,7 +783,7 @@ class TestCafe extends Helper {
    * {{> wait }}
    */
   async wait(sec) {
-    return new Promise((done) => {
+    return new Promise(done => {
       setTimeout(done, sec * 1000)
     })
   }
@@ -938,10 +932,7 @@ class TestCafe extends Helper {
     return ClientFunction(() => {
       const body = document.body
       const html = document.documentElement
-      window.scrollTo(
-        0,
-        Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      )
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight))
     })
       .with({ boundTestRun: this.t })()
       .catch(mapError)
@@ -957,7 +948,7 @@ class TestCafe extends Helper {
       locator = null
     }
 
-    const scrollBy = ClientFunction((offset) => {
+    const scrollBy = ClientFunction(offset => {
       if (window && window.scrollBy && offset) {
         window.scrollBy(offset.x, offset.y)
       }
@@ -1042,10 +1033,10 @@ class TestCafe extends Helper {
   async grabCookie(name) {
     if (!name) {
       const getCookie = ClientFunction(() => {
-        return document.cookie.split(';').map((c) => c.split('='))
+        return document.cookie.split(';').map(c => c.split('='))
       }).with({ boundTestRun: this.t })
       const cookies = await getCookie()
-      return cookies.map((cookie) => ({ name: cookie[0].trim(), value: cookie[1] }))
+      return cookies.map(cookie => ({ name: cookie[0].trim(), value: cookie[1] }))
     }
     const getCookie = ClientFunction(
       () => {
@@ -1088,7 +1079,7 @@ class TestCafe extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
     const clientFn = createClientFunction(
-      (urlPart) => {
+      urlPart => {
         const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
         return currUrl.indexOf(urlPart) > -1
       },
@@ -1113,7 +1104,7 @@ class TestCafe extends Helper {
     }
 
     const clientFn = createClientFunction(
-      (urlPart) => {
+      urlPart => {
         const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
         return currUrl === urlPart
       },
@@ -1174,9 +1165,7 @@ class TestCafe extends Helper {
   async waitToHide(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
-    return this.t
-      .expect(createSelector(locator).filterHidden().with({ boundTestRun: this.t }).exists)
-      .notOk({ timeout: waitTimeout })
+    return this.t.expect(createSelector(locator).filterHidden().with({ boundTestRun: this.t }).exists).notOk({ timeout: waitTimeout })
   }
 
   /**
@@ -1185,9 +1174,7 @@ class TestCafe extends Helper {
   async waitForInvisible(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
-    return this.t
-      .expect(createSelector(locator).filterVisible().with({ boundTestRun: this.t }).exists)
-      .ok({ timeout: waitTimeout })
+    return this.t.expect(createSelector(locator).filterVisible().with({ boundTestRun: this.t }).exists).ok({ timeout: waitTimeout })
   }
 
   /**
@@ -1214,7 +1201,7 @@ class TestCafe extends Helper {
 
 async function waitForFunction(browserFn, waitTimeout) {
   const pause = () =>
-    new Promise((done) => {
+    new Promise(done => {
       setTimeout(done, 50)
     })
 
@@ -1238,13 +1225,13 @@ async function waitForFunction(browserFn, waitTimeout) {
   }
 }
 
-const createSelector = (locator) => {
+const createSelector = locator => {
   locator = new Locator(locator, 'css')
   if (locator.isXPath()) return elementByXPath(locator.value)
   return Selector(locator.simplify())
 }
 
-const elementByXPath = (xpath) => {
+const elementByXPath = xpath => {
   assert(xpath, 'xpath is required')
 
   return Selector(
@@ -1277,9 +1264,7 @@ async function findElements(matcher, locator) {
   locator = new Locator(locator, 'css')
 
   if (!locator.isXPath()) {
-    return matcher
-      ? matcher.find(locator.simplify())
-      : Selector(locator.simplify()).with({ timeout: 0, boundTestRun: this.t })
+    return matcher ? matcher.find(locator.simplify()) : Selector(locator.simplify()).with({ timeout: 0, boundTestRun: this.t })
   }
 
   if (!matcher) return elementByXPath(locator.value).with({ timeout: 0, boundTestRun: this.t })
@@ -1308,12 +1293,7 @@ async function proceedClick(locator, context = null) {
 
   const els = await findClickable.call(this, matcher, locator)
   if (context) {
-    await assertElementExists(
-      els,
-      locator,
-      'Clickable element',
-      `was not found inside element ${new Locator(context).toString()}`,
-    )
+    await assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`)
   } else {
     await assertElementExists(els, locator, 'Clickable element')
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1,28 +1,28 @@
-let webdriverio;
+let webdriverio
 
-const assert = require('assert');
-const path = require('path');
+const assert = require('assert')
+const path = require('path')
 
-const Helper = require('@codeceptjs/helper');
-const promiseRetry = require('promise-retry');
-const stringIncludes = require('../assert/include').includes;
-const { urlEquals, equals } = require('../assert/equal');
-const { debug } = require('../output');
-const { empty } = require('../assert/empty');
-const { truth } = require('../assert/truth');
-const { xpathLocator, fileExists, decodeUrl, chunkArray, convertCssPropertiesToCamelCase, screenshotOutputFolder, getNormalizedKeyAttributeValue, modifierKeys } = require('../utils');
-const { isColorProperty, convertColorToRGBA } = require('../colorUtils');
-const ElementNotFound = require('./errors/ElementNotFound');
-const ConnectionRefused = require('./errors/ConnectionRefused');
-const Locator = require('../locator');
-const { highlightElement } = require('./scripts/highlightElement');
-const { focusElement } = require('./scripts/focusElement');
-const { blurElement } = require('./scripts/blurElement');
-const { dontSeeElementError, seeElementError, seeElementInDOMError, dontSeeElementInDOMError } = require('./errors/ElementAssertion');
-const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions');
+const Helper = require('@codeceptjs/helper')
+const promiseRetry = require('promise-retry')
+const stringIncludes = require('../assert/include').includes
+const { urlEquals, equals } = require('../assert/equal')
+const { debug } = require('../output')
+const { empty } = require('../assert/empty')
+const { truth } = require('../assert/truth')
+const { xpathLocator, fileExists, decodeUrl, chunkArray, convertCssPropertiesToCamelCase, screenshotOutputFolder, getNormalizedKeyAttributeValue, modifierKeys } = require('../utils')
+const { isColorProperty, convertColorToRGBA } = require('../colorUtils')
+const ElementNotFound = require('./errors/ElementNotFound')
+const ConnectionRefused = require('./errors/ConnectionRefused')
+const Locator = require('../locator')
+const { highlightElement } = require('./scripts/highlightElement')
+const { focusElement } = require('./scripts/focusElement')
+const { blurElement } = require('./scripts/blurElement')
+const { dontSeeElementError, seeElementError, seeElementInDOMError, dontSeeElementInDOMError } = require('./errors/ElementAssertion')
+const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions')
 
-const SHADOW = 'shadow';
-const webRoot = 'body';
+const SHADOW = 'shadow'
+const webRoot = 'body'
 
 /**
  * ## Configuration
@@ -53,7 +53,7 @@ const webRoot = 'body';
  * @prop {boolean} [highlightElement] - highlight the interacting elements. Default: false. Note: only activate under verbose mode (--verbose).
  * @prop {string} [logLevel=silent] - level of logging verbosity. Default: silent. Options: trace | debug | info | warn | error | silent. More info: https://webdriver.io/docs/configuration/#loglevel
  */
-const config = {};
+const config = {}
 
 /**
  * WebDriver helper which wraps [webdriverio](http://webdriver.io/) library to
@@ -423,34 +423,34 @@ const config = {};
  */
 class WebDriver extends Helper {
   constructor(config) {
-    super(config);
-    webdriverio = require('webdriverio');
+    super(config)
+    webdriverio = require('webdriverio')
 
     // set defaults
-    this.root = webRoot;
-    this.isWeb = true;
-    this.isRunning = false;
-    this.sessionWindows = {};
-    this.activeSessionName = '';
-    this.customLocatorStrategies = config.customLocatorStrategies;
+    this.root = webRoot
+    this.isWeb = true
+    this.isRunning = false
+    this.sessionWindows = {}
+    this.activeSessionName = ''
+    this.customLocatorStrategies = config.customLocatorStrategies
 
     // for network stuff
-    this.requests = [];
-    this.recording = false;
-    this.recordedAtLeastOnce = false;
+    this.requests = []
+    this.recording = false
+    this.recordedAtLeastOnce = false
 
-    this._setConfig(config);
+    this._setConfig(config)
 
     Locator.addFilter((locator, result) => {
       if (typeof locator === 'string' && locator.indexOf('~') === 0) {
         // accessibility locator
         if (this.isWeb) {
-          result.value = `[aria-label="${locator.slice(1)}"]`;
-          result.type = 'css';
-          result.output = `aria-label=${locator.slice(1)}`;
+          result.value = `[aria-label="${locator.slice(1)}"]`
+          result.type = 'css'
+          result.output = `aria-label=${locator.slice(1)}`
         }
       }
-    });
+    })
   }
 
   _validateConfig(config) {
@@ -470,41 +470,41 @@ class WebDriver extends Helper {
       keepBrowserState: false,
       deprecationWarnings: false,
       highlightElement: false,
-    };
+    }
 
     // override defaults with config
-    config = Object.assign(defaults, config);
+    config = Object.assign(defaults, config)
 
     if (config.host) {
       // webdriverio spec
-      config.hostname = config.host;
-      config.path = config.path ? config.path : '/wd/hub';
+      config.hostname = config.host
+      config.path = config.path ? config.path : '/wd/hub'
     }
 
-    config.baseUrl = config.url || config.baseUrl;
+    config.baseUrl = config.url || config.baseUrl
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
-      config.capabilities = config.desiredCapabilities;
+      config.capabilities = config.desiredCapabilities
     }
-    config.capabilities.browserName = config.browser || config.capabilities.browserName;
-    config.capabilities.browserVersion = config.browserVersion || config.capabilities.browserVersion;
+    config.capabilities.browserName = config.browser || config.capabilities.browserName
+    config.capabilities.browserVersion = config.browserVersion || config.capabilities.browserVersion
     if (config.capabilities.chromeOptions) {
-      config.capabilities['goog:chromeOptions'] = config.capabilities.chromeOptions;
-      delete config.capabilities.chromeOptions;
+      config.capabilities['goog:chromeOptions'] = config.capabilities.chromeOptions
+      delete config.capabilities.chromeOptions
     }
     if (config.capabilities.firefoxOptions) {
-      config.capabilities['moz:firefoxOptions'] = config.capabilities.firefoxOptions;
-      delete config.capabilities.firefoxOptions;
+      config.capabilities['moz:firefoxOptions'] = config.capabilities.firefoxOptions
+      delete config.capabilities.firefoxOptions
     }
     if (config.capabilities.ieOptions) {
-      config.capabilities['se:ieOptions'] = config.capabilities.ieOptions;
-      delete config.capabilities.ieOptions;
+      config.capabilities['se:ieOptions'] = config.capabilities.ieOptions
+      delete config.capabilities.ieOptions
     }
     if (config.capabilities.selenoidOptions) {
-      config.capabilities['selenoid:options'] = config.capabilities.selenoidOptions;
-      delete config.capabilities.selenoidOptions;
+      config.capabilities['selenoid:options'] = config.capabilities.selenoidOptions
+      delete config.capabilities.selenoidOptions
     }
 
-    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000; // convert to seconds
+    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000 // convert to seconds
 
     if (!config.capabilities.platformName && (!config.url || !config.browser)) {
       throw new Error(`
@@ -518,17 +518,17 @@ class WebDriver extends Helper {
               }
             }
           }
-      `);
+      `)
     }
 
-    return config;
+    return config
   }
 
   static _checkRequirements() {
     try {
-      require('webdriverio');
+      require('webdriverio')
     } catch (e) {
-      return ['webdriverio@^6.12.1'];
+      return ['webdriverio@^6.12.1']
     }
   }
 
@@ -544,162 +544,162 @@ class WebDriver extends Helper {
         message: 'Browser in which testing will be performed',
         default: 'chrome',
       },
-    ];
+    ]
   }
 
   _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {
-      this.debugSection('Session', 'Starting singleton browser session');
-      return this._startBrowser();
+      this.debugSection('Session', 'Starting singleton browser session')
+      return this._startBrowser()
     }
   }
 
   _lookupCustomLocator(customStrategy) {
     if (typeof this.customLocatorStrategies !== 'object') {
-      return null;
+      return null
     }
-    const strategy = this.customLocatorStrategies[customStrategy];
-    return typeof strategy === 'function' ? strategy : null;
+    const strategy = this.customLocatorStrategies[customStrategy]
+    return typeof strategy === 'function' ? strategy : null
   }
 
   _isCustomLocator(locator) {
-    const locatorObj = new Locator(locator);
+    const locatorObj = new Locator(locator)
     if (locatorObj.isCustom()) {
-      const customLocator = this._lookupCustomLocator(locatorObj.type);
+      const customLocator = this._lookupCustomLocator(locatorObj.type)
       if (customLocator) {
-        return true;
+        return true
       }
-      throw new Error('Please define "customLocatorStrategies" as an Object and the Locator Strategy as a "function".');
+      throw new Error('Please define "customLocatorStrategies" as an Object and the Locator Strategy as a "function".')
     }
-    return false;
+    return false
   }
 
   async _res(locator) {
-    const res = this._isShadowLocator(locator) || this._isCustomLocator(locator) ? await this._locate(locator) : await this.$$(withStrictLocator(locator));
-    return res;
+    const res = this._isShadowLocator(locator) || this._isCustomLocator(locator) ? await this._locate(locator) : await this.$$(withStrictLocator(locator))
+    return res
   }
 
   async _startBrowser() {
     try {
       if (this.options.multiremote) {
-        this.browser = await webdriverio.multiremote(this.options.multiremote);
+        this.browser = await webdriverio.multiremote(this.options.multiremote)
       } else {
         // remove non w3c capabilities
-        delete this.options.capabilities.protocol;
-        delete this.options.capabilities.hostname;
-        delete this.options.capabilities.port;
-        delete this.options.capabilities.path;
-        this.browser = await webdriverio.remote(this.options);
+        delete this.options.capabilities.protocol
+        delete this.options.capabilities.hostname
+        delete this.options.capabilities.port
+        delete this.options.capabilities.path
+        this.browser = await webdriverio.remote(this.options)
       }
     } catch (err) {
       if (err.toString().indexOf('ECONNREFUSED')) {
-        throw new ConnectionRefused(err);
+        throw new ConnectionRefused(err)
       }
-      throw err;
+      throw err
     }
 
-    this.isRunning = true;
+    this.isRunning = true
     if (this.options.timeouts && this.isWeb) {
-      await this.defineTimeout(this.options.timeouts);
+      await this.defineTimeout(this.options.timeouts)
     }
 
-    await this._resizeWindowIfNeeded(this.browser, this.options.windowSize);
+    await this._resizeWindowIfNeeded(this.browser, this.options.windowSize)
 
-    this.$$ = this.browser.$$.bind(this.browser);
+    this.$$ = this.browser.$$.bind(this.browser)
 
     if (this._isCustomLocatorStrategyDefined()) {
       Object.keys(this.customLocatorStrategies).forEach(async customLocator => {
-        this.debugSection('Weddriver', `adding custom locator strategy: ${customLocator}`);
-        const locatorFunction = this._lookupCustomLocator(customLocator);
-        this.browser.addLocatorStrategy(customLocator, locatorFunction);
-      });
+        this.debugSection('Weddriver', `adding custom locator strategy: ${customLocator}`)
+        const locatorFunction = this._lookupCustomLocator(customLocator)
+        this.browser.addLocatorStrategy(customLocator, locatorFunction)
+      })
     }
 
     if (this.browser.capabilities && this.browser.capabilities.platformName) {
-      this.browser.capabilities.platformName = this.browser.capabilities.platformName.toLowerCase();
+      this.browser.capabilities.platformName = this.browser.capabilities.platformName.toLowerCase()
     }
 
-    return this.browser;
+    return this.browser
   }
 
   _isCustomLocatorStrategyDefined() {
-    return this.customLocatorStrategies && Object.keys(this.customLocatorStrategies).length;
+    return this.customLocatorStrategies && Object.keys(this.customLocatorStrategies).length
   }
 
   async _stopBrowser() {
-    if (this.browser && this.isRunning) await this.browser.deleteSession();
+    if (this.browser && this.isRunning) await this.browser.deleteSession()
   }
 
   async _before() {
-    this.context = this.root;
-    if (this.options.restart && !this.options.manualStart) return this._startBrowser();
-    if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
-    if (this.browser) this.$$ = this.browser.$$.bind(this.browser);
-    return this.browser;
+    this.context = this.root
+    if (this.options.restart && !this.options.manualStart) return this._startBrowser()
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser()
+    if (this.browser) this.$$ = this.browser.$$.bind(this.browser)
+    return this.browser
   }
 
   async _after() {
-    if (!this.isRunning) return;
+    if (!this.isRunning) return
     if (this.options.restart) {
-      this.isRunning = false;
-      return this.browser.deleteSession();
+      this.isRunning = false
+      return this.browser.deleteSession()
     }
-    if (this.browser.isInsideFrame) await this.browser.switchToFrame(null);
+    if (this.browser.isInsideFrame) await this.browser.switchToFrame(null)
 
-    if (this.options.keepBrowserState) return;
+    if (this.options.keepBrowserState) return
 
     if (!this.options.keepCookies && this.options.capabilities.browserName) {
-      this.debugSection('Session', 'cleaning cookies and localStorage');
-      await this.browser.deleteCookies();
+      this.debugSection('Session', 'cleaning cookies and localStorage')
+      await this.browser.deleteCookies()
     }
     await this.browser.execute('localStorage.clear();').catch(err => {
-      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
-    });
-    await this.closeOtherTabs();
-    return this.browser;
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
+    })
+    await this.closeOtherTabs()
+    return this.browser
   }
 
   _afterSuite() {}
 
   _finishTest() {
-    if (!this.options.restart && this.isRunning) return this._stopBrowser();
+    if (!this.options.restart && this.isRunning) return this._stopBrowser()
   }
 
   _session() {
-    const defaultSession = this.browser;
+    const defaultSession = this.browser
     return {
       start: async (sessionName, opts) => {
         // opts.disableScreenshots = true; // screenshots cant be saved as session will be already closed
-        opts = this._validateConfig(Object.assign(this.options, opts));
-        this.debugSection('New Browser', JSON.stringify(opts));
-        const browser = await webdriverio.remote(opts);
-        this.activeSessionName = sessionName;
+        opts = this._validateConfig(Object.assign(this.options, opts))
+        this.debugSection('New Browser', JSON.stringify(opts))
+        const browser = await webdriverio.remote(opts)
+        this.activeSessionName = sessionName
         if (opts.timeouts && this.isWeb) {
-          await this._defineBrowserTimeout(browser, opts.timeouts);
+          await this._defineBrowserTimeout(browser, opts.timeouts)
         }
 
-        await this._resizeWindowIfNeeded(browser, opts.windowSize);
+        await this._resizeWindowIfNeeded(browser, opts.windowSize)
 
-        return browser;
+        return browser
       },
       stop: async browser => {
-        if (!browser) return;
-        return browser.deleteSession();
+        if (!browser) return
+        return browser.deleteSession()
       },
       loadVars: async browser => {
-        if (this.context !== this.root) throw new Error("Can't start session inside within block");
-        this.browser = browser;
-        this.$$ = this.browser.$$.bind(this.browser);
-        this.sessionWindows[this.activeSessionName] = browser;
+        if (this.context !== this.root) throw new Error("Can't start session inside within block")
+        this.browser = browser
+        this.$$ = this.browser.$$.bind(this.browser)
+        this.sessionWindows[this.activeSessionName] = browser
       },
       restoreVars: async session => {
         if (!session) {
-          this.activeSessionName = '';
+          this.activeSessionName = ''
         }
-        this.browser = defaultSession;
-        this.$$ = this.browser.$$.bind(this.browser);
+        this.browser = defaultSession
+        this.$$ = this.browser.$$.bind(this.browser)
       },
-    };
+    }
   }
 
   /**
@@ -721,41 +721,41 @@ class WebDriver extends Helper {
    * @param {function} fn async functuion that executed with WebDriver helper as argument
    */
   useWebDriverTo(description, fn) {
-    return this._useTo(...arguments);
+    return this._useTo(...arguments)
   }
 
   async _failed() {
-    if (this.context !== this.root) await this._withinEnd();
+    if (this.context !== this.root) await this._withinEnd()
   }
 
   async _withinBegin(locator) {
-    const frame = isFrameLocator(locator);
+    const frame = isFrameLocator(locator)
     if (frame) {
-      this.browser.isInsideFrame = true;
+      this.browser.isInsideFrame = true
       if (Array.isArray(frame)) {
         // this.switchTo(null);
-        await forEachAsync(frame, async f => this.switchTo(f));
-        return;
+        await forEachAsync(frame, async f => this.switchTo(f))
+        return
       }
-      await this.switchTo(frame);
-      return;
+      await this.switchTo(frame)
+      return
     }
-    this.context = locator;
+    this.context = locator
 
-    let res = await this.browser.$$(withStrictLocator(locator));
-    assertElementExists(res, locator);
-    res = usingFirstElement(res);
-    this.context = res.selector;
-    this.$$ = res.$$.bind(res);
+    let res = await this.browser.$$(withStrictLocator(locator))
+    assertElementExists(res, locator)
+    res = usingFirstElement(res)
+    this.context = res.selector
+    this.$$ = res.$$.bind(res)
   }
 
   async _withinEnd() {
     if (this.browser.isInsideFrame) {
-      this.browser.isInsideFrame = false;
-      return this.switchTo(null);
+      this.browser.isInsideFrame = false
+      return this.switchTo(null)
     }
-    this.context = this.root;
-    this.$$ = this.browser.$$.bind(this.browser);
+    this.context = this.root
+    this.$$ = this.browser.$$.bind(this.browser)
   }
 
   /**
@@ -764,7 +764,7 @@ class WebDriver extends Helper {
    * @param {object} locator
    */
   _isShadowLocator(locator) {
-    return locator.type === SHADOW || locator[SHADOW];
+    return locator.type === SHADOW || locator[SHADOW]
   }
 
   /**
@@ -773,37 +773,37 @@ class WebDriver extends Helper {
    * @param {object} locator
    */
   async _locateShadow(locator) {
-    const shadow = locator.value ? locator.value : locator[SHADOW];
-    const shadowSequence = [];
-    let elements;
+    const shadow = locator.value ? locator.value : locator[SHADOW]
+    const shadowSequence = []
+    let elements
 
     if (!Array.isArray(shadow)) {
-      throw new Error(`Shadow '${shadow}' should be defined as an Array of elements.`);
+      throw new Error(`Shadow '${shadow}' should be defined as an Array of elements.`)
     }
 
     // traverse through the Shadow locators in sequence
     for (let index = 0; index < shadow.length; index++) {
-      const shadowElement = shadow[index];
-      shadowSequence.push(shadowElement);
+      const shadowElement = shadow[index]
+      shadowSequence.push(shadowElement)
 
       if (!elements) {
-        elements = await this.browser.$$(shadowElement);
+        elements = await this.browser.$$(shadowElement)
       } else if (Array.isArray(elements)) {
-        elements = await elements[0].shadow$$(shadowElement);
+        elements = await elements[0].shadow$$(shadowElement)
       } else if (elements) {
-        elements = await elements.shadow$$(shadowElement);
+        elements = await elements.shadow$$(shadowElement)
       }
 
       if (!elements || !elements[0]) {
         throw new Error(
           `Shadow Element '${shadowElement}' is not found. It is possible the element is incorrect or elements sequence is incorrect. Please verify the sequence '${shadowSequence.join('>')}' is correctly chained.`,
-        );
+        )
       }
     }
 
-    this.debugSection('Elements', `Found ${elements.length} '${SHADOW}' elements`);
+    this.debugSection('Elements', `Found ${elements.length} '${SHADOW}' elements`)
 
-    return elements;
+    return elements
   }
 
   /**
@@ -812,8 +812,8 @@ class WebDriver extends Helper {
    * @param {object} locator
    */
   async _smartWait(locator) {
-    this.debugSection(`SmartWait (${this.options.smartWait}ms)`, `Locating ${JSON.stringify(locator)} in ${this.options.smartWait}`);
-    await this.defineTimeout({ implicit: this.options.smartWait });
+    this.debugSection(`SmartWait (${this.options.smartWait}ms)`, `Locating ${JSON.stringify(locator)} in ${this.options.smartWait}`)
+    await this.defineTimeout({ implicit: this.options.smartWait })
   }
 
   /**
@@ -828,53 +828,53 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locate(locator, smartWait = false) {
-    if (require('../store').debugMode) smartWait = false;
+    if (require('../store').debugMode) smartWait = false
 
     // special locator type for Shadow DOM
     if (this._isShadowLocator(locator)) {
       if (!this.options.smartWait || !smartWait) {
-        const els = await this._locateShadow(locator);
-        return els;
+        const els = await this._locateShadow(locator)
+        return els
       }
 
-      const els = await this._locateShadow(locator);
-      return els;
+      const els = await this._locateShadow(locator)
+      return els
     }
 
     // special locator type for React
     if (locator.react) {
-      const els = await this.browser.react$$(locator.react, locator.props || undefined, locator.state || undefined);
-      this.debugSection('Elements', `Found ${els.length} react components`);
-      return els;
+      const els = await this.browser.react$$(locator.react, locator.props || undefined, locator.state || undefined)
+      this.debugSection('Elements', `Found ${els.length} react components`)
+      return els
     }
 
     if (!this.options.smartWait || !smartWait) {
       if (this._isCustomLocator(locator)) {
-        const locatorObj = new Locator(locator);
-        return this.browser.custom$$(locatorObj.type, locatorObj.value);
+        const locatorObj = new Locator(locator)
+        return this.browser.custom$$(locatorObj.type, locatorObj.value)
       }
 
-      const els = await this.$$(withStrictLocator(locator));
-      return els;
+      const els = await this.$$(withStrictLocator(locator))
+      return els
     }
 
-    await this._smartWait(locator);
+    await this._smartWait(locator)
 
     if (this._isCustomLocator(locator)) {
-      const locatorObj = new Locator(locator);
-      return this.browser.custom$$(locatorObj.type, locatorObj.value);
+      const locatorObj = new Locator(locator)
+      return this.browser.custom$$(locatorObj.type, locatorObj.value)
     }
 
-    const els = await this.$$(withStrictLocator(locator));
-    await this.defineTimeout({ implicit: 0 });
-    return els;
+    const els = await this.$$(withStrictLocator(locator))
+    await this.defineTimeout({ implicit: 0 })
+    return els
   }
 
   _grabCustomLocator(locator) {
     if (typeof locator === 'string') {
-      locator = new Locator(locator);
+      locator = new Locator(locator)
     }
-    return locator.value ? locator.value : locator.custom;
+    return locator.value ? locator.value : locator.custom
   }
 
   /**
@@ -887,7 +887,7 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locateCheckable(locator) {
-    return findCheckable.call(this, locator, this.$$.bind(this)).then(res => res);
+    return findCheckable.call(this, locator, this.$$.bind(this)).then(res => res)
   }
 
   /**
@@ -901,8 +901,8 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locateClickable(locator, context) {
-    const locateFn = prepareLocateFn.call(this, context);
-    return findClickable.call(this, locator, locateFn);
+    const locateFn = prepareLocateFn.call(this, context)
+    return findClickable.call(this, locator, locateFn)
   }
 
   /**
@@ -915,7 +915,7 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locateFields(locator) {
-    return findFields.call(this, locator).then(res => res);
+    return findFields.call(this, locator).then(res => res)
   }
 
   /**
@@ -923,7 +923,7 @@ class WebDriver extends Helper {
    *
    */
   async grabWebElements(locator) {
-    return this._locate(locator);
+    return this._locate(locator)
   }
 
   /**
@@ -939,11 +939,11 @@ class WebDriver extends Helper {
    * @param {*} timeouts WebDriver timeouts object.
    */
   defineTimeout(timeouts) {
-    return this._defineBrowserTimeout(this.browser, timeouts);
+    return this._defineBrowserTimeout(this.browser, timeouts)
   }
 
   _defineBrowserTimeout(browser, timeouts) {
-    return browser.setTimeout(timeouts);
+    return browser.setTimeout(timeouts)
   }
 
   /**
@@ -951,15 +951,15 @@ class WebDriver extends Helper {
    *
    */
   amOnPage(url) {
-    let split_url;
+    let split_url
     if (this.options.basicAuth) {
       if (url.startsWith('/')) {
-        url = this.options.url + url;
+        url = this.options.url + url
       }
-      split_url = url.split('//');
-      url = `${split_url[0]}//${this.options.basicAuth.username}:${this.options.basicAuth.password}@${split_url[1]}`;
+      split_url = url.split('//')
+      url = `${split_url[0]}//${this.options.basicAuth.username}:${this.options.basicAuth.password}@${split_url[1]}`
     }
-    return this.browser.url(url);
+    return this.browser.url(url)
   }
 
   /**
@@ -968,18 +968,18 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async click(locator, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
-    const locateFn = prepareLocateFn.call(this, context);
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findClickable.call(this, locator, locateFn);
+    const res = await findClickable.call(this, locator, locateFn)
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
     } else {
-      assertElementExists(res, locator, 'Clickable element');
+      assertElementExists(res, locator, 'Clickable element')
     }
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
-    return this.browser[clickMethod](getElementId(elem));
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
+    return this.browser[clickMethod](getElementId(elem))
   }
 
   /**
@@ -988,25 +988,25 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async forceClick(locator, context = null) {
-    const locateFn = prepareLocateFn.call(this, context);
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findClickable.call(this, locator, locateFn);
+    const res = await findClickable.call(this, locator, locateFn)
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
     } else {
-      assertElementExists(res, locator, 'Clickable element');
+      assertElementExists(res, locator, 'Clickable element')
     }
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
 
     return this.executeScript(el => {
       if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
+        document.activeElement.blur()
       }
-      const event = document.createEvent('MouseEvent');
-      event.initEvent('click', true, true);
-      return el.dispatchEvent(event);
-    }, elem);
+      const event = document.createEvent('MouseEvent')
+      event.initEvent('click', true, true)
+      return el.dispatchEvent(event)
+    }, elem)
   }
 
   /**
@@ -1015,18 +1015,18 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async doubleClick(locator, context = null) {
-    const locateFn = prepareLocateFn.call(this, context);
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findClickable.call(this, locator, locateFn);
+    const res = await findClickable.call(this, locator, locateFn)
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
     } else {
-      assertElementExists(res, locator, 'Clickable element');
+      assertElementExists(res, locator, 'Clickable element')
     }
 
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
-    return elem.doubleClick();
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
+    return elem.doubleClick()
   }
 
   /**
@@ -1035,24 +1035,24 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async rightClick(locator, context) {
-    const locateFn = prepareLocateFn.call(this, context);
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findClickable.call(this, locator, locateFn);
+    const res = await findClickable.call(this, locator, locateFn)
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
     } else {
-      assertElementExists(res, locator, 'Clickable element');
+      assertElementExists(res, locator, 'Clickable element')
     }
 
-    const el = usingFirstElement(res);
+    const el = usingFirstElement(res)
 
-    await el.moveTo();
+    await el.moveTo()
 
     if (this.browser.isW3C) {
-      return el.click({ button: 'right' });
+      return el.click({ button: 'right' })
     }
     // JSON Wire version
-    await this.browser.buttonDown(2);
+    await this.browser.buttonDown(2)
   }
 
   /**
@@ -1061,24 +1061,24 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async forceRightClick(locator, context = null) {
-    const locateFn = prepareLocateFn.call(this, context);
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findClickable.call(this, locator, locateFn);
+    const res = await findClickable.call(this, locator, locateFn)
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
     } else {
-      assertElementExists(res, locator, 'Clickable element');
+      assertElementExists(res, locator, 'Clickable element')
     }
-    const elem = usingFirstElement(res);
+    const elem = usingFirstElement(res)
 
     return this.executeScript(el => {
       if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
+        document.activeElement.blur()
       }
-      const event = document.createEvent('MouseEvent');
-      event.initEvent('contextmenu', true, true);
-      return el.dispatchEvent(event);
-    }, elem);
+      const event = document.createEvent('MouseEvent')
+      event.initEvent('contextmenu', true, true)
+      return el.dispatchEvent(event)
+    }, elem)
   }
 
   /**
@@ -1088,12 +1088,12 @@ class WebDriver extends Helper {
    *
    */
   async fillField(field, value) {
-    const res = await findFields.call(this, field);
-    assertElementExists(res, field, 'Field');
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
-    await elem.clearValue();
-    await elem.setValue(value.toString());
+    const res = await findFields.call(this, field)
+    assertElementExists(res, field, 'Field')
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
+    await elem.clearValue()
+    await elem.setValue(value.toString())
   }
 
   /**
@@ -1101,11 +1101,11 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async appendField(field, value) {
-    const res = await findFields.call(this, field);
-    assertElementExists(res, field, 'Field');
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
-    return elem.addValue(value.toString());
+    const res = await findFields.call(this, field)
+    assertElementExists(res, field, 'Field')
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
+    return elem.addValue(value.toString())
   }
 
   /**
@@ -1113,44 +1113,44 @@ class WebDriver extends Helper {
    *
    */
   async clearField(field) {
-    const res = await findFields.call(this, field);
-    assertElementExists(res, field, 'Field');
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
-    return elem.clearValue(getElementId(elem));
+    const res = await findFields.call(this, field)
+    assertElementExists(res, field, 'Field')
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
+    return elem.clearValue(getElementId(elem))
   }
 
   /**
    * {{> selectOption }}
    */
   async selectOption(select, option) {
-    const res = await findFields.call(this, select);
-    assertElementExists(res, select, 'Selectable field');
-    const elem = usingFirstElement(res);
-    highlightActiveElement.call(this, elem);
+    const res = await findFields.call(this, select)
+    assertElementExists(res, select, 'Selectable field')
+    const elem = usingFirstElement(res)
+    highlightActiveElement.call(this, elem)
 
     if (!Array.isArray(option)) {
-      option = [option];
+      option = [option]
     }
 
     // select options by visible text
-    let els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byVisibleText(xpathLocator.literal(opt))));
+    let els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byVisibleText(xpathLocator.literal(opt))))
 
     const clickOptionFn = async el => {
-      if (el[0]) el = el[0];
-      const elementId = getElementId(el);
-      if (elementId) return this.browser.elementClick(elementId);
-    };
+      if (el[0]) el = el[0]
+      const elementId = getElementId(el)
+      if (elementId) return this.browser.elementClick(elementId)
+    }
 
     if (Array.isArray(els) && els.length) {
-      return forEachAsync(els, clickOptionFn);
+      return forEachAsync(els, clickOptionFn)
     }
     // select options by value
-    els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byValue(xpathLocator.literal(opt))));
+    els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byValue(xpathLocator.literal(opt))))
     if (els.length === 0) {
-      throw new ElementNotFound(select, `Option "${option}" in`, 'was not found neither by a visible text nor by a value');
+      throw new ElementNotFound(select, `Option "${option}" in`, 'was not found neither by a visible text nor by a value')
     }
-    return forEachAsync(els, clickOptionFn);
+    return forEachAsync(els, clickOptionFn)
   }
 
   /**
@@ -1159,27 +1159,27 @@ class WebDriver extends Helper {
    * {{> attachFile }}
    */
   async attachFile(locator, pathToFile) {
-    let file = path.join(global.codecept_dir, pathToFile);
+    let file = path.join(global.codecept_dir, pathToFile)
     if (!fileExists(file)) {
-      throw new Error(`File at ${file} can not be found on local system`);
+      throw new Error(`File at ${file} can not be found on local system`)
     }
 
-    const res = await findFields.call(this, locator);
-    this.debug(`Uploading ${file}`);
-    assertElementExists(res, locator, 'File field');
-    const el = usingFirstElement(res);
+    const res = await findFields.call(this, locator)
+    this.debug(`Uploading ${file}`)
+    assertElementExists(res, locator, 'File field')
+    const el = usingFirstElement(res)
 
     // Remote Upload (when running Selenium Server)
     if (this.options.remoteFileUpload) {
       try {
-        this.debugSection('File', 'Uploading file to remote server');
-        file = await this.browser.uploadFile(file);
+        this.debugSection('File', 'Uploading file to remote server')
+        file = await this.browser.uploadFile(file)
       } catch (err) {
-        throw new Error(`File can't be transferred to remote server. Set \`remoteFileUpload: false\` in config to upload file locally.\n${err.message}`);
+        throw new Error(`File can't be transferred to remote server. Set \`remoteFileUpload: false\` in config to upload file locally.\n${err.message}`)
       }
     }
 
-    return el.addValue(file);
+    return el.addValue(file)
   }
 
   /**
@@ -1187,19 +1187,19 @@ class WebDriver extends Helper {
    * {{> checkOption }}
    */
   async checkOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
-    const locateFn = prepareLocateFn.call(this, context);
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findCheckable.call(this, field, locateFn);
+    const res = await findCheckable.call(this, field, locateFn)
 
-    assertElementExists(res, field, 'Checkable');
-    const elem = usingFirstElement(res);
-    const elementId = getElementId(elem);
-    highlightActiveElement.call(this, elem);
+    assertElementExists(res, field, 'Checkable')
+    const elem = usingFirstElement(res)
+    const elementId = getElementId(elem)
+    highlightActiveElement.call(this, elem)
 
-    const isSelected = await this.browser.isElementSelected(elementId);
-    if (isSelected) return Promise.resolve(true);
-    return this.browser[clickMethod](elementId);
+    const isSelected = await this.browser.isElementSelected(elementId)
+    if (isSelected) return Promise.resolve(true)
+    return this.browser[clickMethod](elementId)
   }
 
   /**
@@ -1207,19 +1207,19 @@ class WebDriver extends Helper {
    * {{> uncheckOption }}
    */
   async uncheckOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
-    const locateFn = prepareLocateFn.call(this, context);
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
+    const locateFn = prepareLocateFn.call(this, context)
 
-    const res = await findCheckable.call(this, field, locateFn);
+    const res = await findCheckable.call(this, field, locateFn)
 
-    assertElementExists(res, field, 'Checkable');
-    const elem = usingFirstElement(res);
-    const elementId = getElementId(elem);
-    highlightActiveElement.call(this, elem);
+    assertElementExists(res, field, 'Checkable')
+    const elem = usingFirstElement(res)
+    const elementId = getElementId(elem)
+    highlightActiveElement.call(this, elem)
 
-    const isSelected = await this.browser.isElementSelected(elementId);
-    if (!isSelected) return Promise.resolve(true);
-    return this.browser[clickMethod](elementId);
+    const isSelected = await this.browser.isElementSelected(elementId)
+    if (!isSelected) return Promise.resolve(true)
+    return this.browser[clickMethod](elementId)
   }
 
   /**
@@ -1227,14 +1227,14 @@ class WebDriver extends Helper {
    *
    */
   async grabTextFromAll(locator) {
-    const res = await this._locate(locator, true);
-    let val = [];
+    const res = await this._locate(locator, true)
+    let val = []
     await forEachAsync(res, async el => {
-      const text = await this.browser.getElementText(getElementId(el));
-      val.push(text);
-    });
-    this.debugSection('GrabText', String(val));
-    return val;
+      const text = await this.browser.getElementText(getElementId(el))
+      val.push(text)
+    })
+    this.debugSection('GrabText', String(val))
+    return val
   }
 
   /**
@@ -1242,13 +1242,13 @@ class WebDriver extends Helper {
    *
    */
   async grabTextFrom(locator) {
-    const texts = await this.grabTextFromAll(locator);
-    assertElementExists(texts, locator);
+    const texts = await this.grabTextFromAll(locator)
+    assertElementExists(texts, locator)
     if (texts.length > 1) {
-      this.debugSection('GrabText', `Using first element out of ${texts.length}`);
+      this.debugSection('GrabText', `Using first element out of ${texts.length}`)
     }
 
-    return texts[0];
+    return texts[0]
   }
 
   /**
@@ -1256,10 +1256,10 @@ class WebDriver extends Helper {
    *
    */
   async grabHTMLFromAll(locator) {
-    const elems = await this._locate(locator, true);
-    const html = await forEachAsync(elems, elem => elem.getHTML(false));
-    this.debugSection('GrabHTML', String(html));
-    return html;
+    const elems = await this._locate(locator, true)
+    const html = await forEachAsync(elems, elem => elem.getHTML(false))
+    this.debugSection('GrabHTML', String(html))
+    return html
   }
 
   /**
@@ -1267,13 +1267,13 @@ class WebDriver extends Helper {
    *
    */
   async grabHTMLFrom(locator) {
-    const html = await this.grabHTMLFromAll(locator);
-    assertElementExists(html, locator);
+    const html = await this.grabHTMLFromAll(locator)
+    assertElementExists(html, locator)
     if (html.length > 1) {
-      this.debugSection('GrabHTML', `Using first element out of ${html.length}`);
+      this.debugSection('GrabHTML', `Using first element out of ${html.length}`)
     }
 
-    return html[0];
+    return html[0]
   }
 
   /**
@@ -1281,11 +1281,11 @@ class WebDriver extends Helper {
    *
    */
   async grabValueFromAll(locator) {
-    const res = await this._locate(locator, true);
-    const val = await forEachAsync(res, el => el.getValue());
-    this.debugSection('GrabValue', String(val));
+    const res = await this._locate(locator, true)
+    const val = await forEachAsync(res, el => el.getValue())
+    this.debugSection('GrabValue', String(val))
 
-    return val;
+    return val
   }
 
   /**
@@ -1293,92 +1293,92 @@ class WebDriver extends Helper {
    *
    */
   async grabValueFrom(locator) {
-    const values = await this.grabValueFromAll(locator);
-    assertElementExists(values, locator);
+    const values = await this.grabValueFromAll(locator)
+    assertElementExists(values, locator)
     if (values.length > 1) {
-      this.debugSection('GrabValue', `Using first element out of ${values.length}`);
+      this.debugSection('GrabValue', `Using first element out of ${values.length}`)
     }
 
-    return values[0];
+    return values[0]
   }
 
   /**
    * {{> grabCssPropertyFromAll }}
    */
   async grabCssPropertyFromAll(locator, cssProperty) {
-    const res = await this._locate(locator, true);
-    const val = await forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
-    this.debugSection('Grab', String(val));
-    return val;
+    const res = await this._locate(locator, true)
+    const val = await forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty))
+    this.debugSection('Grab', String(val))
+    return val
   }
 
   /**
    * {{> grabCssPropertyFrom }}
    */
   async grabCssPropertyFrom(locator, cssProperty) {
-    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty);
-    assertElementExists(cssValues, locator);
+    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty)
+    assertElementExists(cssValues, locator)
 
     if (cssValues.length > 1) {
-      this.debugSection('GrabCSS', `Using first element out of ${cssValues.length}`);
+      this.debugSection('GrabCSS', `Using first element out of ${cssValues.length}`)
     }
 
-    return cssValues[0];
+    return cssValues[0]
   }
 
   /**
    * {{> grabAttributeFromAll }}
    */
   async grabAttributeFromAll(locator, attr) {
-    const res = await this._locate(locator, true);
-    const val = await forEachAsync(res, async el => el.getAttribute(attr));
-    this.debugSection('GrabAttribute', String(val));
-    return val;
+    const res = await this._locate(locator, true)
+    const val = await forEachAsync(res, async el => el.getAttribute(attr))
+    this.debugSection('GrabAttribute', String(val))
+    return val
   }
 
   /**
    * {{> grabAttributeFrom }}
    */
   async grabAttributeFrom(locator, attr) {
-    const attrs = await this.grabAttributeFromAll(locator, attr);
-    assertElementExists(attrs, locator);
+    const attrs = await this.grabAttributeFromAll(locator, attr)
+    assertElementExists(attrs, locator)
     if (attrs.length > 1) {
-      this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`);
+      this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`)
     }
-    return attrs[0];
+    return attrs[0]
   }
 
   /**
    * {{> seeInTitle }}
    */
   async seeInTitle(text) {
-    const title = await this.browser.getTitle();
-    return stringIncludes('web page title').assert(text, title);
+    const title = await this.browser.getTitle()
+    return stringIncludes('web page title').assert(text, title)
   }
 
   /**
    * {{> seeTitleEquals }}
    */
   async seeTitleEquals(text) {
-    const title = await this.browser.getTitle();
-    return assert.equal(title, text, `expected web page title to be ${text}, but found ${title}`);
+    const title = await this.browser.getTitle()
+    return assert.equal(title, text, `expected web page title to be ${text}, but found ${title}`)
   }
 
   /**
    * {{> dontSeeInTitle }}
    */
   async dontSeeInTitle(text) {
-    const title = await this.browser.getTitle();
-    return stringIncludes('web page title').negate(text, title);
+    const title = await this.browser.getTitle()
+    return stringIncludes('web page title').negate(text, title)
   }
 
   /**
    * {{> grabTitle }}
    */
   async grabTitle() {
-    const title = await this.browser.getTitle();
-    this.debugSection('Title', title);
-    return title;
+    const title = await this.browser.getTitle()
+    this.debugSection('Title', title)
+    return title
   }
 
   /**
@@ -1387,14 +1387,14 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async see(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context);
+    return proceedSee.call(this, 'assert', text, context)
   }
 
   /**
    * {{> seeTextEquals }}
    */
   async seeTextEquals(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context, true);
+    return proceedSee.call(this, 'assert', text, context, true)
   }
 
   /**
@@ -1403,7 +1403,7 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async dontSee(text, context = null) {
-    return proceedSee.call(this, 'negate', text, context);
+    return proceedSee.call(this, 'negate', text, context)
   }
 
   /**
@@ -1411,8 +1411,8 @@ class WebDriver extends Helper {
    *
    */
   async seeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString();
-    return proceedSeeField.call(this, 'assert', field, _value);
+    const _value = typeof value === 'boolean' ? value : value.toString()
+    return proceedSeeField.call(this, 'assert', field, _value)
   }
 
   /**
@@ -1420,8 +1420,8 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString();
-    return proceedSeeField.call(this, 'negate', field, _value);
+    const _value = typeof value === 'boolean' ? value : value.toString()
+    return proceedSeeField.call(this, 'negate', field, _value)
   }
 
   /**
@@ -1429,7 +1429,7 @@ class WebDriver extends Helper {
    * {{> seeCheckboxIsChecked }}
    */
   async seeCheckboxIsChecked(field) {
-    return proceedSeeCheckbox.call(this, 'assert', field);
+    return proceedSeeCheckbox.call(this, 'assert', field)
   }
 
   /**
@@ -1437,7 +1437,7 @@ class WebDriver extends Helper {
    * {{> dontSeeCheckboxIsChecked }}
    */
   async dontSeeCheckboxIsChecked(field) {
-    return proceedSeeCheckbox.call(this, 'negate', field);
+    return proceedSeeCheckbox.call(this, 'negate', field)
   }
 
   /**
@@ -1446,13 +1446,13 @@ class WebDriver extends Helper {
    *
    */
   async seeElement(locator) {
-    const res = await this._locate(locator, true);
-    assertElementExists(res, locator);
-    const selected = await forEachAsync(res, async el => el.isDisplayed());
+    const res = await this._locate(locator, true)
+    assertElementExists(res, locator)
+    const selected = await forEachAsync(res, async el => el.isDisplayed())
     try {
-      return truth(`elements of ${new Locator(locator)}`, 'to be seen').assert(selected);
+      return truth(`elements of ${new Locator(locator)}`, 'to be seen').assert(selected)
     } catch (e) {
-      dontSeeElementError(locator);
+      dontSeeElementError(locator)
     }
   }
 
@@ -1461,15 +1461,15 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async dontSeeElement(locator) {
-    const res = await this._locate(locator, false);
+    const res = await this._locate(locator, false)
     if (!res || res.length === 0) {
-      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(false);
+      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(false)
     }
-    const selected = await forEachAsync(res, async el => el.isDisplayed());
+    const selected = await forEachAsync(res, async el => el.isDisplayed())
     try {
-      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(selected);
+      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(selected)
     } catch (e) {
-      seeElementError(locator);
+      seeElementError(locator)
     }
   }
 
@@ -1478,11 +1478,11 @@ class WebDriver extends Helper {
    *
    */
   async seeElementInDOM(locator) {
-    const res = await this._res(locator);
+    const res = await this._res(locator)
     try {
-      return empty('elements').negate(res);
+      return empty('elements').negate(res)
     } catch (e) {
-      dontSeeElementInDOMError(locator);
+      dontSeeElementInDOMError(locator)
     }
   }
 
@@ -1491,11 +1491,11 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeElementInDOM(locator) {
-    const res = await this._res(locator);
+    const res = await this._res(locator)
     try {
-      return empty('elements').assert(res);
+      return empty('elements').assert(res)
     } catch (e) {
-      seeElementInDOMError(locator);
+      seeElementInDOMError(locator)
     }
   }
 
@@ -1504,8 +1504,8 @@ class WebDriver extends Helper {
    *
    */
   async seeInSource(text) {
-    const source = await this.browser.getPageSource();
-    return stringIncludes('HTML source of a page').assert(text, source);
+    const source = await this.browser.getPageSource()
+    return stringIncludes('HTML source of a page').assert(text, source)
   }
 
   /**
@@ -1513,7 +1513,7 @@ class WebDriver extends Helper {
    *
    */
   async grabSource() {
-    return this.browser.getPageSource();
+    return this.browser.getPageSource()
   }
 
   /**
@@ -1521,27 +1521,27 @@ class WebDriver extends Helper {
    */
   async grabBrowserLogs() {
     if (this.browser.isW3C) {
-      this.debug('Logs not available in W3C specification');
-      return;
+      this.debug('Logs not available in W3C specification')
+      return
     }
-    return this.browser.getLogs('browser');
+    return this.browser.getLogs('browser')
   }
 
   /**
    * {{> grabCurrentUrl }}
    */
   async grabCurrentUrl() {
-    const res = await this.browser.getUrl();
-    this.debugSection('Url', res);
-    return res;
+    const res = await this.browser.getUrl()
+    this.debugSection('Url', res)
+    return res
   }
 
   /**
    * {{> dontSeeInSource }}
    */
   async dontSeeInSource(text) {
-    const source = await this.browser.getPageSource();
-    return stringIncludes('HTML source of a page').negate(text, source);
+    const source = await this.browser.getPageSource()
+    return stringIncludes('HTML source of a page').negate(text, source)
   }
 
   /**
@@ -1549,8 +1549,8 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async seeNumberOfElements(locator, num) {
-    const res = await this._locate(locator);
-    return assert.equal(res.length, num, `expected number of elements (${new Locator(locator)}) is ${num}, but found ${res.length}`);
+    const res = await this._locate(locator)
+    return assert.equal(res.length, num, `expected number of elements (${new Locator(locator)}) is ${num}, but found ${res.length}`)
   }
 
   /**
@@ -1558,83 +1558,83 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async seeNumberOfVisibleElements(locator, num) {
-    const res = await this.grabNumberOfVisibleElements(locator);
-    return assert.equal(res, num, `expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`);
+    const res = await this.grabNumberOfVisibleElements(locator)
+    return assert.equal(res, num, `expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`)
   }
 
   /**
    * {{> seeCssPropertiesOnElements }}
    */
   async seeCssPropertiesOnElements(locator, cssProperties) {
-    const res = await this._locate(locator);
-    assertElementExists(res, locator);
+    const res = await this._locate(locator)
+    assertElementExists(res, locator)
 
-    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties);
-    const elemAmount = res.length;
-    let props = [];
+    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties)
+    const elemAmount = res.length
+    let props = []
 
     for (const element of res) {
       for (const prop of Object.keys(cssProperties)) {
-        const cssProp = await this.grabCssPropertyFrom(locator, prop);
+        const cssProp = await this.grabCssPropertyFrom(locator, prop)
         if (isColorProperty(prop)) {
-          props.push(convertColorToRGBA(cssProp));
+          props.push(convertColorToRGBA(cssProp))
         } else {
-          props.push(cssProp);
+          props.push(cssProp)
         }
       }
     }
 
-    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key]);
-    if (!Array.isArray(props)) props = [props];
-    let chunked = chunkArray(props, values.length);
+    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key])
+    if (!Array.isArray(props)) props = [props]
+    let chunked = chunkArray(props, values.length)
     chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // eslint-disable-next-line eqeqeq
-        if (val[i] != values[i]) return false;
+        if (val[i] != values[i]) return false
       }
-      return true;
-    });
-    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
+      return true
+    })
+    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount)
   }
 
   /**
    * {{> seeAttributesOnElements }}
    */
   async seeAttributesOnElements(locator, attributes) {
-    const res = await this._locate(locator);
-    assertElementExists(res, locator);
-    const elemAmount = res.length;
+    const res = await this._locate(locator)
+    assertElementExists(res, locator)
+    const elemAmount = res.length
 
     let attrs = await forEachAsync(res, async el => {
-      return forEachAsync(Object.keys(attributes), async attr => el.getAttribute(attr));
-    });
+      return forEachAsync(Object.keys(attributes), async attr => el.getAttribute(attr))
+    })
 
-    const values = Object.keys(attributes).map(key => attributes[key]);
-    if (!Array.isArray(attrs)) attrs = [attrs];
-    let chunked = chunkArray(attrs, values.length);
+    const values = Object.keys(attributes).map(key => attributes[key])
+    if (!Array.isArray(attrs)) attrs = [attrs]
+    let chunked = chunkArray(attrs, values.length)
     chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
-        const _actual = Number.isNaN(val[i]) || typeof values[i] === 'string' ? val[i] : Number.parseInt(val[i], 10);
-        const _expected = Number.isNaN(values[i]) || typeof values[i] === 'string' ? values[i] : Number.parseInt(values[i], 10);
+        const _actual = Number.isNaN(val[i]) || typeof values[i] === 'string' ? val[i] : Number.parseInt(val[i], 10)
+        const _expected = Number.isNaN(values[i]) || typeof values[i] === 'string' ? values[i] : Number.parseInt(values[i], 10)
         // the attribute could be a boolean
-        if (typeof _actual === 'boolean') return _actual === _expected;
-        if (_actual !== _expected) return false;
+        if (typeof _actual === 'boolean') return _actual === _expected
+        if (_actual !== _expected) return false
       }
-      return true;
-    });
-    return assert.ok(chunked.length === elemAmount, `expected all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`);
+      return true
+    })
+    return assert.ok(chunked.length === elemAmount, `expected all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`)
   }
 
   /**
    * {{> grabNumberOfVisibleElements }}
    */
   async grabNumberOfVisibleElements(locator) {
-    const res = await this._locate(locator);
+    const res = await this._locate(locator)
 
-    let selected = await forEachAsync(res, async el => el.isDisplayed());
-    if (!Array.isArray(selected)) selected = [selected];
-    selected = selected.filter(val => val === true);
-    return selected.length;
+    let selected = await forEachAsync(res, async el => el.isDisplayed())
+    if (!Array.isArray(selected)) selected = [selected]
+    selected = selected.filter(val => val === true)
+    return selected.length
   }
 
   /**
@@ -1642,8 +1642,8 @@ class WebDriver extends Helper {
    *
    */
   async seeInCurrentUrl(url) {
-    const res = await this.browser.getUrl();
-    return stringIncludes('url').assert(url, decodeUrl(res));
+    const res = await this.browser.getUrl()
+    return stringIncludes('url').assert(url, decodeUrl(res))
   }
 
   /**
@@ -1651,8 +1651,8 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeInCurrentUrl(url) {
-    const res = await this.browser.getUrl();
-    return stringIncludes('url').negate(url, decodeUrl(res));
+    const res = await this.browser.getUrl()
+    return stringIncludes('url').negate(url, decodeUrl(res))
   }
 
   /**
@@ -1660,8 +1660,8 @@ class WebDriver extends Helper {
    *
    */
   async seeCurrentUrlEquals(url) {
-    const res = await this.browser.getUrl();
-    return urlEquals(this.options.url).assert(url, decodeUrl(res));
+    const res = await this.browser.getUrl()
+    return urlEquals(this.options.url).assert(url, decodeUrl(res))
   }
 
   /**
@@ -1669,8 +1669,8 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeCurrentUrlEquals(url) {
-    const res = await this.browser.getUrl();
-    return urlEquals(this.options.url).negate(url, decodeUrl(res));
+    const res = await this.browser.getUrl()
+    return urlEquals(this.options.url).negate(url, decodeUrl(res))
   }
 
   /**
@@ -1679,7 +1679,7 @@ class WebDriver extends Helper {
    * {{> executeScript }}
    */
   executeScript(...args) {
-    return this.browser.execute.apply(this.browser, args);
+    return this.browser.execute.apply(this.browser, args)
   }
 
   /**
@@ -1687,7 +1687,7 @@ class WebDriver extends Helper {
    *
    */
   executeAsyncScript(...args) {
-    return this.browser.executeAsync.apply(this.browser, args);
+    return this.browser.executeAsync.apply(this.browser, args)
   }
 
   /**
@@ -1695,10 +1695,10 @@ class WebDriver extends Helper {
    *
    */
   async scrollIntoView(locator, scrollIntoViewOptions) {
-    const res = await this._locate(withStrictLocator(locator), true);
-    assertElementExists(res, locator);
-    const elem = usingFirstElement(res);
-    return elem.scrollIntoView(scrollIntoViewOptions);
+    const res = await this._locate(withStrictLocator(locator), true)
+    assertElementExists(res, locator)
+    const elem = usingFirstElement(res)
+    return elem.scrollIntoView(scrollIntoViewOptions)
   }
 
   /**
@@ -1707,51 +1707,51 @@ class WebDriver extends Helper {
    */
   async scrollTo(locator, offsetX = 0, offsetY = 0) {
     if (typeof locator === 'number' && typeof offsetX === 'number') {
-      offsetY = offsetX;
-      offsetX = locator;
-      locator = null;
+      offsetY = offsetX
+      offsetX = locator
+      locator = null
     }
 
     if (locator) {
-      const res = await this._locate(withStrictLocator(locator), true);
-      assertElementExists(res, locator);
-      const elem = usingFirstElement(res);
-      const elementId = getElementId(elem);
-      if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(offsetX, offsetY, elementId);
-      const location = await elem.getLocation();
-      assertElementExists(location, locator, 'Failed to receive', 'location');
+      const res = await this._locate(withStrictLocator(locator), true)
+      assertElementExists(res, locator)
+      const elem = usingFirstElement(res)
+      const elementId = getElementId(elem)
+      if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(offsetX, offsetY, elementId)
+      const location = await elem.getLocation()
+      assertElementExists(location, locator, 'Failed to receive', 'location')
 
       return this.browser.execute(
         function (x, y) {
-          return window.scrollTo(x, y);
+          return window.scrollTo(x, y)
         },
         location.x + offsetX,
         location.y + offsetY,
-      );
+      )
     }
 
-    if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(locator, offsetX, offsetY);
+    if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(locator, offsetX, offsetY)
 
     return this.browser.execute(
       function (x, y) {
-        return window.scrollTo(x, y);
+        return window.scrollTo(x, y)
       },
       offsetX,
       offsetY,
-    );
+    )
   }
 
   /**
    * {{> moveCursorTo }}
    */
   async moveCursorTo(locator, xOffset, yOffset) {
-    const res = await this._locate(withStrictLocator(locator), true);
-    assertElementExists(res, locator);
-    const elem = usingFirstElement(res);
+    const res = await this._locate(withStrictLocator(locator), true)
+    assertElementExists(res, locator)
+    const elem = usingFirstElement(res)
     try {
-      await elem.moveTo({ xOffset, yOffset });
+      await elem.moveTo({ xOffset, yOffset })
     } catch (e) {
-      debug(e.message);
+      debug(e.message)
     }
   }
 
@@ -1760,61 +1760,61 @@ class WebDriver extends Helper {
    *
    */
   async saveElementScreenshot(locator, fileName) {
-    const outputFile = screenshotOutputFolder(fileName);
+    const outputFile = screenshotOutputFolder(fileName)
 
-    const res = await this._locate(withStrictLocator(locator), true);
-    assertElementExists(res, locator);
-    const elem = usingFirstElement(res);
+    const res = await this._locate(withStrictLocator(locator), true)
+    assertElementExists(res, locator)
+    const elem = usingFirstElement(res)
 
-    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`);
-    return elem.saveScreenshot(outputFile);
+    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`)
+    return elem.saveScreenshot(outputFile)
   }
 
   /**
    * {{> saveScreenshot }}
    */
   async saveScreenshot(fileName, fullPage = false) {
-    let outputFile = screenshotOutputFolder(fileName);
+    let outputFile = screenshotOutputFolder(fileName)
 
     if (this.activeSessionName) {
-      const browser = this.sessionWindows[this.activeSessionName];
+      const browser = this.sessionWindows[this.activeSessionName]
 
       for (const sessionName in this.sessionWindows) {
-        const activeSessionPage = this.sessionWindows[sessionName];
-        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
+        const activeSessionPage = this.sessionWindows[sessionName]
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`)
 
-        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`)
 
         if (browser) {
-          this.debug(`Screenshot of ${sessionName} session has been saved to ${outputFile}`);
-          return browser.saveScreenshot(outputFile);
+          this.debug(`Screenshot of ${sessionName} session has been saved to ${outputFile}`)
+          return browser.saveScreenshot(outputFile)
         }
       }
     }
 
     if (!fullPage) {
-      this.debug(`Screenshot has been saved to ${outputFile}`);
-      return this.browser.saveScreenshot(outputFile);
+      this.debug(`Screenshot has been saved to ${outputFile}`)
+      return this.browser.saveScreenshot(outputFile)
     }
 
-    const originalWindowSize = await this.browser.getWindowSize();
+    const originalWindowSize = await this.browser.getWindowSize()
 
     let { width, height } = await this.browser
       .execute(function () {
         return {
           height: document.body.scrollHeight,
           width: document.body.scrollWidth,
-        };
+        }
       })
-      .then(res => res);
+      .then(res => res)
 
-    if (height < 100) height = 500; // errors for very small height
+    if (height < 100) height = 500 // errors for very small height
 
-    await this.browser.setWindowSize(width, height);
-    this.debug(`Screenshot has been saved to ${outputFile}, size: ${width}x${height}`);
-    const buffer = await this.browser.saveScreenshot(outputFile);
-    await this.browser.setWindowSize(originalWindowSize.width, originalWindowSize.height);
-    return buffer;
+    await this.browser.setWindowSize(width, height)
+    this.debug(`Screenshot has been saved to ${outputFile}, size: ${width}x${height}`)
+    const buffer = await this.browser.saveScreenshot(outputFile)
+    await this.browser.setWindowSize(originalWindowSize.width, originalWindowSize.height)
+    return buffer
   }
 
   /**
@@ -1822,40 +1822,40 @@ class WebDriver extends Helper {
    * {{> setCookie }}
    */
   async setCookie(cookie) {
-    return this.browser.setCookies(cookie);
+    return this.browser.setCookies(cookie)
   }
 
   /**
    * {{> clearCookie }}
    */
   async clearCookie(cookie) {
-    return this.browser.deleteCookies(cookie);
+    return this.browser.deleteCookies(cookie)
   }
 
   /**
    * {{> seeCookie }}
    */
   async seeCookie(name) {
-    const cookie = await this.browser.getCookies([name]);
-    return truth(`cookie ${name}`, 'to be set').assert(cookie);
+    const cookie = await this.browser.getCookies([name])
+    return truth(`cookie ${name}`, 'to be set').assert(cookie)
   }
 
   /**
    * {{> dontSeeCookie }}
    */
   async dontSeeCookie(name) {
-    const cookie = await this.browser.getCookies([name]);
-    return truth(`cookie ${name}`, 'to be set').negate(cookie);
+    const cookie = await this.browser.getCookies([name])
+    return truth(`cookie ${name}`, 'to be set').negate(cookie)
   }
 
   /**
    * {{> grabCookie }}
    */
   async grabCookie(name) {
-    if (!name) return this.browser.getCookies();
-    const cookie = await this.browser.getCookies([name]);
-    this.debugSection('Cookie', JSON.stringify(cookie));
-    return cookie[0];
+    if (!name) return this.browser.getCookies()
+    const cookie = await this.browser.getCookies([name])
+    this.debugSection('Cookie', JSON.stringify(cookie))
+    return cookie[0]
   }
 
   /**
@@ -1863,33 +1863,33 @@ class WebDriver extends Helper {
    */
   async waitForCookie(name, sec) {
     // by default, we will retry 3 times
-    let retries = 3;
-    const waitTimeout = sec || this.options.waitForTimeoutInSeconds;
+    let retries = 3
+    const waitTimeout = sec || this.options.waitForTimeoutInSeconds
 
     if (sec) {
-      retries = sec;
+      retries = sec
     } else {
-      retries = waitTimeout - 1;
+      retries = waitTimeout - 1
     }
 
     return promiseRetry(
       async (retry, number) => {
         const _grabCookie = async name => {
-          const cookie = await this.browser.getCookies([name]);
-          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`);
-        };
+          const cookie = await this.browser.getCookies([name])
+          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`)
+        }
 
-        this.debugSection('Wait for cookie: ', name);
-        if (number > 1) this.debugSection('Retrying... Attempt #', number);
+        this.debugSection('Wait for cookie: ', name)
+        if (number > 1) this.debugSection('Retrying... Attempt #', number)
 
         try {
-          await _grabCookie(name);
+          await _grabCookie(name)
         } catch (e) {
-          retry(e);
+          retry(e)
         }
       },
       { retries, maxTimeout: 1000 },
-    );
+    )
   }
 
   /**
@@ -1900,9 +1900,9 @@ class WebDriver extends Helper {
   async acceptPopup() {
     return this.browser.getAlertText().then(res => {
       if (res !== null) {
-        return this.browser.acceptAlert();
+        return this.browser.acceptAlert()
       }
-    });
+    })
   }
 
   /**
@@ -1912,9 +1912,9 @@ class WebDriver extends Helper {
   async cancelPopup() {
     return this.browser.getAlertText().then(res => {
       if (res !== null) {
-        return this.browser.dismissAlert();
+        return this.browser.dismissAlert()
       }
-    });
+    })
   }
 
   /**
@@ -1926,10 +1926,10 @@ class WebDriver extends Helper {
   async seeInPopup(text) {
     return this.browser.getAlertText().then(res => {
       if (res === null) {
-        throw new Error('Popup is not opened');
+        throw new Error('Popup is not opened')
       }
-      stringIncludes('text in popup').assert(text, res);
-    });
+      stringIncludes('text in popup').assert(text, res)
+    })
   }
 
   /**
@@ -1937,9 +1937,9 @@ class WebDriver extends Helper {
    */
   async grabPopupText() {
     try {
-      return await this.browser.getAlertText();
+      return await this.browser.getAlertText()
     } catch (err) {
-      this.debugSection('Popup', 'Error getting text from popup');
+      this.debugSection('Popup', 'Error getting text from popup')
     }
   }
 
@@ -1947,9 +1947,9 @@ class WebDriver extends Helper {
    * {{> pressKeyDown }}
    */
   async pressKeyDown(key) {
-    key = getNormalizedKey.call(this, key);
+    key = getNormalizedKey.call(this, key)
     if (!this.browser.isW3C) {
-      return this.browser.sendKeys([key]);
+      return this.browser.sendKeys([key])
     }
     return this.browser.performActions([
       {
@@ -1962,16 +1962,16 @@ class WebDriver extends Helper {
           },
         ],
       },
-    ]);
+    ])
   }
 
   /**
    * {{> pressKeyUp }}
    */
   async pressKeyUp(key) {
-    key = getNormalizedKey.call(this, key);
+    key = getNormalizedKey.call(this, key)
     if (!this.browser.isW3C) {
-      return this.browser.sendKeys([key]);
+      return this.browser.sendKeys([key])
     }
     return this.browser.performActions([
       {
@@ -1984,7 +1984,7 @@ class WebDriver extends Helper {
           },
         ],
       },
-    ]);
+    ])
   }
 
   /**
@@ -1993,25 +1993,25 @@ class WebDriver extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
-    const modifiers = [];
+    const modifiers = []
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k);
+        k = getNormalizedKey.call(this, k)
         if (isModifierKey(k)) {
-          modifiers.push(k);
+          modifiers.push(k)
         } else {
-          key = k;
-          break;
+          key = k
+          break
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key);
+      key = getNormalizedKey.call(this, key)
     }
     for (const modifier of modifiers) {
-      await this.pressKeyDown(modifier);
+      await this.pressKeyDown(modifier)
     }
     if (!this.browser.isW3C) {
-      await this.browser.sendKeys([key]);
+      await this.browser.sendKeys([key])
     } else {
       await this.browser.performActions([
         {
@@ -2028,10 +2028,10 @@ class WebDriver extends Helper {
             },
           ],
         },
-      ]);
+      ])
     }
     for (const modifier of modifiers) {
-      await this.pressKeyUp(modifier);
+      await this.pressKeyUp(modifier)
     }
   }
 
@@ -2040,17 +2040,17 @@ class WebDriver extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
-      keys = keys.toString();
-      keys = keys.split('');
+      keys = keys.toString()
+      keys = keys.split('')
     }
     if (delay) {
       for (const key of keys) {
-        await this.browser.keys(key);
-        await this.wait(delay / 1000);
+        await this.browser.keys(key)
+        await this.wait(delay / 1000)
       }
-      return;
+      return
     }
-    await this.browser.keys(keys);
+    await this.browser.keys(keys)
   }
 
   /**
@@ -2059,27 +2059,27 @@ class WebDriver extends Helper {
    * {{> resizeWindow }}
    */
   async resizeWindow(width, height) {
-    return this.browser.setWindowSize(width, height);
+    return this.browser.setWindowSize(width, height)
   }
 
   async _resizeBrowserWindow(browser, width, height) {
     if (width === 'maximize') {
-      const size = await browser.maximizeWindow();
-      this.debugSection('Window Size', size);
-      return;
+      const size = await browser.maximizeWindow()
+      this.debugSection('Window Size', size)
+      return
     }
     if (browser.isW3C) {
-      return browser.setWindowRect(null, null, parseInt(width, 10), parseInt(height, 10));
+      return browser.setWindowRect(null, null, parseInt(width, 10), parseInt(height, 10))
     }
-    return browser.setWindowSize(parseInt(width, 10), parseInt(height, 10));
+    return browser.setWindowSize(parseInt(width, 10), parseInt(height, 10))
   }
 
   async _resizeWindowIfNeeded(browser, windowSize) {
     if (this.isWeb && windowSize === 'maximize') {
-      await this._resizeBrowserWindow(browser, 'maximize');
+      await this._resizeBrowserWindow(browser, 'maximize')
     } else if (this.isWeb && windowSize && windowSize.indexOf('x') > 0) {
-      const dimensions = windowSize.split('x');
-      await this._resizeBrowserWindow(browser, dimensions[0], dimensions[1]);
+      const dimensions = windowSize.split('x')
+      await this._resizeBrowserWindow(browser, dimensions[0], dimensions[1])
     }
   }
 
@@ -2088,11 +2088,11 @@ class WebDriver extends Helper {
    *
    */
   async focus(locator) {
-    const els = await this._locate(locator);
-    assertElementExists(els, locator, 'Element to focus');
-    const el = usingFirstElement(els);
+    const els = await this._locate(locator)
+    assertElementExists(els, locator, 'Element to focus')
+    const el = usingFirstElement(els)
 
-    await focusElement(el, this.browser);
+    await focusElement(el, this.browser)
   }
 
   /**
@@ -2100,11 +2100,11 @@ class WebDriver extends Helper {
    *
    */
   async blur(locator) {
-    const els = await this._locate(locator);
-    assertElementExists(els, locator, 'Element to blur');
-    const el = usingFirstElement(els);
+    const els = await this._locate(locator)
+    assertElementExists(els, locator, 'Element to blur')
+    const el = usingFirstElement(els)
 
-    await blurElement(el, this.browser);
+    await blurElement(el, this.browser)
   }
 
   /**
@@ -2112,28 +2112,28 @@ class WebDriver extends Helper {
    * {{> dragAndDrop }}
    */
   async dragAndDrop(srcElement, destElement) {
-    let sourceEl = await this._locate(srcElement);
-    assertElementExists(sourceEl, srcElement);
-    sourceEl = usingFirstElement(sourceEl);
+    let sourceEl = await this._locate(srcElement)
+    assertElementExists(sourceEl, srcElement)
+    sourceEl = usingFirstElement(sourceEl)
 
-    let destEl = await this._locate(destElement);
-    assertElementExists(destEl, destElement);
-    destEl = usingFirstElement(destEl);
+    let destEl = await this._locate(destElement)
+    assertElementExists(destEl, destElement)
+    destEl = usingFirstElement(destEl)
 
-    return sourceEl.dragAndDrop(destEl);
+    return sourceEl.dragAndDrop(destEl)
   }
 
   /**
    * {{> dragSlider }}
    */
   async dragSlider(locator, offsetX = 0) {
-    const browser = this.browser;
-    await this.moveCursorTo(locator);
+    const browser = this.browser
+    await this.moveCursorTo(locator)
 
     // for chrome
     if (browser.isW3C) {
-      const xOffset = await this.grabElementBoundingRect(locator, 'x');
-      const yOffset = await this.grabElementBoundingRect(locator, 'y');
+      const xOffset = await this.grabElementBoundingRect(locator, 'x')
+      const yOffset = await this.grabElementBoundingRect(locator, 'y')
 
       return browser.performActions([
         {
@@ -2159,26 +2159,26 @@ class WebDriver extends Helper {
             { type: 'pointerUp', button: 0 },
           ],
         },
-      ]);
+      ])
     }
 
-    await browser.buttonDown(0);
-    await browser.moveToElement(null, offsetX, 0);
-    await browser.buttonUp(0);
+    await browser.buttonDown(0)
+    await browser.moveToElement(null, offsetX, 0)
+    await browser.buttonUp(0)
   }
 
   /**
    * {{> grabAllWindowHandles }}
    */
   async grabAllWindowHandles() {
-    return this.browser.getWindowHandles();
+    return this.browser.getWindowHandles()
   }
 
   /**
    * {{> grabCurrentWindowHandle }}
    */
   async grabCurrentWindowHandle() {
-    return this.browser.getWindowHandle();
+    return this.browser.getWindowHandle()
   }
 
   /**
@@ -2196,22 +2196,22 @@ class WebDriver extends Helper {
    * @param {string} window name of window handle.
    */
   async switchToWindow(window) {
-    await this.browser.switchToWindow(window);
+    await this.browser.switchToWindow(window)
   }
 
   /**
    * {{> closeOtherTabs }}
    */
   async closeOtherTabs() {
-    const handles = await this.browser.getWindowHandles();
-    const currentHandle = await this.browser.getWindowHandle();
-    const otherHandles = handles.filter(handle => handle !== currentHandle);
+    const handles = await this.browser.getWindowHandles()
+    const currentHandle = await this.browser.getWindowHandle()
+    const otherHandles = handles.filter(handle => handle !== currentHandle)
 
     await forEachAsync(otherHandles, async handle => {
-      await this.browser.switchToWindow(handle);
-      await this.browser.closeWindow();
-    });
-    await this.browser.switchToWindow(currentHandle);
+      await this.browser.switchToWindow(handle)
+      await this.browser.closeWindow()
+    })
+    await this.browser.switchToWindow(currentHandle)
   }
 
   /**
@@ -2219,117 +2219,117 @@ class WebDriver extends Helper {
    */
   async wait(sec) {
     return new Promise(resolve => {
-      setTimeout(resolve, sec * 1000);
-    });
+      setTimeout(resolve, sec * 1000)
+    })
   }
 
   /**
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator);
+        const res = await this._res(locator)
         if (!res || res.length === 0) {
-          return false;
+          return false
         }
-        const selected = await forEachAsync(res, async el => this.browser.isElementEnabled(getElementId(el)));
+        const selected = await forEachAsync(res, async el => this.browser.isElementEnabled(getElementId(el)))
         if (Array.isArray(selected)) {
-          return selected.filter(val => val === true).length > 0;
+          return selected.filter(val => val === true).length > 0
         }
-        return selected;
+        return selected
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${new Locator(locator)}) still not enabled after ${aSec} sec`,
       },
-    );
+    )
   }
 
   /**
    * {{> waitForElement }}
    */
   async waitForElement(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator);
-        return res && res.length;
+        const res = await this._res(locator)
+        return res && res.length
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${new Locator(locator)}) still not present on page after ${aSec} sec`,
       },
-    );
+    )
   }
 
   /**
    * {{> waitForClickable }}
    */
   async waitForClickable(locator, waitTimeout) {
-    waitTimeout = waitTimeout || this.options.waitForTimeoutInSeconds;
-    let res = await this._locate(locator);
-    res = usingFirstElement(res);
-    assertElementExists(res, locator);
+    waitTimeout = waitTimeout || this.options.waitForTimeoutInSeconds
+    let res = await this._locate(locator)
+    res = usingFirstElement(res)
+    assertElementExists(res, locator)
 
     return res.waitForClickable({
       timeout: waitTimeout * 1000,
       timeoutMsg: `element ${res.selector} still not clickable after ${waitTimeout} sec`,
-    });
+    })
   }
 
   /**
    * {{> waitInUrl }}
    */
   async waitInUrl(urlPart, sec = null) {
-    const client = this.browser;
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
-    let currUrl = '';
+    const client = this.browser
+    const aSec = sec || this.options.waitForTimeoutInSeconds
+    let currUrl = ''
 
     return client
       .waitUntil(
         function () {
           return this.getUrl().then(res => {
-            currUrl = decodeUrl(res);
-            return currUrl.indexOf(urlPart) > -1;
-          });
+            currUrl = decodeUrl(res)
+            return currUrl.indexOf(urlPart) > -1
+          })
         },
         { timeout: aSec * 1000 },
       )
       .catch(e => {
         if (e.message.indexOf('timeout')) {
-          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`);
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
         }
-        throw e;
-      });
+        throw e
+      })
   }
 
   /**
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
-    const baseUrl = this.options.url;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const baseUrl = this.options.url
     if (urlPart.indexOf('http') < 0) {
-      urlPart = baseUrl + urlPart;
+      urlPart = baseUrl + urlPart
     }
-    let currUrl = '';
+    let currUrl = ''
     return this.browser
       .waitUntil(function () {
         return this.getUrl().then(res => {
-          currUrl = decodeUrl(res);
-          return currUrl === urlPart;
-        });
+          currUrl = decodeUrl(res)
+          return currUrl === urlPart
+        })
       }, aSec * 1000)
       .catch(e => {
         if (e.message.indexOf('timeout')) {
-          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`);
+          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
         }
-        throw e;
-      });
+        throw e
+      })
   }
 
   /**
@@ -2337,48 +2337,48 @@ class WebDriver extends Helper {
    *
    */
   async waitForText(text, sec = null, context = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
-    const _context = context || this.root;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const _context = context || this.root
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this.$$(withStrictLocator.call(this, _context));
-        if (!res || res.length === 0) return false;
-        const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
+        const res = await this.$$(withStrictLocator.call(this, _context))
+        if (!res || res.length === 0) return false
+        const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)))
         if (Array.isArray(selected)) {
-          return selected.filter(part => part.indexOf(text) >= 0).length > 0;
+          return selected.filter(part => part.indexOf(text) >= 0).length > 0
         }
-        return selected.indexOf(text) >= 0;
+        return selected.indexOf(text) >= 0
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${_context}) is not in DOM or there is no element(${_context}) with text "${text}" after ${aSec} sec`,
       },
-    );
+    )
   }
 
   /**
    * {{> waitForValue }}
    */
   async waitForValue(field, value, sec = null) {
-    const client = this.browser;
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const client = this.browser
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return client.waitUntil(
       async () => {
-        const res = await findFields.call(this, field);
-        if (!res || res.length === 0) return false;
-        const selected = await forEachAsync(res, async el => el.getValue());
+        const res = await findFields.call(this, field)
+        if (!res || res.length === 0) return false
+        const selected = await forEachAsync(res, async el => el.getValue())
         if (Array.isArray(selected)) {
-          return selected.filter(part => part.indexOf(value) >= 0).length > 0;
+          return selected.filter(part => part.indexOf(value) >= 0).length > 0
         }
-        return selected.indexOf(value) >= 0;
+        return selected.indexOf(value) >= 0
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${field}) is not in DOM or there is no element(${field}) with value "${value}" after ${aSec} sec`,
       },
-    );
+    )
   }
 
   /**
@@ -2386,251 +2386,251 @@ class WebDriver extends Helper {
    *
    */
   async waitForVisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator);
-        if (!res || res.length === 0) return false;
-        const selected = await forEachAsync(res, async el => el.isDisplayed());
+        const res = await this._res(locator)
+        if (!res || res.length === 0) return false
+        const selected = await forEachAsync(res, async el => el.isDisplayed())
         if (Array.isArray(selected)) {
-          return selected.filter(val => val === true).length > 0;
+          return selected.filter(val => val === true).length > 0
         }
-        return selected;
+        return selected
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${new Locator(locator)}) still not visible after ${aSec} sec`,
       },
-    );
+    )
   }
 
   /**
    * {{> waitNumberOfVisibleElements }}
    */
   async waitNumberOfVisibleElements(locator, num, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator);
-        if (!res || res.length === 0) return false;
-        let selected = await forEachAsync(res, async el => el.isDisplayed());
+        const res = await this._res(locator)
+        if (!res || res.length === 0) return false
+        let selected = await forEachAsync(res, async el => el.isDisplayed())
 
-        if (!Array.isArray(selected)) selected = [selected];
-        selected = selected.filter(val => val === true);
-        return selected.length === num;
+        if (!Array.isArray(selected)) selected = [selected]
+        selected = selected.filter(val => val === true)
+        return selected.length === num
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `The number of elements (${new Locator(locator)}) is not ${num} after ${aSec} sec`,
       },
-    );
+    )
   }
 
   /**
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator);
-        if (!res || res.length === 0) return true;
-        const selected = await forEachAsync(res, async el => el.isDisplayed());
-        return !selected.length;
+        const res = await this._res(locator)
+        if (!res || res.length === 0) return true
+        const selected = await forEachAsync(res, async el => el.isDisplayed())
+        return !selected.length
       },
       { timeout: aSec * 1000, timeoutMsg: `element (${new Locator(locator)}) still visible after ${aSec} sec` },
-    );
+    )
   }
 
   /**
    * {{> waitToHide }}
    */
   async waitToHide(locator, sec = null) {
-    return this.waitForInvisible(locator, sec);
+    return this.waitForInvisible(locator, sec)
   }
 
   /**
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator);
+        const res = await this._res(locator)
         if (!res || res.length === 0) {
-          return true;
+          return true
         }
-        return false;
+        return false
       },
       { timeout: aSec * 1000, timeoutMsg: `element (${new Locator(locator)}) still on page after ${aSec} sec` },
-    );
+    )
   }
 
   /**
    * {{> waitForFunction }}
    */
   async waitForFunction(fn, argsOrSec = null, sec = null) {
-    let args = [];
+    let args = []
     if (argsOrSec) {
       if (Array.isArray(argsOrSec)) {
-        args = argsOrSec;
+        args = argsOrSec
       } else if (typeof argsOrSec === 'number') {
-        sec = argsOrSec;
+        sec = argsOrSec
       }
     }
 
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
 
     return this.browser.waitUntil(async () => this.browser.execute(fn, ...args), {
       timeout: aSec * 1000,
       timeoutMsg: '',
-    });
+    })
   }
 
   /**
    * {{> waitForNumberOfTabs }}
    */
   async waitForNumberOfTabs(expectedTabs, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeoutInSeconds;
-    let currentTabs;
-    let count = 0;
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeoutInSeconds
+    let currentTabs
+    let count = 0
 
     do {
-      currentTabs = await this.grabNumberOfOpenTabs();
-      await this.wait(1);
-      count += 1000;
-      if (currentTabs >= expectedTabs) return;
-    } while (count <= waitTimeout);
+      currentTabs = await this.grabNumberOfOpenTabs()
+      await this.wait(1)
+      count += 1000
+      if (currentTabs >= expectedTabs) return
+    } while (count <= waitTimeout)
 
-    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`)
   }
 
   /**
    * {{> switchTo }}
    */
   async switchTo(locator) {
-    this.browser.isInsideFrame = true;
+    this.browser.isInsideFrame = true
     if (Number.isInteger(locator)) {
-      return this.browser.switchToFrame(locator);
+      return this.browser.switchToFrame(locator)
     }
     if (!locator) {
-      return this.browser.switchToFrame(null);
+      return this.browser.switchToFrame(null)
     }
 
-    let res = await this._locate(locator, true);
-    assertElementExists(res, locator);
-    res = usingFirstElement(res);
-    return this.browser.switchToFrame(res);
+    let res = await this._locate(locator, true)
+    assertElementExists(res, locator)
+    res = usingFirstElement(res)
+    return this.browser.switchToFrame(res)
   }
 
   /**
    * {{> switchToNextTab }}
    */
   async switchToNextTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
-    let target;
-    const current = await this.browser.getWindowHandle();
+    const aSec = sec || this.options.waitForTimeoutInSeconds
+    let target
+    const current = await this.browser.getWindowHandle()
 
     await this.browser.waitUntil(
       async () => {
         await this.browser.getWindowHandles().then(handles => {
           if (handles.indexOf(current) + num + 1 <= handles.length) {
-            target = handles[handles.indexOf(current) + num];
+            target = handles[handles.indexOf(current) + num]
           }
-        });
-        return target;
+        })
+        return target
       },
       { timeout: aSec * 1000, timeoutMsg: `There is no ability to switch to next tab with offset ${num}` },
-    );
-    return this.browser.switchToWindow(target);
+    )
+    return this.browser.switchToWindow(target)
   }
 
   /**
    * {{> switchToPreviousTab }}
    */
   async switchToPreviousTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds;
-    const current = await this.browser.getWindowHandle();
-    let target;
+    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const current = await this.browser.getWindowHandle()
+    let target
 
     await this.browser.waitUntil(
       async () => {
         await this.browser.getWindowHandles().then(handles => {
           if (handles.indexOf(current) - num > -1) {
-            target = handles[handles.indexOf(current) - num];
+            target = handles[handles.indexOf(current) - num]
           }
-        });
-        return target;
+        })
+        return target
       },
       { timeout: aSec * 1000, timeoutMsg: `There is no ability to switch to previous tab with offset ${num}` },
-    );
-    return this.browser.switchToWindow(target);
+    )
+    return this.browser.switchToWindow(target)
   }
 
   /**
    * {{> closeCurrentTab }}
    */
   async closeCurrentTab() {
-    await this.browser.closeWindow();
-    const handles = await this.browser.getWindowHandles();
-    if (handles[0]) await this.browser.switchToWindow(handles[0]);
+    await this.browser.closeWindow()
+    const handles = await this.browser.getWindowHandles()
+    if (handles[0]) await this.browser.switchToWindow(handles[0])
   }
 
   /**
    * {{> openNewTab }}
    */
   async openNewTab(url = 'about:blank', windowName = null) {
-    const client = this.browser;
-    const crypto = require('crypto');
+    const client = this.browser
+    const crypto = require('crypto')
     if (windowName == null) {
-      windowName = crypto.randomBytes(32).toString('hex');
+      windowName = crypto.randomBytes(32).toString('hex')
     }
-    return client.newWindow(url, windowName);
+    return client.newWindow(url, windowName)
   }
 
   /**
    * {{> grabNumberOfOpenTabs }}
    */
   async grabNumberOfOpenTabs() {
-    const pages = await this.browser.getWindowHandles();
-    this.debugSection('Tabs', `Total ${pages.length}`);
-    return pages.length;
+    const pages = await this.browser.getWindowHandles()
+    this.debugSection('Tabs', `Total ${pages.length}`)
+    return pages.length
   }
 
   /**
    * {{> refreshPage }}
    */
   async refreshPage() {
-    const client = this.browser;
-    return client.refresh();
+    const client = this.browser
+    return client.refresh()
   }
 
   /**
    * {{> scrollPageToTop }}
    */
   scrollPageToTop() {
-    const client = this.browser;
+    const client = this.browser
 
     return client.execute(function () {
-      window.scrollTo(0, 0);
-    });
+      window.scrollTo(0, 0)
+    })
   }
 
   /**
    * {{> scrollPageToBottom }}
    */
   scrollPageToBottom() {
-    const client = this.browser;
+    const client = this.browser
 
     return client.execute(function () {
-      const body = document.body;
-      const html = document.documentElement;
-      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight));
-    });
+      const body = document.body
+      const html = document.documentElement
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight))
+    })
   }
 
   /**
@@ -2641,26 +2641,26 @@ class WebDriver extends Helper {
       return {
         x: window.pageXOffset,
         y: window.pageYOffset,
-      };
+      }
     }
 
-    return this.executeScript(getScrollPosition);
+    return this.executeScript(getScrollPosition)
   }
 
   /**
    * {{> grabElementBoundingRect }}
    */
   async grabElementBoundingRect(locator, prop) {
-    const res = await this._locate(locator, true);
-    assertElementExists(res, locator);
-    const el = usingFirstElement(res);
+    const res = await this._locate(locator, true)
+    assertElementExists(res, locator)
+    const el = usingFirstElement(res)
 
     const rect = {
       ...(await el.getLocation()),
       ...(await el.getSize()),
-    };
-    if (prop) return rect[prop];
-    return rect;
+    }
+    if (prop) return rect[prop]
+    return rect
   }
 
   /**
@@ -2682,35 +2682,35 @@ class WebDriver extends Helper {
    * Placeholder for ~ locator only test case write once run on both Appium and WebDriver.
    */
   async runInWeb(fn) {
-    return fn();
+    return fn()
   }
 }
 
 async function proceedSee(assertType, text, context, strict = false) {
-  let description;
+  let description
   if (!context) {
     if (this.context === webRoot) {
-      context = this.context;
-      description = 'web page';
+      context = this.context
+      description = 'web page'
     } else {
-      description = `current context ${this.context}`;
-      context = './/*';
+      description = `current context ${this.context}`
+      context = './/*'
     }
   } else {
-    description = `element ${context}`;
+    description = `element ${context}`
   }
 
-  const smartWaitEnabled = assertType === 'assert';
-  const res = await this._locate(withStrictLocator(context), smartWaitEnabled);
-  assertElementExists(res, context);
-  const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
+  const smartWaitEnabled = assertType === 'assert'
+  const res = await this._locate(withStrictLocator(context), smartWaitEnabled)
+  assertElementExists(res, context)
+  const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)))
   if (strict) {
     if (Array.isArray(selected) && selected.length !== 0) {
-      return selected.map(elText => equals(description)[assertType](text, elText));
+      return selected.map(elText => equals(description)[assertType](text, elText))
     }
-    return equals(description)[assertType](text, selected);
+    return equals(description)[assertType](text, selected)
   }
-  return stringIncludes(description)[assertType](text, selected);
+  return stringIncludes(description)[assertType](text, selected)
 }
 
 /**
@@ -2727,19 +2727,19 @@ async function proceedSee(assertType, text, context, strict = false) {
  * @return {Promise<Array>} - Array of values.
  */
 async function forEachAsync(array, callback, options = { expandArrayResults: true }) {
-  const { expandArrayResults = true } = options;
-  const inputArray = Array.isArray(array) ? array : [array];
-  const values = [];
+  const { expandArrayResults = true } = options
+  const inputArray = Array.isArray(array) ? array : [array]
+  const values = []
   for (let index = 0; index < inputArray.length; index++) {
-    const res = await callback(inputArray[index], index, inputArray);
+    const res = await callback(inputArray[index], index, inputArray)
 
     if (Array.isArray(res) && expandArrayResults) {
-      res.forEach(val => values.push(val));
+      res.forEach(val => values.push(val))
     } else if (res) {
-      values.push(res);
+      values.push(res)
     }
   }
-  return values;
+  return values
 }
 
 /**
@@ -2754,210 +2754,210 @@ async function forEachAsync(array, callback, options = { expandArrayResults: tru
  * @return {Promise<Array>} - Array of values.
  */
 async function filterAsync(array, callback) {
-  const inputArray = Array.isArray(array) ? array : [array];
-  const values = [];
+  const inputArray = Array.isArray(array) ? array : [array]
+  const values = []
   for (let index = 0; index < inputArray.length; index++) {
-    const res = await callback(inputArray[index], index, inputArray);
-    const value = Array.isArray(res) ? res[0] : res;
+    const res = await callback(inputArray[index], index, inputArray)
+    const value = Array.isArray(res) ? res[0] : res
 
     if (value) {
-      values.push(inputArray[index]);
+      values.push(inputArray[index])
     }
   }
-  return values;
+  return values
 }
 
 async function findClickable(locator, locateFn) {
-  locator = new Locator(locator);
+  locator = new Locator(locator)
 
   if (this._isCustomLocator(locator)) {
-    return locateFn(locator.value);
+    return locateFn(locator.value)
   }
 
-  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true);
-  if (!locator.isFuzzy()) return locateFn(locator, true);
+  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true)
+  if (!locator.isFuzzy()) return locateFn(locator, true)
 
-  let els;
-  const literal = xpathLocator.literal(locator.value);
+  let els
+  const literal = xpathLocator.literal(locator.value)
 
-  els = await locateFn(Locator.clickable.narrow(literal));
-  if (els.length) return els;
+  els = await locateFn(Locator.clickable.narrow(literal))
+  if (els.length) return els
 
-  els = await locateFn(Locator.clickable.wide(literal));
-  if (els.length) return els;
+  els = await locateFn(Locator.clickable.wide(literal))
+  if (els.length) return els
 
-  els = await locateFn(Locator.clickable.self(literal));
-  if (els.length) return els;
+  els = await locateFn(Locator.clickable.self(literal))
+  if (els.length) return els
 
-  return locateFn(locator.value); // by css or xpath
+  return locateFn(locator.value) // by css or xpath
 }
 
 async function findFields(locator) {
-  locator = new Locator(locator);
+  locator = new Locator(locator)
 
   if (this._isCustomLocator(locator)) {
-    return this._locate(locator);
+    return this._locate(locator)
   }
 
-  if (locator.isAccessibilityId() && !this.isWeb) return this._locate(locator, true);
-  if (!locator.isFuzzy()) return this._locate(locator, true);
+  if (locator.isAccessibilityId() && !this.isWeb) return this._locate(locator, true)
+  if (!locator.isFuzzy()) return this._locate(locator, true)
 
-  const literal = xpathLocator.literal(locator.value);
-  let els = await this._locate(Locator.field.labelEquals(literal));
-  if (els.length) return els;
+  const literal = xpathLocator.literal(locator.value)
+  let els = await this._locate(Locator.field.labelEquals(literal))
+  if (els.length) return els
 
-  els = await this._locate(Locator.field.labelContains(literal));
-  if (els.length) return els;
+  els = await this._locate(Locator.field.labelContains(literal))
+  if (els.length) return els
 
-  els = await this._locate(Locator.field.byName(literal));
-  if (els.length) return els;
-  return this._locate(locator.value); // by css or xpath
+  els = await this._locate(Locator.field.byName(literal))
+  if (els.length) return els
+  return this._locate(locator.value) // by css or xpath
 }
 
 async function proceedSeeField(assertType, field, value) {
-  const res = await findFields.call(this, field);
-  assertElementExists(res, field, 'Field');
-  const elem = usingFirstElement(res);
-  const elemId = getElementId(elem);
+  const res = await findFields.call(this, field)
+  assertElementExists(res, field, 'Field')
+  const elem = usingFirstElement(res)
+  const elemId = getElementId(elem)
 
   const proceedMultiple = async fields => {
     const fieldResults = toArray(
       await forEachAsync(fields, async el => {
-        const elementId = getElementId(el);
-        return this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value');
+        const elementId = getElementId(el)
+        return this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value')
       }),
-    );
+    )
 
     if (typeof value === 'boolean') {
-      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!fieldResults.length);
+      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!fieldResults.length)
     } else {
       // Assert that results were found so the forEach assert does not silently pass
-      equals(`no. of items matching > 0:  ${field}`)[assertType](true, !!fieldResults.length);
-      fieldResults.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val));
+      equals(`no. of items matching > 0:  ${field}`)[assertType](true, !!fieldResults.length)
+      fieldResults.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val))
     }
-  };
+  }
 
   const proceedSingle = el =>
     el.getValue().then(res => {
       if (res === null) {
-        throw new Error(`Element ${el.selector} has no value attribute`);
+        throw new Error(`Element ${el.selector} has no value attribute`)
       }
-      stringIncludes(`fields by ${field}`)[assertType](value, res);
-    });
+      stringIncludes(`fields by ${field}`)[assertType](value, res)
+    })
 
-  const filterBySelected = async elements => filterAsync(elements, async el => this.browser.isElementSelected(getElementId(el)));
+  const filterBySelected = async elements => filterAsync(elements, async el => this.browser.isElementSelected(getElementId(el)))
 
   const filterSelectedByValue = async (elements, value) => {
     return filterAsync(elements, async el => {
-      const elementId = getElementId(el);
-      const currentValue = this.browser.isW3C ? await el.getValue() : await this.browser.getElementAttribute(elementId, 'value');
-      const isSelected = await this.browser.isElementSelected(elementId);
-      return currentValue === value && isSelected;
-    });
-  };
+      const elementId = getElementId(el)
+      const currentValue = this.browser.isW3C ? await el.getValue() : await this.browser.getElementAttribute(elementId, 'value')
+      const isSelected = await this.browser.isElementSelected(elementId)
+      return currentValue === value && isSelected
+    })
+  }
 
-  const tag = await elem.getTagName();
+  const tag = await elem.getTagName()
   if (tag === 'select') {
-    const subOptions = await this.browser.findElementsFromElement(elemId, 'css', 'option');
+    const subOptions = await this.browser.findElementsFromElement(elemId, 'css', 'option')
 
     if (value === '') {
       // Don't filter by value
-      const selectedOptions = await filterBySelected(subOptions);
-      return proceedMultiple(selectedOptions);
+      const selectedOptions = await filterBySelected(subOptions)
+      return proceedMultiple(selectedOptions)
     }
 
-    const options = await filterSelectedByValue(subOptions, value);
-    return proceedMultiple(options);
+    const options = await filterSelectedByValue(subOptions, value)
+    return proceedMultiple(options)
   }
 
   if (tag === 'input') {
-    const fieldType = await elem.getAttribute('type');
+    const fieldType = await elem.getAttribute('type')
 
     if (fieldType === 'checkbox' || fieldType === 'radio') {
       if (typeof value === 'boolean') {
         // Support boolean values
-        const options = await filterBySelected(res);
-        return proceedMultiple(options);
+        const options = await filterBySelected(res)
+        return proceedMultiple(options)
       }
 
-      const options = await filterSelectedByValue(res, value);
-      return proceedMultiple(options);
+      const options = await filterSelectedByValue(res, value)
+      return proceedMultiple(options)
     }
-    return proceedSingle(elem);
+    return proceedSingle(elem)
   }
-  return proceedSingle(elem);
+  return proceedSingle(elem)
 }
 
 function toArray(item) {
   if (!Array.isArray(item)) {
-    return [item];
+    return [item]
   }
-  return item;
+  return item
 }
 
 async function proceedSeeCheckbox(assertType, field) {
-  const res = await findFields.call(this, field);
-  assertElementExists(res, field, 'Field');
+  const res = await findFields.call(this, field)
+  assertElementExists(res, field, 'Field')
 
-  const selected = await forEachAsync(res, async el => this.browser.isElementSelected(getElementId(el)));
-  return truth(`checkable field "${field}"`, 'to be checked')[assertType](selected);
+  const selected = await forEachAsync(res, async el => this.browser.isElementSelected(getElementId(el)))
+  return truth(`checkable field "${field}"`, 'to be checked')[assertType](selected)
 }
 
 async function findCheckable(locator, locateFn) {
-  let els;
-  locator = new Locator(locator);
+  let els
+  locator = new Locator(locator)
 
   if (this._isCustomLocator(locator)) {
-    return locateFn(locator.value);
+    return locateFn(locator.value)
   }
 
-  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true);
-  if (!locator.isFuzzy()) return locateFn(locator, true);
+  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true)
+  if (!locator.isFuzzy()) return locateFn(locator, true)
 
-  const literal = xpathLocator.literal(locator.value);
-  els = await locateFn(Locator.checkable.byText(literal));
-  if (els.length) return els;
-  els = await locateFn(Locator.checkable.byName(literal));
-  if (els.length) return els;
+  const literal = xpathLocator.literal(locator.value)
+  els = await locateFn(Locator.checkable.byText(literal))
+  if (els.length) return els
+  els = await locateFn(Locator.checkable.byName(literal))
+  if (els.length) return els
 
-  return locateFn(locator.value); // by css or xpath
+  return locateFn(locator.value) // by css or xpath
 }
 
 function withStrictLocator(locator) {
-  locator = new Locator(locator);
-  return locator.simplify();
+  locator = new Locator(locator)
+  return locator.simplify()
 }
 
 function isFrameLocator(locator) {
-  locator = new Locator(locator);
-  if (locator.isFrame()) return locator.value;
-  return false;
+  locator = new Locator(locator)
+  if (locator.isFrame()) return locator.value
+  return false
 }
 
 function assertElementExists(res, locator, prefix, suffix) {
   if (!res || res.length === 0) {
-    throw new ElementNotFound(locator, prefix, suffix);
+    throw new ElementNotFound(locator, prefix, suffix)
   }
 }
 
 function usingFirstElement(els) {
-  if (els.length > 1) debug(`[Elements] Using first element out of ${els.length}`);
-  return els[0];
+  if (els.length > 1) debug(`[Elements] Using first element out of ${els.length}`)
+  return els[0]
 }
 
 function getElementId(el) {
   // W3C WebDriver web element identifier
   // https://w3c.github.io/webdriver/#dfn-web-element-identifier
   if (el['element-6066-11e4-a52e-4f735466cecf']) {
-    return el['element-6066-11e4-a52e-4f735466cecf'];
+    return el['element-6066-11e4-a52e-4f735466cecf']
   }
   // (deprecated) JsonWireProtocol identifier
   // https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object
   if (el.ELEMENT) {
-    return el.ELEMENT;
+    return el.ELEMENT
   }
 
-  return null;
+  return null
 }
 
 // List of known key values to unicode code points
@@ -3077,52 +3077,52 @@ const keyUnicodeMap = {
   Semicolon: '\uE018', // ';' alias
   Slash: '/', // '/' alias
   ZenkakuHankaku: '\uE040',
-};
+}
 
 function convertKeyToRawKey(key) {
   if (Object.prototype.hasOwnProperty.call(keyUnicodeMap, key)) {
-    return keyUnicodeMap[key];
+    return keyUnicodeMap[key]
   }
   // Key is raw key when no representative unicode code point for value
-  return key;
+  return key
 }
 
 function getNormalizedKey(key) {
-  let normalizedKey = getNormalizedKeyAttributeValue(key);
+  let normalizedKey = getNormalizedKeyAttributeValue(key)
   // Always use "left" modifier keys for non-W3C sessions,
   // as JsonWireProtocol does not support "right" modifier keys
   if (!this.browser.isW3C) {
-    normalizedKey = normalizedKey.replace(/^(Alt|Control|Meta|Shift)Right$/, '$1');
+    normalizedKey = normalizedKey.replace(/^(Alt|Control|Meta|Shift)Right$/, '$1')
   }
   if (key !== normalizedKey) {
-    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
+    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`)
   }
-  return convertKeyToRawKey(normalizedKey);
+  return convertKeyToRawKey(normalizedKey)
 }
 
-const unicodeModifierKeys = modifierKeys.map(k => convertKeyToRawKey(k));
+const unicodeModifierKeys = modifierKeys.map(k => convertKeyToRawKey(k))
 function isModifierKey(key) {
-  return unicodeModifierKeys.includes(key);
+  return unicodeModifierKeys.includes(key)
 }
 
 function highlightActiveElement(element) {
   if (this.options.highlightElement && global.debugMode) {
-    highlightElement(element, this.browser);
+    highlightElement(element, this.browser)
   }
 }
 
 function prepareLocateFn(context) {
-  if (!context) return this._locate.bind(this);
+  if (!context) return this._locate.bind(this)
   return l => {
-    l = new Locator(l, 'css');
+    l = new Locator(l, 'css')
     return this._locate(context, true).then(async res => {
-      assertElementExists(res, context, 'Context element');
+      assertElementExists(res, context, 'Context element')
       if (l.react) {
-        return res[0].react$$(l.react, l.props || undefined);
+        return res[0].react$$(l.react, l.props || undefined)
       }
-      return res[0].$$(l.simplify());
-    });
-  };
+      return res[0].$$(l.simplify())
+    })
+  }
 }
 
-module.exports = WebDriver;
+module.exports = WebDriver

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1,48 +1,28 @@
-let webdriverio
+let webdriverio;
 
-const assert = require('assert')
-const path = require('path')
+const assert = require('assert');
+const path = require('path');
 
-const Helper = require('@codeceptjs/helper')
-const promiseRetry = require('promise-retry')
-const stringIncludes = require('../assert/include').includes
-const { urlEquals, equals } = require('../assert/equal')
-const { debug } = require('../output')
-const { empty } = require('../assert/empty')
-const { truth } = require('../assert/truth')
-const {
-  xpathLocator,
-  fileExists,
-  decodeUrl,
-  chunkArray,
-  convertCssPropertiesToCamelCase,
-  screenshotOutputFolder,
-  getNormalizedKeyAttributeValue,
-  modifierKeys,
-} = require('../utils')
-const { isColorProperty, convertColorToRGBA } = require('../colorUtils')
-const ElementNotFound = require('./errors/ElementNotFound')
-const ConnectionRefused = require('./errors/ConnectionRefused')
-const Locator = require('../locator')
-const { highlightElement } = require('./scripts/highlightElement')
-const { focusElement } = require('./scripts/focusElement')
-const { blurElement } = require('./scripts/blurElement')
-const {
-  dontSeeElementError,
-  seeElementError,
-  seeElementInDOMError,
-  dontSeeElementInDOMError,
-} = require('./errors/ElementAssertion')
-const {
-  dontSeeTraffic,
-  seeTraffic,
-  grabRecordedNetworkTraffics,
-  stopRecordingTraffic,
-  flushNetworkTraffics,
-} = require('./network/actions')
+const Helper = require('@codeceptjs/helper');
+const promiseRetry = require('promise-retry');
+const stringIncludes = require('../assert/include').includes;
+const { urlEquals, equals } = require('../assert/equal');
+const { debug } = require('../output');
+const { empty } = require('../assert/empty');
+const { truth } = require('../assert/truth');
+const { xpathLocator, fileExists, decodeUrl, chunkArray, convertCssPropertiesToCamelCase, screenshotOutputFolder, getNormalizedKeyAttributeValue, modifierKeys } = require('../utils');
+const { isColorProperty, convertColorToRGBA } = require('../colorUtils');
+const ElementNotFound = require('./errors/ElementNotFound');
+const ConnectionRefused = require('./errors/ConnectionRefused');
+const Locator = require('../locator');
+const { highlightElement } = require('./scripts/highlightElement');
+const { focusElement } = require('./scripts/focusElement');
+const { blurElement } = require('./scripts/blurElement');
+const { dontSeeElementError, seeElementError, seeElementInDOMError, dontSeeElementInDOMError } = require('./errors/ElementAssertion');
+const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } = require('./network/actions');
 
-const SHADOW = 'shadow'
-const webRoot = 'body'
+const SHADOW = 'shadow';
+const webRoot = 'body';
 
 /**
  * ## Configuration
@@ -73,7 +53,7 @@ const webRoot = 'body'
  * @prop {boolean} [highlightElement] - highlight the interacting elements. Default: false. Note: only activate under verbose mode (--verbose).
  * @prop {string} [logLevel=silent] - level of logging verbosity. Default: silent. Options: trace | debug | info | warn | error | silent. More info: https://webdriver.io/docs/configuration/#loglevel
  */
-const config = {}
+const config = {};
 
 /**
  * WebDriver helper which wraps [webdriverio](http://webdriver.io/) library to
@@ -443,34 +423,34 @@ const config = {}
  */
 class WebDriver extends Helper {
   constructor(config) {
-    super(config)
-    webdriverio = require('webdriverio')
+    super(config);
+    webdriverio = require('webdriverio');
 
     // set defaults
-    this.root = webRoot
-    this.isWeb = true
-    this.isRunning = false
-    this.sessionWindows = {}
-    this.activeSessionName = ''
-    this.customLocatorStrategies = config.customLocatorStrategies
+    this.root = webRoot;
+    this.isWeb = true;
+    this.isRunning = false;
+    this.sessionWindows = {};
+    this.activeSessionName = '';
+    this.customLocatorStrategies = config.customLocatorStrategies;
 
     // for network stuff
-    this.requests = []
-    this.recording = false
-    this.recordedAtLeastOnce = false
+    this.requests = [];
+    this.recording = false;
+    this.recordedAtLeastOnce = false;
 
-    this._setConfig(config)
+    this._setConfig(config);
 
     Locator.addFilter((locator, result) => {
       if (typeof locator === 'string' && locator.indexOf('~') === 0) {
         // accessibility locator
         if (this.isWeb) {
-          result.value = `[aria-label="${locator.slice(1)}"]`
-          result.type = 'css'
-          result.output = `aria-label=${locator.slice(1)}`
+          result.value = `[aria-label="${locator.slice(1)}"]`;
+          result.type = 'css';
+          result.output = `aria-label=${locator.slice(1)}`;
         }
       }
-    })
+    });
   }
 
   _validateConfig(config) {
@@ -490,41 +470,41 @@ class WebDriver extends Helper {
       keepBrowserState: false,
       deprecationWarnings: false,
       highlightElement: false,
-    }
+    };
 
     // override defaults with config
-    config = Object.assign(defaults, config)
+    config = Object.assign(defaults, config);
 
     if (config.host) {
       // webdriverio spec
-      config.hostname = config.host
-      config.path = config.path ? config.path : '/wd/hub'
+      config.hostname = config.host;
+      config.path = config.path ? config.path : '/wd/hub';
     }
 
-    config.baseUrl = config.url || config.baseUrl
+    config.baseUrl = config.url || config.baseUrl;
     if (config.desiredCapabilities && Object.keys(config.desiredCapabilities).length) {
-      config.capabilities = config.desiredCapabilities
+      config.capabilities = config.desiredCapabilities;
     }
-    config.capabilities.browserName = config.browser || config.capabilities.browserName
-    config.capabilities.browserVersion = config.browserVersion || config.capabilities.browserVersion
+    config.capabilities.browserName = config.browser || config.capabilities.browserName;
+    config.capabilities.browserVersion = config.browserVersion || config.capabilities.browserVersion;
     if (config.capabilities.chromeOptions) {
-      config.capabilities['goog:chromeOptions'] = config.capabilities.chromeOptions
-      delete config.capabilities.chromeOptions
+      config.capabilities['goog:chromeOptions'] = config.capabilities.chromeOptions;
+      delete config.capabilities.chromeOptions;
     }
     if (config.capabilities.firefoxOptions) {
-      config.capabilities['moz:firefoxOptions'] = config.capabilities.firefoxOptions
-      delete config.capabilities.firefoxOptions
+      config.capabilities['moz:firefoxOptions'] = config.capabilities.firefoxOptions;
+      delete config.capabilities.firefoxOptions;
     }
     if (config.capabilities.ieOptions) {
-      config.capabilities['se:ieOptions'] = config.capabilities.ieOptions
-      delete config.capabilities.ieOptions
+      config.capabilities['se:ieOptions'] = config.capabilities.ieOptions;
+      delete config.capabilities.ieOptions;
     }
     if (config.capabilities.selenoidOptions) {
-      config.capabilities['selenoid:options'] = config.capabilities.selenoidOptions
-      delete config.capabilities.selenoidOptions
+      config.capabilities['selenoid:options'] = config.capabilities.selenoidOptions;
+      delete config.capabilities.selenoidOptions;
     }
 
-    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000 // convert to seconds
+    config.waitForTimeoutInSeconds = config.waitForTimeout / 1000; // convert to seconds
 
     if (!config.capabilities.platformName && (!config.url || !config.browser)) {
       throw new Error(`
@@ -538,17 +518,17 @@ class WebDriver extends Helper {
               }
             }
           }
-      `)
+      `);
     }
 
-    return config
+    return config;
   }
 
   static _checkRequirements() {
     try {
-      require('webdriverio')
+      require('webdriverio');
     } catch (e) {
-      return ['webdriverio@^6.12.1']
+      return ['webdriverio@^6.12.1'];
     }
   }
 
@@ -564,165 +544,162 @@ class WebDriver extends Helper {
         message: 'Browser in which testing will be performed',
         default: 'chrome',
       },
-    ]
+    ];
   }
 
   _beforeSuite() {
     if (!this.options.restart && !this.options.manualStart && !this.isRunning) {
-      this.debugSection('Session', 'Starting singleton browser session')
-      return this._startBrowser()
+      this.debugSection('Session', 'Starting singleton browser session');
+      return this._startBrowser();
     }
   }
 
   _lookupCustomLocator(customStrategy) {
     if (typeof this.customLocatorStrategies !== 'object') {
-      return null
+      return null;
     }
-    const strategy = this.customLocatorStrategies[customStrategy]
-    return typeof strategy === 'function' ? strategy : null
+    const strategy = this.customLocatorStrategies[customStrategy];
+    return typeof strategy === 'function' ? strategy : null;
   }
 
   _isCustomLocator(locator) {
-    const locatorObj = new Locator(locator)
+    const locatorObj = new Locator(locator);
     if (locatorObj.isCustom()) {
-      const customLocator = this._lookupCustomLocator(locatorObj.type)
+      const customLocator = this._lookupCustomLocator(locatorObj.type);
       if (customLocator) {
-        return true
+        return true;
       }
-      throw new Error('Please define "customLocatorStrategies" as an Object and the Locator Strategy as a "function".')
+      throw new Error('Please define "customLocatorStrategies" as an Object and the Locator Strategy as a "function".');
     }
-    return false
+    return false;
   }
 
   async _res(locator) {
-    const res =
-      this._isShadowLocator(locator) || this._isCustomLocator(locator)
-        ? await this._locate(locator)
-        : await this.$$(withStrictLocator(locator))
-    return res
+    const res = this._isShadowLocator(locator) || this._isCustomLocator(locator) ? await this._locate(locator) : await this.$$(withStrictLocator(locator));
+    return res;
   }
 
   async _startBrowser() {
     try {
       if (this.options.multiremote) {
-        this.browser = await webdriverio.multiremote(this.options.multiremote)
+        this.browser = await webdriverio.multiremote(this.options.multiremote);
       } else {
         // remove non w3c capabilities
-        delete this.options.capabilities.protocol
-        delete this.options.capabilities.hostname
-        delete this.options.capabilities.port
-        delete this.options.capabilities.path
-        this.browser = await webdriverio.remote(this.options)
+        delete this.options.capabilities.protocol;
+        delete this.options.capabilities.hostname;
+        delete this.options.capabilities.port;
+        delete this.options.capabilities.path;
+        this.browser = await webdriverio.remote(this.options);
       }
     } catch (err) {
       if (err.toString().indexOf('ECONNREFUSED')) {
-        throw new ConnectionRefused(err)
+        throw new ConnectionRefused(err);
       }
-      throw err
+      throw err;
     }
 
-    this.isRunning = true
+    this.isRunning = true;
     if (this.options.timeouts && this.isWeb) {
-      await this.defineTimeout(this.options.timeouts)
+      await this.defineTimeout(this.options.timeouts);
     }
 
-    await this._resizeWindowIfNeeded(this.browser, this.options.windowSize)
+    await this._resizeWindowIfNeeded(this.browser, this.options.windowSize);
 
-    this.$$ = this.browser.$$.bind(this.browser)
+    this.$$ = this.browser.$$.bind(this.browser);
 
     if (this._isCustomLocatorStrategyDefined()) {
-      Object.keys(this.customLocatorStrategies).forEach(async (customLocator) => {
-        this.debugSection('Weddriver', `adding custom locator strategy: ${customLocator}`)
-        const locatorFunction = this._lookupCustomLocator(customLocator)
-        this.browser.addLocatorStrategy(customLocator, locatorFunction)
-      })
+      Object.keys(this.customLocatorStrategies).forEach(async customLocator => {
+        this.debugSection('Weddriver', `adding custom locator strategy: ${customLocator}`);
+        const locatorFunction = this._lookupCustomLocator(customLocator);
+        this.browser.addLocatorStrategy(customLocator, locatorFunction);
+      });
     }
 
     if (this.browser.capabilities && this.browser.capabilities.platformName) {
-      this.browser.capabilities.platformName = this.browser.capabilities.platformName.toLowerCase()
+      this.browser.capabilities.platformName = this.browser.capabilities.platformName.toLowerCase();
     }
 
-    return this.browser
+    return this.browser;
   }
 
   _isCustomLocatorStrategyDefined() {
-    return this.customLocatorStrategies && Object.keys(this.customLocatorStrategies).length
+    return this.customLocatorStrategies && Object.keys(this.customLocatorStrategies).length;
   }
 
   async _stopBrowser() {
-    if (this.browser && this.isRunning) await this.browser.deleteSession()
+    if (this.browser && this.isRunning) await this.browser.deleteSession();
   }
 
   async _before() {
-    this.context = this.root
-    if (this.options.restart && !this.options.manualStart) return this._startBrowser()
-    if (!this.isRunning && !this.options.manualStart) return this._startBrowser()
-    if (this.browser) this.$$ = this.browser.$$.bind(this.browser)
-    return this.browser
+    this.context = this.root;
+    if (this.options.restart && !this.options.manualStart) return this._startBrowser();
+    if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
+    if (this.browser) this.$$ = this.browser.$$.bind(this.browser);
+    return this.browser;
   }
 
   async _after() {
-    if (!this.isRunning) return
+    if (!this.isRunning) return;
     if (this.options.restart) {
-      this.isRunning = false
-      return this.browser.deleteSession()
+      this.isRunning = false;
+      return this.browser.deleteSession();
     }
-    if (this.browser.isInsideFrame) await this.browser.switchToFrame(null)
+    if (this.browser.isInsideFrame) await this.browser.switchToFrame(null);
 
-    if (this.options.keepBrowserState) return
+    if (this.options.keepBrowserState) return;
 
     if (!this.options.keepCookies && this.options.capabilities.browserName) {
-      this.debugSection('Session', 'cleaning cookies and localStorage')
-      await this.browser.deleteCookies()
+      this.debugSection('Session', 'cleaning cookies and localStorage');
+      await this.browser.deleteCookies();
     }
-    await this.browser.execute('localStorage.clear();').catch((err) => {
-      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
-    })
-    await this.closeOtherTabs()
-    return this.browser
+    await this.browser.execute('localStorage.clear();').catch(err => {
+      if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err;
+    });
+    await this.closeOtherTabs();
+    return this.browser;
   }
 
   _afterSuite() {}
 
   _finishTest() {
-    if (!this.options.restart && this.isRunning) return this._stopBrowser()
+    if (!this.options.restart && this.isRunning) return this._stopBrowser();
   }
 
   _session() {
-    const defaultSession = this.browser
+    const defaultSession = this.browser;
     return {
       start: async (sessionName, opts) => {
         // opts.disableScreenshots = true; // screenshots cant be saved as session will be already closed
-        opts = this._validateConfig(Object.assign(this.options, opts))
-        this.debugSection('New Browser', JSON.stringify(opts))
-        const browser = await webdriverio.remote(opts)
-        this.activeSessionName = sessionName
+        opts = this._validateConfig(Object.assign(this.options, opts));
+        this.debugSection('New Browser', JSON.stringify(opts));
+        const browser = await webdriverio.remote(opts);
+        this.activeSessionName = sessionName;
         if (opts.timeouts && this.isWeb) {
-          await this._defineBrowserTimeout(browser, opts.timeouts)
+          await this._defineBrowserTimeout(browser, opts.timeouts);
         }
 
-        await this._resizeWindowIfNeeded(browser, opts.windowSize)
+        await this._resizeWindowIfNeeded(browser, opts.windowSize);
 
-        return browser
+        return browser;
       },
-      stop: async (browser) => {
-        if (!browser) return
-        return browser.deleteSession()
+      stop: async browser => {
+        if (!browser) return;
+        return browser.deleteSession();
       },
-      loadVars: async (browser) => {
-        if (this.context !== this.root) throw new Error("Can't start session inside within block")
-        this.browser = browser
-        this.$$ = this.browser.$$.bind(this.browser)
-        this.sessionWindows[this.activeSessionName] = browser
+      loadVars: async browser => {
+        if (this.context !== this.root) throw new Error("Can't start session inside within block");
+        this.browser = browser;
+        this.$$ = this.browser.$$.bind(this.browser);
+        this.sessionWindows[this.activeSessionName] = browser;
       },
-      restoreVars: async (session) => {
+      restoreVars: async session => {
         if (!session) {
-          this.activeSessionName = ''
+          this.activeSessionName = '';
         }
-        this.browser = defaultSession
-        this.$$ = this.browser.$$.bind(this.browser)
+        this.browser = defaultSession;
+        this.$$ = this.browser.$$.bind(this.browser);
       },
-    }
+    };
   }
 
   /**
@@ -744,41 +721,41 @@ class WebDriver extends Helper {
    * @param {function} fn async functuion that executed with WebDriver helper as argument
    */
   useWebDriverTo(description, fn) {
-    return this._useTo(...arguments)
+    return this._useTo(...arguments);
   }
 
   async _failed() {
-    if (this.context !== this.root) await this._withinEnd()
+    if (this.context !== this.root) await this._withinEnd();
   }
 
   async _withinBegin(locator) {
-    const frame = isFrameLocator(locator)
+    const frame = isFrameLocator(locator);
     if (frame) {
-      this.browser.isInsideFrame = true
+      this.browser.isInsideFrame = true;
       if (Array.isArray(frame)) {
         // this.switchTo(null);
-        await forEachAsync(frame, async (f) => this.switchTo(f))
-        return
+        await forEachAsync(frame, async f => this.switchTo(f));
+        return;
       }
-      await this.switchTo(frame)
-      return
+      await this.switchTo(frame);
+      return;
     }
-    this.context = locator
+    this.context = locator;
 
-    let res = await this.browser.$$(withStrictLocator(locator))
-    assertElementExists(res, locator)
-    res = usingFirstElement(res)
-    this.context = res.selector
-    this.$$ = res.$$.bind(res)
+    let res = await this.browser.$$(withStrictLocator(locator));
+    assertElementExists(res, locator);
+    res = usingFirstElement(res);
+    this.context = res.selector;
+    this.$$ = res.$$.bind(res);
   }
 
   async _withinEnd() {
     if (this.browser.isInsideFrame) {
-      this.browser.isInsideFrame = false
-      return this.switchTo(null)
+      this.browser.isInsideFrame = false;
+      return this.switchTo(null);
     }
-    this.context = this.root
-    this.$$ = this.browser.$$.bind(this.browser)
+    this.context = this.root;
+    this.$$ = this.browser.$$.bind(this.browser);
   }
 
   /**
@@ -787,7 +764,7 @@ class WebDriver extends Helper {
    * @param {object} locator
    */
   _isShadowLocator(locator) {
-    return locator.type === SHADOW || locator[SHADOW]
+    return locator.type === SHADOW || locator[SHADOW];
   }
 
   /**
@@ -796,37 +773,37 @@ class WebDriver extends Helper {
    * @param {object} locator
    */
   async _locateShadow(locator) {
-    const shadow = locator.value ? locator.value : locator[SHADOW]
-    const shadowSequence = []
-    let elements
+    const shadow = locator.value ? locator.value : locator[SHADOW];
+    const shadowSequence = [];
+    let elements;
 
     if (!Array.isArray(shadow)) {
-      throw new Error(`Shadow '${shadow}' should be defined as an Array of elements.`)
+      throw new Error(`Shadow '${shadow}' should be defined as an Array of elements.`);
     }
 
     // traverse through the Shadow locators in sequence
     for (let index = 0; index < shadow.length; index++) {
-      const shadowElement = shadow[index]
-      shadowSequence.push(shadowElement)
+      const shadowElement = shadow[index];
+      shadowSequence.push(shadowElement);
 
       if (!elements) {
-        elements = await this.browser.$$(shadowElement)
+        elements = await this.browser.$$(shadowElement);
       } else if (Array.isArray(elements)) {
-        elements = await elements[0].shadow$$(shadowElement)
+        elements = await elements[0].shadow$$(shadowElement);
       } else if (elements) {
-        elements = await elements.shadow$$(shadowElement)
+        elements = await elements.shadow$$(shadowElement);
       }
 
       if (!elements || !elements[0]) {
         throw new Error(
           `Shadow Element '${shadowElement}' is not found. It is possible the element is incorrect or elements sequence is incorrect. Please verify the sequence '${shadowSequence.join('>')}' is correctly chained.`,
-        )
+        );
       }
     }
 
-    this.debugSection('Elements', `Found ${elements.length} '${SHADOW}' elements`)
+    this.debugSection('Elements', `Found ${elements.length} '${SHADOW}' elements`);
 
-    return elements
+    return elements;
   }
 
   /**
@@ -835,11 +812,8 @@ class WebDriver extends Helper {
    * @param {object} locator
    */
   async _smartWait(locator) {
-    this.debugSection(
-      `SmartWait (${this.options.smartWait}ms)`,
-      `Locating ${JSON.stringify(locator)} in ${this.options.smartWait}`,
-    )
-    await this.defineTimeout({ implicit: this.options.smartWait })
+    this.debugSection(`SmartWait (${this.options.smartWait}ms)`, `Locating ${JSON.stringify(locator)} in ${this.options.smartWait}`);
+    await this.defineTimeout({ implicit: this.options.smartWait });
   }
 
   /**
@@ -854,53 +828,53 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locate(locator, smartWait = false) {
-    if (require('../store').debugMode) smartWait = false
+    if (require('../store').debugMode) smartWait = false;
 
     // special locator type for Shadow DOM
     if (this._isShadowLocator(locator)) {
       if (!this.options.smartWait || !smartWait) {
-        const els = await this._locateShadow(locator)
-        return els
+        const els = await this._locateShadow(locator);
+        return els;
       }
 
-      const els = await this._locateShadow(locator)
-      return els
+      const els = await this._locateShadow(locator);
+      return els;
     }
 
     // special locator type for React
     if (locator.react) {
-      const els = await this.browser.react$$(locator.react, locator.props || undefined, locator.state || undefined)
-      this.debugSection('Elements', `Found ${els.length} react components`)
-      return els
+      const els = await this.browser.react$$(locator.react, locator.props || undefined, locator.state || undefined);
+      this.debugSection('Elements', `Found ${els.length} react components`);
+      return els;
     }
 
     if (!this.options.smartWait || !smartWait) {
       if (this._isCustomLocator(locator)) {
-        const locatorObj = new Locator(locator)
-        return this.browser.custom$$(locatorObj.type, locatorObj.value)
+        const locatorObj = new Locator(locator);
+        return this.browser.custom$$(locatorObj.type, locatorObj.value);
       }
 
-      const els = await this.$$(withStrictLocator(locator))
-      return els
+      const els = await this.$$(withStrictLocator(locator));
+      return els;
     }
 
-    await this._smartWait(locator)
+    await this._smartWait(locator);
 
     if (this._isCustomLocator(locator)) {
-      const locatorObj = new Locator(locator)
-      return this.browser.custom$$(locatorObj.type, locatorObj.value)
+      const locatorObj = new Locator(locator);
+      return this.browser.custom$$(locatorObj.type, locatorObj.value);
     }
 
-    const els = await this.$$(withStrictLocator(locator))
-    await this.defineTimeout({ implicit: 0 })
-    return els
+    const els = await this.$$(withStrictLocator(locator));
+    await this.defineTimeout({ implicit: 0 });
+    return els;
   }
 
   _grabCustomLocator(locator) {
     if (typeof locator === 'string') {
-      locator = new Locator(locator)
+      locator = new Locator(locator);
     }
-    return locator.value ? locator.value : locator.custom
+    return locator.value ? locator.value : locator.custom;
   }
 
   /**
@@ -913,7 +887,7 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locateCheckable(locator) {
-    return findCheckable.call(this, locator, this.$$.bind(this)).then((res) => res)
+    return findCheckable.call(this, locator, this.$$.bind(this)).then(res => res);
   }
 
   /**
@@ -927,8 +901,8 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locateClickable(locator, context) {
-    const locateFn = prepareLocateFn.call(this, context)
-    return findClickable.call(this, locator, locateFn)
+    const locateFn = prepareLocateFn.call(this, context);
+    return findClickable.call(this, locator, locateFn);
   }
 
   /**
@@ -941,7 +915,7 @@ class WebDriver extends Helper {
    * @param {CodeceptJS.LocatorOrString} locator element located by CSS|XPath|strict locator.
    */
   async _locateFields(locator) {
-    return findFields.call(this, locator).then((res) => res)
+    return findFields.call(this, locator).then(res => res);
   }
 
   /**
@@ -949,7 +923,7 @@ class WebDriver extends Helper {
    *
    */
   async grabWebElements(locator) {
-    return this._locate(locator)
+    return this._locate(locator);
   }
 
   /**
@@ -965,11 +939,11 @@ class WebDriver extends Helper {
    * @param {*} timeouts WebDriver timeouts object.
    */
   defineTimeout(timeouts) {
-    return this._defineBrowserTimeout(this.browser, timeouts)
+    return this._defineBrowserTimeout(this.browser, timeouts);
   }
 
   _defineBrowserTimeout(browser, timeouts) {
-    return browser.setTimeout(timeouts)
+    return browser.setTimeout(timeouts);
   }
 
   /**
@@ -977,15 +951,15 @@ class WebDriver extends Helper {
    *
    */
   amOnPage(url) {
-    let split_url
+    let split_url;
     if (this.options.basicAuth) {
       if (url.startsWith('/')) {
-        url = this.options.url + url
+        url = this.options.url + url;
       }
-      split_url = url.split('//')
-      url = `${split_url[0]}//${this.options.basicAuth.username}:${this.options.basicAuth.password}@${split_url[1]}`
+      split_url = url.split('//');
+      url = `${split_url[0]}//${this.options.basicAuth.username}:${this.options.basicAuth.password}@${split_url[1]}`;
     }
-    return this.browser.url(url)
+    return this.browser.url(url);
   }
 
   /**
@@ -994,18 +968,18 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async click(locator, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
-    const locateFn = prepareLocateFn.call(this, context)
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findClickable.call(this, locator, locateFn)
+    const res = await findClickable.call(this, locator, locateFn);
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
     } else {
-      assertElementExists(res, locator, 'Clickable element')
+      assertElementExists(res, locator, 'Clickable element');
     }
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
-    return this.browser[clickMethod](getElementId(elem))
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
+    return this.browser[clickMethod](getElementId(elem));
   }
 
   /**
@@ -1014,25 +988,25 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async forceClick(locator, context = null) {
-    const locateFn = prepareLocateFn.call(this, context)
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findClickable.call(this, locator, locateFn)
+    const res = await findClickable.call(this, locator, locateFn);
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
     } else {
-      assertElementExists(res, locator, 'Clickable element')
+      assertElementExists(res, locator, 'Clickable element');
     }
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
 
-    return this.executeScript((el) => {
+    return this.executeScript(el => {
       if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur()
+        document.activeElement.blur();
       }
-      const event = document.createEvent('MouseEvent')
-      event.initEvent('click', true, true)
-      return el.dispatchEvent(event)
-    }, elem)
+      const event = document.createEvent('MouseEvent');
+      event.initEvent('click', true, true);
+      return el.dispatchEvent(event);
+    }, elem);
   }
 
   /**
@@ -1041,18 +1015,18 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async doubleClick(locator, context = null) {
-    const locateFn = prepareLocateFn.call(this, context)
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findClickable.call(this, locator, locateFn)
+    const res = await findClickable.call(this, locator, locateFn);
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
     } else {
-      assertElementExists(res, locator, 'Clickable element')
+      assertElementExists(res, locator, 'Clickable element');
     }
 
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
-    return elem.doubleClick()
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
+    return elem.doubleClick();
   }
 
   /**
@@ -1061,24 +1035,24 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async rightClick(locator, context) {
-    const locateFn = prepareLocateFn.call(this, context)
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findClickable.call(this, locator, locateFn)
+    const res = await findClickable.call(this, locator, locateFn);
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
     } else {
-      assertElementExists(res, locator, 'Clickable element')
+      assertElementExists(res, locator, 'Clickable element');
     }
 
-    const el = usingFirstElement(res)
+    const el = usingFirstElement(res);
 
-    await el.moveTo()
+    await el.moveTo();
 
     if (this.browser.isW3C) {
-      return el.click({ button: 'right' })
+      return el.click({ button: 'right' });
     }
     // JSON Wire version
-    await this.browser.buttonDown(2)
+    await this.browser.buttonDown(2);
   }
 
   /**
@@ -1087,24 +1061,24 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async forceRightClick(locator, context = null) {
-    const locateFn = prepareLocateFn.call(this, context)
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findClickable.call(this, locator, locateFn)
+    const res = await findClickable.call(this, locator, locateFn);
     if (context) {
-      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`)
+      assertElementExists(res, locator, 'Clickable element', `was not found inside element ${new Locator(context)}`);
     } else {
-      assertElementExists(res, locator, 'Clickable element')
+      assertElementExists(res, locator, 'Clickable element');
     }
-    const elem = usingFirstElement(res)
+    const elem = usingFirstElement(res);
 
-    return this.executeScript((el) => {
+    return this.executeScript(el => {
       if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur()
+        document.activeElement.blur();
       }
-      const event = document.createEvent('MouseEvent')
-      event.initEvent('contextmenu', true, true)
-      return el.dispatchEvent(event)
-    }, elem)
+      const event = document.createEvent('MouseEvent');
+      event.initEvent('contextmenu', true, true);
+      return el.dispatchEvent(event);
+    }, elem);
   }
 
   /**
@@ -1114,12 +1088,12 @@ class WebDriver extends Helper {
    *
    */
   async fillField(field, value) {
-    const res = await findFields.call(this, field)
-    assertElementExists(res, field, 'Field')
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
-    await elem.clearValue()
-    await elem.setValue(value.toString())
+    const res = await findFields.call(this, field);
+    assertElementExists(res, field, 'Field');
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
+    await elem.clearValue();
+    await elem.setValue(value.toString());
   }
 
   /**
@@ -1127,11 +1101,11 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async appendField(field, value) {
-    const res = await findFields.call(this, field)
-    assertElementExists(res, field, 'Field')
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
-    return elem.addValue(value.toString())
+    const res = await findFields.call(this, field);
+    assertElementExists(res, field, 'Field');
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
+    return elem.addValue(value.toString());
   }
 
   /**
@@ -1139,60 +1113,44 @@ class WebDriver extends Helper {
    *
    */
   async clearField(field) {
-    const res = await findFields.call(this, field)
-    assertElementExists(res, field, 'Field')
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
-    return elem.clearValue(getElementId(elem))
+    const res = await findFields.call(this, field);
+    assertElementExists(res, field, 'Field');
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
+    return elem.clearValue(getElementId(elem));
   }
 
   /**
    * {{> selectOption }}
    */
   async selectOption(select, option) {
-    const res = await findFields.call(this, select)
-    assertElementExists(res, select, 'Selectable field')
-    const elem = usingFirstElement(res)
-    highlightActiveElement.call(this, elem)
+    const res = await findFields.call(this, select);
+    assertElementExists(res, select, 'Selectable field');
+    const elem = usingFirstElement(res);
+    highlightActiveElement.call(this, elem);
 
     if (!Array.isArray(option)) {
-      option = [option]
+      option = [option];
     }
 
     // select options by visible text
-    let els = await forEachAsync(option, async (opt) =>
-      this.browser.findElementsFromElement(
-        getElementId(elem),
-        'xpath',
-        Locator.select.byVisibleText(xpathLocator.literal(opt)),
-      ),
-    )
+    let els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byVisibleText(xpathLocator.literal(opt))));
 
-    const clickOptionFn = async (el) => {
-      if (el[0]) el = el[0]
-      const elementId = getElementId(el)
-      if (elementId) return this.browser.elementClick(elementId)
-    }
+    const clickOptionFn = async el => {
+      if (el[0]) el = el[0];
+      const elementId = getElementId(el);
+      if (elementId) return this.browser.elementClick(elementId);
+    };
 
     if (Array.isArray(els) && els.length) {
-      return forEachAsync(els, clickOptionFn)
+      return forEachAsync(els, clickOptionFn);
     }
     // select options by value
-    els = await forEachAsync(option, async (opt) =>
-      this.browser.findElementsFromElement(
-        getElementId(elem),
-        'xpath',
-        Locator.select.byValue(xpathLocator.literal(opt)),
-      ),
-    )
+    els = await forEachAsync(option, async opt => this.browser.findElementsFromElement(getElementId(elem), 'xpath', Locator.select.byValue(xpathLocator.literal(opt))));
     if (els.length === 0) {
-      throw new ElementNotFound(
-        select,
-        `Option "${option}" in`,
-        'was not found neither by a visible text nor by a value',
-      )
+      throw new ElementNotFound(select, `Option "${option}" in`, 'was not found neither by a visible text nor by a value');
     }
-    return forEachAsync(els, clickOptionFn)
+    return forEachAsync(els, clickOptionFn);
   }
 
   /**
@@ -1201,29 +1159,27 @@ class WebDriver extends Helper {
    * {{> attachFile }}
    */
   async attachFile(locator, pathToFile) {
-    let file = path.join(global.codecept_dir, pathToFile)
+    let file = path.join(global.codecept_dir, pathToFile);
     if (!fileExists(file)) {
-      throw new Error(`File at ${file} can not be found on local system`)
+      throw new Error(`File at ${file} can not be found on local system`);
     }
 
-    const res = await findFields.call(this, locator)
-    this.debug(`Uploading ${file}`)
-    assertElementExists(res, locator, 'File field')
-    const el = usingFirstElement(res)
+    const res = await findFields.call(this, locator);
+    this.debug(`Uploading ${file}`);
+    assertElementExists(res, locator, 'File field');
+    const el = usingFirstElement(res);
 
     // Remote Upload (when running Selenium Server)
     if (this.options.remoteFileUpload) {
       try {
-        this.debugSection('File', 'Uploading file to remote server')
-        file = await this.browser.uploadFile(file)
+        this.debugSection('File', 'Uploading file to remote server');
+        file = await this.browser.uploadFile(file);
       } catch (err) {
-        throw new Error(
-          `File can't be transferred to remote server. Set \`remoteFileUpload: false\` in config to upload file locally.\n${err.message}`,
-        )
+        throw new Error(`File can't be transferred to remote server. Set \`remoteFileUpload: false\` in config to upload file locally.\n${err.message}`);
       }
     }
 
-    return el.addValue(file)
+    return el.addValue(file);
   }
 
   /**
@@ -1231,19 +1187,19 @@ class WebDriver extends Helper {
    * {{> checkOption }}
    */
   async checkOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
-    const locateFn = prepareLocateFn.call(this, context)
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findCheckable.call(this, field, locateFn)
+    const res = await findCheckable.call(this, field, locateFn);
 
-    assertElementExists(res, field, 'Checkable')
-    const elem = usingFirstElement(res)
-    const elementId = getElementId(elem)
-    highlightActiveElement.call(this, elem)
+    assertElementExists(res, field, 'Checkable');
+    const elem = usingFirstElement(res);
+    const elementId = getElementId(elem);
+    highlightActiveElement.call(this, elem);
 
-    const isSelected = await this.browser.isElementSelected(elementId)
-    if (isSelected) return Promise.resolve(true)
-    return this.browser[clickMethod](elementId)
+    const isSelected = await this.browser.isElementSelected(elementId);
+    if (isSelected) return Promise.resolve(true);
+    return this.browser[clickMethod](elementId);
   }
 
   /**
@@ -1251,19 +1207,19 @@ class WebDriver extends Helper {
    * {{> uncheckOption }}
    */
   async uncheckOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
-    const locateFn = prepareLocateFn.call(this, context)
+    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick';
+    const locateFn = prepareLocateFn.call(this, context);
 
-    const res = await findCheckable.call(this, field, locateFn)
+    const res = await findCheckable.call(this, field, locateFn);
 
-    assertElementExists(res, field, 'Checkable')
-    const elem = usingFirstElement(res)
-    const elementId = getElementId(elem)
-    highlightActiveElement.call(this, elem)
+    assertElementExists(res, field, 'Checkable');
+    const elem = usingFirstElement(res);
+    const elementId = getElementId(elem);
+    highlightActiveElement.call(this, elem);
 
-    const isSelected = await this.browser.isElementSelected(elementId)
-    if (!isSelected) return Promise.resolve(true)
-    return this.browser[clickMethod](elementId)
+    const isSelected = await this.browser.isElementSelected(elementId);
+    if (!isSelected) return Promise.resolve(true);
+    return this.browser[clickMethod](elementId);
   }
 
   /**
@@ -1271,10 +1227,14 @@ class WebDriver extends Helper {
    *
    */
   async grabTextFromAll(locator) {
-    const res = await this._locate(locator, true)
-    const val = await forEachAsync(res, (el) => this.browser.getElementText(getElementId(el)))
-    this.debugSection('GrabText', String(val))
-    return val
+    const res = await this._locate(locator, true);
+    let val = [];
+    await forEachAsync(res, async el => {
+      const text = await this.browser.getElementText(getElementId(el));
+      val.push(text);
+    });
+    this.debugSection('GrabText', String(val));
+    return val;
   }
 
   /**
@@ -1282,13 +1242,13 @@ class WebDriver extends Helper {
    *
    */
   async grabTextFrom(locator) {
-    const texts = await this.grabTextFromAll(locator)
-    assertElementExists(texts, locator)
+    const texts = await this.grabTextFromAll(locator);
+    assertElementExists(texts, locator);
     if (texts.length > 1) {
-      this.debugSection('GrabText', `Using first element out of ${texts.length}`)
+      this.debugSection('GrabText', `Using first element out of ${texts.length}`);
     }
 
-    return texts[0]
+    return texts[0];
   }
 
   /**
@@ -1296,10 +1256,10 @@ class WebDriver extends Helper {
    *
    */
   async grabHTMLFromAll(locator) {
-    const elems = await this._locate(locator, true)
-    const html = await forEachAsync(elems, (elem) => elem.getHTML(false))
-    this.debugSection('GrabHTML', String(html))
-    return html
+    const elems = await this._locate(locator, true);
+    const html = await forEachAsync(elems, elem => elem.getHTML(false));
+    this.debugSection('GrabHTML', String(html));
+    return html;
   }
 
   /**
@@ -1307,13 +1267,13 @@ class WebDriver extends Helper {
    *
    */
   async grabHTMLFrom(locator) {
-    const html = await this.grabHTMLFromAll(locator)
-    assertElementExists(html, locator)
+    const html = await this.grabHTMLFromAll(locator);
+    assertElementExists(html, locator);
     if (html.length > 1) {
-      this.debugSection('GrabHTML', `Using first element out of ${html.length}`)
+      this.debugSection('GrabHTML', `Using first element out of ${html.length}`);
     }
 
-    return html[0]
+    return html[0];
   }
 
   /**
@@ -1321,11 +1281,11 @@ class WebDriver extends Helper {
    *
    */
   async grabValueFromAll(locator) {
-    const res = await this._locate(locator, true)
-    const val = await forEachAsync(res, (el) => el.getValue())
-    this.debugSection('GrabValue', String(val))
+    const res = await this._locate(locator, true);
+    const val = await forEachAsync(res, el => el.getValue());
+    this.debugSection('GrabValue', String(val));
 
-    return val
+    return val;
   }
 
   /**
@@ -1333,92 +1293,92 @@ class WebDriver extends Helper {
    *
    */
   async grabValueFrom(locator) {
-    const values = await this.grabValueFromAll(locator)
-    assertElementExists(values, locator)
+    const values = await this.grabValueFromAll(locator);
+    assertElementExists(values, locator);
     if (values.length > 1) {
-      this.debugSection('GrabValue', `Using first element out of ${values.length}`)
+      this.debugSection('GrabValue', `Using first element out of ${values.length}`);
     }
 
-    return values[0]
+    return values[0];
   }
 
   /**
    * {{> grabCssPropertyFromAll }}
    */
   async grabCssPropertyFromAll(locator, cssProperty) {
-    const res = await this._locate(locator, true)
-    const val = await forEachAsync(res, async (el) => this.browser.getElementCSSValue(getElementId(el), cssProperty))
-    this.debugSection('Grab', String(val))
-    return val
+    const res = await this._locate(locator, true);
+    const val = await forEachAsync(res, async el => this.browser.getElementCSSValue(getElementId(el), cssProperty));
+    this.debugSection('Grab', String(val));
+    return val;
   }
 
   /**
    * {{> grabCssPropertyFrom }}
    */
   async grabCssPropertyFrom(locator, cssProperty) {
-    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty)
-    assertElementExists(cssValues, locator)
+    const cssValues = await this.grabCssPropertyFromAll(locator, cssProperty);
+    assertElementExists(cssValues, locator);
 
     if (cssValues.length > 1) {
-      this.debugSection('GrabCSS', `Using first element out of ${cssValues.length}`)
+      this.debugSection('GrabCSS', `Using first element out of ${cssValues.length}`);
     }
 
-    return cssValues[0]
+    return cssValues[0];
   }
 
   /**
    * {{> grabAttributeFromAll }}
    */
   async grabAttributeFromAll(locator, attr) {
-    const res = await this._locate(locator, true)
-    const val = await forEachAsync(res, async (el) => el.getAttribute(attr))
-    this.debugSection('GrabAttribute', String(val))
-    return val
+    const res = await this._locate(locator, true);
+    const val = await forEachAsync(res, async el => el.getAttribute(attr));
+    this.debugSection('GrabAttribute', String(val));
+    return val;
   }
 
   /**
    * {{> grabAttributeFrom }}
    */
   async grabAttributeFrom(locator, attr) {
-    const attrs = await this.grabAttributeFromAll(locator, attr)
-    assertElementExists(attrs, locator)
+    const attrs = await this.grabAttributeFromAll(locator, attr);
+    assertElementExists(attrs, locator);
     if (attrs.length > 1) {
-      this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`)
+      this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`);
     }
-    return attrs[0]
+    return attrs[0];
   }
 
   /**
    * {{> seeInTitle }}
    */
   async seeInTitle(text) {
-    const title = await this.browser.getTitle()
-    return stringIncludes('web page title').assert(text, title)
+    const title = await this.browser.getTitle();
+    return stringIncludes('web page title').assert(text, title);
   }
 
   /**
    * {{> seeTitleEquals }}
    */
   async seeTitleEquals(text) {
-    const title = await this.browser.getTitle()
-    return assert.equal(title, text, `expected web page title to be ${text}, but found ${title}`)
+    const title = await this.browser.getTitle();
+    return assert.equal(title, text, `expected web page title to be ${text}, but found ${title}`);
   }
 
   /**
    * {{> dontSeeInTitle }}
    */
   async dontSeeInTitle(text) {
-    const title = await this.browser.getTitle()
-    return stringIncludes('web page title').negate(text, title)
+    const title = await this.browser.getTitle();
+    return stringIncludes('web page title').negate(text, title);
   }
 
   /**
    * {{> grabTitle }}
    */
   async grabTitle() {
-    const title = await this.browser.getTitle()
-    this.debugSection('Title', title)
-    return title
+    const title = await this.browser.getTitle();
+    this.debugSection('Title', title);
+    return title;
   }
 
   /**
@@ -1427,14 +1387,14 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async see(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context)
+    return proceedSee.call(this, 'assert', text, context);
   }
 
   /**
    * {{> seeTextEquals }}
    */
   async seeTextEquals(text, context = null) {
-    return proceedSee.call(this, 'assert', text, context, true)
+    return proceedSee.call(this, 'assert', text, context, true);
   }
 
   /**
@@ -1443,7 +1403,7 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async dontSee(text, context = null) {
-    return proceedSee.call(this, 'negate', text, context)
+    return proceedSee.call(this, 'negate', text, context);
   }
 
   /**
@@ -1451,8 +1411,8 @@ class WebDriver extends Helper {
    *
    */
   async seeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString()
-    return proceedSeeField.call(this, 'assert', field, _value)
+    const _value = typeof value === 'boolean' ? value : value.toString();
+    return proceedSeeField.call(this, 'assert', field, _value);
   }
 
   /**
@@ -1460,8 +1420,8 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeInField(field, value) {
-    const _value = typeof value === 'boolean' ? value : value.toString()
-    return proceedSeeField.call(this, 'negate', field, _value)
+    const _value = typeof value === 'boolean' ? value : value.toString();
+    return proceedSeeField.call(this, 'negate', field, _value);
   }
 
   /**
@@ -1469,7 +1429,7 @@ class WebDriver extends Helper {
    * {{> seeCheckboxIsChecked }}
    */
   async seeCheckboxIsChecked(field) {
-    return proceedSeeCheckbox.call(this, 'assert', field)
+    return proceedSeeCheckbox.call(this, 'assert', field);
   }
 
   /**
@@ -1477,7 +1437,7 @@ class WebDriver extends Helper {
    * {{> dontSeeCheckboxIsChecked }}
    */
   async dontSeeCheckboxIsChecked(field) {
-    return proceedSeeCheckbox.call(this, 'negate', field)
+    return proceedSeeCheckbox.call(this, 'negate', field);
   }
 
   /**
@@ -1486,13 +1446,13 @@ class WebDriver extends Helper {
    *
    */
   async seeElement(locator) {
-    const res = await this._locate(locator, true)
-    assertElementExists(res, locator)
-    const selected = await forEachAsync(res, async (el) => el.isDisplayed())
+    const res = await this._locate(locator, true);
+    assertElementExists(res, locator);
+    const selected = await forEachAsync(res, async el => el.isDisplayed());
     try {
-      return truth(`elements of ${new Locator(locator)}`, 'to be seen').assert(selected)
+      return truth(`elements of ${new Locator(locator)}`, 'to be seen').assert(selected);
     } catch (e) {
-      dontSeeElementError(locator)
+      dontSeeElementError(locator);
     }
   }
 
@@ -1501,15 +1461,15 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async dontSeeElement(locator) {
-    const res = await this._locate(locator, false)
+    const res = await this._locate(locator, false);
     if (!res || res.length === 0) {
-      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(false)
+      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(false);
     }
-    const selected = await forEachAsync(res, async (el) => el.isDisplayed())
+    const selected = await forEachAsync(res, async el => el.isDisplayed());
     try {
-      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(selected)
+      return truth(`elements of ${new Locator(locator)}`, 'to be seen').negate(selected);
     } catch (e) {
-      seeElementError(locator)
+      seeElementError(locator);
     }
   }
 
@@ -1518,11 +1478,11 @@ class WebDriver extends Helper {
    *
    */
   async seeElementInDOM(locator) {
-    const res = await this._res(locator)
+    const res = await this._res(locator);
     try {
-      return empty('elements').negate(res)
+      return empty('elements').negate(res);
     } catch (e) {
-      dontSeeElementInDOMError(locator)
+      dontSeeElementInDOMError(locator);
     }
   }
 
@@ -1531,11 +1491,11 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeElementInDOM(locator) {
-    const res = await this._res(locator)
+    const res = await this._res(locator);
     try {
-      return empty('elements').assert(res)
+      return empty('elements').assert(res);
     } catch (e) {
-      seeElementInDOMError(locator)
+      seeElementInDOMError(locator);
     }
   }
 
@@ -1544,8 +1504,8 @@ class WebDriver extends Helper {
    *
    */
   async seeInSource(text) {
-    const source = await this.browser.getPageSource()
-    return stringIncludes('HTML source of a page').assert(text, source)
+    const source = await this.browser.getPageSource();
+    return stringIncludes('HTML source of a page').assert(text, source);
   }
 
   /**
@@ -1553,7 +1513,7 @@ class WebDriver extends Helper {
    *
    */
   async grabSource() {
-    return this.browser.getPageSource()
+    return this.browser.getPageSource();
   }
 
   /**
@@ -1561,27 +1521,27 @@ class WebDriver extends Helper {
    */
   async grabBrowserLogs() {
     if (this.browser.isW3C) {
-      this.debug('Logs not available in W3C specification')
-      return
+      this.debug('Logs not available in W3C specification');
+      return;
     }
-    return this.browser.getLogs('browser')
+    return this.browser.getLogs('browser');
   }
 
   /**
    * {{> grabCurrentUrl }}
    */
   async grabCurrentUrl() {
-    const res = await this.browser.getUrl()
-    this.debugSection('Url', res)
-    return res
+    const res = await this.browser.getUrl();
+    this.debugSection('Url', res);
+    return res;
   }
 
   /**
    * {{> dontSeeInSource }}
    */
   async dontSeeInSource(text) {
-    const source = await this.browser.getPageSource()
-    return stringIncludes('HTML source of a page').negate(text, source)
+    const source = await this.browser.getPageSource();
+    return stringIncludes('HTML source of a page').negate(text, source);
   }
 
   /**
@@ -1589,12 +1549,8 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async seeNumberOfElements(locator, num) {
-    const res = await this._locate(locator)
-    return assert.equal(
-      res.length,
-      num,
-      `expected number of elements (${new Locator(locator)}) is ${num}, but found ${res.length}`,
-    )
+    const res = await this._locate(locator);
+    return assert.equal(res.length, num, `expected number of elements (${new Locator(locator)}) is ${num}, but found ${res.length}`);
   }
 
   /**
@@ -1602,93 +1558,83 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async seeNumberOfVisibleElements(locator, num) {
-    const res = await this.grabNumberOfVisibleElements(locator)
-    return assert.equal(
-      res,
-      num,
-      `expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`,
-    )
+    const res = await this.grabNumberOfVisibleElements(locator);
+    return assert.equal(res, num, `expected number of visible elements (${new Locator(locator)}) is ${num}, but found ${res}`);
   }
 
   /**
    * {{> seeCssPropertiesOnElements }}
    */
   async seeCssPropertiesOnElements(locator, cssProperties) {
-    const res = await this._locate(locator)
-    assertElementExists(res, locator)
+    const res = await this._locate(locator);
+    assertElementExists(res, locator);
 
-    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties)
-    const elemAmount = res.length
-    let props = []
+    const cssPropertiesCamelCase = convertCssPropertiesToCamelCase(cssProperties);
+    const elemAmount = res.length;
+    let props = [];
 
     for (const element of res) {
       for (const prop of Object.keys(cssProperties)) {
-        const cssProp = await this.grabCssPropertyFrom(locator, prop)
+        const cssProp = await this.grabCssPropertyFrom(locator, prop);
         if (isColorProperty(prop)) {
-          props.push(convertColorToRGBA(cssProp))
+          props.push(convertColorToRGBA(cssProp));
         } else {
-          props.push(cssProp)
+          props.push(cssProp);
         }
       }
     }
 
-    const values = Object.keys(cssPropertiesCamelCase).map((key) => cssPropertiesCamelCase[key])
-    if (!Array.isArray(props)) props = [props]
-    let chunked = chunkArray(props, values.length)
-    chunked = chunked.filter((val) => {
+    const values = Object.keys(cssPropertiesCamelCase).map(key => cssPropertiesCamelCase[key]);
+    if (!Array.isArray(props)) props = [props];
+    let chunked = chunkArray(props, values.length);
+    chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
         // eslint-disable-next-line eqeqeq
-        if (val[i] != values[i]) return false
+        if (val[i] != values[i]) return false;
       }
-      return true
-    })
-    return equals(
-      `all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`,
-    ).assert(chunked.length, elemAmount)
+      return true;
+    });
+    return equals(`all elements (${new Locator(locator)}) to have CSS property ${JSON.stringify(cssProperties)}`).assert(chunked.length, elemAmount);
   }
 
   /**
    * {{> seeAttributesOnElements }}
    */
   async seeAttributesOnElements(locator, attributes) {
-    const res = await this._locate(locator)
-    assertElementExists(res, locator)
-    const elemAmount = res.length
+    const res = await this._locate(locator);
+    assertElementExists(res, locator);
+    const elemAmount = res.length;
 
-    let attrs = await forEachAsync(res, async (el) => {
-      return forEachAsync(Object.keys(attributes), async (attr) => el.getAttribute(attr))
-    })
+    let attrs = await forEachAsync(res, async el => {
+      return forEachAsync(Object.keys(attributes), async attr => el.getAttribute(attr));
+    });
 
-    const values = Object.keys(attributes).map((key) => attributes[key])
-    if (!Array.isArray(attrs)) attrs = [attrs]
-    let chunked = chunkArray(attrs, values.length)
-    chunked = chunked.filter((val) => {
+    const values = Object.keys(attributes).map(key => attributes[key]);
+    if (!Array.isArray(attrs)) attrs = [attrs];
+    let chunked = chunkArray(attrs, values.length);
+    chunked = chunked.filter(val => {
       for (let i = 0; i < val.length; ++i) {
-        const _actual = Number.isNaN(val[i]) || typeof values[i] === 'string' ? val[i] : Number.parseInt(val[i], 10)
-        const _expected =
-          Number.isNaN(values[i]) || typeof values[i] === 'string' ? values[i] : Number.parseInt(values[i], 10)
+        const _actual = Number.isNaN(val[i]) || typeof values[i] === 'string' ? val[i] : Number.parseInt(val[i], 10);
+        const _expected = Number.isNaN(values[i]) || typeof values[i] === 'string' ? values[i] : Number.parseInt(values[i], 10);
         // the attribute could be a boolean
-        if (typeof _actual === 'boolean') return _actual === _expected
-        if (_actual !== _expected) return false
+        if (typeof _actual === 'boolean') return _actual === _expected;
+        if (_actual !== _expected) return false;
       }
-      return true
-    })
-    return assert.ok(
-      chunked.length === elemAmount,
-      `expected all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`,
-    )
+      return true;
+    });
+    return assert.ok(chunked.length === elemAmount, `expected all elements (${new Locator(locator)}) to have attributes ${JSON.stringify(attributes)}`);
   }
 
   /**
    * {{> grabNumberOfVisibleElements }}
    */
   async grabNumberOfVisibleElements(locator) {
-    const res = await this._locate(locator)
+    const res = await this._locate(locator);
 
-    let selected = await forEachAsync(res, async (el) => el.isDisplayed())
-    if (!Array.isArray(selected)) selected = [selected]
-    selected = selected.filter((val) => val === true)
-    return selected.length
+    let selected = await forEachAsync(res, async el => el.isDisplayed());
+    if (!Array.isArray(selected)) selected = [selected];
+    selected = selected.filter(val => val === true);
+    return selected.length;
   }
 
   /**
@@ -1696,8 +1642,8 @@ class WebDriver extends Helper {
    *
    */
   async seeInCurrentUrl(url) {
-    const res = await this.browser.getUrl()
-    return stringIncludes('url').assert(url, decodeUrl(res))
+    const res = await this.browser.getUrl();
+    return stringIncludes('url').assert(url, decodeUrl(res));
   }
 
   /**
@@ -1705,8 +1651,8 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeInCurrentUrl(url) {
-    const res = await this.browser.getUrl()
-    return stringIncludes('url').negate(url, decodeUrl(res))
+    const res = await this.browser.getUrl();
+    return stringIncludes('url').negate(url, decodeUrl(res));
   }
 
   /**
@@ -1714,8 +1660,8 @@ class WebDriver extends Helper {
    *
    */
   async seeCurrentUrlEquals(url) {
-    const res = await this.browser.getUrl()
-    return urlEquals(this.options.url).assert(url, decodeUrl(res))
+    const res = await this.browser.getUrl();
+    return urlEquals(this.options.url).assert(url, decodeUrl(res));
   }
 
   /**
@@ -1723,8 +1669,8 @@ class WebDriver extends Helper {
    *
    */
   async dontSeeCurrentUrlEquals(url) {
-    const res = await this.browser.getUrl()
-    return urlEquals(this.options.url).negate(url, decodeUrl(res))
+    const res = await this.browser.getUrl();
+    return urlEquals(this.options.url).negate(url, decodeUrl(res));
   }
 
   /**
@@ -1733,7 +1679,7 @@ class WebDriver extends Helper {
    * {{> executeScript }}
    */
   executeScript(...args) {
-    return this.browser.execute.apply(this.browser, args)
+    return this.browser.execute.apply(this.browser, args);
   }
 
   /**
@@ -1741,7 +1687,7 @@ class WebDriver extends Helper {
    *
    */
   executeAsyncScript(...args) {
-    return this.browser.executeAsync.apply(this.browser, args)
+    return this.browser.executeAsync.apply(this.browser, args);
   }
 
   /**
@@ -1749,10 +1695,10 @@ class WebDriver extends Helper {
    *
    */
   async scrollIntoView(locator, scrollIntoViewOptions) {
-    const res = await this._locate(withStrictLocator(locator), true)
-    assertElementExists(res, locator)
-    const elem = usingFirstElement(res)
-    return elem.scrollIntoView(scrollIntoViewOptions)
+    const res = await this._locate(withStrictLocator(locator), true);
+    assertElementExists(res, locator);
+    const elem = usingFirstElement(res);
+    return elem.scrollIntoView(scrollIntoViewOptions);
   }
 
   /**
@@ -1761,51 +1707,51 @@ class WebDriver extends Helper {
    */
   async scrollTo(locator, offsetX = 0, offsetY = 0) {
     if (typeof locator === 'number' && typeof offsetX === 'number') {
-      offsetY = offsetX
-      offsetX = locator
-      locator = null
+      offsetY = offsetX;
+      offsetX = locator;
+      locator = null;
     }
 
     if (locator) {
-      const res = await this._locate(withStrictLocator(locator), true)
-      assertElementExists(res, locator)
-      const elem = usingFirstElement(res)
-      const elementId = getElementId(elem)
-      if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(offsetX, offsetY, elementId)
-      const location = await elem.getLocation()
-      assertElementExists(location, locator, 'Failed to receive', 'location')
+      const res = await this._locate(withStrictLocator(locator), true);
+      assertElementExists(res, locator);
+      const elem = usingFirstElement(res);
+      const elementId = getElementId(elem);
+      if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(offsetX, offsetY, elementId);
+      const location = await elem.getLocation();
+      assertElementExists(location, locator, 'Failed to receive', 'location');
 
       return this.browser.execute(
         function (x, y) {
-          return window.scrollTo(x, y)
+          return window.scrollTo(x, y);
         },
         location.x + offsetX,
         location.y + offsetY,
-      )
+      );
     }
 
-    if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(locator, offsetX, offsetY)
+    if (this.browser.isMobile && !this.browser.isW3C) return this.browser.touchScroll(locator, offsetX, offsetY);
 
     return this.browser.execute(
       function (x, y) {
-        return window.scrollTo(x, y)
+        return window.scrollTo(x, y);
       },
       offsetX,
       offsetY,
-    )
+    );
   }
 
   /**
    * {{> moveCursorTo }}
    */
   async moveCursorTo(locator, xOffset, yOffset) {
-    const res = await this._locate(withStrictLocator(locator), true)
-    assertElementExists(res, locator)
-    const elem = usingFirstElement(res)
+    const res = await this._locate(withStrictLocator(locator), true);
+    assertElementExists(res, locator);
+    const elem = usingFirstElement(res);
     try {
-      await elem.moveTo({ xOffset, yOffset })
+      await elem.moveTo({ xOffset, yOffset });
     } catch (e) {
-      debug(e.message)
+      debug(e.message);
     }
   }
 
@@ -1814,61 +1760,61 @@ class WebDriver extends Helper {
    *
    */
   async saveElementScreenshot(locator, fileName) {
-    const outputFile = screenshotOutputFolder(fileName)
+    const outputFile = screenshotOutputFolder(fileName);
 
-    const res = await this._locate(withStrictLocator(locator), true)
-    assertElementExists(res, locator)
-    const elem = usingFirstElement(res)
+    const res = await this._locate(withStrictLocator(locator), true);
+    assertElementExists(res, locator);
+    const elem = usingFirstElement(res);
 
-    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`)
-    return elem.saveScreenshot(outputFile)
+    this.debug(`Screenshot of ${new Locator(locator)} element has been saved to ${outputFile}`);
+    return elem.saveScreenshot(outputFile);
   }
 
   /**
    * {{> saveScreenshot }}
    */
   async saveScreenshot(fileName, fullPage = false) {
-    let outputFile = screenshotOutputFolder(fileName)
+    let outputFile = screenshotOutputFolder(fileName);
 
     if (this.activeSessionName) {
-      const browser = this.sessionWindows[this.activeSessionName]
+      const browser = this.sessionWindows[this.activeSessionName];
 
       for (const sessionName in this.sessionWindows) {
-        const activeSessionPage = this.sessionWindows[sessionName]
-        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`)
+        const activeSessionPage = this.sessionWindows[sessionName];
+        outputFile = screenshotOutputFolder(`${sessionName}_${fileName}`);
 
-        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`)
+        this.debug(`${sessionName} - Screenshot is saving to ${outputFile}`);
 
         if (browser) {
-          this.debug(`Screenshot of ${sessionName} session has been saved to ${outputFile}`)
-          return browser.saveScreenshot(outputFile)
+          this.debug(`Screenshot of ${sessionName} session has been saved to ${outputFile}`);
+          return browser.saveScreenshot(outputFile);
         }
       }
     }
 
     if (!fullPage) {
-      this.debug(`Screenshot has been saved to ${outputFile}`)
-      return this.browser.saveScreenshot(outputFile)
+      this.debug(`Screenshot has been saved to ${outputFile}`);
+      return this.browser.saveScreenshot(outputFile);
     }
 
-    const originalWindowSize = await this.browser.getWindowSize()
+    const originalWindowSize = await this.browser.getWindowSize();
 
     let { width, height } = await this.browser
       .execute(function () {
         return {
           height: document.body.scrollHeight,
           width: document.body.scrollWidth,
-        }
+        };
       })
-      .then((res) => res)
+      .then(res => res);
 
-    if (height < 100) height = 500 // errors for very small height
+    if (height < 100) height = 500; // errors for very small height
 
-    await this.browser.setWindowSize(width, height)
-    this.debug(`Screenshot has been saved to ${outputFile}, size: ${width}x${height}`)
-    const buffer = await this.browser.saveScreenshot(outputFile)
-    await this.browser.setWindowSize(originalWindowSize.width, originalWindowSize.height)
-    return buffer
+    await this.browser.setWindowSize(width, height);
+    this.debug(`Screenshot has been saved to ${outputFile}, size: ${width}x${height}`);
+    const buffer = await this.browser.saveScreenshot(outputFile);
+    await this.browser.setWindowSize(originalWindowSize.width, originalWindowSize.height);
+    return buffer;
   }
 
   /**
@@ -1876,40 +1822,40 @@ class WebDriver extends Helper {
    * {{> setCookie }}
    */
   async setCookie(cookie) {
-    return this.browser.setCookies(cookie)
+    return this.browser.setCookies(cookie);
   }
 
   /**
    * {{> clearCookie }}
    */
   async clearCookie(cookie) {
-    return this.browser.deleteCookies(cookie)
+    return this.browser.deleteCookies(cookie);
   }
 
   /**
    * {{> seeCookie }}
    */
   async seeCookie(name) {
-    const cookie = await this.browser.getCookies([name])
-    return truth(`cookie ${name}`, 'to be set').assert(cookie)
+    const cookie = await this.browser.getCookies([name]);
+    return truth(`cookie ${name}`, 'to be set').assert(cookie);
   }
 
   /**
    * {{> dontSeeCookie }}
    */
   async dontSeeCookie(name) {
-    const cookie = await this.browser.getCookies([name])
-    return truth(`cookie ${name}`, 'to be set').negate(cookie)
+    const cookie = await this.browser.getCookies([name]);
+    return truth(`cookie ${name}`, 'to be set').negate(cookie);
   }
 
   /**
    * {{> grabCookie }}
    */
   async grabCookie(name) {
-    if (!name) return this.browser.getCookies()
-    const cookie = await this.browser.getCookies([name])
-    this.debugSection('Cookie', JSON.stringify(cookie))
-    return cookie[0]
+    if (!name) return this.browser.getCookies();
+    const cookie = await this.browser.getCookies([name]);
+    this.debugSection('Cookie', JSON.stringify(cookie));
+    return cookie[0];
   }
 
   /**
@@ -1917,33 +1863,33 @@ class WebDriver extends Helper {
    */
   async waitForCookie(name, sec) {
     // by default, we will retry 3 times
-    let retries = 3
-    const waitTimeout = sec || this.options.waitForTimeoutInSeconds
+    let retries = 3;
+    const waitTimeout = sec || this.options.waitForTimeoutInSeconds;
 
     if (sec) {
-      retries = sec
+      retries = sec;
     } else {
-      retries = waitTimeout - 1
+      retries = waitTimeout - 1;
     }
 
     return promiseRetry(
       async (retry, number) => {
-        const _grabCookie = async (name) => {
-          const cookie = await this.browser.getCookies([name])
-          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`)
-        }
+        const _grabCookie = async name => {
+          const cookie = await this.browser.getCookies([name]);
+          if (cookie.length === 0) throw Error(`Cookie ${name} is not found after ${retries}s`);
+        };
 
-        this.debugSection('Wait for cookie: ', name)
-        if (number > 1) this.debugSection('Retrying... Attempt #', number)
+        this.debugSection('Wait for cookie: ', name);
+        if (number > 1) this.debugSection('Retrying... Attempt #', number);
 
         try {
-          await _grabCookie(name)
+          await _grabCookie(name);
         } catch (e) {
-          retry(e)
+          retry(e);
         }
       },
       { retries, maxTimeout: 1000 },
-    )
+    );
   }
 
   /**
@@ -1952,11 +1898,11 @@ class WebDriver extends Helper {
    * libraries](http://jster.net/category/windows-modals-popups).
    */
   async acceptPopup() {
-    return this.browser.getAlertText().then((res) => {
+    return this.browser.getAlertText().then(res => {
       if (res !== null) {
-        return this.browser.acceptAlert()
+        return this.browser.acceptAlert();
       }
-    })
+    });
   }
 
   /**
@@ -1964,11 +1910,11 @@ class WebDriver extends Helper {
    *
    */
   async cancelPopup() {
-    return this.browser.getAlertText().then((res) => {
+    return this.browser.getAlertText().then(res => {
       if (res !== null) {
-        return this.browser.dismissAlert()
+        return this.browser.dismissAlert();
       }
-    })
+    });
   }
 
   /**
@@ -1978,12 +1924,12 @@ class WebDriver extends Helper {
    * @param {string} text value to check.
    */
   async seeInPopup(text) {
-    return this.browser.getAlertText().then((res) => {
+    return this.browser.getAlertText().then(res => {
       if (res === null) {
-        throw new Error('Popup is not opened')
+        throw new Error('Popup is not opened');
       }
-      stringIncludes('text in popup').assert(text, res)
-    })
+      stringIncludes('text in popup').assert(text, res);
+    });
   }
 
   /**
@@ -1991,9 +1937,9 @@ class WebDriver extends Helper {
    */
   async grabPopupText() {
     try {
-      return await this.browser.getAlertText()
+      return await this.browser.getAlertText();
     } catch (err) {
-      this.debugSection('Popup', 'Error getting text from popup')
+      this.debugSection('Popup', 'Error getting text from popup');
     }
   }
 
@@ -2001,9 +1947,9 @@ class WebDriver extends Helper {
    * {{> pressKeyDown }}
    */
   async pressKeyDown(key) {
-    key = getNormalizedKey.call(this, key)
+    key = getNormalizedKey.call(this, key);
     if (!this.browser.isW3C) {
-      return this.browser.sendKeys([key])
+      return this.browser.sendKeys([key]);
     }
     return this.browser.performActions([
       {
@@ -2016,16 +1962,16 @@ class WebDriver extends Helper {
           },
         ],
       },
-    ])
+    ]);
   }
 
   /**
    * {{> pressKeyUp }}
    */
   async pressKeyUp(key) {
-    key = getNormalizedKey.call(this, key)
+    key = getNormalizedKey.call(this, key);
     if (!this.browser.isW3C) {
-      return this.browser.sendKeys([key])
+      return this.browser.sendKeys([key]);
     }
     return this.browser.performActions([
       {
@@ -2038,7 +1984,7 @@ class WebDriver extends Helper {
           },
         ],
       },
-    ])
+    ]);
   }
 
   /**
@@ -2047,25 +1993,25 @@ class WebDriver extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
-    const modifiers = []
+    const modifiers = [];
     if (Array.isArray(key)) {
       for (let k of key) {
-        k = getNormalizedKey.call(this, k)
+        k = getNormalizedKey.call(this, k);
         if (isModifierKey(k)) {
-          modifiers.push(k)
+          modifiers.push(k);
         } else {
-          key = k
-          break
+          key = k;
+          break;
         }
       }
     } else {
-      key = getNormalizedKey.call(this, key)
+      key = getNormalizedKey.call(this, key);
     }
     for (const modifier of modifiers) {
-      await this.pressKeyDown(modifier)
+      await this.pressKeyDown(modifier);
     }
     if (!this.browser.isW3C) {
-      await this.browser.sendKeys([key])
+      await this.browser.sendKeys([key]);
     } else {
       await this.browser.performActions([
         {
@@ -2082,10 +2028,10 @@ class WebDriver extends Helper {
             },
           ],
         },
-      ])
+      ]);
     }
     for (const modifier of modifiers) {
-      await this.pressKeyUp(modifier)
+      await this.pressKeyUp(modifier);
     }
   }
 
@@ -2094,17 +2040,17 @@ class WebDriver extends Helper {
    */
   async type(keys, delay = null) {
     if (!Array.isArray(keys)) {
-      keys = keys.toString()
-      keys = keys.split('')
+      keys = keys.toString();
+      keys = keys.split('');
     }
     if (delay) {
       for (const key of keys) {
-        await this.browser.keys(key)
-        await this.wait(delay / 1000)
+        await this.browser.keys(key);
+        await this.wait(delay / 1000);
       }
-      return
+      return;
     }
-    await this.browser.keys(keys)
+    await this.browser.keys(keys);
   }
 
   /**
@@ -2113,27 +2059,27 @@ class WebDriver extends Helper {
    * {{> resizeWindow }}
    */
   async resizeWindow(width, height) {
-    return this.browser.setWindowSize(width, height)
+    return this.browser.setWindowSize(width, height);
   }
 
   async _resizeBrowserWindow(browser, width, height) {
     if (width === 'maximize') {
-      const size = await browser.maximizeWindow()
-      this.debugSection('Window Size', size)
-      return
+      const size = await browser.maximizeWindow();
+      this.debugSection('Window Size', size);
+      return;
     }
     if (browser.isW3C) {
-      return browser.setWindowRect(null, null, parseInt(width, 10), parseInt(height, 10))
+      return browser.setWindowRect(null, null, parseInt(width, 10), parseInt(height, 10));
     }
-    return browser.setWindowSize(parseInt(width, 10), parseInt(height, 10))
+    return browser.setWindowSize(parseInt(width, 10), parseInt(height, 10));
   }
 
   async _resizeWindowIfNeeded(browser, windowSize) {
     if (this.isWeb && windowSize === 'maximize') {
-      await this._resizeBrowserWindow(browser, 'maximize')
+      await this._resizeBrowserWindow(browser, 'maximize');
     } else if (this.isWeb && windowSize && windowSize.indexOf('x') > 0) {
-      const dimensions = windowSize.split('x')
-      await this._resizeBrowserWindow(browser, dimensions[0], dimensions[1])
+      const dimensions = windowSize.split('x');
+      await this._resizeBrowserWindow(browser, dimensions[0], dimensions[1]);
     }
   }
 
@@ -2142,11 +2088,11 @@ class WebDriver extends Helper {
    *
    */
   async focus(locator) {
-    const els = await this._locate(locator)
-    assertElementExists(els, locator, 'Element to focus')
-    const el = usingFirstElement(els)
+    const els = await this._locate(locator);
+    assertElementExists(els, locator, 'Element to focus');
+    const el = usingFirstElement(els);
 
-    await focusElement(el, this.browser)
+    await focusElement(el, this.browser);
   }
 
   /**
@@ -2154,11 +2100,11 @@ class WebDriver extends Helper {
    *
    */
   async blur(locator) {
-    const els = await this._locate(locator)
-    assertElementExists(els, locator, 'Element to blur')
-    const el = usingFirstElement(els)
+    const els = await this._locate(locator);
+    assertElementExists(els, locator, 'Element to blur');
+    const el = usingFirstElement(els);
 
-    await blurElement(el, this.browser)
+    await blurElement(el, this.browser);
   }
 
   /**
@@ -2166,28 +2112,28 @@ class WebDriver extends Helper {
    * {{> dragAndDrop }}
    */
   async dragAndDrop(srcElement, destElement) {
-    let sourceEl = await this._locate(srcElement)
-    assertElementExists(sourceEl, srcElement)
-    sourceEl = usingFirstElement(sourceEl)
+    let sourceEl = await this._locate(srcElement);
+    assertElementExists(sourceEl, srcElement);
+    sourceEl = usingFirstElement(sourceEl);
 
-    let destEl = await this._locate(destElement)
-    assertElementExists(destEl, destElement)
-    destEl = usingFirstElement(destEl)
+    let destEl = await this._locate(destElement);
+    assertElementExists(destEl, destElement);
+    destEl = usingFirstElement(destEl);
 
-    return sourceEl.dragAndDrop(destEl)
+    return sourceEl.dragAndDrop(destEl);
   }
 
   /**
    * {{> dragSlider }}
    */
   async dragSlider(locator, offsetX = 0) {
-    const browser = this.browser
-    await this.moveCursorTo(locator)
+    const browser = this.browser;
+    await this.moveCursorTo(locator);
 
     // for chrome
     if (browser.isW3C) {
-      const xOffset = await this.grabElementBoundingRect(locator, 'x')
-      const yOffset = await this.grabElementBoundingRect(locator, 'y')
+      const xOffset = await this.grabElementBoundingRect(locator, 'x');
+      const yOffset = await this.grabElementBoundingRect(locator, 'y');
 
       return browser.performActions([
         {
@@ -2213,26 +2159,26 @@ class WebDriver extends Helper {
             { type: 'pointerUp', button: 0 },
           ],
         },
-      ])
+      ]);
     }
 
-    await browser.buttonDown(0)
-    await browser.moveToElement(null, offsetX, 0)
-    await browser.buttonUp(0)
+    await browser.buttonDown(0);
+    await browser.moveToElement(null, offsetX, 0);
+    await browser.buttonUp(0);
   }
 
   /**
    * {{> grabAllWindowHandles }}
    */
   async grabAllWindowHandles() {
-    return this.browser.getWindowHandles()
+    return this.browser.getWindowHandles();
   }
 
   /**
    * {{> grabCurrentWindowHandle }}
    */
   async grabCurrentWindowHandle() {
-    return this.browser.getWindowHandle()
+    return this.browser.getWindowHandle();
   }
 
   /**
@@ -2250,140 +2196,140 @@ class WebDriver extends Helper {
    * @param {string} window name of window handle.
    */
   async switchToWindow(window) {
-    await this.browser.switchToWindow(window)
+    await this.browser.switchToWindow(window);
   }
 
   /**
    * {{> closeOtherTabs }}
    */
   async closeOtherTabs() {
-    const handles = await this.browser.getWindowHandles()
-    const currentHandle = await this.browser.getWindowHandle()
-    const otherHandles = handles.filter((handle) => handle !== currentHandle)
+    const handles = await this.browser.getWindowHandles();
+    const currentHandle = await this.browser.getWindowHandle();
+    const otherHandles = handles.filter(handle => handle !== currentHandle);
 
-    await forEachAsync(otherHandles, async (handle) => {
-      await this.browser.switchToWindow(handle)
-      await this.browser.closeWindow()
-    })
-    await this.browser.switchToWindow(currentHandle)
+    await forEachAsync(otherHandles, async handle => {
+      await this.browser.switchToWindow(handle);
+      await this.browser.closeWindow();
+    });
+    await this.browser.switchToWindow(currentHandle);
   }
 
   /**
    * {{> wait }}
    */
   async wait(sec) {
-    return new Promise((resolve) => {
-      setTimeout(resolve, sec * 1000)
-    })
+    return new Promise(resolve => {
+      setTimeout(resolve, sec * 1000);
+    });
   }
 
   /**
    * {{> waitForEnabled }}
    */
   async waitForEnabled(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator)
+        const res = await this._res(locator);
         if (!res || res.length === 0) {
-          return false
+          return false;
         }
-        const selected = await forEachAsync(res, async (el) => this.browser.isElementEnabled(getElementId(el)))
+        const selected = await forEachAsync(res, async el => this.browser.isElementEnabled(getElementId(el)));
         if (Array.isArray(selected)) {
-          return selected.filter((val) => val === true).length > 0
+          return selected.filter(val => val === true).length > 0;
         }
-        return selected
+        return selected;
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${new Locator(locator)}) still not enabled after ${aSec} sec`,
       },
-    )
+    );
   }
 
   /**
    * {{> waitForElement }}
    */
   async waitForElement(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator)
-        return res && res.length
+        const res = await this._res(locator);
+        return res && res.length;
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${new Locator(locator)}) still not present on page after ${aSec} sec`,
       },
-    )
+    );
   }
 
   /**
    * {{> waitForClickable }}
    */
   async waitForClickable(locator, waitTimeout) {
-    waitTimeout = waitTimeout || this.options.waitForTimeoutInSeconds
-    let res = await this._locate(locator)
-    res = usingFirstElement(res)
-    assertElementExists(res, locator)
+    waitTimeout = waitTimeout || this.options.waitForTimeoutInSeconds;
+    let res = await this._locate(locator);
+    res = usingFirstElement(res);
+    assertElementExists(res, locator);
 
     return res.waitForClickable({
       timeout: waitTimeout * 1000,
       timeoutMsg: `element ${res.selector} still not clickable after ${waitTimeout} sec`,
-    })
+    });
   }
 
   /**
    * {{> waitInUrl }}
    */
   async waitInUrl(urlPart, sec = null) {
-    const client = this.browser
-    const aSec = sec || this.options.waitForTimeoutInSeconds
-    let currUrl = ''
+    const client = this.browser;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    let currUrl = '';
 
     return client
       .waitUntil(
         function () {
-          return this.getUrl().then((res) => {
-            currUrl = decodeUrl(res)
-            return currUrl.indexOf(urlPart) > -1
-          })
+          return this.getUrl().then(res => {
+            currUrl = decodeUrl(res);
+            return currUrl.indexOf(urlPart) > -1;
+          });
         },
         { timeout: aSec * 1000 },
       )
-      .catch((e) => {
+      .catch(e => {
         if (e.message.indexOf('timeout')) {
-          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`);
         }
-        throw e
-      })
+        throw e;
+      });
   }
 
   /**
    * {{> waitUrlEquals }}
    */
   async waitUrlEquals(urlPart, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
-    const baseUrl = this.options.url
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const baseUrl = this.options.url;
     if (urlPart.indexOf('http') < 0) {
-      urlPart = baseUrl + urlPart
+      urlPart = baseUrl + urlPart;
     }
-    let currUrl = ''
+    let currUrl = '';
     return this.browser
       .waitUntil(function () {
-        return this.getUrl().then((res) => {
-          currUrl = decodeUrl(res)
-          return currUrl === urlPart
-        })
+        return this.getUrl().then(res => {
+          currUrl = decodeUrl(res);
+          return currUrl === urlPart;
+        });
       }, aSec * 1000)
-      .catch((e) => {
+      .catch(e => {
         if (e.message.indexOf('timeout')) {
-          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`);
         }
-        throw e
-      })
+        throw e;
+      });
   }
 
   /**
@@ -2391,48 +2337,48 @@ class WebDriver extends Helper {
    *
    */
   async waitForText(text, sec = null, context = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
-    const _context = context || this.root
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const _context = context || this.root;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this.$$(withStrictLocator.call(this, _context))
-        if (!res || res.length === 0) return false
-        const selected = await forEachAsync(res, async (el) => this.browser.getElementText(getElementId(el)))
+        const res = await this.$$(withStrictLocator.call(this, _context));
+        if (!res || res.length === 0) return false;
+        const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
         if (Array.isArray(selected)) {
-          return selected.filter((part) => part.indexOf(text) >= 0).length > 0
+          return selected.filter(part => part.indexOf(text) >= 0).length > 0;
         }
-        return selected.indexOf(text) >= 0
+        return selected.indexOf(text) >= 0;
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${_context}) is not in DOM or there is no element(${_context}) with text "${text}" after ${aSec} sec`,
       },
-    )
+    );
   }
 
   /**
    * {{> waitForValue }}
    */
   async waitForValue(field, value, sec = null) {
-    const client = this.browser
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const client = this.browser;
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return client.waitUntil(
       async () => {
-        const res = await findFields.call(this, field)
-        if (!res || res.length === 0) return false
-        const selected = await forEachAsync(res, async (el) => el.getValue())
+        const res = await findFields.call(this, field);
+        if (!res || res.length === 0) return false;
+        const selected = await forEachAsync(res, async el => el.getValue());
         if (Array.isArray(selected)) {
-          return selected.filter((part) => part.indexOf(value) >= 0).length > 0
+          return selected.filter(part => part.indexOf(value) >= 0).length > 0;
         }
-        return selected.indexOf(value) >= 0
+        return selected.indexOf(value) >= 0;
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${field}) is not in DOM or there is no element(${field}) with value "${value}" after ${aSec} sec`,
       },
-    )
+    );
   }
 
   /**
@@ -2440,254 +2386,251 @@ class WebDriver extends Helper {
    *
    */
   async waitForVisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator)
-        if (!res || res.length === 0) return false
-        const selected = await forEachAsync(res, async (el) => el.isDisplayed())
+        const res = await this._res(locator);
+        if (!res || res.length === 0) return false;
+        const selected = await forEachAsync(res, async el => el.isDisplayed());
         if (Array.isArray(selected)) {
-          return selected.filter((val) => val === true).length > 0
+          return selected.filter(val => val === true).length > 0;
         }
-        return selected
+        return selected;
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `element (${new Locator(locator)}) still not visible after ${aSec} sec`,
       },
-    )
+    );
   }
 
   /**
    * {{> waitNumberOfVisibleElements }}
    */
   async waitNumberOfVisibleElements(locator, num, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator)
-        if (!res || res.length === 0) return false
-        let selected = await forEachAsync(res, async (el) => el.isDisplayed())
+        const res = await this._res(locator);
+        if (!res || res.length === 0) return false;
+        let selected = await forEachAsync(res, async el => el.isDisplayed());
 
-        if (!Array.isArray(selected)) selected = [selected]
-        selected = selected.filter((val) => val === true)
-        return selected.length === num
+        if (!Array.isArray(selected)) selected = [selected];
+        selected = selected.filter(val => val === true);
+        return selected.length === num;
       },
       {
         timeout: aSec * 1000,
         timeoutMsg: `The number of elements (${new Locator(locator)}) is not ${num} after ${aSec} sec`,
       },
-    )
+    );
   }
 
   /**
    * {{> waitForInvisible }}
    */
   async waitForInvisible(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator)
-        if (!res || res.length === 0) return true
-        const selected = await forEachAsync(res, async (el) => el.isDisplayed())
-        return !selected.length
+        const res = await this._res(locator);
+        if (!res || res.length === 0) return true;
+        const selected = await forEachAsync(res, async el => el.isDisplayed());
+        return !selected.length;
       },
       { timeout: aSec * 1000, timeoutMsg: `element (${new Locator(locator)}) still visible after ${aSec} sec` },
-    )
+    );
   }
 
   /**
    * {{> waitToHide }}
    */
   async waitToHide(locator, sec = null) {
-    return this.waitForInvisible(locator, sec)
+    return this.waitForInvisible(locator, sec);
   }
 
   /**
    * {{> waitForDetached }}
    */
   async waitForDetached(locator, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(
       async () => {
-        const res = await this._res(locator)
+        const res = await this._res(locator);
         if (!res || res.length === 0) {
-          return true
+          return true;
         }
-        return false
+        return false;
       },
       { timeout: aSec * 1000, timeoutMsg: `element (${new Locator(locator)}) still on page after ${aSec} sec` },
-    )
+    );
   }
 
   /**
    * {{> waitForFunction }}
    */
   async waitForFunction(fn, argsOrSec = null, sec = null) {
-    let args = []
+    let args = [];
     if (argsOrSec) {
       if (Array.isArray(argsOrSec)) {
-        args = argsOrSec
+        args = argsOrSec;
       } else if (typeof argsOrSec === 'number') {
-        sec = argsOrSec
+        sec = argsOrSec;
       }
     }
 
-    const aSec = sec || this.options.waitForTimeoutInSeconds
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
 
     return this.browser.waitUntil(async () => this.browser.execute(fn, ...args), {
       timeout: aSec * 1000,
       timeoutMsg: '',
-    })
+    });
   }
 
   /**
    * {{> waitForNumberOfTabs }}
    */
   async waitForNumberOfTabs(expectedTabs, sec) {
-    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeoutInSeconds
-    let currentTabs
-    let count = 0
+    const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeoutInSeconds;
+    let currentTabs;
+    let count = 0;
 
     do {
-      currentTabs = await this.grabNumberOfOpenTabs()
-      await this.wait(1)
-      count += 1000
-      if (currentTabs >= expectedTabs) return
-    } while (count <= waitTimeout)
+      currentTabs = await this.grabNumberOfOpenTabs();
+      await this.wait(1);
+      count += 1000;
+      if (currentTabs >= expectedTabs) return;
+    } while (count <= waitTimeout);
 
-    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`)
+    throw new Error(`Expected ${expectedTabs} tabs are not met after ${waitTimeout / 1000} sec.`);
   }
 
   /**
    * {{> switchTo }}
    */
   async switchTo(locator) {
-    this.browser.isInsideFrame = true
+    this.browser.isInsideFrame = true;
     if (Number.isInteger(locator)) {
-      return this.browser.switchToFrame(locator)
+      return this.browser.switchToFrame(locator);
     }
     if (!locator) {
-      return this.browser.switchToFrame(null)
+      return this.browser.switchToFrame(null);
     }
 
-    let res = await this._locate(locator, true)
-    assertElementExists(res, locator)
-    res = usingFirstElement(res)
-    return this.browser.switchToFrame(res)
+    let res = await this._locate(locator, true);
+    assertElementExists(res, locator);
+    res = usingFirstElement(res);
+    return this.browser.switchToFrame(res);
   }
 
   /**
    * {{> switchToNextTab }}
    */
   async switchToNextTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
-    let target
-    const current = await this.browser.getWindowHandle()
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    let target;
+    const current = await this.browser.getWindowHandle();
 
     await this.browser.waitUntil(
       async () => {
-        await this.browser.getWindowHandles().then((handles) => {
+        await this.browser.getWindowHandles().then(handles => {
           if (handles.indexOf(current) + num + 1 <= handles.length) {
-            target = handles[handles.indexOf(current) + num]
+            target = handles[handles.indexOf(current) + num];
           }
-        })
-        return target
+        });
+        return target;
       },
       { timeout: aSec * 1000, timeoutMsg: `There is no ability to switch to next tab with offset ${num}` },
-    )
-    return this.browser.switchToWindow(target)
+    );
+    return this.browser.switchToWindow(target);
   }
 
   /**
    * {{> switchToPreviousTab }}
    */
   async switchToPreviousTab(num = 1, sec = null) {
-    const aSec = sec || this.options.waitForTimeoutInSeconds
-    const current = await this.browser.getWindowHandle()
-    let target
+    const aSec = sec || this.options.waitForTimeoutInSeconds;
+    const current = await this.browser.getWindowHandle();
+    let target;
 
     await this.browser.waitUntil(
       async () => {
-        await this.browser.getWindowHandles().then((handles) => {
+        await this.browser.getWindowHandles().then(handles => {
           if (handles.indexOf(current) - num > -1) {
-            target = handles[handles.indexOf(current) - num]
+            target = handles[handles.indexOf(current) - num];
           }
-        })
-        return target
+        });
+        return target;
       },
       { timeout: aSec * 1000, timeoutMsg: `There is no ability to switch to previous tab with offset ${num}` },
-    )
-    return this.browser.switchToWindow(target)
+    );
+    return this.browser.switchToWindow(target);
   }
 
   /**
    * {{> closeCurrentTab }}
    */
   async closeCurrentTab() {
-    await this.browser.closeWindow()
-    const handles = await this.browser.getWindowHandles()
-    if (handles[0]) await this.browser.switchToWindow(handles[0])
+    await this.browser.closeWindow();
+    const handles = await this.browser.getWindowHandles();
+    if (handles[0]) await this.browser.switchToWindow(handles[0]);
   }
 
   /**
    * {{> openNewTab }}
    */
   async openNewTab(url = 'about:blank', windowName = null) {
-    const client = this.browser
-    const crypto = require('crypto')
+    const client = this.browser;
+    const crypto = require('crypto');
     if (windowName == null) {
-      windowName = crypto.randomBytes(32).toString('hex')
+      windowName = crypto.randomBytes(32).toString('hex');
     }
-    return client.newWindow(url, windowName)
+    return client.newWindow(url, windowName);
   }
 
   /**
    * {{> grabNumberOfOpenTabs }}
    */
   async grabNumberOfOpenTabs() {
-    const pages = await this.browser.getWindowHandles()
-    this.debugSection('Tabs', `Total ${pages.length}`)
-    return pages.length
+    const pages = await this.browser.getWindowHandles();
+    this.debugSection('Tabs', `Total ${pages.length}`);
+    return pages.length;
   }
 
   /**
    * {{> refreshPage }}
    */
   async refreshPage() {
-    const client = this.browser
-    return client.refresh()
+    const client = this.browser;
+    return client.refresh();
   }
 
   /**
    * {{> scrollPageToTop }}
    */
   scrollPageToTop() {
-    const client = this.browser
+    const client = this.browser;
 
     return client.execute(function () {
-      window.scrollTo(0, 0)
-    })
+      window.scrollTo(0, 0);
+    });
   }
 
   /**
    * {{> scrollPageToBottom }}
    */
   scrollPageToBottom() {
-    const client = this.browser
+    const client = this.browser;
 
     return client.execute(function () {
-      const body = document.body
-      const html = document.documentElement
-      window.scrollTo(
-        0,
-        Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight),
-      )
-    })
+      const body = document.body;
+      const html = document.documentElement;
+      window.scrollTo(0, Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight));
+    });
   }
 
   /**
@@ -2698,26 +2641,26 @@ class WebDriver extends Helper {
       return {
         x: window.pageXOffset,
         y: window.pageYOffset,
-      }
+      };
     }
 
-    return this.executeScript(getScrollPosition)
+    return this.executeScript(getScrollPosition);
   }
 
   /**
    * {{> grabElementBoundingRect }}
    */
   async grabElementBoundingRect(locator, prop) {
-    const res = await this._locate(locator, true)
-    assertElementExists(res, locator)
-    const el = usingFirstElement(res)
+    const res = await this._locate(locator, true);
+    assertElementExists(res, locator);
+    const el = usingFirstElement(res);
 
     const rect = {
       ...(await el.getLocation()),
       ...(await el.getSize()),
-    }
-    if (prop) return rect[prop]
-    return rect
+    };
+    if (prop) return rect[prop];
+    return rect;
   }
 
   /**
@@ -2739,35 +2682,35 @@ class WebDriver extends Helper {
    * Placeholder for ~ locator only test case write once run on both Appium and WebDriver.
    */
   async runInWeb(fn) {
-    return fn()
+    return fn();
   }
 }
 
 async function proceedSee(assertType, text, context, strict = false) {
-  let description
+  let description;
   if (!context) {
     if (this.context === webRoot) {
-      context = this.context
-      description = 'web page'
+      context = this.context;
+      description = 'web page';
     } else {
-      description = `current context ${this.context}`
-      context = './/*'
+      description = `current context ${this.context}`;
+      context = './/*';
     }
   } else {
-    description = `element ${context}`
+    description = `element ${context}`;
   }
 
-  const smartWaitEnabled = assertType === 'assert'
-  const res = await this._locate(withStrictLocator(context), smartWaitEnabled)
-  assertElementExists(res, context)
-  const selected = await forEachAsync(res, async (el) => this.browser.getElementText(getElementId(el)))
+  const smartWaitEnabled = assertType === 'assert';
+  const res = await this._locate(withStrictLocator(context), smartWaitEnabled);
+  assertElementExists(res, context);
+  const selected = await forEachAsync(res, async el => this.browser.getElementText(getElementId(el)));
   if (strict) {
     if (Array.isArray(selected) && selected.length !== 0) {
-      return selected.map((elText) => equals(description)[assertType](text, elText))
+      return selected.map(elText => equals(description)[assertType](text, elText));
     }
-    return equals(description)[assertType](text, selected)
+    return equals(description)[assertType](text, selected);
   }
-  return stringIncludes(description)[assertType](text, selected)
+  return stringIncludes(description)[assertType](text, selected);
 }
 
 /**
@@ -2784,19 +2727,19 @@ async function proceedSee(assertType, text, context, strict = false) {
  * @return {Promise<Array>} - Array of values.
  */
 async function forEachAsync(array, callback, options = { expandArrayResults: true }) {
-  const { expandArrayResults = true } = options
-  const inputArray = Array.isArray(array) ? array : [array]
-  const values = []
+  const { expandArrayResults = true } = options;
+  const inputArray = Array.isArray(array) ? array : [array];
+  const values = [];
   for (let index = 0; index < inputArray.length; index++) {
-    const res = await callback(inputArray[index], index, inputArray)
+    const res = await callback(inputArray[index], index, inputArray);
 
     if (Array.isArray(res) && expandArrayResults) {
-      res.forEach((val) => values.push(val))
+      res.forEach(val => values.push(val));
     } else if (res) {
-      values.push(res)
+      values.push(res);
     }
   }
-  return values
+  return values;
 }
 
 /**
@@ -2811,213 +2754,210 @@ async function forEachAsync(array, callback, options = { expandArrayResults: tru
  * @return {Promise<Array>} - Array of values.
  */
 async function filterAsync(array, callback) {
-  const inputArray = Array.isArray(array) ? array : [array]
-  const values = []
+  const inputArray = Array.isArray(array) ? array : [array];
+  const values = [];
   for (let index = 0; index < inputArray.length; index++) {
-    const res = await callback(inputArray[index], index, inputArray)
-    const value = Array.isArray(res) ? res[0] : res
+    const res = await callback(inputArray[index], index, inputArray);
+    const value = Array.isArray(res) ? res[0] : res;
 
     if (value) {
-      values.push(inputArray[index])
+      values.push(inputArray[index]);
     }
   }
-  return values
+  return values;
 }
 
 async function findClickable(locator, locateFn) {
-  locator = new Locator(locator)
+  locator = new Locator(locator);
 
   if (this._isCustomLocator(locator)) {
-    return locateFn(locator.value)
+    return locateFn(locator.value);
   }
 
-  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true)
-  if (!locator.isFuzzy()) return locateFn(locator, true)
+  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true);
+  if (!locator.isFuzzy()) return locateFn(locator, true);
 
-  let els
-  const literal = xpathLocator.literal(locator.value)
+  let els;
+  const literal = xpathLocator.literal(locator.value);
 
-  els = await locateFn(Locator.clickable.narrow(literal))
-  if (els.length) return els
+  els = await locateFn(Locator.clickable.narrow(literal));
+  if (els.length) return els;
 
-  els = await locateFn(Locator.clickable.wide(literal))
-  if (els.length) return els
+  els = await locateFn(Locator.clickable.wide(literal));
+  if (els.length) return els;
 
-  els = await locateFn(Locator.clickable.self(literal))
-  if (els.length) return els
+  els = await locateFn(Locator.clickable.self(literal));
+  if (els.length) return els;
 
-  return locateFn(locator.value) // by css or xpath
+  return locateFn(locator.value); // by css or xpath
 }
 
 async function findFields(locator) {
-  locator = new Locator(locator)
+  locator = new Locator(locator);
 
   if (this._isCustomLocator(locator)) {
-    return this._locate(locator)
+    return this._locate(locator);
   }
 
-  if (locator.isAccessibilityId() && !this.isWeb) return this._locate(locator, true)
-  if (!locator.isFuzzy()) return this._locate(locator, true)
+  if (locator.isAccessibilityId() && !this.isWeb) return this._locate(locator, true);
+  if (!locator.isFuzzy()) return this._locate(locator, true);
 
-  const literal = xpathLocator.literal(locator.value)
-  let els = await this._locate(Locator.field.labelEquals(literal))
-  if (els.length) return els
+  const literal = xpathLocator.literal(locator.value);
+  let els = await this._locate(Locator.field.labelEquals(literal));
+  if (els.length) return els;
 
-  els = await this._locate(Locator.field.labelContains(literal))
-  if (els.length) return els
+  els = await this._locate(Locator.field.labelContains(literal));
+  if (els.length) return els;
 
-  els = await this._locate(Locator.field.byName(literal))
-  if (els.length) return els
-  return this._locate(locator.value) // by css or xpath
+  els = await this._locate(Locator.field.byName(literal));
+  if (els.length) return els;
+  return this._locate(locator.value); // by css or xpath
 }
 
 async function proceedSeeField(assertType, field, value) {
-  const res = await findFields.call(this, field)
-  assertElementExists(res, field, 'Field')
-  const elem = usingFirstElement(res)
-  const elemId = getElementId(elem)
+  const res = await findFields.call(this, field);
+  assertElementExists(res, field, 'Field');
+  const elem = usingFirstElement(res);
+  const elemId = getElementId(elem);
 
-  const proceedMultiple = async (fields) => {
+  const proceedMultiple = async fields => {
     const fieldResults = toArray(
-      await forEachAsync(fields, async (el) => {
-        const elementId = getElementId(el)
-        return this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value')
+      await forEachAsync(fields, async el => {
+        const elementId = getElementId(el);
+        return this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value');
       }),
-    )
+    );
 
     if (typeof value === 'boolean') {
-      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!fieldResults.length)
+      equals(`no. of items matching > 0: ${field}`)[assertType](value, !!fieldResults.length);
     } else {
       // Assert that results were found so the forEach assert does not silently pass
-      equals(`no. of items matching > 0:  ${field}`)[assertType](true, !!fieldResults.length)
-      fieldResults.forEach((val) => stringIncludes(`fields by ${field}`)[assertType](value, val))
+      equals(`no. of items matching > 0:  ${field}`)[assertType](true, !!fieldResults.length);
+      fieldResults.forEach(val => stringIncludes(`fields by ${field}`)[assertType](value, val));
     }
-  }
+  };
 
-  const proceedSingle = (el) =>
-    el.getValue().then((res) => {
+  const proceedSingle = el =>
+    el.getValue().then(res => {
       if (res === null) {
-        throw new Error(`Element ${el.selector} has no value attribute`)
+        throw new Error(`Element ${el.selector} has no value attribute`);
       }
-      stringIncludes(`fields by ${field}`)[assertType](value, res)
-    })
+      stringIncludes(`fields by ${field}`)[assertType](value, res);
+    });
 
-  const filterBySelected = async (elements) =>
-    filterAsync(elements, async (el) => this.browser.isElementSelected(getElementId(el)))
+  const filterBySelected = async elements => filterAsync(elements, async el => this.browser.isElementSelected(getElementId(el)));
 
   const filterSelectedByValue = async (elements, value) => {
-    return filterAsync(elements, async (el) => {
-      const elementId = getElementId(el)
-      const currentValue = this.browser.isW3C
-        ? await el.getValue()
-        : await this.browser.getElementAttribute(elementId, 'value')
-      const isSelected = await this.browser.isElementSelected(elementId)
-      return currentValue === value && isSelected
-    })
-  }
+    return filterAsync(elements, async el => {
+      const elementId = getElementId(el);
+      const currentValue = this.browser.isW3C ? await el.getValue() : await this.browser.getElementAttribute(elementId, 'value');
+      const isSelected = await this.browser.isElementSelected(elementId);
+      return currentValue === value && isSelected;
+    });
+  };
 
-  const tag = await elem.getTagName()
+  const tag = await elem.getTagName();
   if (tag === 'select') {
-    const subOptions = await this.browser.findElementsFromElement(elemId, 'css', 'option')
+    const subOptions = await this.browser.findElementsFromElement(elemId, 'css', 'option');
 
     if (value === '') {
       // Don't filter by value
-      const selectedOptions = await filterBySelected(subOptions)
-      return proceedMultiple(selectedOptions)
+      const selectedOptions = await filterBySelected(subOptions);
+      return proceedMultiple(selectedOptions);
     }
 
-    const options = await filterSelectedByValue(subOptions, value)
-    return proceedMultiple(options)
+    const options = await filterSelectedByValue(subOptions, value);
+    return proceedMultiple(options);
   }
 
   if (tag === 'input') {
-    const fieldType = await elem.getAttribute('type')
+    const fieldType = await elem.getAttribute('type');
 
     if (fieldType === 'checkbox' || fieldType === 'radio') {
       if (typeof value === 'boolean') {
         // Support boolean values
-        const options = await filterBySelected(res)
-        return proceedMultiple(options)
+        const options = await filterBySelected(res);
+        return proceedMultiple(options);
       }
 
-      const options = await filterSelectedByValue(res, value)
-      return proceedMultiple(options)
+      const options = await filterSelectedByValue(res, value);
+      return proceedMultiple(options);
     }
-    return proceedSingle(elem)
+    return proceedSingle(elem);
   }
-  return proceedSingle(elem)
+  return proceedSingle(elem);
 }
 
 function toArray(item) {
   if (!Array.isArray(item)) {
-    return [item]
+    return [item];
   }
-  return item
+  return item;
 }
 
 async function proceedSeeCheckbox(assertType, field) {
-  const res = await findFields.call(this, field)
-  assertElementExists(res, field, 'Field')
+  const res = await findFields.call(this, field);
+  assertElementExists(res, field, 'Field');
 
-  const selected = await forEachAsync(res, async (el) => this.browser.isElementSelected(getElementId(el)))
-  return truth(`checkable field "${field}"`, 'to be checked')[assertType](selected)
+  const selected = await forEachAsync(res, async el => this.browser.isElementSelected(getElementId(el)));
+  return truth(`checkable field "${field}"`, 'to be checked')[assertType](selected);
 }
 
 async function findCheckable(locator, locateFn) {
-  let els
-  locator = new Locator(locator)
+  let els;
+  locator = new Locator(locator);
 
   if (this._isCustomLocator(locator)) {
-    return locateFn(locator.value)
+    return locateFn(locator.value);
   }
 
-  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true)
-  if (!locator.isFuzzy()) return locateFn(locator, true)
+  if (locator.isAccessibilityId() && !this.isWeb) return locateFn(locator, true);
+  if (!locator.isFuzzy()) return locateFn(locator, true);
 
-  const literal = xpathLocator.literal(locator.value)
-  els = await locateFn(Locator.checkable.byText(literal))
-  if (els.length) return els
-  els = await locateFn(Locator.checkable.byName(literal))
-  if (els.length) return els
+  const literal = xpathLocator.literal(locator.value);
+  els = await locateFn(Locator.checkable.byText(literal));
+  if (els.length) return els;
+  els = await locateFn(Locator.checkable.byName(literal));
+  if (els.length) return els;
 
-  return locateFn(locator.value) // by css or xpath
+  return locateFn(locator.value); // by css or xpath
 }
 
 function withStrictLocator(locator) {
-  locator = new Locator(locator)
-  return locator.simplify()
+  locator = new Locator(locator);
+  return locator.simplify();
 }
 
 function isFrameLocator(locator) {
-  locator = new Locator(locator)
-  if (locator.isFrame()) return locator.value
-  return false
+  locator = new Locator(locator);
+  if (locator.isFrame()) return locator.value;
+  return false;
 }
 
 function assertElementExists(res, locator, prefix, suffix) {
   if (!res || res.length === 0) {
-    throw new ElementNotFound(locator, prefix, suffix)
+    throw new ElementNotFound(locator, prefix, suffix);
   }
 }
 
 function usingFirstElement(els) {
-  if (els.length > 1) debug(`[Elements] Using first element out of ${els.length}`)
-  return els[0]
+  if (els.length > 1) debug(`[Elements] Using first element out of ${els.length}`);
+  return els[0];
 }
 
 function getElementId(el) {
   // W3C WebDriver web element identifier
   // https://w3c.github.io/webdriver/#dfn-web-element-identifier
   if (el['element-6066-11e4-a52e-4f735466cecf']) {
-    return el['element-6066-11e4-a52e-4f735466cecf']
+    return el['element-6066-11e4-a52e-4f735466cecf'];
   }
   // (deprecated) JsonWireProtocol identifier
   // https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#webelement-json-object
   if (el.ELEMENT) {
-    return el.ELEMENT
+    return el.ELEMENT;
   }
 
-  return null
+  return null;
 }
 
 // List of known key values to unicode code points
@@ -3137,52 +3077,52 @@ const keyUnicodeMap = {
   Semicolon: '\uE018', // ';' alias
   Slash: '/', // '/' alias
   ZenkakuHankaku: '\uE040',
-}
+};
 
 function convertKeyToRawKey(key) {
   if (Object.prototype.hasOwnProperty.call(keyUnicodeMap, key)) {
-    return keyUnicodeMap[key]
+    return keyUnicodeMap[key];
   }
   // Key is raw key when no representative unicode code point for value
-  return key
+  return key;
 }
 
 function getNormalizedKey(key) {
-  let normalizedKey = getNormalizedKeyAttributeValue(key)
+  let normalizedKey = getNormalizedKeyAttributeValue(key);
   // Always use "left" modifier keys for non-W3C sessions,
   // as JsonWireProtocol does not support "right" modifier keys
   if (!this.browser.isW3C) {
-    normalizedKey = normalizedKey.replace(/^(Alt|Control|Meta|Shift)Right$/, '$1')
+    normalizedKey = normalizedKey.replace(/^(Alt|Control|Meta|Shift)Right$/, '$1');
   }
   if (key !== normalizedKey) {
-    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`)
+    this.debugSection('Input', `Mapping key '${key}' to '${normalizedKey}'`);
   }
-  return convertKeyToRawKey(normalizedKey)
+  return convertKeyToRawKey(normalizedKey);
 }
 
-const unicodeModifierKeys = modifierKeys.map((k) => convertKeyToRawKey(k))
+const unicodeModifierKeys = modifierKeys.map(k => convertKeyToRawKey(k));
 function isModifierKey(key) {
-  return unicodeModifierKeys.includes(key)
+  return unicodeModifierKeys.includes(key);
 }
 
 function highlightActiveElement(element) {
   if (this.options.highlightElement && global.debugMode) {
-    highlightElement(element, this.browser)
+    highlightElement(element, this.browser);
   }
 }
 
 function prepareLocateFn(context) {
-  if (!context) return this._locate.bind(this)
-  return (l) => {
-    l = new Locator(l, 'css')
-    return this._locate(context, true).then(async (res) => {
-      assertElementExists(res, context, 'Context element')
+  if (!context) return this._locate.bind(this);
+  return l => {
+    l = new Locator(l, 'css');
+    return this._locate(context, true).then(async res => {
+      assertElementExists(res, context, 'Context element');
       if (l.react) {
-        return res[0].react$$(l.react, l.props || undefined)
+        return res[0].react$$(l.react, l.props || undefined);
       }
-      return res[0].$$(l.simplify())
-    })
-  }
+      return res[0].$$(l.simplify());
+    });
+  };
 }
 
-module.exports = WebDriver
+module.exports = WebDriver;

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -27,7 +27,7 @@ const addStep = (step, fn) => {
 
 const parameterTypeRegistry = new ParameterTypeRegistry()
 
-const matchStep = (step) => {
+const matchStep = step => {
   for (const stepName in steps) {
     if (stepName.indexOf('/') === 0) {
       const regExpArr = stepName.match(/^\/(.*?)\/([gimy]*)$/) || []
@@ -43,7 +43,7 @@ const matchStep = (step) => {
     const res = expression.match(step)
     if (res) {
       const fn = steps[stepName]
-      fn.params = res.map((arg) => arg.getValue())
+      fn.params = res.map(arg => arg.getValue())
       return fn
     }
   }
@@ -58,7 +58,7 @@ const getSteps = () => {
   return steps
 }
 
-const defineParameterType = (options) => {
+const defineParameterType = options => {
   const parameterType = buildParameterType(options)
   parameterTypeRegistry.defineParameterType(parameterType)
 }

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -28,7 +28,7 @@ module.exports = (text, file) => {
     throw new Error(`No 'Features' available in Gherkin '${file}' provided!`)
   }
   const suite = new Suite(ast.feature.name, new Context())
-  const tags = ast.feature.tags.map((t) => t.name)
+  const tags = ast.feature.tags.map(t => t.name)
   suite.title = `${suite.title} ${tags.join(' ')}`.trim()
   suite.tags = tags || []
   suite.comment = ast.feature.description
@@ -41,12 +41,12 @@ module.exports = (text, file) => {
   suite.beforeAll('codeceptjs.beforeSuite', () => scenario.suiteSetup(suite))
   suite.afterAll('codeceptjs.afterSuite', () => scenario.suiteTeardown(suite))
 
-  const runSteps = async (steps) => {
+  const runSteps = async steps => {
     for (const step of steps) {
       const metaStep = new Step.MetaStep(null, step.text)
       metaStep.actor = step.keyword.trim()
       let helperStep
-      const setMetaStep = (step) => {
+      const setMetaStep = step => {
         helperStep = step
         if (step.metaStep) {
           if (step.metaStep === metaStep) {
@@ -104,14 +104,9 @@ module.exports = (text, file) => {
       )
       continue
     }
-    if (
-      child.scenario &&
-      (currentLanguage
-        ? child.scenario.keyword === currentLanguage.contexts.ScenarioOutline
-        : child.scenario.keyword === 'Scenario Outline')
-    ) {
+    if (child.scenario && (currentLanguage ? child.scenario.keyword === currentLanguage.contexts.ScenarioOutline : child.scenario.keyword === 'Scenario Outline')) {
       for (const examples of child.scenario.examples) {
-        const fields = examples.tableHeader.cells.map((c) => c.value)
+        const fields = examples.tableHeader.cells.map(c => c.value)
         for (const example of examples.tableBody) {
           let exampleSteps = [...child.scenario.steps]
           const current = {}
@@ -120,13 +115,13 @@ module.exports = (text, file) => {
             const value = transform('gherkin.examples', example.cells[index].value)
             example.cells[index].value = value
             current[placeholder] = value
-            exampleSteps = exampleSteps.map((step) => {
+            exampleSteps = exampleSteps.map(step => {
               step = { ...step }
               step.text = step.text.split(`<${placeholder}>`).join(value)
               return step
             })
           }
-          const tags = child.scenario.tags.map((t) => t.name).concat(examples.tags.map((t) => t.name))
+          const tags = child.scenario.tags.map(t => t.name).concat(examples.tags.map(t => t.name))
           let title = `${child.scenario.name} ${JSON.stringify(current)} ${tags.join(' ')}`.trim()
 
           for (const [key, value] of Object.entries(current)) {
@@ -145,7 +140,7 @@ module.exports = (text, file) => {
     }
 
     if (child.scenario) {
-      const tags = child.scenario.tags.map((t) => t.name)
+      const tags = child.scenario.tags.map(t => t.name)
       const title = `${child.scenario.name} ${tags.join(' ')}`.trim()
       const test = new Test(title, async () => runSteps(child.scenario.steps))
       test.tags = suite.tags.concat(tags)
@@ -162,8 +157,8 @@ function transformTable(table) {
   for (const id in table.rows) {
     const cells = table.rows[id].cells
     str += cells
-      .map((c) => c.value)
-      .map((c) => c.padEnd(15))
+      .map(c => c.value)
+      .map(c => c.padEnd(15))
       .join(' | ')
     str += '\n'
   }
@@ -172,12 +167,12 @@ function transformTable(table) {
 function addExampleInTable(exampleSteps, placeholders) {
   const steps = JSON.parse(JSON.stringify(exampleSteps))
   for (const placeholder in placeholders) {
-    steps.map((step) => {
+    steps.map(step => {
       step = { ...step }
       if (step.dataTable) {
         for (const id in step.dataTable.rows) {
           const cells = step.dataTable.rows[id].cells
-          cells.map((c) => (c.value = c.value.replace(`<${placeholder}>`, placeholders[placeholder])))
+          cells.map(c => (c.value = c.value.replace(`<${placeholder}>`, placeholders[placeholder])))
         }
       }
       return step

--- a/lib/interfaces/inject.js
+++ b/lib/interfaces/inject.js
@@ -1,24 +1,24 @@
-const parser = require('../parser');
+const parser = require('../parser')
 
 const getInjectedArguments = (fn, test) => {
-  const container = require('../container');
-  const testArgs = {};
-  const params = parser.getParams(fn) || [];
-  const objects = container.support();
+  const container = require('../container')
+  const testArgs = {}
+  const params = parser.getParams(fn) || []
+  const objects = container.support()
   for (const key of params) {
-    testArgs[key] = {};
+    testArgs[key] = {}
     if (test && test.inject && test.inject[key]) {
       // @FIX: need fix got inject
-      testArgs[key] = test.inject[key];
-      continue;
+      testArgs[key] = test.inject[key]
+      continue
     }
     if (!objects[key]) {
-      throw new Error(`Object of type ${key} is not defined in container`);
+      throw new Error(`Object of type ${key} is not defined in container`)
     }
-    testArgs[key] = container.support(key);
+    testArgs[key] = container.support(key)
   }
 
-  return testArgs;
-};
+  return testArgs
+}
 
-module.exports.getInjectedArguments = getInjectedArguments;
+module.exports.getInjectedArguments = getInjectedArguments

--- a/lib/interfaces/scenarioConfig.js
+++ b/lib/interfaces/scenarioConfig.js
@@ -104,7 +104,7 @@ class ScenarioConfig {
    * @returns {this}
    */
   injectDependencies(dependencies) {
-    Object.keys(dependencies).forEach((key) => {
+    Object.keys(dependencies).forEach(key => {
       this.test.inject[key] = dependencies[key]
     })
     return this

--- a/lib/listener/artifacts.js
+++ b/lib/listener/artifacts.js
@@ -5,11 +5,11 @@ const recorder = require('../recorder')
  * Create and clean up empty artifacts
  */
 module.exports = function () {
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     test.artifacts = {}
   })
 
-  event.dispatcher.on(event.test.after, (test) => {
+  event.dispatcher.on(event.test.after, test => {
     recorder.add('clean up empty artifacts', () => {
       for (const key in test.artifacts || {}) {
         if (!test.artifacts[key]) delete test.artifacts[key]

--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -3,7 +3,7 @@ const event = require('../event')
 module.exports = function () {
   let failedTests = []
 
-  event.dispatcher.on(event.test.failed, (testOrSuite) => {
+  event.dispatcher.on(event.test.failed, testOrSuite => {
     // NOTE When an error happens in one of the hooks (BeforeAll/BeforeEach...) the event object
     // is a suite and not a test
     const id = testOrSuite.uid || (testOrSuite.ctx && testOrSuite.ctx.test.uid) || 'empty'
@@ -11,14 +11,14 @@ module.exports = function () {
   })
 
   // if test was successful after retries
-  event.dispatcher.on(event.test.passed, (testOrSuite) => {
+  event.dispatcher.on(event.test.passed, testOrSuite => {
     // NOTE When an error happens in one of the hooks (BeforeAll/BeforeEach...) the event object
     // is a suite and not a test
     const id = testOrSuite.uid || (testOrSuite.ctx && testOrSuite.ctx.test.uid) || 'empty'
-    failedTests = failedTests.filter((failed) => id !== failed)
+    failedTests = failedTests.filter(failed => id !== failed)
   })
 
-  process.on('beforeExit', (code) => {
+  process.on('beforeExit', code => {
     if (failedTests.length) {
       code = 1
     }

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -12,7 +12,7 @@ module.exports = function () {
 
   const runHelpersHook = (hook, param) => {
     if (store.dryRun) return
-    Object.values(helpers).forEach((helper) => {
+    Object.values(helpers).forEach(helper => {
       if (helper[hook]) {
         helper[hook](param)
       }
@@ -21,55 +21,55 @@ module.exports = function () {
 
   const runAsyncHelpersHook = (hook, param, force) => {
     if (store.dryRun) return
-    Object.keys(helpers).forEach((key) => {
+    Object.keys(helpers).forEach(key => {
       if (!helpers[key][hook]) return
       recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force, false)
     })
   }
 
-  event.dispatcher.on(event.suite.before, (suite) => {
+  event.dispatcher.on(event.suite.before, suite => {
     // if (suite.parent) return; // only for root suite
     runAsyncHelpersHook('_beforeSuite', suite, true)
   })
 
-  event.dispatcher.on(event.suite.after, (suite) => {
+  event.dispatcher.on(event.suite.after, suite => {
     // if (suite.parent) return; // only for root suite
     runAsyncHelpersHook('_afterSuite', suite, true)
   })
 
-  event.dispatcher.on(event.test.started, (test) => {
+  event.dispatcher.on(event.test.started, test => {
     runHelpersHook('_test', test)
-    recorder.catch((e) => error(e))
+    recorder.catch(e => error(e))
   })
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     // schedule config to revert changes
     runAsyncHelpersHook('_before', test, true)
-    recorder.catchWithoutStop((e) => error(e))
+    recorder.catchWithoutStop(e => error(e))
   })
 
-  event.dispatcher.on(event.test.passed, (test) => {
+  event.dispatcher.on(event.test.passed, test => {
     runAsyncHelpersHook('_passed', test, true)
     // should not fail test execution, so errors should be caught
-    recorder.catchWithoutStop((e) => error(e))
+    recorder.catchWithoutStop(e => error(e))
   })
 
-  event.dispatcher.on(event.test.failed, (test) => {
+  event.dispatcher.on(event.test.failed, test => {
     runAsyncHelpersHook('_failed', test, true)
     // should not fail test execution, so errors should be caught
-    recorder.catchWithoutStop((e) => error(e))
+    recorder.catchWithoutStop(e => error(e))
   })
 
   event.dispatcher.on(event.test.after, () => {
     runAsyncHelpersHook('_after', {}, true)
-    recorder.catchWithoutStop((e) => error(e))
+    recorder.catchWithoutStop(e => error(e))
   })
 
-  event.dispatcher.on(event.step.before, (step) => {
+  event.dispatcher.on(event.step.before, step => {
     runAsyncHelpersHook('_beforeStep', step)
   })
 
-  event.dispatcher.on(event.step.after, (step) => {
+  event.dispatcher.on(event.step.after, step => {
     runAsyncHelpersHook('_afterStep', step)
   })
 

--- a/lib/listener/mocha.js
+++ b/lib/listener/mocha.js
@@ -8,7 +8,7 @@ module.exports = function () {
     mocha = container.mocha()
   })
 
-  event.dispatcher.on(event.test.passed, (test) => {
+  event.dispatcher.on(event.test.passed, test => {
     mocha.Runner.emit('pass', test)
   })
 

--- a/lib/listener/retry.js
+++ b/lib/listener/retry.js
@@ -6,7 +6,7 @@ const { isNotSet } = require('../utils')
 const hooks = ['Before', 'After', 'BeforeSuite', 'AfterSuite']
 
 module.exports = function () {
-  event.dispatcher.on(event.suite.before, (suite) => {
+  event.dispatcher.on(event.suite.before, suite => {
     let retryConfig = Config.get('retry')
     if (!retryConfig) return
 
@@ -28,8 +28,8 @@ module.exports = function () {
       }
 
       hooks
-        .filter((hook) => !!config[hook])
-        .forEach((hook) => {
+        .filter(hook => !!config[hook])
+        .forEach(hook => {
           if (isNotSet(suite.opts[`retry${hook}`])) suite.opts[`retry${hook}`] = config[hook]
         })
 
@@ -41,7 +41,7 @@ module.exports = function () {
     }
   })
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     let retryConfig = Config.get('retry')
     if (!retryConfig) return
 
@@ -54,7 +54,7 @@ module.exports = function () {
       retryConfig = [retryConfig]
     }
 
-    retryConfig = retryConfig.filter((config) => !!config.Scenario)
+    retryConfig = retryConfig.filter(config => !!config.Scenario)
 
     for (const config of retryConfig) {
       if (config.grep) {

--- a/lib/listener/steps.js
+++ b/lib/listener/steps.js
@@ -10,39 +10,39 @@ let currentHook
  * Register steps inside tests
  */
 module.exports = function () {
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     test.startedAt = +new Date()
     test.artifacts = {}
   })
 
-  event.dispatcher.on(event.test.started, (test) => {
+  event.dispatcher.on(event.test.started, test => {
     currentTest = test
     currentTest.steps = []
     if (!('retryNum' in currentTest)) currentTest.retryNum = 0
     else currentTest.retryNum += 1
   })
 
-  event.dispatcher.on(event.test.after, (test) => {
+  event.dispatcher.on(event.test.after, test => {
     currentTest = null
   })
 
-  event.dispatcher.on(event.test.finished, (test) => {})
+  event.dispatcher.on(event.test.finished, test => {})
 
-  event.dispatcher.on(event.hook.started, (suite) => {
+  event.dispatcher.on(event.hook.started, suite => {
     currentHook = suite.ctx.test
     currentHook.steps = []
 
     if (suite.ctx && suite.ctx.test) output.log(`--- STARTED ${suite.ctx.test.title} ---`)
   })
 
-  event.dispatcher.on(event.hook.passed, (suite) => {
+  event.dispatcher.on(event.hook.passed, suite => {
     currentHook = null
     if (suite.ctx && suite.ctx.test) output.log(`--- ENDED ${suite.ctx.test.title} ---`)
   })
 
   event.dispatcher.on(event.test.failed, () => {
     const cutSteps = function (current) {
-      const failureIndex = current.steps.findIndex((el) => el.status === 'failed')
+      const failureIndex = current.steps.findIndex(el => el.status === 'failed')
       // To be sure that failed test will be failed in report
       current.state = 'failed'
       current.steps.length = failureIndex + 1
@@ -65,7 +65,7 @@ module.exports = function () {
     currentTest.state = 'passed'
   })
 
-  event.dispatcher.on(event.step.started, (step) => {
+  event.dispatcher.on(event.step.started, step => {
     step.startedAt = +new Date()
     step.test = currentTest
     if (currentHook && Array.isArray(currentHook.steps)) {
@@ -75,7 +75,7 @@ module.exports = function () {
     currentTest.steps.push(step)
   })
 
-  event.dispatcher.on(event.step.finished, (step) => {
+  event.dispatcher.on(event.step.finished, step => {
     step.finishedAt = +new Date()
     if (step.startedAt) step.duration = step.finishedAt - step.startedAt
     debug(`Step '${step}' finished; Duration: ${step.duration || 0}ms`)

--- a/lib/listener/timeout.js
+++ b/lib/listener/timeout.js
@@ -16,7 +16,7 @@ module.exports = function () {
     return
   }
 
-  event.dispatcher.on(event.suite.before, (suite) => {
+  event.dispatcher.on(event.suite.before, suite => {
     suiteTimeout = []
     let timeoutConfig = Config.get('timeout')
 
@@ -30,7 +30,7 @@ module.exports = function () {
         timeoutConfig = [timeoutConfig]
       }
 
-      for (const config of timeoutConfig.filter((c) => !!c.Feature)) {
+      for (const config of timeoutConfig.filter(c => !!c.Feature)) {
         if (config.grep) {
           if (!suite.title.includes(config.grep)) continue
         }
@@ -42,7 +42,7 @@ module.exports = function () {
     output.log(`Timeouts: ${suiteTimeout}`)
   })
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     currentTest = test
     let testTimeout = null
 
@@ -53,7 +53,7 @@ module.exports = function () {
         timeoutConfig = [timeoutConfig]
       }
 
-      for (const config of timeoutConfig.filter((c) => !!c.Scenario)) {
+      for (const config of timeoutConfig.filter(c => !!c.Scenario)) {
         console.log('Test Timeout', config, test.title.includes(config.grep))
         if (config.grep) {
           if (!test.title.includes(config.grep)) continue
@@ -69,15 +69,15 @@ module.exports = function () {
     timeout *= 1000
   })
 
-  event.dispatcher.on(event.test.passed, (test) => {
+  event.dispatcher.on(event.test.passed, test => {
     currentTest = null
   })
 
-  event.dispatcher.on(event.test.failed, (test) => {
+  event.dispatcher.on(event.test.failed, test => {
     currentTest = null
   })
 
-  event.dispatcher.on(event.step.before, (step) => {
+  event.dispatcher.on(event.step.before, step => {
     if (typeof timeout !== 'number') return
 
     if (timeout < 0) {
@@ -87,7 +87,7 @@ module.exports = function () {
     }
   })
 
-  event.dispatcher.on(event.step.finished, (step) => {
+  event.dispatcher.on(event.step.finished, step => {
     if (typeof timeout === 'number' && !Number.isNaN(timeout)) timeout -= step.duration
 
     if (typeof timeout === 'number' && timeout <= 0 && recorder.isRunning()) {

--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -66,25 +66,25 @@ module.exports = function (config) {
 
   if (!helper) return // no helpers for auto-delay
 
-  event.dispatcher.on(event.step.before, (step) => {
+  event.dispatcher.on(event.step.before, step => {
     if (config.methods.indexOf(step.helperMethod) < 0) return // skip non-actions
 
     recorder.add('auto-delay', async () => {
       if (store.debugMode) return // no need to delay in debug
       log(`Delaying for ${config.delayBefore}ms`)
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         setTimeout(resolve, config.delayBefore)
       })
     })
   })
 
-  event.dispatcher.on(event.step.after, (step) => {
+  event.dispatcher.on(event.step.after, step => {
     if (config.methods.indexOf(step.helperMethod) < 0) return // skip non-actions
 
     recorder.add('auto-delay', async () => {
       if (store.debugMode) return // no need to delay in debug
       log(`Delaying for ${config.delayAfter}ms`)
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         setTimeout(resolve, config.delayAfter)
       })
     })

--- a/lib/plugin/autoLogin.js
+++ b/lib/plugin/autoLogin.js
@@ -8,7 +8,7 @@ const { debug } = require('../output')
 const isAsyncFunction = require('../utils').isAsyncFunction
 
 const defaultUser = {
-  fetch: (I) => I.grabCookie(),
+  fetch: I => I.grabCookie(),
   check: () => {},
   restore: (I, cookies) => {
     I.amOnPage('/') // open a page
@@ -253,7 +253,7 @@ const defaultConfig = {
 module.exports = function (config) {
   config = Object.assign(defaultConfig, config)
   Object.keys(config.users).map(
-    (u) =>
+    u =>
       (config.users[u] = {
         ...defaultUser,
         ...config.users[u],
@@ -275,12 +275,11 @@ module.exports = function (config) {
     }
   }
 
-  const loginFunction = async (name) => {
+  const loginFunction = async name => {
     const userSession = config.users[name]
     const I = container.support('I')
     const cookies = store[`${name}_session`]
-    const shouldAwait =
-      isAsyncFunction(userSession.login) || isAsyncFunction(userSession.restore) || isAsyncFunction(userSession.check)
+    const shouldAwait = isAsyncFunction(userSession.login) || isAsyncFunction(userSession.restore) || isAsyncFunction(userSession.check)
 
     const loginAndSave = async () => {
       if (shouldAwait) {
@@ -311,7 +310,7 @@ module.exports = function (config) {
       userSession.restore(I, cookies)
       userSession.check(I, cookies)
     }
-    recorder.session.catch((err) => {
+    recorder.session.catch(err => {
       debug(`Failed auto login for ${name} due to ${err}`)
       debug('Logging in again')
       recorder.session.start('auto login')
@@ -320,7 +319,7 @@ module.exports = function (config) {
           recorder.add(() => recorder.session.restore('auto login'))
           recorder.catch(() => debug('continue'))
         })
-        .catch((err) => {
+        .catch(err => {
           recorder.session.restore('auto login')
           recorder.session.restore('check login')
           recorder.throw(err)

--- a/lib/plugin/commentStep.js
+++ b/lib/plugin/commentStep.js
@@ -104,7 +104,7 @@ module.exports = function (config) {
     currentCommentStep = null
   })
 
-  event.dispatcher.on(event.step.started, (step) => {
+  event.dispatcher.on(event.step.started, step => {
     if (currentCommentStep) {
       const metaStep = getRootMetaStep(step)
 

--- a/lib/plugin/coverage.js
+++ b/lib/plugin/coverage.js
@@ -15,7 +15,7 @@ const supportedHelpers = ['Puppeteer', 'Playwright', 'WebDriver']
 
 const v8CoverageHelpers = {
   Playwright: {
-    startCoverage: async (page) => {
+    startCoverage: async page => {
       await Promise.all([
         page.coverage.startJSCoverage({
           resetOnNavigation: false,
@@ -26,16 +26,13 @@ const v8CoverageHelpers = {
       ])
     },
     takeCoverage: async (page, coverageReport) => {
-      const [jsCoverage, cssCoverage] = await Promise.all([
-        page.coverage.stopJSCoverage(),
-        page.coverage.stopCSSCoverage(),
-      ])
+      const [jsCoverage, cssCoverage] = await Promise.all([page.coverage.stopJSCoverage(), page.coverage.stopCSSCoverage()])
       const coverageList = [...jsCoverage, ...cssCoverage]
       await coverageReport.add(coverageList)
     },
   },
   Puppeteer: {
-    startCoverage: async (page) => {
+    startCoverage: async page => {
       await Promise.all([
         page.coverage.startJSCoverage({
           resetOnNavigation: false,
@@ -47,13 +44,10 @@ const v8CoverageHelpers = {
       ])
     },
     takeCoverage: async (page, coverageReport) => {
-      const [jsCoverage, cssCoverage] = await Promise.all([
-        page.coverage.stopJSCoverage(),
-        page.coverage.stopCSSCoverage(),
-      ])
+      const [jsCoverage, cssCoverage] = await Promise.all([page.coverage.stopJSCoverage(), page.coverage.stopCSSCoverage()])
       // to raw V8 script coverage
       const coverageList = [
-        ...jsCoverage.map((it) => {
+        ...jsCoverage.map(it => {
           return {
             source: it.text,
             ...it.rawScriptCoverage,
@@ -65,7 +59,7 @@ const v8CoverageHelpers = {
     },
   },
   WebDriver: {
-    startCoverage: async (page) => {
+    startCoverage: async page => {
       await Promise.all([
         page.coverage.startJSCoverage({
           resetOnNavigation: false,
@@ -77,13 +71,10 @@ const v8CoverageHelpers = {
       ])
     },
     takeCoverage: async (page, coverageReport) => {
-      const [jsCoverage, cssCoverage] = await Promise.all([
-        page.coverage.stopJSCoverage(),
-        page.coverage.stopCSSCoverage(),
-      ])
+      const [jsCoverage, cssCoverage] = await Promise.all([page.coverage.stopJSCoverage(), page.coverage.stopCSSCoverage()])
       // to raw V8 script coverage
       const coverageList = [
-        ...jsCoverage.map((it) => {
+        ...jsCoverage.map(it => {
           return {
             source: it.text,
             ...it.rawScriptCoverage,
@@ -131,7 +122,7 @@ module.exports = function (config) {
   let coverageRunning = false
 
   const v8Names = Object.keys(v8CoverageHelpers)
-  const helperName = Object.keys(helpers).find((it) => v8Names.includes(it))
+  const helperName = Object.keys(helpers).find(it => v8Names.includes(it))
   if (!helperName) {
     console.error(`Coverage is only supported in ${supportedHelpers.join(' or ')}`)
     // no helpers for screenshot
@@ -180,7 +171,7 @@ module.exports = function (config) {
   })
 
   // Save coverage data after every test run
-  event.dispatcher.on(event.test.after, (test) => {
+  event.dispatcher.on(event.test.after, test => {
     recorder.add(
       'take coverage',
       async () => {

--- a/lib/plugin/customLocator.js
+++ b/lib/plugin/customLocator.js
@@ -111,7 +111,7 @@ const defaultConfig = {
  * I.click('=sign-up'); // matches => [data-qa=sign-up],[data-test=sign-up]
  * ```
  */
-module.exports = (config) => {
+module.exports = config => {
   config = { ...defaultConfig, ...config }
 
   Locator.addFilter((value, locatorObj) => {
@@ -125,7 +125,7 @@ module.exports = (config) => {
     if (config.strategy.toLowerCase() === 'xpath') {
       locatorObj.value = `.//*[${[]
         .concat(config.attribute)
-        .map((attr) => `@${attr}=${xpathLocator.literal(val)}`)
+        .map(attr => `@${attr}=${xpathLocator.literal(val)}`)
         .join(' or ')}]`
       locatorObj.type = 'xpath'
     }
@@ -133,7 +133,7 @@ module.exports = (config) => {
     if (config.strategy.toLowerCase() === 'css') {
       locatorObj.value = []
         .concat(config.attribute)
-        .map((attr) => `[${attr}=${val}]`)
+        .map(attr => `[${attr}=${val}]`)
         .join(',')
       locatorObj.type = 'css'
     }

--- a/lib/plugin/debugErrors.js
+++ b/lib/plugin/debugErrors.js
@@ -43,7 +43,7 @@ module.exports = function (config = {}) {
 
   if (!helper) return // no helpers for screenshot
 
-  event.dispatcher.on(event.test.failed, (test) => {
+  event.dispatcher.on(event.test.failed, test => {
     recorder.add('HTML snapshot failed test', async () => {
       try {
         const currentOutputLevel = output.level()
@@ -56,7 +56,7 @@ module.exports = function (config = {}) {
         const errors = scanForErrorMessages(html, config.errorClasses)
         if (errors.length) {
           output.debug('Detected errors in HTML code')
-          errors.forEach((error) => output.debug(error))
+          errors.forEach(error => output.debug(error))
           test.artifacts.errors = errors
         }
       } catch (err) {

--- a/lib/plugin/eachElement.js
+++ b/lib/plugin/eachElement.js
@@ -72,7 +72,7 @@ function eachElement(purpose, locator, fn) {
   if (store.dryRun) return
   const helpers = Object.values(container.helpers())
 
-  const helper = helpers.filter((h) => !!h._locate)[0]
+  const helper = helpers.filter(h => !!h._locate)[0]
 
   if (!helper) {
     throw new Error('No helper enabled with _locate method with returns a list of elements.')

--- a/lib/plugin/fakerTransform.js
+++ b/lib/plugin/fakerTransform.js
@@ -40,7 +40,7 @@ const transform = require('../transform')
  *
  */
 module.exports = function (config) {
-  transform.addTransformerBeforeAll('gherkin.examples', (value) => {
+  transform.addTransformerBeforeAll('gherkin.examples', value => {
     if (typeof value === 'string' && value.length > 0) {
       return faker.helpers.fake(value)
     }

--- a/lib/plugin/heal.js
+++ b/lib/plugin/heal.js
@@ -31,10 +31,7 @@ const defaultConfig = {
 module.exports = function (config = {}) {
   if (store.debugMode && !process.env.DEBUG) {
     event.dispatcher.on(event.test.failed, () => {
-      output.plugin(
-        'heal',
-        'Healing is disabled in --debug mode, use DEBUG="codeceptjs:heal" to enable it in debug mode',
-      )
+      output.plugin('heal', 'Healing is disabled in --debug mode, use DEBUG="codeceptjs:heal" to enable it in debug mode')
     })
     return
   }
@@ -48,21 +45,21 @@ module.exports = function (config = {}) {
 
   config = Object.assign(defaultConfig, config)
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     currentTest = test
     healedSteps = 0
     caughtError = null
   })
 
-  event.dispatcher.on(event.step.started, (step) => (currentStep = step))
+  event.dispatcher.on(event.step.started, step => (currentStep = step))
 
-  event.dispatcher.on(event.step.after, (step) => {
+  event.dispatcher.on(event.step.after, step => {
     if (isHealing) return
     if (healTries >= config.healLimit) return // out of limit
 
     if (!heal.hasCorrespondingRecipes(step)) return
 
-    recorder.catchWithoutStop(async (err) => {
+    recorder.catchWithoutStop(async err => {
       isHealing = true
       if (caughtError === err) throw err // avoid double handling
       caughtError = err
@@ -99,7 +96,7 @@ module.exports = function (config = {}) {
 
     print(`${colors.bold(heal.fixes.length)} ${heal.fixes.length === 1 ? 'step was' : 'steps were'} healed`)
 
-    const suggestions = heal.fixes.filter((fix) => fix.recipe && heal.recipes[fix.recipe].suggest)
+    const suggestions = heal.fixes.filter(fix => fix.recipe && heal.recipes[fix.recipe].suggest)
 
     if (!suggestions.length) return
 

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -76,14 +76,14 @@ const defaultConfig = {
  * ```
  *
  */
-module.exports = (config) => {
+module.exports = config => {
   config = Object.assign(defaultConfig, config)
   config.ignoredSteps = config.ignoredSteps.concat(config.defaultIgnoredSteps)
   const customWhen = config.when
 
   let enableRetry = false
 
-  const when = (err) => {
+  const when = err => {
     if (!enableRetry) return
     const store = require('../store')
     if (store.debugMode) return false
@@ -92,7 +92,7 @@ module.exports = (config) => {
   }
   config.when = when
 
-  event.dispatcher.on(event.step.started, (step) => {
+  event.dispatcher.on(event.step.started, step => {
     if (process.env.TRY_TO === 'true') {
       log('Info: RetryFailedStep plugin is disabled inside tryTo block')
       return
@@ -112,7 +112,7 @@ module.exports = (config) => {
     enableRetry = false
   })
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     if (test && test.disableRetryFailedStep) return // disable retry when a test is not active
     // this env var is used to set the retries inside _before() block of helpers
     process.env.FAILED_STEP_RETRIES = config.retries

--- a/lib/plugin/retryTo.js
+++ b/lib/plugin/retryTo.js
@@ -100,7 +100,7 @@ module.exports = function (config) {
         })
 
         // Catch errors and retry
-        recorder.session.catch((err) => {
+        recorder.session.catch(err => {
           recorder.session.restore(`retryTo ${tries}`)
           if (tries <= maxTries) {
             debug(`Error ${err}... Retrying`)
@@ -112,7 +112,7 @@ module.exports = function (config) {
         })
       }
 
-      recorder.add('retryTo', tryBlock).catch((err) => {
+      recorder.add('retryTo', tryBlock).catch(err => {
         console.error('An error occurred:', err)
         done(null)
       })

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -63,9 +63,7 @@ module.exports = function (config) {
   }
 
   if (Codeceptjs.container.mocha()) {
-    options.reportDir =
-      Codeceptjs.container.mocha().options.reporterOptions &&
-      Codeceptjs.container.mocha().options.reporterOptions.reportDir
+    options.reportDir = Codeceptjs.container.mocha().options.reporterOptions && Codeceptjs.container.mocha().options.reporterOptions.reportDir
   }
 
   if (options.disableScreenshots) {
@@ -73,12 +71,9 @@ module.exports = function (config) {
     return
   }
 
-  event.dispatcher.on(event.test.failed, (test) => {
+  event.dispatcher.on(event.test.failed, test => {
     if (test.ctx?._runnable.title.includes('hook: ')) {
-      output.plugin(
-        'screenshotOnFail',
-        'BeforeSuite/AfterSuite do not have any access to the browser, hence it could not take screenshot.',
-      )
+      output.plugin('screenshotOnFail', 'BeforeSuite/AfterSuite do not have any access to the browser, hence it could not take screenshot.')
       return
     }
     recorder.add(
@@ -90,8 +85,7 @@ module.exports = function (config) {
         if (fileName.indexOf('{') !== -1) {
           fileName = fileName.substr(0, fileName.indexOf('{') - 3).trim()
         }
-        if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook')
-          fileName = clearString(`${test.title}_${test.ctx.test.title}`)
+        if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`)
         if (options.uniqueScreenshotNames && test) {
           const uuid = _getUUID(test)
           fileName = `${fileName.substring(0, 10)}_${uuid}.failed.png`
@@ -112,34 +106,20 @@ module.exports = function (config) {
 
           if (!test.artifacts) test.artifacts = {}
           test.artifacts.screenshot = path.join(global.output_dir, fileName)
-          if (
-            Container.mocha().options.reporterOptions['mocha-junit-reporter'] &&
-            Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments
-          ) {
+          if (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments) {
             test.attachments = [path.join(global.output_dir, fileName)]
           }
 
           const allureReporter = Container.plugins('allure')
           if (allureReporter) {
-            allureReporter.addAttachment(
-              'Main session - Last Seen Screenshot',
-              fs.readFileSync(path.join(global.output_dir, fileName)),
-              dataType,
-            )
+            allureReporter.addAttachment('Main session - Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), dataType)
 
             if (helper.activeSessionName) {
               const sessions = helper.sessionPages || helper.sessionWindows
               for (const sessionName in sessions) {
                 const screenshotFileName = `${sessionName}_${fileName}`
-                test.artifacts[`${sessionName.replace(/ /g, '_')}_screenshot`] = path.join(
-                  global.output_dir,
-                  screenshotFileName,
-                )
-                allureReporter.addAttachment(
-                  `${sessionName} - Last Seen Screenshot`,
-                  fs.readFileSync(path.join(global.output_dir, screenshotFileName)),
-                  dataType,
-                )
+                test.artifacts[`${sessionName.replace(/ /g, '_')}_screenshot`] = path.join(global.output_dir, screenshotFileName)
+                allureReporter.addAttachment(`${sessionName} - Last Seen Screenshot`, fs.readFileSync(path.join(global.output_dir, screenshotFileName)), dataType)
               }
             }
           }
@@ -150,14 +130,7 @@ module.exports = function (config) {
           }
         } catch (err) {
           output.plugin(err)
-          if (
-            err &&
-            err.type &&
-            err.type === 'RuntimeError' &&
-            err.message &&
-            (err.message.indexOf('was terminated due to') > -1 ||
-              err.message.indexOf('no such window: target window already closed') > -1)
-          ) {
+          if (err && err.type && err.type === 'RuntimeError' && err.message && (err.message.indexOf('was terminated due to') > -1 || err.message.indexOf('no such window: target window already closed') > -1)) {
             output.log(`Can't make screenshot, ${err}`)
             helper.isRunning = false
           }

--- a/lib/plugin/selenoid.js
+++ b/lib/plugin/selenoid.js
@@ -41,12 +41,7 @@ const dockerCreateScriptArr = [
   'aerokube/selenoid:latest-release -log-output-dir /opt/selenoid/logs',
 ]
 
-const dockerImageCheckScript = [
-  'docker images',
-  "--filter reference='selenoid/video-recorder'",
-  "--filter reference='selenoid/chrome:latest'",
-  "--filter reference='selenoid/firefox:latest'",
-].join(' ')
+const dockerImageCheckScript = ['docker images', "--filter reference='selenoid/video-recorder'", "--filter reference='selenoid/chrome:latest'", "--filter reference='selenoid/firefox:latest'"].join(' ')
 
 let dockerCreateScript = dockerCreateScriptArr.join(' ')
 let dockerStartScript = 'docker start $name$'
@@ -56,8 +51,8 @@ let seleniumUrl = 'http://localhost:$port$'
 const supportedHelpers = ['WebDriver']
 const SELENOID_START_TIMEOUT = 2000
 const SELENOID_STOP_TIMEOUT = 10000
-const wait = (time) =>
-  new Promise((res) => {
+const wait = time =>
+  new Promise(res => {
     setTimeout(() => {
       // @ts-ignore
       res()
@@ -179,7 +174,7 @@ const wait = (time) =>
  *
  */
 
-const selenoid = (config) => {
+const selenoid = config => {
   const helpers = container.helpers()
   let helperName
 
@@ -194,14 +189,7 @@ const selenoid = (config) => {
     return // no helpers for Selenoid
   }
 
-  const {
-    autoStart,
-    name = 'selenoid',
-    deletePassed = true,
-    additionalParams = '',
-    autoCreate = true,
-    port = 4444,
-  } = config
+  const { autoStart, name = 'selenoid', deletePassed = true, additionalParams = '', autoCreate = true, port = 4444 } = config
   const passedTests = []
 
   recorder.startUnlessRunning()
@@ -213,7 +201,7 @@ const selenoid = (config) => {
         output.debug('Staring Selenoid... ')
         return createAndStart(autoCreate)
           .then(() => output.debug('Selenoid started'))
-          .catch((err) => {
+          .catch(err => {
             throw new Error(err.stack)
           })
       })
@@ -226,7 +214,7 @@ const selenoid = (config) => {
           .then(() => deletePassedTests(passedTests))
           .then(stopSelenoid)
           .then(() => output.debug('Selenoid stopped'))
-          .catch((err) => {
+          .catch(err => {
             throw new Error(err.stack)
           })
       })
@@ -241,7 +229,7 @@ const selenoid = (config) => {
     }
   })
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     switch (helperName) {
       case 'WebDriver':
         setTestConfigForWebdriver(test)
@@ -250,7 +238,7 @@ const selenoid = (config) => {
   })
 
   if (config.enableVideo) {
-    event.dispatcher.on(event.test.passed, (test) => {
+    event.dispatcher.on(event.test.passed, test => {
       if (deletePassed) {
         passedTests.push(test.title)
       } else {
@@ -258,7 +246,7 @@ const selenoid = (config) => {
       }
     })
 
-    event.dispatcher.on(event.test.failed, (test) => {
+    event.dispatcher.on(event.test.failed, test => {
       test.artifacts.video = videoSaved(test)
     })
   }
@@ -312,16 +300,12 @@ const pullImage = async () => {
   console.time('Pulled containers')
   if (!stdout.includes('selenoid/video-recorder')) {
     output.debug('Pulling selenoid/video-recorder...')
-    resultPromise = exec('docker pull selenoid/video-recorder:latest-release').then(() =>
-      output.debug('Pulled in selenoid/video-recorder'),
-    )
+    resultPromise = exec('docker pull selenoid/video-recorder:latest-release').then(() => output.debug('Pulled in selenoid/video-recorder'))
     pulls.push(resultPromise)
   }
   if (!stdout.includes('selenoid/chrome')) {
     output.debug('Pulling selenoid/chrome...')
-    resultPromise = exec('docker pull selenoid/chrome:latest').then(() =>
-      output.debug('Pulled in selenoid/video-recorder'),
-    )
+    resultPromise = exec('docker pull selenoid/chrome:latest').then(() => output.debug('Pulled in selenoid/video-recorder'))
     pulls.push(resultPromise)
   }
   if (!stdout.includes('selenoid/firefox')) {
@@ -341,16 +325,12 @@ function createAndStart(autoCreate) {
 }
 
 function deletePassedTests(passedTests) {
-  const deleteVideoPromiseList = passedTests
-    .map(clearString)
-    .map((test) => axios.delete(`${seleniumUrl}/video/${test}.mp4`))
-  const deleteLogPromiseList = passedTests
-    .map(clearString)
-    .map((test) => axios.delete(`${seleniumUrl}/logs/${test}.log`))
+  const deleteVideoPromiseList = passedTests.map(clearString).map(test => axios.delete(`${seleniumUrl}/video/${test}.mp4`))
+  const deleteLogPromiseList = passedTests.map(clearString).map(test => axios.delete(`${seleniumUrl}/logs/${test}.log`))
 
   return Promise.all(deleteVideoPromiseList.concat(deleteLogPromiseList))
     .then(() => output.debug('Deleted videos and logs for all passed tests'))
-    .catch((err) => output.error(`Error while deleting video and log files ${err.stack}`))
+    .catch(err => output.error(`Error while deleting video and log files ${err.stack}`))
 }
 
 function setOptionsForWebdriver(config) {

--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -89,11 +89,11 @@ module.exports = function (config) {
   const pad = '0000'
   const reportDir = config.output ? path.resolve(global.codecept_dir, config.output) : defaultConfig.output
 
-  event.dispatcher.on(event.suite.before, (suite) => {
+  event.dispatcher.on(event.suite.before, suite => {
     stepNum = -1
   })
 
-  event.dispatcher.on(event.test.before, (test) => {
+  event.dispatcher.on(event.test.before, test => {
     const sha256hash = crypto
       .createHash('sha256')
       .update(test.file + test.title)
@@ -107,15 +107,15 @@ module.exports = function (config) {
     currentTest = test
   })
 
-  event.dispatcher.on(event.step.failed, (step) => {
+  event.dispatcher.on(event.step.failed, step => {
     recorder.add('screenshot of failed test', async () => persistStep(step), true)
   })
 
-  event.dispatcher.on(event.step.after, (step) => {
+  event.dispatcher.on(event.step.after, step => {
     recorder.add('screenshot of step of test', async () => persistStep(step), true)
   })
 
-  event.dispatcher.on(event.test.passed, (test) => {
+  event.dispatcher.on(event.test.passed, test => {
     if (!config.deleteSuccessful) return persist(test)
     // cleanup
     deleteDir(dir)
@@ -123,10 +123,7 @@ module.exports = function (config) {
 
   event.dispatcher.on(event.test.failed, (test, err) => {
     if (test.ctx._runnable.title.includes('hook: ')) {
-      output.plugin(
-        'stepByStepReport',
-        'BeforeSuite/AfterSuite do not have any access to the browser, hence it could not take screenshot.',
-      )
+      output.plugin('stepByStepReport', 'BeforeSuite/AfterSuite do not have any access to the browser, hence it could not take screenshot.')
       return
     }
     persist(test, err)
@@ -150,7 +147,7 @@ module.exports = function (config) {
     try {
       const items = fs.readdirSync(dirPath, { withFileTypes: true })
 
-      items.forEach((item) => {
+      items.forEach(item => {
         if (item.isDirectory() && item.name.startsWith('record_')) {
           const recordFolderPath = path.join(dirPath, item.name)
           const indexPath = path.join(recordFolderPath, 'index.html')
@@ -190,9 +187,7 @@ module.exports = function (config) {
 
     fs.writeFileSync(path.join(reportDir, 'records.html'), indexHTML)
 
-    output.print(
-      `${figures.circleFilled} Step-by-step preview: ${colors.white.bold(`file://${reportDir}/records.html`)}`,
-    )
+    output.print(`${figures.circleFilled} Step-by-step preview: ${colors.white.bold(`file://${reportDir}/records.html`)}`)
   }
 
   async function persistStep(step) {

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -61,12 +61,12 @@ const defaultConfig = {
  * ```
  *
  */
-module.exports = (config) => {
+module.exports = config => {
   config = Object.assign(defaultConfig, config)
   // below override rule makes sure customTimeoutSteps go first but then they override noTimeoutSteps in case of exact pattern match
   config.customTimeoutSteps = config.customTimeoutSteps.concat(config.noTimeoutSteps).concat(config.customTimeoutSteps)
 
-  event.dispatcher.on(event.step.before, (step) => {
+  event.dispatcher.on(event.step.before, step => {
     let stepTimeout
     for (let stepRule of config.customTimeoutSteps) {
       let customTimeout = 0
@@ -74,19 +74,12 @@ module.exports = (config) => {
         if (stepRule.length > 1) customTimeout = stepRule[1]
         stepRule = stepRule[0]
       }
-      if (
-        stepRule instanceof RegExp
-          ? step.name.match(stepRule)
-          : step.name === stepRule || (stepRule.indexOf('*') && step.name.startsWith(stepRule.slice(0, -1)))
-      ) {
+      if (stepRule instanceof RegExp ? step.name.match(stepRule) : step.name === stepRule || (stepRule.indexOf('*') && step.name.startsWith(stepRule.slice(0, -1)))) {
         stepTimeout = customTimeout
         break
       }
     }
     stepTimeout = stepTimeout === undefined ? config.timeout : stepTimeout
-    step.setTimeout(
-      stepTimeout * 1000,
-      config.overrideStepLimits ? TIMEOUT_ORDER.stepTimeoutHard : TIMEOUT_ORDER.stepTimeoutSoft,
-    )
+    step.setTimeout(stepTimeout * 1000, config.overrideStepLimits ? TIMEOUT_ORDER.stepTimeoutHard : TIMEOUT_ORDER.stepTimeoutSoft)
   })
 }

--- a/lib/plugin/subtitles.js
+++ b/lib/plugin/subtitles.js
@@ -29,12 +29,12 @@ let testStartedAt
  * ```
  */
 module.exports = function () {
-  event.dispatcher.on(event.test.before, (_) => {
+  event.dispatcher.on(event.test.before, _ => {
     testStartedAt = Date.now()
     steps = {}
   })
 
-  event.dispatcher.on(event.step.started, (step) => {
+  event.dispatcher.on(event.step.started, step => {
     const stepStartedAt = Date.now()
     step.id = uuidv4()
 
@@ -50,13 +50,13 @@ module.exports = function () {
     }
   })
 
-  event.dispatcher.on(event.step.finished, (step) => {
+  event.dispatcher.on(event.step.finished, step => {
     if (step && step.id && steps[step.id]) {
       steps[step.id].end = formatTimestamp(Date.now() - testStartedAt)
     }
   })
 
-  event.dispatcher.on(event.test.after, async (test) => {
+  event.dispatcher.on(event.test.after, async test => {
     if (test && test.artifacts && test.artifacts.video) {
       const stepsSortedByStartTime = Object.values(steps)
       stepsSortedByStartTime.sort((stepA, stepB) => {

--- a/lib/plugin/tryTo.js
+++ b/lib/plugin/tryTo.js
@@ -92,7 +92,7 @@ function tryTo(callback) {
         recorder.session.restore('tryTo')
         return result
       })
-      recorder.session.catch((err) => {
+      recorder.session.catch(err => {
         result = false
         const msg = err.inspect ? err.inspect() : err.toString()
         debug(`Unsuccessful try > ${msg}`)

--- a/lib/plugin/wdio.js
+++ b/lib/plugin/wdio.js
@@ -81,7 +81,7 @@ let restartsSession
  * * ... - additional configuration passed into services.
  *
  */
-module.exports = (config) => {
+module.exports = config => {
   // Keep initial configs to pass as options to wdio services
   const wdioOptions = { ...config }
   const webDriver = container.helpers('WebDriver')
@@ -116,9 +116,7 @@ module.exports = (config) => {
       continue
     }
 
-    throw new Error(
-      `Couldn't initialize service ${name} from wdio plugin config.\nIt should be available either in '@wdio/${name.toLowerCase()}-service' package`,
-    )
+    throw new Error(`Couldn't initialize service ${name} from wdio plugin config.\nIt should be available either in '@wdio/${name.toLowerCase()}-service' package`)
   }
 
   debug(`services ${services}, launchers ${launchers}`)
@@ -144,7 +142,7 @@ module.exports = (config) => {
     }
 
     if (service.afterSession) {
-      event.dispatcher.on(event.all.result, (result) => {
+      event.dispatcher.on(event.all.result, result => {
         recorder.add(`service ${name} all.after`, async () => {
           await service.afterSession(result)
         })
@@ -152,21 +150,21 @@ module.exports = (config) => {
     }
 
     if (service.beforeSuite) {
-      event.dispatcher.on(event.suite.before, (suite) => {
+      event.dispatcher.on(event.suite.before, suite => {
         debug(`suite started: ${suite.title}`)
         recorder.add(`service ${name} suite.before`, () => service.beforeSuite(suite))
       })
     }
 
     if (service.afterSuite) {
-      event.dispatcher.on(event.suite.after, (suite) => {
+      event.dispatcher.on(event.suite.after, suite => {
         debug(`suite finished: ${suite.title}`)
         recorder.add(`service ${name} suite.after`, () => service.afterSuite(suite))
       })
     }
 
     if (service.beforeTest) {
-      event.dispatcher.on(event.test.started, async (test) => {
+      event.dispatcher.on(event.test.started, async test => {
         if (test.parent) {
           test.parent.toString = () => test.parent.title
         }
@@ -181,7 +179,7 @@ module.exports = (config) => {
     }
 
     if (service.afterTest) {
-      event.dispatcher.on(event.test.finished, async (test) => {
+      event.dispatcher.on(event.test.finished, async test => {
         debug(`test finished: ${test.title}`)
         await service.afterTest(test)
       })
@@ -206,7 +204,7 @@ module.exports = (config) => {
     }
 
     if (!restartsSession && service.after) {
-      event.dispatcher.on(event.all.result, (result) => service.after(result))
+      event.dispatcher.on(event.all.result, result => service.after(result))
     }
   }
 

--- a/lib/template/heal.js
+++ b/lib/template/heal.js
@@ -6,17 +6,8 @@ heal.addRecipe('ai', {
     html: ({ I }) => I.grabHTMLFrom('body'),
   },
   suggest: true,
-  steps: [
-    'click',
-    'fillField',
-    'appendField',
-    'selectOption',
-    'attachFile',
-    'checkOption',
-    'uncheckOption',
-    'doubleClick',
-  ],
-  fn: async (args) => {
+  steps: ['click', 'fillField', 'appendField', 'selectOption', 'attachFile', 'checkOption', 'uncheckOption', 'doubleClick'],
+  fn: async args => {
     return ai.healFailedStep(args)
   },
 })

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,9 +2,9 @@ module.exports = {
   printWidth: 220,
   tabWidth: 2,
   useTabs: false,
-  semi: true,
+  semi: false,
   singleQuote: true,
   trailingComma: 'all',
   bracketSameLine: false,
   arrowParens: 'avoid',
-};
+}

--- a/runok.js
+++ b/runok.js
@@ -14,7 +14,7 @@ const semver = require('semver')
 
 let documentation
 
-import('documentation').then((mod) => (documentation = mod))
+import('documentation').then(mod => (documentation = mod))
 
 const helperMarkDownFile = function (name) {
   return `docs/helpers/${name}.md`
@@ -46,7 +46,7 @@ module.exports = {
   async docsPlugins() {
     // generate documentation for plugins
     await npx(`documentation build lib/plugin/*.js -o docs/plugins.md ${documentjsCliArgs}`)
-    await replaceInFile('docs/plugins.md', (cfg) => {
+    await replaceInFile('docs/plugins.md', cfg => {
       cfg.replace(/^/, '---\npermalink: plugins\nsidebarDepth: \nsidebar: auto\ntitle: Plugins\n---\n\n')
     })
   },
@@ -55,7 +55,7 @@ module.exports = {
     // generate docs for CI services
     stopOnFail()
 
-    writeToFile('docs/docker.md', (cfg) => {
+    writeToFile('docs/docker.md', cfg => {
       cfg.line('---')
       cfg.line('permalink: /docker')
       cfg.line('layout: Section')
@@ -90,47 +90,43 @@ Our community prepared some valuable recipes for setting up CI systems with Code
       if (topic.slug === 'about-the-continuous-integration-category') continue
       body += `* ### [${topic.title}](https://codecept.discourse.group/t/${topic.slug}/)\n`
     }
-    writeToFile('docs/continuous-integration.md', (cfg) => cfg.line(body))
+    writeToFile('docs/continuous-integration.md', cfg => cfg.line(body))
   },
 
   async docsExternalHelpers() {
     // generate documentation for helpers outside of main repo
     console.log('Building @codecepjs/detox helper docs')
     let helper = 'Detox'
-    replaceInFile(`node_modules/@codeceptjs/detox-helper/${helper}.js`, (cfg) => {
+    replaceInFile(`node_modules/@codeceptjs/detox-helper/${helper}.js`, cfg => {
       cfg.replace(/CodeceptJS.LocatorOrString/g, 'string | object')
       cfg.replace(/LocatorOrString/g, 'string | object')
     })
-    await npx(
-      `documentation build node_modules/@codeceptjs/detox-helper/${helper}.js -o ${helperMarkDownFile(helper)} ${documentjsCliArgs}`,
-    )
+    await npx(`documentation build node_modules/@codeceptjs/detox-helper/${helper}.js -o ${helperMarkDownFile(helper)} ${documentjsCliArgs}`)
 
-    await writeToFile(helperMarkDownFile(helper), (cfg) => {
+    await writeToFile(helperMarkDownFile(helper), cfg => {
       cfg.line(`---\npermalink: /helpers/${helper}\nsidebar: auto\ntitle: ${helper}\n---\n\n# ${helper}\n\n`)
       cfg.textFromFile(helperMarkDownFile(helper))
     })
 
-    replaceInFile(`node_modules/@codeceptjs/detox-helper/${helper}.js`, (cfg) => {
+    replaceInFile(`node_modules/@codeceptjs/detox-helper/${helper}.js`, cfg => {
       cfg.replace(/string \| object/g, 'CodeceptJS.LocatorOrString')
       cfg.replace(/string \| object/g, 'LocatorOrString')
     })
 
     console.log('Building @codeceptjs/mock-request')
     helper = 'MockRequest'
-    replaceInFile('node_modules/@codeceptjs/mock-request/index.js', (cfg) => {
+    replaceInFile('node_modules/@codeceptjs/mock-request/index.js', cfg => {
       cfg.replace(/CodeceptJS.LocatorOrString/g, 'string | object')
       cfg.replace(/LocatorOrString/g, 'string | object')
     })
-    await npx(
-      `documentation build node_modules/@codeceptjs/mock-request/index.js -o ${helperMarkDownFile(helper)} ${documentjsCliArgs}`,
-    )
+    await npx(`documentation build node_modules/@codeceptjs/mock-request/index.js -o ${helperMarkDownFile(helper)} ${documentjsCliArgs}`)
 
-    await writeToFile(helperMarkDownFile(helper), (cfg) => {
+    await writeToFile(helperMarkDownFile(helper), cfg => {
       cfg.line(`---\npermalink: /helpers/${helper}\nsidebar: auto\ntitle: ${helper}\n---\n\n# ${helper}\n\n`)
       cfg.textFromFile(helperMarkDownFile(helper))
     })
 
-    replaceInFile('node_modules/@codeceptjs/mock-request/index.js', (cfg) => {
+    replaceInFile('node_modules/@codeceptjs/mock-request/index.js', cfg => {
       cfg.replace(/string \| object/g, 'CodeceptJS.LocatorOrString')
       cfg.replace(/string \| object/g, 'LocatorOrString')
     })
@@ -139,11 +135,9 @@ Our community prepared some valuable recipes for setting up CI systems with Code
   async docsExternalPlugins() {
     // generate documentation for helpers outside of main repo
     console.log('Building Vue plugin docs')
-    const resp = await axios.get(
-      'https://raw.githubusercontent.com/codecept-js/vue-cli-plugin-codeceptjs-puppeteer/master/README.md',
-    )
+    const resp = await axios.get('https://raw.githubusercontent.com/codecept-js/vue-cli-plugin-codeceptjs-puppeteer/master/README.md')
 
-    writeToFile('docs/vue.md', (cfg) => {
+    writeToFile('docs/vue.md', cfg => {
       cfg.line('---\npermalink: /vue\nlayout: Section\nsidebar: false\ntitle: Testing Vue Apps\n---\n\n')
       cfg.line(resp.data)
     })
@@ -153,13 +147,13 @@ Our community prepared some valuable recipes for setting up CI systems with Code
 
   async buildLibWithDocs(forTypings = false) {
     // generate documentation for helpers
-    const files = fs.readdirSync('lib/helper').filter((f) => path.extname(f) === '.js')
+    const files = fs.readdirSync('lib/helper').filter(f => path.extname(f) === '.js')
 
-    const partials = fs.readdirSync('docs/webapi').filter((f) => path.extname(f) === '.mustache')
-    const placeholders = partials.map((file) => `{{> ${path.basename(file, '.mustache')} }}`)
+    const partials = fs.readdirSync('docs/webapi').filter(f => path.extname(f) === '.mustache')
+    const placeholders = partials.map(file => `{{> ${path.basename(file, '.mustache')} }}`)
     const templates = partials
-      .map((file) => fs.readFileSync(`docs/webapi/${file}`).toString())
-      .map((template) =>
+      .map(file => fs.readFileSync(`docs/webapi/${file}`).toString())
+      .map(template =>
         template
           .replace(/^/gm, '   * ')
           .replace(/^/, '\n')
@@ -170,7 +164,7 @@ Our community prepared some valuable recipes for setting up CI systems with Code
       const name = path.basename(file, '.js')
       console.log(`Building helpers with docs for ${name}`)
       copy(`lib/helper/${file}`, `docs/build/${file}`)
-      replaceInFile(`docs/build/${file}`, (cfg) => {
+      replaceInFile(`docs/build/${file}`, cfg => {
         for (const i in placeholders) {
           cfg.replace(placeholders[i], templates[i])
         }
@@ -187,33 +181,31 @@ Our community prepared some valuable recipes for setting up CI systems with Code
 
   async docsHelpers() {
     // generate documentation for helpers
-    const files = fs.readdirSync('lib/helper').filter((f) => path.extname(f) === '.js')
+    const files = fs.readdirSync('lib/helper').filter(f => path.extname(f) === '.js')
 
     const ignoreList = ['Polly', 'MockRequest'] // WebDriverIO won't be documented and should be removed
 
-    const partials = fs.readdirSync('docs/webapi').filter((f) => path.extname(f) === '.mustache')
-    const placeholders = partials.map((file) => `{{> ${path.basename(file, '.mustache')} }}`)
+    const partials = fs.readdirSync('docs/webapi').filter(f => path.extname(f) === '.mustache')
+    const placeholders = partials.map(file => `{{> ${path.basename(file, '.mustache')} }}`)
     const templates = partials
-      .map((file) => fs.readFileSync(`docs/webapi/${file}`).toString())
-      .map((template) =>
+      .map(file => fs.readFileSync(`docs/webapi/${file}`).toString())
+      .map(template =>
         template
           .replace(/^/gm, '   * ')
           .replace(/^/, '\n')
           .replace(/\s*\* /, ''),
       )
 
-    const sharedPartials = fs.readdirSync('docs/shared').filter((f) => path.extname(f) === '.mustache')
-    const sharedPlaceholders = sharedPartials.map((file) => `{{ ${path.basename(file, '.mustache')} }}`)
-    const sharedTemplates = sharedPartials
-      .map((file) => fs.readFileSync(`docs/shared/${file}`).toString())
-      .map((template) => `\n\n\n${template}`)
+    const sharedPartials = fs.readdirSync('docs/shared').filter(f => path.extname(f) === '.mustache')
+    const sharedPlaceholders = sharedPartials.map(file => `{{ ${path.basename(file, '.mustache')} }}`)
+    const sharedTemplates = sharedPartials.map(file => fs.readFileSync(`docs/shared/${file}`).toString()).map(template => `\n\n\n${template}`)
 
     for (const file of files) {
       const name = path.basename(file, '.js')
       if (ignoreList.indexOf(name) >= 0) continue
       console.log(`Writing documentation for ${name}`)
       copy(`lib/helper/${file}`, `docs/build/${file}`)
-      replaceInFile(`docs/build/${file}`, (cfg) => {
+      replaceInFile(`docs/build/${file}`, cfg => {
         for (const i in placeholders) {
           cfg.replace(placeholders[i], templates[i])
         }
@@ -225,18 +217,18 @@ Our community prepared some valuable recipes for setting up CI systems with Code
       })
 
       await npx(`documentation build docs/build/${file} -o docs/helpers/${name}.md ${documentjsCliArgs}`)
-      replaceInFile(helperMarkDownFile(name), (cfg) => {
+      replaceInFile(helperMarkDownFile(name), cfg => {
         cfg.replace(/\(optional, default.*?\)/gm, '')
         cfg.replace(/\\*/gm, '')
       })
 
-      replaceInFile(helperMarkDownFile(name), (cfg) => {
+      replaceInFile(helperMarkDownFile(name), cfg => {
         for (const i in sharedPlaceholders) {
           cfg.replace(sharedPlaceholders[i], sharedTemplates[i])
         }
       })
 
-      replaceInFile(helperMarkDownFile(name), (cfg) => {
+      replaceInFile(helperMarkDownFile(name), cfg => {
         const regex = /## config((.|\n)*)\[1\]/m
         const fullText = fs.readFileSync(helperMarkDownFile(name)).toString()
         const text = fullText.match(regex)
@@ -250,7 +242,7 @@ Our community prepared some valuable recipes for setting up CI systems with Code
         await this.docsAppium()
       }
 
-      await writeToFile(helperMarkDownFile(name), (cfg) => {
+      await writeToFile(helperMarkDownFile(name), cfg => {
         cfg.append(`---
 permalink: /helpers/${name}
 editLink: false
@@ -267,13 +259,13 @@ title: ${name}
   async wiki() {
     // publish wiki pages to website
     if (!fs.existsSync('docs/wiki/Home.md')) {
-      await git((fn) => {
+      await git(fn => {
         fn.clone('git@github.com:codeceptjs/CodeceptJS.wiki.git', 'docs/wiki')
       })
     }
-    await chdir('docs/wiki', () => git((cfg) => cfg.pull('origin master')))
+    await chdir('docs/wiki', () => git(cfg => cfg.pull('origin master')))
 
-    await writeToFile('docs/community-helpers.md', (cfg) => {
+    await writeToFile('docs/community-helpers.md', cfg => {
       cfg.line('---')
       cfg.line('permalink: /community-helpers')
       cfg.line('title: Community Helpers')
@@ -281,14 +273,12 @@ title: ${name}
       cfg.line('---')
       cfg.line('')
       cfg.line('# Community Helpers')
-      cfg.line(
-        '> Share your helpers at our [Wiki Page](https://github.com/codeceptjs/CodeceptJS/wiki/Community-Helpers)',
-      )
+      cfg.line('> Share your helpers at our [Wiki Page](https://github.com/codeceptjs/CodeceptJS/wiki/Community-Helpers)')
       cfg.line('')
       cfg.textFromFile('docs/wiki/Community-Helpers-&-Plugins.md')
     })
 
-    writeToFile('docs/examples.md', (cfg) => {
+    writeToFile('docs/examples.md', cfg => {
       cfg.line('---')
       cfg.line('permalink: /examples')
       cfg.line('layout: Section')
@@ -302,7 +292,7 @@ title: ${name}
       cfg.textFromFile('docs/wiki/Examples.md')
     })
 
-    writeToFile('docs/books.md', (cfg) => {
+    writeToFile('docs/books.md', cfg => {
       cfg.line('---')
       cfg.line('permalink: /books')
       cfg.line('layout: Section')
@@ -312,13 +302,11 @@ title: ${name}
       cfg.line('---')
       cfg.line('')
       cfg.line('# Books & Posts')
-      cfg.line(
-        '> Add your own books or posts to our [Wiki Page](https://github.com/codeceptjs/CodeceptJS/wiki/Books-&-Posts)',
-      )
+      cfg.line('> Add your own books or posts to our [Wiki Page](https://github.com/codeceptjs/CodeceptJS/wiki/Books-&-Posts)')
       cfg.textFromFile('docs/wiki/Books-&-Posts.md')
     })
 
-    writeToFile('docs/videos.md', (cfg) => {
+    writeToFile('docs/videos.md', cfg => {
       cfg.line('---')
       cfg.line('permalink: /videos')
       cfg.line('layout: Section')
@@ -334,20 +322,7 @@ title: ${name}
 
   async docsAppium() {
     // generates docs for appium
-    const onlyWeb = [
-      /Title/,
-      /Popup/,
-      /Cookie/,
-      /Url/,
-      /^press/,
-      /^refreshPage/,
-      /^resizeWindow/,
-      /Script$/,
-      /cursor/,
-      /Css/,
-      /Tab$/,
-      /^wait/,
-    ]
+    const onlyWeb = [/Title/, /Popup/, /Cookie/, /Url/, /^press/, /^refreshPage/, /^resizeWindow/, /Script$/, /cursor/, /Css/, /Tab$/, /^wait/]
     const webdriverDoc = await documentation.build(['docs/build/WebDriver.js'], {
       shallow: true,
       order: 'asc',
@@ -359,8 +334,8 @@ title: ${name}
 
     // copy all public methods from webdriver
     for (const method of webdriverDoc[0].members.instance) {
-      if (onlyWeb.filter((f) => method.name.match(f)).length) continue
-      if (doc[0].members.instance.filter((m) => m.name === method.name).length) continue
+      if (onlyWeb.filter(f => method.name.match(f)).length) continue
+      if (doc[0].members.instance.filter(m => m.name === method.name).length) continue
       doc[0].members.instance.push(method)
     }
     const output = await documentation.formats.md(doc)
@@ -378,12 +353,12 @@ title: ${name}
       await exec(`rm -rf ${dir}`)
     }
 
-    await git((fn) => fn.clone('git@github.com:codeceptjs/website.git', dir))
+    await git(fn => fn.clone('git@github.com:codeceptjs/website.git', dir))
     await copy('docs', 'website/docs')
 
     await chdir(dir, async () => {
       stopOnFail(false)
-      await git((fn) => {
+      await git(fn => {
         fn.add('-A')
         fn.commit('-m "synchronized with docs"')
         fn.pull()
@@ -406,7 +381,7 @@ title: ${name}
     if (releaseType) {
       packageInfo.version = semver.inc(packageInfo.version, releaseType)
       fs.writeFileSync('package.json', JSON.stringify(packageInfo))
-      await git((cmd) => {
+      await git(cmd => {
         cmd.add('package.json')
         cmd.commit('-m "version bump"')
       })
@@ -416,7 +391,7 @@ title: ${name}
     await this.docs()
     await this.def()
     await this.publishSite()
-    await git((cmd) => {
+    await git(cmd => {
       cmd.pull()
       cmd.tag(version)
       cmd.push('origin 3.x --tags')
@@ -465,9 +440,7 @@ ${changelog}`
 
   async getCommitLog() {
     console.log('Gathering commits...')
-    const logs = await exec(
-      'git log --grep "chore(deps" --invert-grep --pretty=\'format:* %s - by @%aN\' $(git describe --abbrev=0 --tags)..HEAD | grep "DOC: " -v',
-    )
+    const logs = await exec('git log --grep "chore(deps" --invert-grep --pretty=\'format:* %s - by @%aN\' $(git describe --abbrev=0 --tags)..HEAD | grep "DOC: " -v')
     console.log(logs.data.stdout)
   },
 
@@ -485,9 +458,9 @@ ${changelog}`
       // Filter out bot accounts
       const excludeUsers = ['dependabot[bot]', 'actions-user']
 
-      const filteredContributors = response.data.filter((contributor) => !excludeUsers.includes(contributor.login))
+      const filteredContributors = response.data.filter(contributor => !excludeUsers.includes(contributor.login))
 
-      const contributors = filteredContributors.map((contributor) => {
+      const contributors = filteredContributors.map(contributor => {
         return `
 <td align="center">
   <a href="${contributor.html_url}">
@@ -519,10 +492,7 @@ ${changelog}`
       const match = content.match(contributorsSectionRegex)
 
       if (match) {
-        const updatedContent = content.replace(
-          contributorsSectionRegex,
-          `${match[1]}\n${contributorsTable}\n${match[3]}`,
-        )
+        const updatedContent = content.replace(contributorsSectionRegex, `${match[1]}\n${contributorsTable}\n${match[3]}`)
         fs.writeFileSync(readmePath, updatedContent, 'utf-8')
       } else {
         // If no contributors section exists, add one at the end
@@ -540,7 +510,7 @@ ${changelog}`
     try {
       const output = execSync('npm view codeceptjs versions --json').toString()
       const versions = JSON.parse(output)
-      const betaVersions = versions.filter((version) => version.includes('beta'))
+      const betaVersions = versions.filter(version => version.includes('beta'))
       const latestBeta = betaVersions.length ? betaVersions[betaVersions.length - 1] : null
       console.log(`Current beta version: ${latestBeta}`)
       return latestBeta
@@ -591,7 +561,7 @@ async function processChangelog() {
   // helper
   changelog = changelog.replace(/\s\[(\w+)\]\s/gm, ' **[$1]** ')
 
-  writeToFile('docs/changelog.md', (cfg) => {
+  writeToFile('docs/changelog.md', cfg => {
     cfg.line('---')
     cfg.line('permalink: /changelog')
     cfg.line('title: Releases')

--- a/test/acceptance/codecept.Playwright.coverage.js
+++ b/test/acceptance/codecept.Playwright.coverage.js
@@ -1,4 +1,4 @@
-const TestHelper = require('../support/TestHelper');
+const TestHelper = require('../support/TestHelper')
 
 module.exports.config = {
   tests: './*_test.js',
@@ -51,4 +51,4 @@ module.exports.config = {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],
   },
-};
+}

--- a/test/acceptance/codecept.Playwright.js
+++ b/test/acceptance/codecept.Playwright.js
@@ -1,4 +1,4 @@
-const TestHelper = require('../support/TestHelper');
+const TestHelper = require('../support/TestHelper')
 
 module.exports.config = {
   tests: './*_test.js',
@@ -41,4 +41,4 @@ module.exports.config = {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],
   },
-};
+}

--- a/test/acceptance/codecept.Playwright.retryTo.js
+++ b/test/acceptance/codecept.Playwright.retryTo.js
@@ -1,4 +1,4 @@
-const TestHelper = require('../support/TestHelper');
+const TestHelper = require('../support/TestHelper')
 
 module.exports.config = {
   tests: './*_test.js',
@@ -43,4 +43,4 @@ module.exports.config = {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],
   },
-};
+}

--- a/test/acceptance/codecept.Puppeteer.js
+++ b/test/acceptance/codecept.Puppeteer.js
@@ -1,4 +1,4 @@
-const TestHelper = require('../support/TestHelper');
+const TestHelper = require('../support/TestHelper')
 
 module.exports.config = {
   tests: './*_test.js',
@@ -33,4 +33,4 @@ module.exports.config = {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],
   },
-};
+}

--- a/test/acceptance/codecept.Testcafe.js
+++ b/test/acceptance/codecept.Testcafe.js
@@ -1,4 +1,4 @@
-const TestHelper = require('../support/TestHelper');
+const TestHelper = require('../support/TestHelper')
 
 module.exports.config = {
   tests: './*_test.js',
@@ -21,4 +21,4 @@ module.exports.config = {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],
   },
-};
+}

--- a/test/acceptance/codecept.WebDriver.js
+++ b/test/acceptance/codecept.WebDriver.js
@@ -1,4 +1,4 @@
-const TestHelper = require('../support/TestHelper');
+const TestHelper = require('../support/TestHelper')
 
 module.exports.config = {
   tests: './*_test.js',
@@ -28,7 +28,7 @@ module.exports.config = {
   include: {},
   bootstrap: async () =>
     new Promise(done => {
-      setTimeout(done, 5000);
+      setTimeout(done, 5000)
     }), // let's wait for selenium
   mocha: {},
   name: 'acceptance',
@@ -41,4 +41,4 @@ module.exports.config = {
     features: './gherkin/*.feature',
     steps: ['./gherkin/steps.js'],
   },
-};
+}

--- a/test/acceptance/config_test.js
+++ b/test/acceptance/config_test.js
@@ -20,7 +20,7 @@ Scenario('change config 3 @WebDriverIO @Puppeteer @Playwright', ({ I }) => {
 Scenario('change config 4 @WebDriverIO @Puppeteer @Playwright', ({ I }) => {
   I.amOnPage('/')
   I.seeInCurrentUrl('codecept.io')
-}).config((test) => {
+}).config(test => {
   return { url: 'https://codecept.io/', capabilities: { 'moz:title': test.title } }
 })
 
@@ -40,7 +40,7 @@ Scenario('change config 6 @WebDriverIO @Puppeteer @Playwright', ({ I }) => {
   I.amOnPage('/')
   I.seeInCurrentUrl('codecept.io')
 }).config(async () => {
-  await new Promise((r) => {
+  await new Promise(r => {
     setTimeout(r, 50)
   })
   return { url: 'https://codecept.io' }

--- a/test/acceptance/retryTo_test.js
+++ b/test/acceptance/retryTo_test.js
@@ -3,14 +3,14 @@ const { I } = inject()
 Feature('Plugins')
 
 Scenario('retryTo works with await steps @plugin', async () => {
-  await retryTo(async (tryNum) => {
+  await retryTo(async tryNum => {
     const foo = await I.grabCurrentUrl()
     if (tryNum < 3) I.waitForVisible('.nothing', 1)
   }, 4)
 })
 
 Scenario('retryTo works with non await steps @plugin', async () => {
-  await retryTo(async (tryNum) => {
+  await retryTo(async tryNum => {
     if (tryNum < 3) I.waitForVisible('.nothing', 1)
   }, 4)
 })
@@ -18,7 +18,7 @@ Scenario('retryTo works with non await steps @plugin', async () => {
 Scenario('Should be succeed', async ({ I }) => {
   I.amOnPage('http://example.org')
   I.waitForVisible('.nothing', 1) // should fail here but it won't terminate
-  await retryTo((tryNum) => {
+  await retryTo(tryNum => {
     I.see('.doesNotMatter')
   }, 10)
 })
@@ -30,7 +30,7 @@ Scenario('Should fail after reached max retries', async () => {
 })
 
 Scenario('Should succeed at the third attempt @plugin', async () => {
-  await retryTo(async (tryNum) => {
+  await retryTo(async tryNum => {
     if (tryNum < 2) throw new Error('Custom pluginRetryTo Error')
   }, 3)
 })

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -88,19 +88,13 @@ Scenario('should save screenshot for sessions @WebDriverIO @Puppeteer @Playwrigh
   })
 
   const fileName = clearString(this.title)
-  const [original, failed] = await I.getSHA256Digests([
-    `${output_dir}/original.png`,
-    `${output_dir}/john_${fileName}.failed.png`,
-  ])
+  const [original, failed] = await I.getSHA256Digests([`${output_dir}/original.png`, `${output_dir}/john_${fileName}.failed.png`])
 
   // Assert that screenshots of same page in same session are equal
   await I.expectEqual(original, failed)
 
   // Assert that screenshots of sessions are created
-  const [main_original, session_failed] = await I.getSHA256Digests([
-    `${output_dir}/main_session.png`,
-    `${output_dir}/john_${fileName}.failed.png`,
-  ])
+  const [main_original, session_failed] = await I.getSHA256Digests([`${output_dir}/main_session.png`, `${output_dir}/john_${fileName}.failed.png`])
   await I.expectNotEqual(main_original, session_failed)
 })
 

--- a/test/acceptance/within_test.js
+++ b/test/acceptance/within_test.js
@@ -77,33 +77,27 @@ Scenario('within on nested iframe depth 2 @WebDriverIO @Puppeteer @Playwright', 
   I.dontSee('Email Address')
 })
 
-Scenario(
-  'within on nested iframe depth 2 and mixed id and xpath selector @WebDriverIO @Puppeteer @Playwright',
-  ({ I }) => {
-    I.amOnPage('/iframe_nested')
-    within({ frame: ['#wrapperId', '[name=content]'] }, () => {
-      I.fillField('rus', 'Updated')
-      I.click('Sign in!')
-      I.see('Email Address')
-    })
-    I.see('Nested Iframe test')
-    I.dontSee('Email Address')
-  },
-)
+Scenario('within on nested iframe depth 2 and mixed id and xpath selector @WebDriverIO @Puppeteer @Playwright', ({ I }) => {
+  I.amOnPage('/iframe_nested')
+  within({ frame: ['#wrapperId', '[name=content]'] }, () => {
+    I.fillField('rus', 'Updated')
+    I.click('Sign in!')
+    I.see('Email Address')
+  })
+  I.see('Nested Iframe test')
+  I.dontSee('Email Address')
+})
 
-Scenario(
-  'within on nested iframe depth 2 and mixed class and xpath selector @WebDriverIO @Puppeteer @Playwright',
-  ({ I }) => {
-    I.amOnPage('/iframe_nested')
-    within({ frame: ['.wrapperClass', '[name=content]'] }, () => {
-      I.fillField('rus', 'Updated')
-      I.click('Sign in!')
-      I.see('Email Address')
-    })
-    I.see('Nested Iframe test')
-    I.dontSee('Email Address')
-  },
-)
+Scenario('within on nested iframe depth 2 and mixed class and xpath selector @WebDriverIO @Puppeteer @Playwright', ({ I }) => {
+  I.amOnPage('/iframe_nested')
+  within({ frame: ['.wrapperClass', '[name=content]'] }, () => {
+    I.fillField('rus', 'Updated')
+    I.click('Sign in!')
+    I.see('Email Address')
+  })
+  I.see('Nested Iframe test')
+  I.dontSee('Email Address')
+})
 
 Scenario('should throw exception if element not found @WebDriverIO @Puppeteer @Playwright', async ({ I }) => {
   I.amOnPage('/form/textarea')

--- a/test/data/app/view/info.php
+++ b/test/data/app/view/info.php
@@ -5,7 +5,7 @@
 </head>
 <style>
     .span {
-        height: 15px; 
+        height: 15px;
     }
     h4 {
         font-weight: 300;
@@ -63,5 +63,12 @@
 </div>
 <div class="issue2928" style="width: 100px; height: 40px; visibility:hidden; background: red">visibility:hidden</div>
 <div class="issue2928" style="width: 100px; height: 40px; background: green">no visibility hidden</div>
+
+<tr>
+<td><p>Field1</p></td>
+<td><p id="p-no-text"></p>sometext</td>
+</tr>
+
 </body>
+
 </html>

--- a/test/graphql/GraphQLDataFactory_test.js
+++ b/test/graphql/GraphQLDataFactory_test.js
@@ -49,7 +49,7 @@ describe('GraphQLDataFactory', function () {
         createUser: {
           factory: path.join(__dirname, '/../data/graphql/users_factory.js'),
           query: creatUserQuery,
-          revert: (data) => {
+          revert: data => {
             return {
               query: deleteOperationQuery,
               variables: { id: data.id },
@@ -60,7 +60,7 @@ describe('GraphQLDataFactory', function () {
     })
   })
 
-  after((done) => {
+  after(done => {
     // Prepare db.json for the next test run
     try {
       fs.writeFileSync(dbFile, JSON.stringify(data))
@@ -70,7 +70,7 @@ describe('GraphQLDataFactory', function () {
     setTimeout(done, 1000)
   })
 
-  beforeEach((done) => {
+  beforeEach(done => {
     try {
       fs.writeFileSync(dbFile, JSON.stringify(data))
     } catch (err) {
@@ -103,7 +103,7 @@ describe('GraphQLDataFactory', function () {
     it('should update request with onRequest', async () => {
       I = new GraphQLDataFactory({
         endpoint: graphql_url,
-        onRequest: (request) => {
+        onRequest: request => {
           if (request.data.variables && request.data.variables.input) {
             request.data.variables.input.name = 'Dante'
           }
@@ -112,7 +112,7 @@ describe('GraphQLDataFactory', function () {
           createUser: {
             factory: path.join(__dirname, '/../data/graphql/users_factory.js'),
             query: creatUserQuery,
-            revert: (data) => {
+            revert: data => {
               return {
                 query: deleteOperationQuery,
                 variables: { id: data.id },
@@ -155,7 +155,7 @@ describe('GraphQLDataFactory', function () {
           createUser: {
             factory: path.join(__dirname, '/../data/graphql/users_factory.js'),
             query: creatUserQuery,
-            revert: (data) => {
+            revert: data => {
               return {
                 query: deleteOperationQuery,
                 variables: { id: data.id },

--- a/test/graphql/GraphQL_test.js
+++ b/test/graphql/GraphQL_test.js
@@ -23,7 +23,7 @@ const data = {
 }
 
 describe('GraphQL', () => {
-  before((done) => {
+  before(done => {
     try {
       fs.writeFileSync(dbFile, JSON.stringify(data))
     } catch (err) {
@@ -32,7 +32,7 @@ describe('GraphQL', () => {
     setTimeout(done, 1500)
   })
 
-  beforeEach((done) => {
+  beforeEach(done => {
     I = new GraphQL({
       endpoint: graphql_url,
       defaultHeaders: {

--- a/test/helper/AppiumV2_ios_test.js
+++ b/test/helper/AppiumV2_ios_test.js
@@ -1,24 +1,24 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const assert = chai.assert;
-const path = require('path');
+const expect = chai.expect
+const assert = chai.assert
+const path = require('path')
 
-const Appium = require('../../lib/helper/Appium');
-const AssertionFailedError = require('../../lib/assert/error');
-const fileExists = require('../../lib/utils').fileExists;
-global.codeceptjs = require('../../lib');
+const Appium = require('../../lib/helper/Appium')
+const AssertionFailedError = require('../../lib/assert/error')
+const fileExists = require('../../lib/utils').fileExists
+global.codeceptjs = require('../../lib')
 
-let app;
+let app
 // iOS test app is built from https://github.com/appium/ios-test-app and uploaded to Saucelabs
-const apk_path = 'storage:filename=TestApp-iphonesimulator.zip';
-const smallWait = 3;
+const apk_path = 'storage:filename=TestApp-iphonesimulator.zip'
+const smallWait = 3
 
 describe('Appium iOS Tests', function () {
-  this.timeout(0);
+  this.timeout(0)
 
   before(async () => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     app = new Appium({
       app: apk_path,
       appiumV2: true,
@@ -41,162 +41,162 @@ describe('Appium iOS Tests', function () {
       port: 80,
       user: process.env.SAUCE_USERNAME,
       key: process.env.SAUCE_ACCESS_KEY,
-    });
-    await app._beforeSuite();
-    app.isWeb = false;
-    await app._before();
-  });
+    })
+    await app._beforeSuite()
+    app.isWeb = false
+    await app._before()
+  })
 
   after(async () => {
-    await app._after();
-  });
+    await app._after()
+  })
 
   describe('app installation : #removeApp', () => {
     describe('#grabAllContexts, #grabContext, #grabOrientation, #grabSettings', () => {
       it('should grab all available contexts for screen', async () => {
-        await app.resetApp();
-        const val = await app.grabAllContexts();
-        assert.deepEqual(val, ['NATIVE_APP']);
-      });
+        await app.resetApp()
+        const val = await app.grabAllContexts()
+        assert.deepEqual(val, ['NATIVE_APP'])
+      })
 
       it('should grab current context', async () => {
-        const val = await app.grabContext();
-        assert.equal(val, 'NATIVE_APP');
-      });
+        const val = await app.grabContext()
+        assert.equal(val, 'NATIVE_APP')
+      })
 
       it('should grab custom settings', async () => {
-        const val = await app.grabSettings();
-        assert.deepEqual(val, { imageElementTapStrategy: 'w3cActions' });
-      });
-    });
-  });
+        const val = await app.grabSettings()
+        assert.deepEqual(val, { imageElementTapStrategy: 'w3cActions' })
+      })
+    })
+  })
 
   describe('device orientation : #seeOrientationIs #setOrientation', () => {
     it('should return correct status about device orientation', async () => {
-      await app.seeOrientationIs('PORTRAIT');
+      await app.seeOrientationIs('PORTRAIT')
       try {
-        await app.seeOrientationIs('LANDSCAPE');
+        await app.seeOrientationIs('LANDSCAPE')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected orientation to be LANDSCAPE');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected orientation to be LANDSCAPE')
       }
-    });
-  });
+    })
+  })
 
   describe('#hideDeviceKeyboard', () => {
     it('should hide device Keyboard @quick', async () => {
-      await app.resetApp();
-      await app.click('~IntegerA');
+      await app.resetApp()
+      await app.click('~IntegerA')
       try {
-        await app.click('~locationStatus');
+        await app.click('~locationStatus')
       } catch (e) {
-        e.message.should.include('element');
+        e.message.should.include('element')
       }
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.click('~locationStatus');
-    });
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.click('~locationStatus')
+    })
 
     it('should assert if no keyboard', async () => {
       try {
-        await app.hideDeviceKeyboard('pressKey', 'Done');
+        await app.hideDeviceKeyboard('pressKey', 'Done')
       } catch (e) {
-        e.message.should.include('An unknown server-side error occurred while processing the command. Original error: Soft keyboard not present, cannot hide keyboard');
+        e.message.should.include('An unknown server-side error occurred while processing the command. Original error: Soft keyboard not present, cannot hide keyboard')
       }
-    });
-  });
+    })
+  })
 
   describe('see text : #see', () => {
     it('should work inside elements @second', async () => {
-      await app.resetApp();
-      await app.see('Compute Sum', '~ComputeSumButton');
-    });
-  });
+      await app.resetApp()
+      await app.see('Compute Sum', '~ComputeSumButton')
+    })
+  })
 
   describe('#appendField', () => {
     it('should be able to send special keys to element @second', async () => {
-      await app.resetApp();
-      await app.waitForElement('~IntegerA', smallWait);
-      await app.click('~IntegerA');
-      await app.appendField('~IntegerA', '1');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.see('1', '~IntegerA');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~IntegerA', smallWait)
+      await app.click('~IntegerA')
+      await app.appendField('~IntegerA', '1')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.see('1', '~IntegerA')
+    })
+  })
 
   describe('#waitForText', () => {
     it('should return error if not present', async () => {
       try {
-        await app.waitForText('Nothing here', 1, '~IntegerA');
+        await app.waitForText('Nothing here', 1, '~IntegerA')
       } catch (e) {
-        e.message.should.contain('element (~IntegerA) is not in DOM or there is no element(~IntegerA) with text "Nothing here" after 1 sec');
+        e.message.should.contain('element (~IntegerA) is not in DOM or there is no element(~IntegerA) with text "Nothing here" after 1 sec')
       }
-    });
-  });
+    })
+  })
 
   describe('#seeNumberOfElements @second', () => {
     it('should return 1 as count', async () => {
-      await app.resetApp();
-      await app.seeNumberOfElements('~IntegerA', 1);
-    });
-  });
+      await app.resetApp()
+      await app.seeNumberOfElements('~IntegerA', 1)
+    })
+  })
 
   describe('see element : #seeElement, #dontSeeElement', () => {
     it('should check visible elements on page @quick', async () => {
-      await app.resetApp();
-      await app.seeElement('~IntegerA');
-      await app.dontSeeElement('#something-beyond');
-      await app.dontSeeElement('//input[@id="something-beyond"]');
-    });
-  });
+      await app.resetApp()
+      await app.seeElement('~IntegerA')
+      await app.dontSeeElement('#something-beyond')
+      await app.dontSeeElement('//input[@id="something-beyond"]')
+    })
+  })
 
   describe('#click @quick', () => {
     it('should click by accessibility id', async () => {
-      await app.resetApp();
-      await app.tap('~ComputeSumButton');
-      await app.see('0');
-    });
-  });
+      await app.resetApp()
+      await app.tap('~ComputeSumButton')
+      await app.see('0')
+    })
+  })
 
   describe('#fillField @second', () => {
     it('should fill field by accessibility id', async () => {
-      await app.resetApp();
-      await app.waitForElement('~IntegerA', smallWait);
-      await app.click('~IntegerA');
-      await app.fillField('~IntegerA', '1');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.see('1', '~IntegerA');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~IntegerA', smallWait)
+      await app.click('~IntegerA')
+      await app.fillField('~IntegerA', '1')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.see('1', '~IntegerA')
+    })
+  })
 
   describe('#grabTextFrom, #grabValueFrom, #grabAttributeFrom @quick', () => {
     it('should grab text from page', async () => {
-      await app.resetApp();
-      const val = await app.grabTextFrom('~ComputeSumButton');
-      assert.equal(val, 'Compute Sum');
-    });
+      await app.resetApp()
+      const val = await app.grabTextFrom('~ComputeSumButton')
+      assert.equal(val, 'Compute Sum')
+    })
 
     it('should grab attribute from element', async () => {
-      await app.resetApp();
-      const val = await app.grabAttributeFrom('~ComputeSumButton', 'label');
-      assert.equal(val, 'Compute Sum');
-    });
+      await app.resetApp()
+      const val = await app.grabAttributeFrom('~ComputeSumButton', 'label')
+      assert.equal(val, 'Compute Sum')
+    })
 
     it('should be able to grab elements', async () => {
-      await app.resetApp();
-      const id = await app.grabNumberOfVisibleElements('~ComputeSumButton');
-      assert.strictEqual(1, id);
-    });
-  });
+      await app.resetApp()
+      const id = await app.grabNumberOfVisibleElements('~ComputeSumButton')
+      assert.strictEqual(1, id)
+    })
+  })
 
   describe('#saveScreenshot', () => {
     beforeEach(() => {
-      global.output_dir = path.join(global.codecept_dir, 'output');
-    });
+      global.output_dir = path.join(global.codecept_dir, 'output')
+    })
 
     it('should create a screenshot file in output dir', async () => {
-      const sec = new Date().getUTCMilliseconds();
-      await app.saveScreenshot(`screenshot_${sec}.png`);
-      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists');
-    });
-  });
-});
+      const sec = new Date().getUTCMilliseconds()
+      await app.saveScreenshot(`screenshot_${sec}.png`)
+      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists')
+    })
+  })
+})

--- a/test/helper/AppiumV2_test.js
+++ b/test/helper/AppiumV2_test.js
@@ -1,18 +1,18 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const assert = chai.assert;
+const expect = chai.expect
+const assert = chai.assert
 
-let app;
-const apk_path = 'storage:filename=selendroid-test-app-0.17.0.apk';
-const smallWait = 3;
+let app
+const apk_path = 'storage:filename=selendroid-test-app-0.17.0.apk'
+const smallWait = 3
 
 describe('Appium', function () {
   // this.retries(1);
-  this.timeout(0);
+  this.timeout(0)
 
   before(async () => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     app = new Appium({
       app: apk_path,
       appiumV2: true,
@@ -37,290 +37,290 @@ describe('Appium', function () {
       // host: 'localhost',
       user: process.env.SAUCE_USERNAME,
       key: process.env.SAUCE_ACCESS_KEY,
-    });
-    await app._beforeSuite();
-    app.isWeb = false;
-    await app._before();
-  });
+    })
+    await app._beforeSuite()
+    app.isWeb = false
+    await app._before()
+  })
 
   after(async () => {
-    await app._after();
-  });
+    await app._after()
+  })
 
   describe('app installation : #seeAppIsInstalled, #installApp, #removeApp, #seeAppIsNotInstalled', () => {
     describe('#grabAllContexts, #grabContext, #grabCurrentActivity, #grabNetworkConnection, #grabOrientation, #grabSettings', () => {
       it('should grab all available contexts for screen', async () => {
-        await app.resetApp();
-        await app.waitForElement('~buttonStartWebviewCD', smallWait);
-        await app.click('~buttonStartWebviewCD');
-        const val = await app.grabAllContexts();
-        assert.deepEqual(val, ['NATIVE_APP', 'WEBVIEW_io.selendroid.testapp']);
-      });
+        await app.resetApp()
+        await app.waitForElement('~buttonStartWebviewCD', smallWait)
+        await app.click('~buttonStartWebviewCD')
+        const val = await app.grabAllContexts()
+        assert.deepEqual(val, ['NATIVE_APP', 'WEBVIEW_io.selendroid.testapp'])
+      })
 
       it('should grab current context', async () => {
-        const val = await app.grabContext();
-        assert.equal(val, 'NATIVE_APP');
-      });
+        const val = await app.grabContext()
+        assert.equal(val, 'NATIVE_APP')
+      })
 
       it('should grab current activity of app', async () => {
-        const val = await app.grabCurrentActivity();
-        assert.equal(val, '.HomeScreenActivity');
-      });
+        const val = await app.grabCurrentActivity()
+        assert.equal(val, '.HomeScreenActivity')
+      })
 
       it('should grab network connection settings', async () => {
-        await app.setNetworkConnection(4);
-        const val = await app.grabNetworkConnection();
-        assert.equal(val.value, 4);
-        assert.equal(val.inAirplaneMode, false);
-        assert.equal(val.hasWifi, false);
-        assert.equal(val.hasData, true);
-      });
+        await app.setNetworkConnection(4)
+        const val = await app.grabNetworkConnection()
+        assert.equal(val.value, 4)
+        assert.equal(val.inAirplaneMode, false)
+        assert.equal(val.hasWifi, false)
+        assert.equal(val.hasData, true)
+      })
 
       it('should grab orientation', async () => {
-        const val = await app.grabOrientation();
-        assert.equal(val, 'PORTRAIT');
-      });
+        const val = await app.grabOrientation()
+        assert.equal(val, 'PORTRAIT')
+      })
 
       it('should grab custom settings', async () => {
-        const val = await app.grabSettings();
-        assert.deepEqual(val, { ignoreUnimportantViews: false });
-      });
-    });
+        const val = await app.grabSettings()
+        assert.deepEqual(val, { ignoreUnimportantViews: false })
+      })
+    })
 
     it('should remove App and install it again', async () => {
-      await app.seeAppIsInstalled('io.selendroid.testapp');
-      await app.removeApp('io.selendroid.testapp');
-      await app.seeAppIsNotInstalled('io.selendroid.testapp');
-      await app.installApp(apk_path);
-      await app.seeAppIsInstalled('io.selendroid.testapp');
-    });
+      await app.seeAppIsInstalled('io.selendroid.testapp')
+      await app.removeApp('io.selendroid.testapp')
+      await app.seeAppIsNotInstalled('io.selendroid.testapp')
+      await app.installApp(apk_path)
+      await app.seeAppIsInstalled('io.selendroid.testapp')
+    })
 
     it('should return true if app is installed @quick', async () => {
-      const status = await app.checkIfAppIsInstalled('io.selendroid.testapp');
-      expect(status).to.be.true;
-    });
+      const status = await app.checkIfAppIsInstalled('io.selendroid.testapp')
+      expect(status).to.be.true
+    })
 
     it('should assert when app is/is not installed', async () => {
       try {
-        await app.seeAppIsInstalled('io.super.app');
+        await app.seeAppIsInstalled('io.super.app')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected app io.super.app to be installed');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected app io.super.app to be installed')
       }
 
       try {
-        await app.seeAppIsNotInstalled('io.selendroid.testapp');
+        await app.seeAppIsNotInstalled('io.selendroid.testapp')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected app io.selendroid.testapp not to be installed');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected app io.selendroid.testapp not to be installed')
       }
-    });
-  });
+    })
+  })
 
   describe('see seeCurrentActivity: #seeCurrentActivityIs', () => {
     it('should return .HomeScreenActivity for default screen', async () => {
-      await app.seeCurrentActivityIs('.HomeScreenActivity');
-    });
+      await app.seeCurrentActivityIs('.HomeScreenActivity')
+    })
 
     it('should assert for wrong screen', async () => {
       try {
-        await app.seeCurrentActivityIs('.SuperScreen');
+        await app.seeCurrentActivityIs('.SuperScreen')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected current activity to be .SuperScreen');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected current activity to be .SuperScreen')
       }
-    });
-  });
+    })
+  })
 
   describe('device lock : #seeDeviceIsLocked, #seeDeviceIsUnlocked', () => {
     it('should return correct status about lock @second', async () => {
-      await app.seeDeviceIsUnlocked();
+      await app.seeDeviceIsUnlocked()
       try {
-        await app.seeDeviceIsLocked();
+        await app.seeDeviceIsLocked()
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected device to be locked');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected device to be locked')
       }
-    });
-  });
+    })
+  })
 
   describe('device orientation : #seeOrientationIs #setOrientation', () => {
     it('should return correct status about lock', async () => {
-      await app.seeOrientationIs('PORTRAIT');
+      await app.seeOrientationIs('PORTRAIT')
       try {
-        await app.seeOrientationIs('LANDSCAPE');
+        await app.seeOrientationIs('LANDSCAPE')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected orientation to be LANDSCAPE');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected orientation to be LANDSCAPE')
       }
-    });
+    })
 
     it('should set device orientation', async () => {
-      await app.resetApp();
-      await app.waitForElement('~buttonStartWebviewCD', smallWait);
-      await app.click('~buttonStartWebviewCD');
-      await app.setOrientation('LANDSCAPE');
-      await app.seeOrientationIs('LANDSCAPE');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~buttonStartWebviewCD', smallWait)
+      await app.click('~buttonStartWebviewCD')
+      await app.setOrientation('LANDSCAPE')
+      await app.seeOrientationIs('LANDSCAPE')
+    })
+  })
 
   describe('app context and activity: #switchToContext, #switchToWeb, #switchToNative', () => {
     it('should switch context', async () => {
-      await app.resetApp();
-      await app.waitForElement('~buttonStartWebviewCD', smallWait);
-      await app.click('~buttonStartWebviewCD');
-      await app.switchToContext('WEBVIEW_io.selendroid.testapp');
-      const val = await app.grabContext();
-      return assert.equal(val, 'WEBVIEW_io.selendroid.testapp');
-    });
+      await app.resetApp()
+      await app.waitForElement('~buttonStartWebviewCD', smallWait)
+      await app.click('~buttonStartWebviewCD')
+      await app.switchToContext('WEBVIEW_io.selendroid.testapp')
+      const val = await app.grabContext()
+      return assert.equal(val, 'WEBVIEW_io.selendroid.testapp')
+    })
 
     it('should switch to native and web contexts @quick', async () => {
-      await app.resetApp();
-      await app.click('~buttonStartWebviewCD');
-      await app.see('WebView location');
-      await app.switchToWeb();
-      let val = await app.grabContext();
-      assert.equal(val, 'WEBVIEW_io.selendroid.testapp');
-      await app.see('Prefered Car');
-      assert.ok(app.isWeb);
-      await app.switchToNative();
-      val = await app.grabContext();
-      assert.equal(val, 'NATIVE_APP');
-      return assert.ok(!app.isWeb);
-    });
+      await app.resetApp()
+      await app.click('~buttonStartWebviewCD')
+      await app.see('WebView location')
+      await app.switchToWeb()
+      let val = await app.grabContext()
+      assert.equal(val, 'WEBVIEW_io.selendroid.testapp')
+      await app.see('Prefered Car')
+      assert.ok(app.isWeb)
+      await app.switchToNative()
+      val = await app.grabContext()
+      assert.equal(val, 'NATIVE_APP')
+      return assert.ok(!app.isWeb)
+    })
 
     it('should switch activity', async () => {
-      await app.startActivity('io.selendroid.testapp', '.RegisterUserActivity');
-      const val = await app.grabCurrentActivity();
-      assert.equal(val, '.RegisterUserActivity');
-    });
-  });
+      await app.startActivity('io.selendroid.testapp', '.RegisterUserActivity')
+      const val = await app.grabCurrentActivity()
+      assert.equal(val, '.RegisterUserActivity')
+    })
+  })
 
   describe('#setNetworkConnection, #setSettings', () => {
     it('should set Network Connection (airplane mode on)', async () => {
-      await app.setNetworkConnection(1);
-      const val = await app.grabNetworkConnection();
-      return assert.equal(val.value, 1);
-    });
+      await app.setNetworkConnection(1)
+      const val = await app.grabNetworkConnection()
+      return assert.equal(val.value, 1)
+    })
 
     it('should set custom settings', async () => {
-      await app.setSettings({ cyberdelia: 'open' });
-      const val = await app.grabSettings();
-      assert.deepEqual(val, { ignoreUnimportantViews: false, cyberdelia: 'open' });
-    });
-  });
+      await app.setSettings({ cyberdelia: 'open' })
+      const val = await app.grabSettings()
+      assert.deepEqual(val, { ignoreUnimportantViews: false, cyberdelia: 'open' })
+    })
+  })
 
   describe('#hideDeviceKeyboard', () => {
     it('should hide device Keyboard @quick', async () => {
-      await app.resetApp();
-      await app.click('~startUserRegistrationCD');
+      await app.resetApp()
+      await app.click('~startUserRegistrationCD')
       try {
-        await app.click('//android.widget.CheckBox');
+        await app.click('//android.widget.CheckBox')
       } catch (e) {
-        e.message.should.include('element');
+        e.message.should.include('element')
       }
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.click('//android.widget.CheckBox');
-    });
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.click('//android.widget.CheckBox')
+    })
 
     it('should assert if no keyboard', async () => {
       try {
-        await app.hideDeviceKeyboard('pressKey', 'Done');
+        await app.hideDeviceKeyboard('pressKey', 'Done')
       } catch (e) {
-        e.message.should.include('An unknown server-side error occurred while processing the command. Original error: Soft keyboard not present, cannot hide keyboard');
+        e.message.should.include('An unknown server-side error occurred while processing the command. Original error: Soft keyboard not present, cannot hide keyboard')
       }
-    });
-  });
+    })
+  })
 
   describe('#sendDeviceKeyEvent', () => {
     it('should react on pressing keycode', async () => {
-      await app.sendDeviceKeyEvent(3);
-      await app.waitForVisible('~Apps');
-    });
-  });
+      await app.sendDeviceKeyEvent(3)
+      await app.waitForVisible('~Apps')
+    })
+  })
 
   describe('#openNotifications', () => {
     it('should react on notification opening', async () => {
       try {
-        await app.seeElement('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]');
+        await app.seeElement('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected elements of //android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"] to be seen');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected elements of //android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"] to be seen')
       }
-      await app.openNotifications();
-      await app.waitForVisible('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]', 10);
-    });
-  });
+      await app.openNotifications()
+      await app.waitForVisible('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]', 10)
+    })
+  })
 
   describe('#makeTouchAction', () => {
     it('should react on touch actions', async () => {
-      await app.resetApp();
-      await app.waitForElement('~buttonStartWebviewCD', smallWait);
-      await app.tap('~buttonStartWebviewCD');
-      const val = await app.grabCurrentActivity();
-      assert.equal(val, '.WebViewActivity');
-    });
+      await app.resetApp()
+      await app.waitForElement('~buttonStartWebviewCD', smallWait)
+      await app.tap('~buttonStartWebviewCD')
+      const val = await app.grabCurrentActivity()
+      assert.equal(val, '.WebViewActivity')
+    })
 
     it('should react on swipe action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipe("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1200, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vx = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vx.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipe("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1200, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vx = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vx.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('should react on swipeDown action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('run simplified swipeDown @quick', async () => {
-      await app.resetApp();
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 120, 100);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      assert.equal(type, 'FLICK');
-    });
+      await app.resetApp()
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 120, 100)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      assert.equal(type, 'FLICK')
+    })
 
     it('should react on swipeUp action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeUp("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vy: -\d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeUp("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vy: -\d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('should react on swipeRight action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeRight("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeRight("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('should react on swipeLeft action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeLeft("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vx: -\d\d000\.0 pps/), 'to be like 21000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeLeft("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vx: -\d\d000\.0 pps/), 'to be like 21000.0 pps')
+    })
 
     it('should react on touchPerform action', async () => {
       await app.touchPerform([
@@ -332,283 +332,283 @@ describe('Appium', function () {
           },
         },
         { action: 'release' },
-      ]);
-      const val = await app.grabCurrentActivity();
-      assert.equal(val, '.HomeScreenActivity');
-    });
+      ])
+      const val = await app.grabCurrentActivity()
+      assert.equal(val, '.HomeScreenActivity')
+    })
 
     it('should assert when you dont scroll the document anymore', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
       try {
-        await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 500);
+        await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 500)
       } catch (e) {
-        e.message.should.include('Scroll to the end and element android.widget.CheckBox was not found');
+        e.message.should.include('Scroll to the end and element android.widget.CheckBox was not found')
       }
-    });
+    })
 
     it('should react on swipeTo action', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+    })
 
     describe('#performTouchAction', () => {
       it('should react on swipeUp action @second', async () => {
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(parseInt(vy.split(' ')[1], 10)).to.be.below(1006);
-      });
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(parseInt(vy.split(' ')[1], 10)).to.be.below(1006)
+      })
 
       it('should react on swipeDown action @second', async () => {
-        await app.resetApp();
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(parseInt(vy.split(' ')[1], 10)).to.be.above(-300);
-      });
+        await app.resetApp()
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(parseInt(vy.split(' ')[1], 10)).to.be.above(-300)
+      })
 
       it('should react on swipeLeft action', async () => {
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeLeft("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(vy.split(' ')[1]).to.be.below(730);
-      });
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeLeft("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(vy.split(' ')[1]).to.be.below(730)
+      })
 
       it('should react on swipeRight action', async () => {
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeRight("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(vy.split(' ')[1]).to.be.above(278);
-      });
-    });
-  });
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeRight("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(vy.split(' ')[1]).to.be.above(278)
+      })
+    })
+  })
 
   describe('#pullFile', () => {
     it('should pull file to local machine', async () => {
-      const savepath = path.join(__dirname, `/../data/output/testpullfile${new Date().getTime()}.png`);
-      await app.pullFile('/storage/emulated/0/DCIM/sauce_logo.png', savepath);
-      assert.ok(fileExists(savepath), null, 'file does not exists');
-    });
-  });
+      const savepath = path.join(__dirname, `/../data/output/testpullfile${new Date().getTime()}.png`)
+      await app.pullFile('/storage/emulated/0/DCIM/sauce_logo.png', savepath)
+      assert.ok(fileExists(savepath), null, 'file does not exists')
+    })
+  })
 
   describe('see text : #see', () => {
     it('should work inside elements @second', async () => {
-      await app.resetApp();
-      await app.see('EN Button', '~buttonTestCD');
-      await app.see('Hello');
-      await app.dontSee('Welcome', '~buttonTestCD');
-    });
+      await app.resetApp()
+      await app.see('EN Button', '~buttonTestCD')
+      await app.see('Hello')
+      await app.dontSee('Welcome', '~buttonTestCD')
+    })
 
     it('should work inside web view as normally @quick', async () => {
-      await app.resetApp();
-      await app.click('~buttonStartWebviewCD');
-      await app.switchToWeb();
-      await app.see('Prefered Car:');
-    });
-  });
+      await app.resetApp()
+      await app.click('~buttonStartWebviewCD')
+      await app.switchToWeb()
+      await app.see('Prefered Car:')
+    })
+  })
 
   describe('#appendField', () => {
     it('should be able to send special keys to element @second', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.click('~email of the customer');
-      await app.appendField('~email of the customer', '1');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('1', '#io.selendroid.testapp:id/label_email_data');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.click('~email of the customer')
+      await app.appendField('~email of the customer', '1')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('1', '#io.selendroid.testapp:id/label_email_data')
+    })
+  })
 
   describe('#seeInSource', () => {
     it('should check for text to be in HTML source', async () => {
-      await app.seeInSource('class="android.widget.Button" package="io.selendroid.testapp" content-desc="buttonTestCD"');
-      await app.dontSeeInSource('<meta');
-    });
-  });
+      await app.seeInSource('class="android.widget.Button" package="io.selendroid.testapp" content-desc="buttonTestCD"')
+      await app.dontSeeInSource('<meta')
+    })
+  })
 
   describe('#waitForText', () => {
     it('should return error if not present', async () => {
       try {
-        await app.waitForText('Nothing here', 1, '~buttonTestCD');
+        await app.waitForText('Nothing here', 1, '~buttonTestCD')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.be.equal('expected element ~buttonTestCD to include "Nothing here"');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.be.equal('expected element ~buttonTestCD to include "Nothing here"')
       }
-    });
-  });
+    })
+  })
 
   describe('#seeNumberOfElements @second', () => {
     it('should return 1 as count', async () => {
-      await app.resetApp();
-      await app.seeNumberOfElements('~buttonTestCD', 1);
-    });
-  });
+      await app.resetApp()
+      await app.seeNumberOfElements('~buttonTestCD', 1)
+    })
+  })
 
   describe('see element : #seeElement, #dontSeeElement', () => {
     it('should check visible elements on page @quick', async () => {
-      await app.resetApp();
-      await app.seeElement('//android.widget.Button[@content-desc = "buttonTestCD"]');
-      await app.dontSeeElement('#something-beyond');
-      await app.dontSeeElement('//input[@id="something-beyond"]');
-    });
-  });
+      await app.resetApp()
+      await app.seeElement('//android.widget.Button[@content-desc = "buttonTestCD"]')
+      await app.dontSeeElement('#something-beyond')
+      await app.dontSeeElement('//input[@id="something-beyond"]')
+    })
+  })
 
   describe('#click @quick', () => {
     it('should click by accessibility id', async () => {
-      await app.resetApp();
-      await app.tap('~startUserRegistrationCD');
-      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]');
-    });
+      await app.resetApp()
+      await app.tap('~startUserRegistrationCD')
+      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]')
+    })
 
     it('should click by xpath', async () => {
-      await app.resetApp();
-      await app.click('//android.widget.ImageButton[@content-desc = "startUserRegistrationCD"]');
-      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]');
-    });
-  });
+      await app.resetApp()
+      await app.click('//android.widget.ImageButton[@content-desc = "startUserRegistrationCD"]')
+      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]')
+    })
+  })
 
   describe('#fillField, #appendField @second', () => {
     it('should fill field by accessibility id', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('~email of the customer', 'Nothing special');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('~email of the customer', 'Nothing special')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+    })
 
     it('should fill field by xpath', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('//android.widget.EditText[@content-desc="email of the customer"]', 'Nothing special');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('//android.widget.EditText[@content-desc="email of the customer"]', 'Nothing special')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+    })
 
     it('should append field value @second', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('~email of the customer', 'Nothing special');
-      await app.appendField('~email of the customer', 'blabla');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('Nothing specialblabla', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('~email of the customer', 'Nothing special')
+      await app.appendField('~email of the customer', 'blabla')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('Nothing specialblabla', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+    })
+  })
 
   describe('#clearField', () => {
     it('should clear a given element', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('~email of the customer', 'Nothing special');
-      await app.see('Nothing special', '~email of the customer');
-      await app.clearField('~email of the customer');
-      await app.dontSee('Nothing special', '~email of the customer');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('~email of the customer', 'Nothing special')
+      await app.see('Nothing special', '~email of the customer')
+      await app.clearField('~email of the customer')
+      await app.dontSee('Nothing special', '~email of the customer')
+    })
+  })
 
   describe('#grabTextFrom, #grabValueFrom, #grabAttributeFrom @quick', () => {
     it('should grab text from page', async () => {
-      await app.resetApp();
-      const val = await app.grabTextFrom('//android.widget.Button[@content-desc="buttonTestCD"]');
-      assert.equal(val, 'EN Button');
-    });
+      await app.resetApp()
+      const val = await app.grabTextFrom('//android.widget.Button[@content-desc="buttonTestCD"]')
+      assert.equal(val, 'EN Button')
+    })
 
     it('should grab attribute from element', async () => {
-      await app.resetApp();
-      const val = await app.grabAttributeFrom('//android.widget.Button[@content-desc="buttonTestCD"]', 'resourceId');
-      assert.equal(val, 'io.selendroid.testapp:id/buttonTest');
-    });
+      await app.resetApp()
+      const val = await app.grabAttributeFrom('//android.widget.Button[@content-desc="buttonTestCD"]', 'resourceId')
+      assert.equal(val, 'io.selendroid.testapp:id/buttonTest')
+    })
 
     it('should be able to grab elements', async () => {
-      await app.resetApp();
-      await app.tap('~startUserRegistrationCD');
-      await app.tap('~email of the customer');
-      await app.appendField('//android.widget.EditText[@content-desc="email of the customer"]', '1');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('1', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-      const id = await app.grabNumberOfVisibleElements('//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]', 'contentDescription');
-      assert.strictEqual(1, id);
-    });
-  });
+      await app.resetApp()
+      await app.tap('~startUserRegistrationCD')
+      await app.tap('~email of the customer')
+      await app.appendField('//android.widget.EditText[@content-desc="email of the customer"]', '1')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('1', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+      const id = await app.grabNumberOfVisibleElements('//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]', 'contentDescription')
+      assert.strictEqual(1, id)
+    })
+  })
 
   describe('#saveScreenshot @quick', () => {
     beforeEach(() => {
-      global.output_dir = path.join(global.codecept_dir, 'output');
-    });
+      global.output_dir = path.join(global.codecept_dir, 'output')
+    })
 
     it('should create a screenshot file in output dir', async () => {
-      const sec = new Date().getUTCMilliseconds();
-      await app.saveScreenshot(`screenshot_${sec}.png`);
-      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists');
-    });
-  });
+      const sec = new Date().getUTCMilliseconds()
+      await app.saveScreenshot(`screenshot_${sec}.png`)
+      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists')
+    })
+  })
 
   describe('#runOnIOS, #runOnAndroid, #runInWeb', () => {
     it('should use Android locators', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click({ android: '~startUserRegistrationCD', ios: 'fake-element' });
-      await app.see('Welcome to register a new User');
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click({ android: '~startUserRegistrationCD', ios: 'fake-element' })
+      await app.see('Welcome to register a new User')
+    })
 
     it('should execute only on Android @quick', () => {
-      let platform = null;
+      let platform = null
       app.runOnIOS(() => {
-        platform = 'ios';
-      });
+        platform = 'ios'
+      })
       app.runOnAndroid(() => {
-        platform = 'android';
-      });
+        platform = 'android'
+      })
       app.runOnAndroid({ platformVersion: '7.0' }, () => {
-        platform = 'android7';
-      });
+        platform = 'android7'
+      })
 
-      assert.equal('android', platform);
-    });
+      assert.equal('android', platform)
+    })
 
     it('should execute only on Android >= 5.0 @quick', () => {
       app.runOnAndroid(
         caps => caps.platformVersion >= 5,
         () => {},
-      );
-    });
+      )
+    })
 
     it('should execute only in Web', () => {
-      app.isWeb = true;
-      let executed = false;
+      app.isWeb = true
+      let executed = false
       app.runOnIOS(() => {
-        executed = true;
-      });
-      assert.ok(!executed);
-    });
-  });
-});
+        executed = true
+      })
+      assert.ok(!executed)
+    })
+  })
+})

--- a/test/helper/Appium_test.js
+++ b/test/helper/Appium_test.js
@@ -1,25 +1,25 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const assert = chai.assert;
+const expect = chai.expect
+const assert = chai.assert
 
-const path = require('path');
+const path = require('path')
 
-const Appium = require('../../lib/helper/Appium');
-const AssertionFailedError = require('../../lib/assert/error');
-const fileExists = require('../../lib/utils').fileExists;
-global.codeceptjs = require('../../lib');
+const Appium = require('../../lib/helper/Appium')
+const AssertionFailedError = require('../../lib/assert/error')
+const fileExists = require('../../lib/utils').fileExists
+global.codeceptjs = require('../../lib')
 
-let app;
-const apk_path = 'storage:filename=selendroid-test-app-0.17.0.apk';
-const smallWait = 3;
+let app
+const apk_path = 'storage:filename=selendroid-test-app-0.17.0.apk'
+const smallWait = 3
 
 describe('Appium', function () {
   // this.retries(1);
-  this.timeout(0);
+  this.timeout(0)
 
   before(async () => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     app = new Appium({
       app: apk_path,
       desiredCapabilities: {
@@ -41,290 +41,290 @@ describe('Appium', function () {
       // host: 'localhost',
       user: process.env.SAUCE_USERNAME,
       key: process.env.SAUCE_ACCESS_KEY,
-    });
-    await app._beforeSuite();
-    app.isWeb = false;
-    await app._before();
-  });
+    })
+    await app._beforeSuite()
+    app.isWeb = false
+    await app._before()
+  })
 
   after(async () => {
-    await app._after();
-  });
+    await app._after()
+  })
 
   describe('app installation : #seeAppIsInstalled, #installApp, #removeApp, #seeAppIsNotInstalled', () => {
     describe('#grabAllContexts, #grabContext, #grabCurrentActivity, #grabNetworkConnection, #grabOrientation, #grabSettings', () => {
       it('should grab all available contexts for screen', async () => {
-        await app.resetApp();
-        await app.waitForElement('~buttonStartWebviewCD', smallWait);
-        await app.click('~buttonStartWebviewCD');
-        const val = await app.grabAllContexts();
-        assert.deepEqual(val, ['NATIVE_APP', 'WEBVIEW_io.selendroid.testapp']);
-      });
+        await app.resetApp()
+        await app.waitForElement('~buttonStartWebviewCD', smallWait)
+        await app.click('~buttonStartWebviewCD')
+        const val = await app.grabAllContexts()
+        assert.deepEqual(val, ['NATIVE_APP', 'WEBVIEW_io.selendroid.testapp'])
+      })
 
       it('should grab current context', async () => {
-        const val = await app.grabContext();
-        assert.equal(val, 'NATIVE_APP');
-      });
+        const val = await app.grabContext()
+        assert.equal(val, 'NATIVE_APP')
+      })
 
       it('should grab current activity of app', async () => {
-        const val = await app.grabCurrentActivity();
-        assert.equal(val, '.HomeScreenActivity');
-      });
+        const val = await app.grabCurrentActivity()
+        assert.equal(val, '.HomeScreenActivity')
+      })
 
       it('should grab network connection settings', async () => {
-        await app.setNetworkConnection(4);
-        const val = await app.grabNetworkConnection();
-        assert.equal(val.value, 4);
-        assert.equal(val.inAirplaneMode, false);
-        assert.equal(val.hasWifi, false);
-        assert.equal(val.hasData, true);
-      });
+        await app.setNetworkConnection(4)
+        const val = await app.grabNetworkConnection()
+        assert.equal(val.value, 4)
+        assert.equal(val.inAirplaneMode, false)
+        assert.equal(val.hasWifi, false)
+        assert.equal(val.hasData, true)
+      })
 
       it('should grab orientation', async () => {
-        const val = await app.grabOrientation();
-        assert.equal(val, 'PORTRAIT');
-      });
+        const val = await app.grabOrientation()
+        assert.equal(val, 'PORTRAIT')
+      })
 
       it('should grab custom settings', async () => {
-        const val = await app.grabSettings();
-        assert.deepEqual(val, { ignoreUnimportantViews: false });
-      });
-    });
+        const val = await app.grabSettings()
+        assert.deepEqual(val, { ignoreUnimportantViews: false })
+      })
+    })
 
     it('should remove App and install it again', async () => {
-      await app.seeAppIsInstalled('io.selendroid.testapp');
-      await app.removeApp('io.selendroid.testapp');
-      await app.seeAppIsNotInstalled('io.selendroid.testapp');
-      await app.installApp(apk_path);
-      await app.seeAppIsInstalled('io.selendroid.testapp');
-    });
+      await app.seeAppIsInstalled('io.selendroid.testapp')
+      await app.removeApp('io.selendroid.testapp')
+      await app.seeAppIsNotInstalled('io.selendroid.testapp')
+      await app.installApp(apk_path)
+      await app.seeAppIsInstalled('io.selendroid.testapp')
+    })
 
     it('should return true if app is installed @quick', async () => {
-      const status = await app.checkIfAppIsInstalled('io.selendroid.testapp');
-      expect(status).to.be.true;
-    });
+      const status = await app.checkIfAppIsInstalled('io.selendroid.testapp')
+      expect(status).to.be.true
+    })
 
     it('should assert when app is/is not installed', async () => {
       try {
-        await app.seeAppIsInstalled('io.super.app');
+        await app.seeAppIsInstalled('io.super.app')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected app io.super.app to be installed');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected app io.super.app to be installed')
       }
 
       try {
-        await app.seeAppIsNotInstalled('io.selendroid.testapp');
+        await app.seeAppIsNotInstalled('io.selendroid.testapp')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected app io.selendroid.testapp not to be installed');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected app io.selendroid.testapp not to be installed')
       }
-    });
-  });
+    })
+  })
 
   describe('see seeCurrentActivity: #seeCurrentActivityIs', () => {
     it('should return .HomeScreenActivity for default screen', async () => {
-      await app.seeCurrentActivityIs('.HomeScreenActivity');
-    });
+      await app.seeCurrentActivityIs('.HomeScreenActivity')
+    })
 
     it('should assert for wrong screen', async () => {
       try {
-        await app.seeCurrentActivityIs('.SuperScreen');
+        await app.seeCurrentActivityIs('.SuperScreen')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected current activity to be .SuperScreen');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected current activity to be .SuperScreen')
       }
-    });
-  });
+    })
+  })
 
   describe('device lock : #seeDeviceIsLocked, #seeDeviceIsUnlocked', () => {
     it('should return correct status about lock @second', async () => {
-      await app.seeDeviceIsUnlocked();
+      await app.seeDeviceIsUnlocked()
       try {
-        await app.seeDeviceIsLocked();
+        await app.seeDeviceIsLocked()
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected device to be locked');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected device to be locked')
       }
-    });
-  });
+    })
+  })
 
   describe('device orientation : #seeOrientationIs #setOrientation', () => {
     it('should return correct status about lock', async () => {
-      await app.seeOrientationIs('PORTRAIT');
+      await app.seeOrientationIs('PORTRAIT')
       try {
-        await app.seeOrientationIs('LANDSCAPE');
+        await app.seeOrientationIs('LANDSCAPE')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected orientation to be LANDSCAPE');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected orientation to be LANDSCAPE')
       }
-    });
+    })
 
     it('should set device orientation', async () => {
-      await app.resetApp();
-      await app.waitForElement('~buttonStartWebviewCD', smallWait);
-      await app.click('~buttonStartWebviewCD');
-      await app.setOrientation('LANDSCAPE');
-      await app.seeOrientationIs('LANDSCAPE');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~buttonStartWebviewCD', smallWait)
+      await app.click('~buttonStartWebviewCD')
+      await app.setOrientation('LANDSCAPE')
+      await app.seeOrientationIs('LANDSCAPE')
+    })
+  })
 
   describe('app context and activity: #switchToContext, #switchToWeb, #switchToNative', () => {
     it('should switch context', async () => {
-      await app.resetApp();
-      await app.waitForElement('~buttonStartWebviewCD', smallWait);
-      await app.click('~buttonStartWebviewCD');
-      await app.switchToContext('WEBVIEW_io.selendroid.testapp');
-      const val = await app.grabContext();
-      return assert.equal(val, 'WEBVIEW_io.selendroid.testapp');
-    });
+      await app.resetApp()
+      await app.waitForElement('~buttonStartWebviewCD', smallWait)
+      await app.click('~buttonStartWebviewCD')
+      await app.switchToContext('WEBVIEW_io.selendroid.testapp')
+      const val = await app.grabContext()
+      return assert.equal(val, 'WEBVIEW_io.selendroid.testapp')
+    })
 
     it('should switch to native and web contexts @quick', async () => {
-      await app.resetApp();
-      await app.click('~buttonStartWebviewCD');
-      await app.see('WebView location');
-      await app.switchToWeb();
-      let val = await app.grabContext();
-      assert.equal(val, 'WEBVIEW_io.selendroid.testapp');
-      await app.see('Prefered Car');
-      assert.ok(app.isWeb);
-      await app.switchToNative();
-      val = await app.grabContext();
-      assert.equal(val, 'NATIVE_APP');
-      return assert.ok(!app.isWeb);
-    });
+      await app.resetApp()
+      await app.click('~buttonStartWebviewCD')
+      await app.see('WebView location')
+      await app.switchToWeb()
+      let val = await app.grabContext()
+      assert.equal(val, 'WEBVIEW_io.selendroid.testapp')
+      await app.see('Prefered Car')
+      assert.ok(app.isWeb)
+      await app.switchToNative()
+      val = await app.grabContext()
+      assert.equal(val, 'NATIVE_APP')
+      return assert.ok(!app.isWeb)
+    })
 
     it('should switch activity', async () => {
-      await app.startActivity('io.selendroid.testapp', '.RegisterUserActivity');
-      const val = await app.grabCurrentActivity();
-      assert.equal(val, '.RegisterUserActivity');
-    });
-  });
+      await app.startActivity('io.selendroid.testapp', '.RegisterUserActivity')
+      const val = await app.grabCurrentActivity()
+      assert.equal(val, '.RegisterUserActivity')
+    })
+  })
 
   describe('#setNetworkConnection, #setSettings', () => {
     it('should set Network Connection (airplane mode on)', async () => {
-      await app.setNetworkConnection(1);
-      const val = await app.grabNetworkConnection();
-      return assert.equal(val.value, 1);
-    });
+      await app.setNetworkConnection(1)
+      const val = await app.grabNetworkConnection()
+      return assert.equal(val.value, 1)
+    })
 
     it('should set custom settings', async () => {
-      await app.setSettings({ cyberdelia: 'open' });
-      const val = await app.grabSettings();
-      assert.deepEqual(val, { ignoreUnimportantViews: false, cyberdelia: 'open' });
-    });
-  });
+      await app.setSettings({ cyberdelia: 'open' })
+      const val = await app.grabSettings()
+      assert.deepEqual(val, { ignoreUnimportantViews: false, cyberdelia: 'open' })
+    })
+  })
 
   describe('#hideDeviceKeyboard', () => {
     it('should hide device Keyboard @quick', async () => {
-      await app.resetApp();
-      await app.click('~startUserRegistrationCD');
+      await app.resetApp()
+      await app.click('~startUserRegistrationCD')
       try {
-        await app.click('//android.widget.CheckBox');
+        await app.click('//android.widget.CheckBox')
       } catch (e) {
-        e.message.should.include('element');
+        e.message.should.include('element')
       }
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.click('//android.widget.CheckBox');
-    });
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.click('//android.widget.CheckBox')
+    })
 
     it('should assert if no keyboard', async () => {
       try {
-        await app.hideDeviceKeyboard('pressKey', 'Done');
+        await app.hideDeviceKeyboard('pressKey', 'Done')
       } catch (e) {
-        e.message.should.include('An unknown server-side error occurred while processing the command. Original error: Soft keyboard not present, cannot hide keyboard');
+        e.message.should.include('An unknown server-side error occurred while processing the command. Original error: Soft keyboard not present, cannot hide keyboard')
       }
-    });
-  });
+    })
+  })
 
   describe('#sendDeviceKeyEvent', () => {
     it('should react on pressing keycode', async () => {
-      await app.sendDeviceKeyEvent(3);
-      await app.waitForVisible('~Apps');
-    });
-  });
+      await app.sendDeviceKeyEvent(3)
+      await app.waitForVisible('~Apps')
+    })
+  })
 
   describe('#openNotifications', () => {
     it('should react on notification opening', async () => {
       try {
-        await app.seeElement('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]');
+        await app.seeElement('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('expected elements of //android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"] to be seen');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('expected elements of //android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"] to be seen')
       }
-      await app.openNotifications();
-      await app.waitForVisible('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]', 10);
-    });
-  });
+      await app.openNotifications()
+      await app.waitForVisible('//android.widget.FrameLayout[@resource-id="com.android.systemui:id/quick_settings_container"]', 10)
+    })
+  })
 
   describe('#makeTouchAction', () => {
     it('should react on touch actions', async () => {
-      await app.resetApp();
-      await app.waitForElement('~buttonStartWebviewCD', smallWait);
-      await app.tap('~buttonStartWebviewCD');
-      const val = await app.grabCurrentActivity();
-      assert.equal(val, '.WebViewActivity');
-    });
+      await app.resetApp()
+      await app.waitForElement('~buttonStartWebviewCD', smallWait)
+      await app.tap('~buttonStartWebviewCD')
+      const val = await app.grabCurrentActivity()
+      assert.equal(val, '.WebViewActivity')
+    })
 
     it('should react on swipe action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipe("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1200, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vx = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vx.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipe("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1200, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vx = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vx.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('should react on swipeDown action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vy: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('run simplified swipeDown @quick', async () => {
-      await app.resetApp();
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 120, 100);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      assert.equal(type, 'FLICK');
-    });
+      await app.resetApp()
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeDown("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 120, 100)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      assert.equal(type, 'FLICK')
+    })
 
     it('should react on swipeUp action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeUp("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vy: -\d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeUp("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 1200, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vy: -\d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('should react on swipeRight action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeRight("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeRight("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vx: \d\d000\.0 pps/), 'to be like dd000.0 pps')
+    })
 
     it('should react on swipeLeft action', async () => {
-      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      await app.swipeLeft("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000);
-      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']");
-      assert.equal(type, 'FLICK');
-      assert.ok(vy.match(/vx: -\d\d000\.0 pps/), 'to be like 21000.0 pps');
-    });
+      await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+      await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      await app.swipeLeft("//android.widget.LinearLayout[@resource-id = 'io.selendroid.testapp:id/LinearLayout1']", 800, 1000)
+      const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+      const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view3']")
+      assert.equal(type, 'FLICK')
+      assert.ok(vy.match(/vx: -\d\d000\.0 pps/), 'to be like 21000.0 pps')
+    })
 
     it('should react on touchPerform action', async () => {
       await app.touchPerform([
@@ -336,283 +336,283 @@ describe('Appium', function () {
           },
         },
         { action: 'release' },
-      ]);
-      const val = await app.grabCurrentActivity();
-      assert.equal(val, '.HomeScreenActivity');
-    });
+      ])
+      const val = await app.grabCurrentActivity()
+      assert.equal(val, '.HomeScreenActivity')
+    })
 
     it('should assert when you dont scroll the document anymore', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
       try {
-        await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 500);
+        await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 500)
       } catch (e) {
-        e.message.should.include('Scroll to the end and element android.widget.CheckBox was not found');
+        e.message.should.include('Scroll to the end and element android.widget.CheckBox was not found')
       }
-    });
+    })
 
     it('should react on swipeTo action', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.swipeTo('//android.widget.CheckBox', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+    })
 
     describe('#performTouchAction', () => {
       it('should react on swipeUp action @second', async () => {
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(parseInt(vy.split(' ')[1], 10)).to.be.below(1006);
-      });
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(parseInt(vy.split(' ')[1], 10)).to.be.below(1006)
+      })
 
       it('should react on swipeDown action @second', async () => {
-        await app.resetApp();
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(parseInt(vy.split(' ')[1], 10)).to.be.above(-300);
-      });
+        await app.resetApp()
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeUp("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(parseInt(vy.split(' ')[1], 10)).to.be.above(-300)
+      })
 
       it('should react on swipeLeft action', async () => {
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeLeft("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(vy.split(' ')[1]).to.be.below(730);
-      });
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeLeft("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(vy.split(' ')[1]).to.be.below(730)
+      })
 
       it('should react on swipeRight action', async () => {
-        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']");
-        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        await app.swipeRight("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']");
-        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']");
-        assert.equal(type, 'FLICK');
-        expect(vy.split(' ')[1]).to.be.above(278);
-      });
-    });
-  });
+        await app.click("//android.widget.Button[@resource-id = 'io.selendroid.testapp:id/touchTest']")
+        await app.waitForText('Gesture Type', 10, "//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        await app.swipeRight("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const type = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/gesture_type_text_view']")
+        const vy = await app.grabTextFrom("//android.widget.TextView[@resource-id = 'io.selendroid.testapp:id/text_view4']")
+        assert.equal(type, 'FLICK')
+        expect(vy.split(' ')[1]).to.be.above(278)
+      })
+    })
+  })
 
   describe('#pullFile', () => {
     it('should pull file to local machine', async () => {
-      const savepath = path.join(__dirname, `/../data/output/testpullfile${new Date().getTime()}.png`);
-      await app.pullFile('/storage/emulated/0/DCIM/sauce_logo.png', savepath);
-      assert.ok(fileExists(savepath), null, 'file does not exists');
-    });
-  });
+      const savepath = path.join(__dirname, `/../data/output/testpullfile${new Date().getTime()}.png`)
+      await app.pullFile('/storage/emulated/0/DCIM/sauce_logo.png', savepath)
+      assert.ok(fileExists(savepath), null, 'file does not exists')
+    })
+  })
 
   describe('see text : #see', () => {
     it('should work inside elements @second', async () => {
-      await app.resetApp();
-      await app.see('EN Button', '~buttonTestCD');
-      await app.see('Hello');
-      await app.dontSee('Welcome', '~buttonTestCD');
-    });
+      await app.resetApp()
+      await app.see('EN Button', '~buttonTestCD')
+      await app.see('Hello')
+      await app.dontSee('Welcome', '~buttonTestCD')
+    })
 
     it('should work inside web view as normally @quick', async () => {
-      await app.resetApp();
-      await app.click('~buttonStartWebviewCD');
-      await app.switchToWeb();
-      await app.see('Prefered Car:');
-    });
-  });
+      await app.resetApp()
+      await app.click('~buttonStartWebviewCD')
+      await app.switchToWeb()
+      await app.see('Prefered Car:')
+    })
+  })
 
   describe('#appendField', () => {
     it('should be able to send special keys to element @second', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.click('~email of the customer');
-      await app.appendField('~email of the customer', '1');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('1', '#io.selendroid.testapp:id/label_email_data');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.click('~email of the customer')
+      await app.appendField('~email of the customer', '1')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('1', '#io.selendroid.testapp:id/label_email_data')
+    })
+  })
 
   describe('#seeInSource', () => {
     it('should check for text to be in HTML source', async () => {
-      await app.seeInSource('class="android.widget.Button" package="io.selendroid.testapp" content-desc="buttonTestCD"');
-      await app.dontSeeInSource('<meta');
-    });
-  });
+      await app.seeInSource('class="android.widget.Button" package="io.selendroid.testapp" content-desc="buttonTestCD"')
+      await app.dontSeeInSource('<meta')
+    })
+  })
 
   describe('#waitForText', () => {
     it('should return error if not present', async () => {
       try {
-        await app.waitForText('Nothing here', 1, '~buttonTestCD');
+        await app.waitForText('Nothing here', 1, '~buttonTestCD')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.be.equal('expected element ~buttonTestCD to include "Nothing here"');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.be.equal('expected element ~buttonTestCD to include "Nothing here"')
       }
-    });
-  });
+    })
+  })
 
   describe('#seeNumberOfElements @second', () => {
     it('should return 1 as count', async () => {
-      await app.resetApp();
-      await app.seeNumberOfElements('~buttonTestCD', 1);
-    });
-  });
+      await app.resetApp()
+      await app.seeNumberOfElements('~buttonTestCD', 1)
+    })
+  })
 
   describe('see element : #seeElement, #dontSeeElement', () => {
     it('should check visible elements on page @quick', async () => {
-      await app.resetApp();
-      await app.seeElement('//android.widget.Button[@content-desc = "buttonTestCD"]');
-      await app.dontSeeElement('#something-beyond');
-      await app.dontSeeElement('//input[@id="something-beyond"]');
-    });
-  });
+      await app.resetApp()
+      await app.seeElement('//android.widget.Button[@content-desc = "buttonTestCD"]')
+      await app.dontSeeElement('#something-beyond')
+      await app.dontSeeElement('//input[@id="something-beyond"]')
+    })
+  })
 
   describe('#click @quick', () => {
     it('should click by accessibility id', async () => {
-      await app.resetApp();
-      await app.tap('~startUserRegistrationCD');
-      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]');
-    });
+      await app.resetApp()
+      await app.tap('~startUserRegistrationCD')
+      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]')
+    })
 
     it('should click by xpath', async () => {
-      await app.resetApp();
-      await app.click('//android.widget.ImageButton[@content-desc = "startUserRegistrationCD"]');
-      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]');
-    });
-  });
+      await app.resetApp()
+      await app.click('//android.widget.ImageButton[@content-desc = "startUserRegistrationCD"]')
+      await app.seeElement('//android.widget.TextView[@content-desc="label_usernameCD"]')
+    })
+  })
 
   describe('#fillField, #appendField @second', () => {
     it('should fill field by accessibility id', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('~email of the customer', 'Nothing special');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('~email of the customer', 'Nothing special')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+    })
 
     it('should fill field by xpath', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('//android.widget.EditText[@content-desc="email of the customer"]', 'Nothing special');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('//android.widget.EditText[@content-desc="email of the customer"]', 'Nothing special')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('Nothing special', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+    })
 
     it('should append field value @second', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('~email of the customer', 'Nothing special');
-      await app.appendField('~email of the customer', 'blabla');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('Nothing specialblabla', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('~email of the customer', 'Nothing special')
+      await app.appendField('~email of the customer', 'blabla')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('Nothing specialblabla', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+    })
+  })
 
   describe('#clearField', () => {
     it('should clear a given element', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click('~startUserRegistrationCD');
-      await app.fillField('~email of the customer', 'Nothing special');
-      await app.see('Nothing special', '~email of the customer');
-      await app.clearField('~email of the customer');
-      await app.dontSee('Nothing special', '~email of the customer');
-    });
-  });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click('~startUserRegistrationCD')
+      await app.fillField('~email of the customer', 'Nothing special')
+      await app.see('Nothing special', '~email of the customer')
+      await app.clearField('~email of the customer')
+      await app.dontSee('Nothing special', '~email of the customer')
+    })
+  })
 
   describe('#grabTextFrom, #grabValueFrom, #grabAttributeFrom @quick', () => {
     it('should grab text from page', async () => {
-      await app.resetApp();
-      const val = await app.grabTextFrom('//android.widget.Button[@content-desc="buttonTestCD"]');
-      assert.equal(val, 'EN Button');
-    });
+      await app.resetApp()
+      const val = await app.grabTextFrom('//android.widget.Button[@content-desc="buttonTestCD"]')
+      assert.equal(val, 'EN Button')
+    })
 
     it('should grab attribute from element', async () => {
-      await app.resetApp();
-      const val = await app.grabAttributeFrom('//android.widget.Button[@content-desc="buttonTestCD"]', 'resourceId');
-      assert.equal(val, 'io.selendroid.testapp:id/buttonTest');
-    });
+      await app.resetApp()
+      const val = await app.grabAttributeFrom('//android.widget.Button[@content-desc="buttonTestCD"]', 'resourceId')
+      assert.equal(val, 'io.selendroid.testapp:id/buttonTest')
+    })
 
     it('should be able to grab elements', async () => {
-      await app.resetApp();
-      await app.tap('~startUserRegistrationCD');
-      await app.tap('~email of the customer');
-      await app.appendField('//android.widget.EditText[@content-desc="email of the customer"]', '1');
-      await app.hideDeviceKeyboard('pressKey', 'Done');
-      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700);
-      await app.click('//android.widget.Button');
-      await app.see('1', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]');
-      const id = await app.grabNumberOfVisibleElements('//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]', 'contentDescription');
-      assert.strictEqual(1, id);
-    });
-  });
+      await app.resetApp()
+      await app.tap('~startUserRegistrationCD')
+      await app.tap('~email of the customer')
+      await app.appendField('//android.widget.EditText[@content-desc="email of the customer"]', '1')
+      await app.hideDeviceKeyboard('pressKey', 'Done')
+      await app.swipeTo('//android.widget.Button', '//android.widget.ScrollView/android.widget.LinearLayout', 'up', 30, 100, 700)
+      await app.click('//android.widget.Button')
+      await app.see('1', '//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]')
+      const id = await app.grabNumberOfVisibleElements('//android.widget.TextView[@resource-id="io.selendroid.testapp:id/label_email_data"]', 'contentDescription')
+      assert.strictEqual(1, id)
+    })
+  })
 
   describe('#saveScreenshot @quick', () => {
     beforeEach(() => {
-      global.output_dir = path.join(global.codecept_dir, 'output');
-    });
+      global.output_dir = path.join(global.codecept_dir, 'output')
+    })
 
     it('should create a screenshot file in output dir', async () => {
-      const sec = new Date().getUTCMilliseconds();
-      await app.saveScreenshot(`screenshot_${sec}.png`);
-      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists');
-    });
-  });
+      const sec = new Date().getUTCMilliseconds()
+      await app.saveScreenshot(`screenshot_${sec}.png`)
+      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists')
+    })
+  })
 
   describe('#runOnIOS, #runOnAndroid, #runInWeb', () => {
     it('should use Android locators', async () => {
-      await app.resetApp();
-      await app.waitForElement('~startUserRegistrationCD', smallWait);
-      await app.click({ android: '~startUserRegistrationCD', ios: 'fake-element' });
-      await app.see('Welcome to register a new User');
-    });
+      await app.resetApp()
+      await app.waitForElement('~startUserRegistrationCD', smallWait)
+      await app.click({ android: '~startUserRegistrationCD', ios: 'fake-element' })
+      await app.see('Welcome to register a new User')
+    })
 
     it('should execute only on Android @quick', () => {
-      let platform = null;
+      let platform = null
       app.runOnIOS(() => {
-        platform = 'ios';
-      });
+        platform = 'ios'
+      })
       app.runOnAndroid(() => {
-        platform = 'android';
-      });
+        platform = 'android'
+      })
       app.runOnAndroid({ platformVersion: '7.0' }, () => {
-        platform = 'android7';
-      });
+        platform = 'android7'
+      })
 
-      assert.equal('android', platform);
-    });
+      assert.equal('android', platform)
+    })
 
     it('should execute only on Android >= 5.0 @quick', () => {
       app.runOnAndroid(
         caps => caps.platformVersion >= 5,
         () => {},
-      );
-    });
+      )
+    })
 
     it('should execute only in Web', () => {
-      app.isWeb = true;
-      let executed = false;
+      app.isWeb = true
+      let executed = false
       app.runOnIOS(() => {
-        executed = true;
-      });
-      assert.ok(!executed);
-    });
-  });
-});
+        executed = true
+      })
+      assert.ok(!executed)
+    })
+  })
+})

--- a/test/helper/JSONResponse_test.js
+++ b/test/helper/JSONResponse_test.js
@@ -1,10 +1,10 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const joi = require('joi');
-const JSONResponse = require('../../lib/helper/JSONResponse');
-const Container = require('../../lib/container');
-global.codeceptjs = require('../../lib');
+const expect = chai.expect
+const joi = require('joi')
+const JSONResponse = require('../../lib/helper/JSONResponse')
+const Container = require('../../lib/container')
+global.codeceptjs = require('../../lib')
 
 const data = {
   posts: [
@@ -20,10 +20,10 @@ const data = {
   user: {
     name: 'davert',
   },
-};
+}
 
-let restHelper;
-let I;
+let restHelper
+let I
 
 describe('JSONResponse', () => {
   beforeEach(() => {
@@ -31,125 +31,125 @@ describe('JSONResponse', () => {
       helpers: {
         REST: {},
       },
-    });
+    })
 
-    I = new JSONResponse();
-    I._beforeSuite();
-    restHelper = Container.helpers('REST');
-  });
+    I = new JSONResponse()
+    I._beforeSuite()
+    restHelper = Container.helpers('REST')
+  })
 
   describe('response codes', () => {
     it('should check 200x codes', async () => {
-      restHelper.config.onResponse({ status: 204 });
-      I.seeResponseCodeIs(204);
-      I.dontSeeResponseCodeIs(200);
-      I.seeResponseCodeIsSuccessful();
-    });
+      restHelper.config.onResponse({ status: 204 })
+      I.seeResponseCodeIs(204)
+      I.dontSeeResponseCodeIs(200)
+      I.seeResponseCodeIsSuccessful()
+    })
 
     it('should check 300x codes', async () => {
-      restHelper.config.onResponse({ status: 304 });
-      I.seeResponseCodeIs(304);
-      I.dontSeeResponseCodeIs(200);
-      I.seeResponseCodeIsRedirection();
-    });
+      restHelper.config.onResponse({ status: 304 })
+      I.seeResponseCodeIs(304)
+      I.dontSeeResponseCodeIs(200)
+      I.seeResponseCodeIsRedirection()
+    })
 
     it('should check 400x codes', async () => {
-      restHelper.config.onResponse({ status: 404 });
-      I.seeResponseCodeIs(404);
-      I.dontSeeResponseCodeIs(200);
-      I.seeResponseCodeIsClientError();
-    });
+      restHelper.config.onResponse({ status: 404 })
+      I.seeResponseCodeIs(404)
+      I.dontSeeResponseCodeIs(200)
+      I.seeResponseCodeIsClientError()
+    })
 
     it('should check 500x codes', async () => {
-      restHelper.config.onResponse({ status: 504 });
-      I.seeResponseCodeIs(504);
-      I.dontSeeResponseCodeIs(200);
-      I.seeResponseCodeIsServerError();
-    });
+      restHelper.config.onResponse({ status: 504 })
+      I.seeResponseCodeIs(504)
+      I.dontSeeResponseCodeIs(200)
+      I.seeResponseCodeIsServerError()
+    })
 
     it('should throw error on invalid code', () => {
-      restHelper.config.onResponse({ status: 504 });
-      expect(() => I.seeResponseCodeIs(200)).to.throw('Response code');
-    });
-  });
+      restHelper.config.onResponse({ status: 504 })
+      expect(() => I.seeResponseCodeIs(200)).to.throw('Response code')
+    })
+  })
 
   describe('response data', () => {
     it('should check for json inclusion', () => {
-      restHelper.config.onResponse({ data });
+      restHelper.config.onResponse({ data })
       I.seeResponseContainsJson({
         posts: [{ id: 2 }],
-      });
+      })
       I.seeResponseContainsJson({
         posts: [{ id: 1, author: 'davert' }],
-      });
-      expect(() => I.seeResponseContainsJson({ posts: [{ id: 2, author: 'boss' }] })).to.throw('expected { …(2) } to deeply match { Object (posts) }');
-    });
+      })
+      expect(() => I.seeResponseContainsJson({ posts: [{ id: 2, author: 'boss' }] })).to.throw('expected { …(2) } to deeply match { Object (posts) }')
+    })
 
     it('should check for json inclusion - returned Array', () => {
-      const arrayData = [{ ...data }];
-      restHelper.config.onResponse({ data: arrayData });
+      const arrayData = [{ ...data }]
+      restHelper.config.onResponse({ data: arrayData })
       I.seeResponseContainsJson({
         posts: [{ id: 2 }],
-      });
+      })
       I.seeResponseContainsJson({
         posts: [{ id: 1, author: 'davert' }],
-      });
-      expect(() => I.seeResponseContainsJson({ posts: [{ id: 2, author: 'boss' }] })).to.throw('No elements in array matched {"posts":[{"id":2,"author":"boss"}]}');
-    });
+      })
+      expect(() => I.seeResponseContainsJson({ posts: [{ id: 2, author: 'boss' }] })).to.throw('No elements in array matched {"posts":[{"id":2,"author":"boss"}]}')
+    })
 
     it('should check for json inclusion - returned Array of 2 items', () => {
-      const arrayData = [{ ...data }, { posts: { id: 3 } }];
-      restHelper.config.onResponse({ data: arrayData });
+      const arrayData = [{ ...data }, { posts: { id: 3 } }]
+      restHelper.config.onResponse({ data: arrayData })
       I.seeResponseContainsJson({
         posts: { id: 3 },
-      });
-    });
+      })
+    })
 
     it('should simply check for json inclusion', () => {
-      restHelper.config.onResponse({ data: { user: { name: 'jon', email: 'jon@doe.com' } } });
-      I.seeResponseContainsJson({ user: { name: 'jon' } });
-      I.dontSeeResponseContainsJson({ user: { name: 'jo' } });
-      I.dontSeeResponseContainsJson({ name: 'joe' });
-    });
+      restHelper.config.onResponse({ data: { user: { name: 'jon', email: 'jon@doe.com' } } })
+      I.seeResponseContainsJson({ user: { name: 'jon' } })
+      I.dontSeeResponseContainsJson({ user: { name: 'jo' } })
+      I.dontSeeResponseContainsJson({ name: 'joe' })
+    })
 
     it('should simply check for json inclusion - returned Array', () => {
-      restHelper.config.onResponse({ data: [{ user: { name: 'jon', email: 'jon@doe.com' } }] });
-      I.seeResponseContainsJson({ user: { name: 'jon' } });
-      I.dontSeeResponseContainsJson({ user: { name: 'jo' } });
-      I.dontSeeResponseContainsJson({ name: 'joe' });
-    });
+      restHelper.config.onResponse({ data: [{ user: { name: 'jon', email: 'jon@doe.com' } }] })
+      I.seeResponseContainsJson({ user: { name: 'jon' } })
+      I.dontSeeResponseContainsJson({ user: { name: 'jo' } })
+      I.dontSeeResponseContainsJson({ name: 'joe' })
+    })
 
     it('should simply check for json equality', () => {
-      restHelper.config.onResponse({ data: { user: 1 } });
-      I.seeResponseEquals({ user: 1 });
-    });
+      restHelper.config.onResponse({ data: { user: 1 } })
+      I.seeResponseEquals({ user: 1 })
+    })
 
     it('should simply check for json equality - returned Array', () => {
-      restHelper.config.onResponse({ data: [{ user: 1 }] });
-      I.seeResponseEquals([{ user: 1 }]);
-    });
+      restHelper.config.onResponse({ data: [{ user: 1 }] })
+      I.seeResponseEquals([{ user: 1 }])
+    })
 
     it('should check json contains keys', () => {
-      restHelper.config.onResponse({ data: { user: 1, post: 2 } });
-      I.seeResponseContainsKeys(['user', 'post']);
-    });
+      restHelper.config.onResponse({ data: { user: 1, post: 2 } })
+      I.seeResponseContainsKeys(['user', 'post'])
+    })
 
     it('should check json contains keys - returned Array', () => {
-      restHelper.config.onResponse({ data: [{ user: 1, post: 2 }] });
-      I.seeResponseContainsKeys(['user', 'post']);
-    });
+      restHelper.config.onResponse({ data: [{ user: 1, post: 2 }] })
+      I.seeResponseContainsKeys(['user', 'post'])
+    })
 
     it('should check for json by callback', () => {
-      restHelper.config.onResponse({ data });
+      restHelper.config.onResponse({ data })
       const fn = ({ expect, data }) => {
-        expect(data).to.have.keys(['posts', 'user']);
-      };
-      I.seeResponseValidByCallback(fn);
-      expect(fn.toString()).to.include('expect(data).to.have');
-    });
+        expect(data).to.have.keys(['posts', 'user'])
+      }
+      I.seeResponseValidByCallback(fn)
+      expect(fn.toString()).to.include('expect(data).to.have')
+    })
 
     it('should check for json by joi schema', () => {
-      restHelper.config.onResponse({ data });
+      restHelper.config.onResponse({ data })
       const schema = joi.object({
         posts: joi.array().items({
           id: joi.number(),
@@ -159,12 +159,12 @@ describe('JSONResponse', () => {
         user: joi.object({
           name: joi.string(),
         }),
-      });
+      })
       const fn = () => {
-        return schema;
-      };
-      I.seeResponseMatchesJsonSchema(fn);
-      I.seeResponseMatchesJsonSchema(schema);
-    });
-  });
-});
+        return schema
+      }
+      I.seeResponseMatchesJsonSchema(fn)
+      I.seeResponseMatchesJsonSchema(schema)
+    })
+  })
+})

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -1,37 +1,37 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const assert = chai.assert;
-const expect = chai.expect;
+const assert = chai.assert
+const expect = chai.expect
 
-const path = require('path');
-const fs = require('fs');
+const path = require('path')
+const fs = require('fs')
 
-const playwright = require('playwright');
+const playwright = require('playwright')
 
-const TestHelper = require('../support/TestHelper');
-const Playwright = require('../../lib/helper/Playwright');
+const TestHelper = require('../support/TestHelper')
+const Playwright = require('../../lib/helper/Playwright')
 
-const AssertionFailedError = require('../../lib/assert/error');
-const webApiTests = require('./webapi');
-const FileSystem = require('../../lib/helper/FileSystem');
-const { deleteDir } = require('../../lib/utils');
-const Secret = require('../../lib/secret');
-global.codeceptjs = require('../../lib');
+const AssertionFailedError = require('../../lib/assert/error')
+const webApiTests = require('./webapi')
+const FileSystem = require('../../lib/helper/FileSystem')
+const { deleteDir } = require('../../lib/utils')
+const Secret = require('../../lib/secret')
+global.codeceptjs = require('../../lib')
 
-const dataFile = path.join(__dirname, '/../data/app/db');
-const formContents = require('../../lib/utils').test.submittedData(dataFile);
+const dataFile = path.join(__dirname, '/../data/app/db')
+const formContents = require('../../lib/utils').test.submittedData(dataFile)
 
-let I;
-let page;
-let FS;
-const siteUrl = TestHelper.siteUrl();
+let I
+let page
+let FS
+const siteUrl = TestHelper.siteUrl()
 
 describe('Playwright', function () {
-  this.timeout(35000);
-  this.retries(1);
+  this.timeout(35000)
+  this.retries(1)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Playwright({
       url: siteUrl,
@@ -46,173 +46,173 @@ describe('Playwright', function () {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       },
       defaultPopupAction: 'accept',
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     webApiTests.init({
       I,
       siteUrl,
-    });
+    })
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(async () => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   describe('restart browser: #restartBrowser', () => {
     it('should open a new tab after restart of browser', async () => {
-      await I.restartBrowser();
-      await I.wait(1);
-      const numPages = await I.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
-    });
-  });
+      await I.restartBrowser()
+      await I.wait(1)
+      const numPages = await I.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
+    })
+  })
 
   describe('open page : #amOnPage', () => {
     it('should open main page of configured site', async () => {
-      await I.amOnPage('/');
-      const url = await page.url();
-      await url.should.eql(`${siteUrl}/`);
-    });
+      await I.amOnPage('/')
+      const url = await page.url()
+      await url.should.eql(`${siteUrl}/`)
+    })
     it('should open any page of configured site', async () => {
-      await I.amOnPage('/info');
-      const url = await page.url();
-      return url.should.eql(`${siteUrl}/info`);
-    });
+      await I.amOnPage('/info')
+      const url = await page.url()
+      return url.should.eql(`${siteUrl}/info`)
+    })
 
     it('should open absolute url', async () => {
-      await I.amOnPage(siteUrl);
-      const url = await page.url();
-      return url.should.eql(`${siteUrl}/`);
-    });
+      await I.amOnPage(siteUrl)
+      const url = await page.url()
+      return url.should.eql(`${siteUrl}/`)
+    })
 
     it('should open any page of configured site without leading slash', async () => {
-      await I.amOnPage('info');
-      const url = await page.url();
-      return url.should.eql(`${siteUrl}/info`);
-    });
+      await I.amOnPage('info')
+      const url = await page.url()
+      return url.should.eql(`${siteUrl}/info`)
+    })
 
     it('should open blank page', async () => {
-      await I.amOnPage('about:blank');
-      const url = await page.url();
-      return url.should.eql('about:blank');
-    });
-  });
+      await I.amOnPage('about:blank')
+      const url = await page.url()
+      return url.should.eql('about:blank')
+    })
+  })
 
   describe('grabDataFromPerformanceTiming', () => {
     it('should return data from performance timing', async () => {
-      await I.amOnPage('/');
-      const res = await I.grabDataFromPerformanceTiming();
-      expect(res).to.have.property('responseEnd');
-      expect(res).to.have.property('domInteractive');
-      expect(res).to.have.property('domContentLoadedEventEnd');
-      expect(res).to.have.property('loadEventEnd');
-    });
-  });
+      await I.amOnPage('/')
+      const res = await I.grabDataFromPerformanceTiming()
+      expect(res).to.have.property('responseEnd')
+      expect(res).to.have.property('domInteractive')
+      expect(res).to.have.property('domContentLoadedEventEnd')
+      expect(res).to.have.property('loadEventEnd')
+    })
+  })
 
   describe('#seeCssPropertiesOnElements', () => {
     it('should check background-color css property for given element', async () => {
       try {
-        await I.amOnPage('https://codecept.io/helpers/Playwright/');
-        await I.seeCssPropertiesOnElements('.navbar', { 'background-color': 'rgb(128, 90, 213)' });
+        await I.amOnPage('https://codecept.io/helpers/Playwright/')
+        await I.seeCssPropertiesOnElements('.navbar', { 'background-color': 'rgb(128, 90, 213)' })
       } catch (e) {
-        e.message.should.include("expected element (.navbar) to have CSS property { 'background-color': 'rgb(128, 90, 213)' }");
+        e.message.should.include("expected element (.navbar) to have CSS property { 'background-color': 'rgb(128, 90, 213)' }")
       }
-    });
-  });
+    })
+  })
 
-  webApiTests.tests();
+  webApiTests.tests()
 
   describe('#click', () => {
     it('should not try to click on invisible elements', async () => {
-      await I.amOnPage('/invisible_elements');
-      await I.click('Hello World');
-    });
-  });
+      await I.amOnPage('/invisible_elements')
+      await I.click('Hello World')
+    })
+  })
   describe('#grabCheckedElementStatus', () => {
     it('check grabCheckedElementStatus', async () => {
-      await I.amOnPage('/invisible_elements');
-      let result = await I.grabCheckedElementStatus({ id: 'html' });
-      assert.equal(result, true);
-      result = await I.grabCheckedElementStatus({ id: 'css' });
-      assert.equal(result, false);
-      result = await I.grabCheckedElementStatus({ id: 'js' });
-      assert.equal(result, true);
-      result = await I.grabCheckedElementStatus({ id: 'ts' });
-      assert.equal(result, false);
+      await I.amOnPage('/invisible_elements')
+      let result = await I.grabCheckedElementStatus({ id: 'html' })
+      assert.equal(result, true)
+      result = await I.grabCheckedElementStatus({ id: 'css' })
+      assert.equal(result, false)
+      result = await I.grabCheckedElementStatus({ id: 'js' })
+      assert.equal(result, true)
+      result = await I.grabCheckedElementStatus({ id: 'ts' })
+      assert.equal(result, false)
       try {
-        await I.grabCheckedElementStatus({ id: 'basic' });
+        await I.grabCheckedElementStatus({ id: 'basic' })
       } catch (e) {
-        assert.equal(e.message, 'Element is not a checkbox or radio input');
+        assert.equal(e.message, 'Element is not a checkbox or radio input')
       }
-    });
-  });
+    })
+  })
   describe('#grabDisabledElementStatus', () => {
     it('check isElementDisabled', async () => {
-      await I.amOnPage('/invisible_elements');
-      let result = await I.grabDisabledElementStatus({ id: 'fortran' });
-      assert.equal(result, true);
-      result = await I.grabDisabledElementStatus({ id: 'basic' });
-      assert.equal(result, false);
-    });
-  });
+      await I.amOnPage('/invisible_elements')
+      let result = await I.grabDisabledElementStatus({ id: 'fortran' })
+      assert.equal(result, true)
+      result = await I.grabDisabledElementStatus({ id: 'basic' })
+      assert.equal(result, false)
+    })
+  })
 
   describe('#waitForFunction', () => {
     it('should wait for function returns true', () => {
-      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(() => window.__waitJs, 3));
-    });
+      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(() => window.__waitJs, 3))
+    })
 
     it('should pass arguments and wait for function returns true', () => {
-      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(varName => window[varName], ['__waitJs'], 3));
-    });
-  });
+      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(varName => window[varName], ['__waitJs'], 3))
+    })
+  })
 
   describe('#waitForVisible #waitForInvisible - within block', () => {
     it('should wait for visible element', async () => {
-      await I.amOnPage('/iframe');
+      await I.amOnPage('/iframe')
       await I._withinBegin({
         frame: '#number-frame-1234',
-      });
+      })
 
-      await I.waitForVisible('h1');
-    });
+      await I.waitForVisible('h1')
+    })
 
     it('should wait for invisible element', async () => {
-      await I.amOnPage('/iframe');
+      await I.amOnPage('/iframe')
       await I._withinBegin({
         frame: '#number-frame-1234',
-      });
+      })
 
-      await I.waitForInvisible('h9');
-    });
+      await I.waitForInvisible('h9')
+    })
 
     it('should wait for element to hide', async () => {
-      await I.amOnPage('/iframe');
+      await I.amOnPage('/iframe')
       await I._withinBegin({
         frame: '#number-frame-1234',
-      });
+      })
 
-      await I.waitToHide('h9');
-    });
+      await I.waitToHide('h9')
+    })
 
     it('should wait for invisible combined with dontseeElement', async () => {
-      await I.amOnPage('https://codecept.io/');
-      await I.waitForVisible('.frameworks');
-      await I.waitForVisible('[alt="React"]');
-      await I.waitForVisible('.mountains');
+      await I.amOnPage('https://codecept.io/')
+      await I.waitForVisible('.frameworks')
+      await I.waitForVisible('[alt="React"]')
+      await I.waitForVisible('.mountains')
       await I._withinBegin('.mountains', async () => {
-        await I.dontSeeElement('[alt="React"]');
-        await I.waitForInvisible('[alt="React"]', 2);
-      });
-    });
-  });
+        await I.dontSeeElement('[alt="React"]')
+        await I.waitForInvisible('[alt="React"]', 2)
+      })
+    })
+  })
 
   describe('#waitToHide', () => {
     it('should wait for hidden element', () => {
@@ -220,17 +220,17 @@ describe('Playwright', function () {
         .then(() => I.see('Step One Button'))
         .then(() => I.waitToHide('#step_1', 2))
         .then(() => I.dontSeeElement('#step_1'))
-        .then(() => I.dontSee('Step One Button'));
-    });
+        .then(() => I.dontSee('Step One Button'))
+    })
 
     it('should wait for hidden element by XPath', () => {
       return I.amOnPage('/form/wait_invisible')
         .then(() => I.see('Step One Button'))
         .then(() => I.waitToHide('//div[@id="step_1"]', 2))
         .then(() => I.dontSeeElement('//div[@id="step_1"]'))
-        .then(() => I.dontSee('Step One Button'));
-    });
-  });
+        .then(() => I.dontSee('Step One Button'))
+    })
+  })
 
   describe('#waitNumberOfVisibleElements', () => {
     it('should wait for a specified number of elements on the page', () =>
@@ -238,53 +238,53 @@ describe('Playwright', function () {
         .then(() => I.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3))
         .then(() => I.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec');
-        }));
+          e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec')
+        }))
 
     it('should wait for a specified number of elements on the page using a css selector', () =>
       I.amOnPage('/info')
         .then(() => I.waitNumberOfVisibleElements('#grab-multiple > a', 3))
         .then(() => I.waitNumberOfVisibleElements('#grab-multiple > a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec');
-        }));
+          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec')
+        }))
 
     it('should wait for a specified number of elements which are not yet attached to the DOM', () =>
       I.amOnPage('/form/wait_num_elements')
         .then(() => I.waitNumberOfVisibleElements('.title', 2, 3))
         .then(() => I.see('Hello'))
-        .then(() => I.see('World')));
+        .then(() => I.see('World')))
 
     it('should wait for 0 number of visible elements', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.waitNumberOfVisibleElements('#step_1', 0);
-    });
-  });
+      await I.amOnPage('/form/wait_invisible')
+      await I.waitNumberOfVisibleElements('#step_1', 0)
+    })
+  })
 
   describe('#moveCursorTo', () => {
     it('should trigger hover event', () =>
       I.amOnPage('/form/hover')
         .then(() => I.moveCursorTo('#hover'))
-        .then(() => I.see('Hovered', '#show')));
+        .then(() => I.see('Hovered', '#show')))
 
     it('should not trigger hover event because of the offset is beyond the element', () =>
       I.amOnPage('/form/hover')
         .then(() => I.moveCursorTo('#hover', 100, 100))
-        .then(() => I.dontSee('Hovered', '#show')));
-  });
+        .then(() => I.dontSee('Hovered', '#show')))
+  })
 
   describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', () =>
       I.amOnPage('/')
         .then(() => I.wait(1))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 1)));
+        .then(numPages => assert.equal(numPages, 1)))
 
     it('should switch to next tab', () =>
       I.amOnPage('/info')
@@ -296,7 +296,7 @@ describe('Playwright', function () {
         .then(() => I.wait(2))
         .then(() => I.seeCurrentUrlEquals('/login'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 2)));
+        .then(numPages => assert.equal(numPages, 2)))
 
     it('should assert when there is no ability to switch to next tab', () =>
       I.amOnPage('/')
@@ -306,8 +306,8 @@ describe('Playwright', function () {
         .then(() => I.wait(2))
         .then(() => assert.equal(true, false, 'Throw an error if it gets this far (which it should not)!'))
         .catch(e => {
-          assert.equal(e.message, 'There is no ability to switch to next tab with offset 2');
-        }));
+          assert.equal(e.message, 'There is no ability to switch to next tab with offset 2')
+        }))
 
     it('should close current tab', () =>
       I.amOnPage('/info')
@@ -321,7 +321,7 @@ describe('Playwright', function () {
         .then(() => I.wait(1))
         .then(() => I.seeInCurrentUrl('/info'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 1)));
+        .then(numPages => assert.equal(numPages, 1)))
 
     it('should close other tabs', () =>
       I.amOnPage('/')
@@ -335,7 +335,7 @@ describe('Playwright', function () {
         .then(() => I.waitForNumberOfTabs(1))
         .then(() => I.seeInCurrentUrl('/login'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 1)));
+        .then(numPages => assert.equal(numPages, 1)))
 
     it('should open new tab', () =>
       I.amOnPage('/info')
@@ -343,7 +343,7 @@ describe('Playwright', function () {
         .then(() => I.wait(1))
         .then(() => I.seeInCurrentUrl('about:blank'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 2)));
+        .then(numPages => assert.equal(numPages, 2)))
 
     it('should switch to previous tab', () =>
       I.amOnPage('/info')
@@ -352,7 +352,7 @@ describe('Playwright', function () {
         .then(() => I.seeInCurrentUrl('about:blank'))
         .then(() => I.switchToPreviousTab())
         .then(() => I.wait(2))
-        .then(() => I.seeInCurrentUrl('/info')));
+        .then(() => I.seeInCurrentUrl('/info')))
 
     it('should assert when there is no ability to switch to previous tab', () =>
       I.amOnPage('/info')
@@ -363,9 +363,9 @@ describe('Playwright', function () {
         .then(() => I.wait(2))
         .then(() => I.waitInUrl('/info'))
         .catch(e => {
-          assert.equal(e.message, 'There is no ability to switch to previous tab with offset 2');
-        }));
-  });
+          assert.equal(e.message, 'There is no ability to switch to previous tab with offset 2')
+        }))
+  })
 
   describe('popup : #acceptPopup, #seeInPopup, #cancelPopup, #grabPopupText', () => {
     it('should accept popup window', () =>
@@ -373,103 +373,103 @@ describe('Playwright', function () {
         .then(() => I.amAcceptingPopups())
         .then(() => I.click('Confirm'))
         .then(() => I.acceptPopup())
-        .then(() => I.see('Yes', '#result')));
+        .then(() => I.see('Yes', '#result')))
 
     it('should accept popup window (using default popup action type)', () =>
       I.amOnPage('/form/popup')
         .then(() => I.click('Confirm'))
         .then(() => I.acceptPopup())
-        .then(() => I.see('Yes', '#result')));
+        .then(() => I.see('Yes', '#result')))
 
     it('should cancel popup', () =>
       I.amOnPage('/form/popup')
         .then(() => I.amCancellingPopups())
         .then(() => I.click('Confirm'))
         .then(() => I.cancelPopup())
-        .then(() => I.see('No', '#result')));
+        .then(() => I.see('No', '#result')))
 
     it('should check text in popup', () =>
       I.amOnPage('/form/popup')
         .then(() => I.amCancellingPopups())
         .then(() => I.click('Alert'))
         .then(() => I.seeInPopup('Really?'))
-        .then(() => I.cancelPopup()));
+        .then(() => I.cancelPopup()))
 
     it('should grab text from popup', () =>
       I.amOnPage('/form/popup')
         .then(() => I.amCancellingPopups())
         .then(() => I.click('Alert'))
         .then(() => I.grabPopupText())
-        .then(text => assert.equal(text, 'Really?')));
+        .then(text => assert.equal(text, 'Really?')))
 
     it('should return null if no popup is visible (do not throw an error)', () =>
       I.amOnPage('/form/popup')
         .then(() => I.grabPopupText())
-        .then(text => assert.equal(text, null)));
-  });
+        .then(text => assert.equal(text, null)))
+  })
 
   describe('#seeNumberOfElements', () => {
-    it('should return 1 as count', () => I.amOnPage('/').then(() => I.seeNumberOfElements('#area1', 1)));
-  });
+    it('should return 1 as count', () => I.amOnPage('/').then(() => I.seeNumberOfElements('#area1', 1)))
+  })
 
   describe('#switchTo', () => {
     it('should switch reference to iframe content', () => {
-      I.amOnPage('/iframe');
-      I.switchTo('[name="content"]');
-      I.see('Information');
-      I.see('Lots of valuable data here');
-    });
+      I.amOnPage('/iframe')
+      I.switchTo('[name="content"]')
+      I.see('Information')
+      I.see('Lots of valuable data here')
+    })
 
     it('should return error if iframe selector is invalid', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo('#invalidIframeSelector'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath');
-        }));
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath')
+        }))
 
     it('should return error if iframe selector is not iframe', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo('h1'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath');
-        }));
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath')
+        }))
 
     it('should return to parent frame given a null locator', async () => {
-      I.amOnPage('/iframe');
-      I.switchTo('[name="content"]');
-      I.see('Information');
-      I.see('Lots of valuable data here');
-      I.switchTo(null);
-      I.see('Iframe test');
-    });
+      I.amOnPage('/iframe')
+      I.switchTo('[name="content"]')
+      I.see('Information')
+      I.see('Lots of valuable data here')
+      I.switchTo(null)
+      I.see('Iframe test')
+    })
 
     it('should switch to iframe using css', () => {
-      I.amOnPage('/iframe');
-      I.switchTo('iframe#number-frame-1234');
-      I.see('Information');
-      I.see('Lots of valuable data here');
-    });
+      I.amOnPage('/iframe')
+      I.switchTo('iframe#number-frame-1234')
+      I.see('Information')
+      I.see('Lots of valuable data here')
+    })
 
     it('should switch to iframe using css when there are more than one iframes', () => {
-      I.amOnPage('/iframes');
-      I.switchTo('iframe#number-frame-1234');
-      I.see('Information');
-    });
-  });
+      I.amOnPage('/iframes')
+      I.switchTo('iframe#number-frame-1234')
+      I.see('Information')
+    })
+  })
 
   describe('#seeInSource, #grabSource', () => {
     it('should check for text to be in HTML source', () =>
       I.amOnPage('/')
         .then(() => I.seeInSource('<title>TestEd Beta 2.0</title>'))
-        .then(() => I.dontSeeInSource('<meta')));
+        .then(() => I.dontSeeInSource('<meta')))
 
     it('should grab the source', () =>
       I.amOnPage('/')
         .then(() => I.grabSource())
-        .then(source => assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')));
-  });
+        .then(source => assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')))
+  })
 
   describe('#seeTitleEquals', () => {
     it('should check that title is equal to provided one', () =>
@@ -478,10 +478,10 @@ describe('Playwright', function () {
         .then(() => I.seeTitleEquals('TestEd Beta 2.'))
         .then(() => assert.equal(true, false, 'Throw an error because it should not get this far!'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('expected web page title "TestEd Beta 2.0" to equal "TestEd Beta 2."');
-        }));
-  });
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('expected web page title "TestEd Beta 2.0" to equal "TestEd Beta 2."')
+        }))
+  })
 
   describe('#seeTextEquals', () => {
     it('should check text is equal to provided one', () =>
@@ -490,256 +490,256 @@ describe('Playwright', function () {
         .then(() => I.seeTextEquals('Welcome to test app', 'h1'))
         .then(() => assert.equal(true, false, 'Throw an error because it should not get this far!'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"');
-        }));
-  });
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"')
+        }))
+  })
 
   describe('#selectOption', () => {
     it('should select option by label and partial option text', async () => {
-      await I.amOnPage('/form/select');
-      await I.selectOption('Select your age', '21-');
-      await I.click('Submit');
-      assert.equal(formContents('age'), 'adult');
-    });
-  });
+      await I.amOnPage('/form/select')
+      await I.selectOption('Select your age', '21-')
+      await I.click('Submit')
+      assert.equal(formContents('age'), 'adult')
+    })
+  })
 
   describe('#_locateClickable', () => {
     it('should locate a button to click', () =>
       I.amOnPage('/form/checkbox')
         .then(() => I._locateClickable('Submit'))
         .then(res => {
-          res.length.should.be.equal(1);
-        }));
+          res.length.should.be.equal(1)
+        }))
 
     it('should not locate a non-existing checkbox using _locateClickable', () =>
       I.amOnPage('/form/checkbox')
         .then(() => I._locateClickable('I disagree'))
-        .then(res => res.length.should.be.equal(0)));
-  });
+        .then(res => res.length.should.be.equal(0)))
+  })
 
   describe('#_locateCheckable', () => {
     it('should locate a checkbox', () =>
       I.amOnPage('/form/checkbox')
         .then(() => I._locateCheckable('I Agree'))
-        .then(res => res.should.be.not.undefined));
-  });
+        .then(res => res.should.be.not.undefined))
+  })
 
   describe('#_locateFields', () => {
     it('should locate a field', () =>
       I.amOnPage('/form/field')
         .then(() => I._locateFields('Name'))
-        .then(res => res.length.should.be.equal(1)));
+        .then(res => res.length.should.be.equal(1)))
 
     it('should not locate a non-existing field', () =>
       I.amOnPage('/form/field')
         .then(() => I._locateFields('Mother-in-law'))
-        .then(res => res.length.should.be.equal(0)));
-  });
+        .then(res => res.length.should.be.equal(0)))
+  })
 
   describe('check fields: #seeInField, #seeCheckboxIsChecked, ...', () => {
     it('should throw error if field is not empty', () =>
       I.amOnPage('/form/empty')
         .then(() => I.seeInField('#empty_input', 'Ayayay'))
         .catch(e => {
-          e.should.be.instanceOf(AssertionFailedError);
-          e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"');
-        }));
+          e.should.be.instanceOf(AssertionFailedError)
+          e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"')
+        }))
 
     it('should check values in checkboxes', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.dontSeeInField('checkbox[]', 'not seen one');
-      await I.seeInField('checkbox[]', 'see test one');
-      await I.dontSeeInField('checkbox[]', 'not seen two');
-      await I.seeInField('checkbox[]', 'see test two');
-      await I.dontSeeInField('checkbox[]', 'not seen three');
-      await I.seeInField('checkbox[]', 'see test three');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.dontSeeInField('checkbox[]', 'not seen one')
+      await I.seeInField('checkbox[]', 'see test one')
+      await I.dontSeeInField('checkbox[]', 'not seen two')
+      await I.seeInField('checkbox[]', 'see test two')
+      await I.dontSeeInField('checkbox[]', 'not seen three')
+      await I.seeInField('checkbox[]', 'see test three')
+    })
 
     it('should check values are the secret type in checkboxes', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.dontSeeInField('checkbox[]', Secret.secret('not seen one'));
-      await I.seeInField('checkbox[]', Secret.secret('see test one'));
-      await I.dontSeeInField('checkbox[]', Secret.secret('not seen two'));
-      await I.seeInField('checkbox[]', Secret.secret('see test two'));
-      await I.dontSeeInField('checkbox[]', Secret.secret('not seen three'));
-      await I.seeInField('checkbox[]', Secret.secret('see test three'));
-    });
+      await I.amOnPage('/form/field_values')
+      await I.dontSeeInField('checkbox[]', Secret.secret('not seen one'))
+      await I.seeInField('checkbox[]', Secret.secret('see test one'))
+      await I.dontSeeInField('checkbox[]', Secret.secret('not seen two'))
+      await I.seeInField('checkbox[]', Secret.secret('see test two'))
+      await I.dontSeeInField('checkbox[]', Secret.secret('not seen three'))
+      await I.seeInField('checkbox[]', Secret.secret('see test three'))
+    })
 
     it('should check values with boolean', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('checkbox1', true);
-      await I.dontSeeInField('checkbox1', false);
-      await I.seeInField('checkbox2', false);
-      await I.dontSeeInField('checkbox2', true);
-      await I.seeInField('radio2', true);
-      await I.dontSeeInField('radio2', false);
-      await I.seeInField('radio3', false);
-      await I.dontSeeInField('radio3', true);
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('checkbox1', true)
+      await I.dontSeeInField('checkbox1', false)
+      await I.seeInField('checkbox2', false)
+      await I.dontSeeInField('checkbox2', true)
+      await I.seeInField('radio2', true)
+      await I.dontSeeInField('radio2', false)
+      await I.seeInField('radio3', false)
+      await I.dontSeeInField('radio3', true)
+    })
 
     it('should check values in radio', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('radio1', 'see test one');
-      await I.dontSeeInField('radio1', 'not seen one');
-      await I.dontSeeInField('radio1', 'not seen two');
-      await I.dontSeeInField('radio1', 'not seen three');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('radio1', 'see test one')
+      await I.dontSeeInField('radio1', 'not seen one')
+      await I.dontSeeInField('radio1', 'not seen two')
+      await I.dontSeeInField('radio1', 'not seen three')
+    })
 
     it('should check values in select', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('select1', 'see test one');
-      await I.dontSeeInField('select1', 'not seen one');
-      await I.dontSeeInField('select1', 'not seen two');
-      await I.dontSeeInField('select1', 'not seen three');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('select1', 'see test one')
+      await I.dontSeeInField('select1', 'not seen one')
+      await I.dontSeeInField('select1', 'not seen two')
+      await I.dontSeeInField('select1', 'not seen three')
+    })
 
     it('should check for empty select field', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('select3', '');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('select3', '')
+    })
 
     it('should check for select multiple field', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.dontSeeInField('select2', 'not seen one');
-      await I.seeInField('select2', 'see test one');
-      await I.dontSeeInField('select2', 'not seen two');
-      await I.seeInField('select2', 'see test two');
-      await I.dontSeeInField('select2', 'not seen three');
-      await I.seeInField('select2', 'see test three');
-    });
-  });
+      await I.amOnPage('/form/field_values')
+      await I.dontSeeInField('select2', 'not seen one')
+      await I.seeInField('select2', 'see test one')
+      await I.dontSeeInField('select2', 'not seen two')
+      await I.seeInField('select2', 'see test two')
+      await I.dontSeeInField('select2', 'not seen three')
+      await I.seeInField('select2', 'see test three')
+    })
+  })
 
   describe('#clearField', () => {
     it('should clear input', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', 'value that is cleared using I.clearField()');
-      await I.clearField('Name');
-      await I.dontSeeInField('Name', 'value that is cleared using I.clearField()');
-    });
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', 'value that is cleared using I.clearField()')
+      await I.clearField('Name')
+      await I.dontSeeInField('Name', 'value that is cleared using I.clearField()')
+    })
 
     it('should clear div textarea', async () => {
-      await I.amOnPage('/form/field');
-      await I.clearField('#textarea');
-      await I.dontSeeInField('#textarea', 'I look like textarea');
-    });
+      await I.amOnPage('/form/field')
+      await I.clearField('#textarea')
+      await I.dontSeeInField('#textarea', 'I look like textarea')
+    })
 
     it('should clear textarea', async () => {
-      await I.amOnPage('/form/textarea');
-      await I.fillField('#description', 'value that is cleared using I.clearField()');
-      await I.clearField('#description');
-      await I.dontSeeInField('#description', 'value that is cleared using I.clearField()');
-    });
+      await I.amOnPage('/form/textarea')
+      await I.fillField('#description', 'value that is cleared using I.clearField()')
+      await I.clearField('#description')
+      await I.dontSeeInField('#description', 'value that is cleared using I.clearField()')
+    })
 
     xit('should clear contenteditable', async () => {
       const isClearMethodPresent = await I.usePlaywrightTo('check if new Playwright .clear() method present', async ({ page }) => {
-        return typeof page.locator().clear === 'function';
-      });
+        return typeof page.locator().clear === 'function'
+      })
       if (!isClearMethodPresent) {
-        this.skip();
+        this.skip()
       }
 
-      await I.amOnPage('/form/contenteditable');
-      await I.clearField('#contenteditableDiv');
-      await I.dontSee('This is editable. Click here to edit this text.', '#contenteditableDiv');
-    });
-  });
+      await I.amOnPage('/form/contenteditable')
+      await I.clearField('#contenteditableDiv')
+      await I.dontSee('This is editable. Click here to edit this text.', '#contenteditableDiv')
+    })
+  })
 
   describe('#pressKey, #pressKeyDown, #pressKeyUp', () => {
     it('should be able to send special keys to element', async () => {
-      await I.amOnPage('/form/field');
-      await I.appendField('Name', '-');
+      await I.amOnPage('/form/field')
+      await I.appendField('Name', '-')
 
-      await I.pressKey(['Right Shift', 'Home']);
-      await I.pressKey('Delete');
+      await I.pressKey(['Right Shift', 'Home'])
+      await I.pressKey('Delete')
 
       // Sequence only executes up to first non-modifier key ('Digit1')
-      await I.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4']);
-      await I.pressKey('1');
-      await I.pressKey('2');
-      await I.pressKey('3');
-      await I.pressKey('ArrowLeft');
-      await I.pressKey('Left Arrow');
-      await I.pressKey('arrow_left');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('a');
-      await I.pressKey('KeyB');
-      await I.pressKeyUp('ShiftLeft');
-      await I.pressKey('C');
-      await I.seeInField('Name', '!ABC123');
-    });
+      await I.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4'])
+      await I.pressKey('1')
+      await I.pressKey('2')
+      await I.pressKey('3')
+      await I.pressKey('ArrowLeft')
+      await I.pressKey('Left Arrow')
+      await I.pressKey('arrow_left')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('a')
+      await I.pressKey('KeyB')
+      await I.pressKeyUp('ShiftLeft')
+      await I.pressKey('C')
+      await I.seeInField('Name', '!ABC123')
+    })
 
     it('should use modifier key based on operating system', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', 'value that is cleared using select all shortcut');
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', 'value that is cleared using select all shortcut')
 
-      await I.pressKey(['ControlOrCommand', 'a']);
-      await I.pressKey('Backspace');
-      await I.dontSeeInField('Name', 'value that is cleared using select all shortcut');
-    });
+      await I.pressKey(['ControlOrCommand', 'a'])
+      await I.pressKey('Backspace')
+      await I.dontSeeInField('Name', 'value that is cleared using select all shortcut')
+    })
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', '');
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', '')
 
-      await I.pressKey(';');
-      await I.pressKey(['Shift', ';']);
-      await I.pressKey(['Shift', 'Semicolon']);
-      await I.pressKey('=');
-      await I.pressKey(['Shift', '=']);
-      await I.pressKey(['Shift', 'Equal']);
-      await I.pressKey('*');
-      await I.pressKey(['Shift', '*']);
-      await I.pressKey(['Shift', 'Multiply']);
-      await I.pressKey('+');
-      await I.pressKey(['Shift', '+']);
-      await I.pressKey(['Shift', 'Add']);
-      await I.pressKey(',');
-      await I.pressKey(['Shift', ',']);
-      await I.pressKey(['Shift', 'Comma']);
-      await I.pressKey(['Shift', 'NumpadComma']);
-      await I.pressKey(['Shift', 'Separator']);
-      await I.pressKey('-');
-      await I.pressKey(['Shift', '-']);
-      await I.pressKey(['Shift', 'Subtract']);
-      await I.pressKey('.');
-      await I.pressKey(['Shift', '.']);
-      await I.pressKey('/');
-      await I.pressKey(['Shift', '/']);
-      await I.pressKey(['Shift', 'Divide']);
-      await I.pressKey(['Shift', 'Slash']);
+      await I.pressKey(';')
+      await I.pressKey(['Shift', ';'])
+      await I.pressKey(['Shift', 'Semicolon'])
+      await I.pressKey('=')
+      await I.pressKey(['Shift', '='])
+      await I.pressKey(['Shift', 'Equal'])
+      await I.pressKey('*')
+      await I.pressKey(['Shift', '*'])
+      await I.pressKey(['Shift', 'Multiply'])
+      await I.pressKey('+')
+      await I.pressKey(['Shift', '+'])
+      await I.pressKey(['Shift', 'Add'])
+      await I.pressKey(',')
+      await I.pressKey(['Shift', ','])
+      await I.pressKey(['Shift', 'Comma'])
+      await I.pressKey(['Shift', 'NumpadComma'])
+      await I.pressKey(['Shift', 'Separator'])
+      await I.pressKey('-')
+      await I.pressKey(['Shift', '-'])
+      await I.pressKey(['Shift', 'Subtract'])
+      await I.pressKey('.')
+      await I.pressKey(['Shift', '.'])
+      await I.pressKey('/')
+      await I.pressKey(['Shift', '/'])
+      await I.pressKey(['Shift', 'Divide'])
+      await I.pressKey(['Shift', 'Slash'])
 
-      await I.seeInField('Name', ';::=++***+++,<<<<-_-.>/?/?');
-    });
-  });
+      await I.seeInField('Name', ';::=++***+++,<<<<-_-.>/?/?')
+    })
+  })
 
   describe('#waitForEnabled', () => {
     it('should wait for input text field to be enabled', () =>
       I.amOnPage('/form/wait_enabled')
         .then(() => I.waitForEnabled('#text', 2))
         .then(() => I.fillField('#text', 'hello world'))
-        .then(() => I.seeInField('#text', 'hello world')));
+        .then(() => I.seeInField('#text', 'hello world')))
 
     it('should wait for input text field to be enabled by xpath', () =>
       I.amOnPage('/form/wait_enabled')
         .then(() => I.waitForEnabled("//*[@name = 'test']", 2))
         .then(() => I.fillField('#text', 'hello world'))
-        .then(() => I.seeInField('#text', 'hello world')));
+        .then(() => I.seeInField('#text', 'hello world')))
 
     it('should wait for a button to be enabled', () =>
       I.amOnPage('/form/wait_enabled')
         .then(() => I.waitForEnabled('#text', 2))
         .then(() => I.click('#button'))
-        .then(() => I.see('button was clicked', '#message')));
-  });
+        .then(() => I.see('button was clicked', '#message')))
+  })
 
   describe('#waitForDisabled', () => {
-    it('should wait for input text field to be disabled', () => I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)));
+    it('should wait for input text field to be disabled', () => I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)))
 
-    it('should wait for input text field to be enabled by xpath', () => I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled("//*[@name = 'test']", 1)));
+    it('should wait for input text field to be enabled by xpath', () => I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled("//*[@name = 'test']", 1)))
 
-    it('should wait for a button to be disabled', () => I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)));
-  });
+    it('should wait for a button to be disabled', () => I.amOnPage('/form/wait_disabled').then(() => I.waitForDisabled('#text', 1)))
+  })
 
   describe('#waitForValue', () => {
     it('should wait for expected value for given locator', () =>
@@ -747,106 +747,106 @@ describe('Playwright', function () {
         .then(() => I.waitForValue('//input[@name= "rus"]', 'Верно'))
         .then(() => I.waitForValue('//input[@name= "rus"]', 'Верно3', 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec');
-        }));
+          e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec')
+        }))
 
     it('should wait for expected value for given css locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.seeInField('#text', 'Hamburg'))
         .then(() => I.waitForValue('#text', 'Brisbane', 2.5))
-        .then(() => I.seeInField('#text', 'Brisbane')));
+        .then(() => I.seeInField('#text', 'Brisbane')))
 
     it('should wait for expected value for given xpath locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.seeInField('#text', 'Hamburg'))
         .then(() => I.waitForValue('//input[@value = "Grüße aus Hamburg"]', 'Brisbane', 2.5))
-        .then(() => I.seeInField('#text', 'Brisbane')));
+        .then(() => I.seeInField('#text', 'Brisbane')))
 
     it('should only wait for one of the matching elements to contain the value given xpath locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.waitForValue('//input[@type = "text"]', 'Brisbane', 4))
         .then(() => I.seeInField('#text', 'Brisbane'))
-        .then(() => I.seeInField('#text2', 'London')));
+        .then(() => I.seeInField('#text2', 'London')))
 
     it('should only wait for one of the matching elements to contain the value given css locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.waitForValue('.inputbox', 'Brisbane', 4))
         .then(() => I.seeInField('#text', 'Brisbane'))
-        .then(() => I.seeInField('#text2', 'London')));
-  });
+        .then(() => I.seeInField('#text2', 'London')))
+  })
 
   describe('#grabHTMLFrom', () => {
     it('should grab inner html from an element using xpath query', () =>
       I.amOnPage('/')
         .then(() => I.grabHTMLFrom('//title'))
-        .then(html => assert.equal(html, 'TestEd Beta 2.0')));
+        .then(html => assert.equal(html, 'TestEd Beta 2.0')))
 
     it('should grab inner html from an element using id query', () =>
       I.amOnPage('/')
         .then(() => I.grabHTMLFrom('#area1'))
-        .then(html => assert.equal(html.trim(), '<a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>')));
+        .then(html => assert.equal(html.trim(), '<a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>')))
 
     it('should grab inner html from multiple elements', () =>
       I.amOnPage('/')
         .then(() => I.grabHTMLFromAll('//a'))
-        .then(html => assert.equal(html.length, 5)));
+        .then(html => assert.equal(html.length, 5)))
 
     it('should grab inner html from within an iframe', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo({ frame: 'iframe' }))
         .then(() => I.grabHTMLFrom('#new-tab'))
-        .then(html => assert.equal(html.trim(), '<a href="/login" target="_blank">New tab</a>')));
-  });
+        .then(html => assert.equal(html.trim(), '<a href="/login" target="_blank">New tab</a>')))
+  })
 
   describe('#grabBrowserLogs', () => {
     it('should grab browser logs', () =>
       I.amOnPage('/')
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry');
+            console.log('Test log entry')
           }),
         )
         .then(() => I.grabBrowserLogs())
         .then(logs => {
-          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1);
-          assert.equal(matchingLogs.length, 1);
-        }));
+          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1)
+          assert.equal(matchingLogs.length, 1)
+        }))
 
     it('should grab browser logs in new tab', () =>
       I.amOnPage('/')
         .then(() => I.openNewTab())
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry');
+            console.log('Test log entry')
           }),
         )
         .then(() => I.grabBrowserLogs())
         .then(logs => {
-          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1);
-          assert.equal(matchingLogs.length, 1);
-        }));
+          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1)
+          assert.equal(matchingLogs.length, 1)
+        }))
 
     it('should grab browser logs in two tabs', () =>
       I.amOnPage('/')
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry 1');
+            console.log('Test log entry 1')
           }),
         )
         .then(() => I.openNewTab())
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry 2');
+            console.log('Test log entry 2')
           }),
         )
         .then(() => I.grabBrowserLogs())
         .then(logs => {
-          const matchingLogs = logs.filter(log => log.text().includes('Test log entry'));
-          assert.equal(matchingLogs.length, 2);
-        }));
+          const matchingLogs = logs.filter(log => log.text().includes('Test log entry'))
+          assert.equal(matchingLogs.length, 2)
+        }))
 
     it('should grab browser logs in next tab', () =>
       I.amOnPage('/info')
@@ -854,28 +854,28 @@ describe('Playwright', function () {
         .then(() => I.switchToNextTab())
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry');
+            console.log('Test log entry')
           }),
         )
         .then(() => I.grabBrowserLogs())
         .then(logs => {
-          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1);
-          assert.equal(matchingLogs.length, 1);
-        }));
-  });
+          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1)
+          assert.equal(matchingLogs.length, 1)
+        }))
+  })
 
   describe('#dragAndDrop', () => {
     it('Drag item from source to target (no iframe) @dragNdrop - customized steps', () =>
       I.amOnPage('https://jqueryui.com/resources/demos/droppable/default.html')
         .then(() => I.seeElementInDOM('#draggable'))
         .then(() => I.dragAndDrop('#draggable', '#droppable'))
-        .then(() => I.see('Dropped')));
+        .then(() => I.see('Dropped')))
 
     it('Drag item from source to target (no iframe) @dragNdrop - using Playwright API', () =>
       I.amOnPage('https://jqueryui.com/resources/demos/droppable/default.html')
         .then(() => I.seeElementInDOM('#draggable'))
         .then(() => I.dragAndDrop('#draggable', '#droppable', { force: true }))
-        .then(() => I.see('Dropped')));
+        .then(() => I.see('Dropped')))
 
     xit('Drag and drop from within an iframe', () =>
       I.amOnPage('https://jqueryui.com/droppable')
@@ -883,8 +883,8 @@ describe('Playwright', function () {
         .then(() => I.switchTo('//iframe[@class="demo-frame"]'))
         .then(() => I.seeElementInDOM('#draggable'))
         .then(() => I.dragAndDrop('#draggable', '#droppable'))
-        .then(() => I.see('Dropped')));
-  });
+        .then(() => I.see('Dropped')))
+  })
 
   describe('#switchTo frame', () => {
     it('should switch to frame using name', () =>
@@ -893,7 +893,7 @@ describe('Playwright', function () {
         .then(() => I.dontSee('Information', 'h1'))
         .then(() => I.switchTo('iframe'))
         .then(() => I.see('Information', 'h1'))
-        .then(() => I.dontSee('Iframe test', 'h1')));
+        .then(() => I.dontSee('Iframe test', 'h1')))
 
     it('should switch to root frame', () =>
       I.amOnPage('/iframe')
@@ -903,7 +903,7 @@ describe('Playwright', function () {
         .then(() => I.see('Information', 'h1'))
         .then(() => I.dontSee('Iframe test', 'h1'))
         .then(() => I.switchTo())
-        .then(() => I.see('Iframe test', 'h1')));
+        .then(() => I.see('Iframe test', 'h1')))
 
     it('should switch to frame using frame number', () =>
       I.amOnPage('/iframe')
@@ -911,197 +911,197 @@ describe('Playwright', function () {
         .then(() => I.dontSee('Information', 'h1'))
         .then(() => I.switchTo(0))
         .then(() => I.see('Information', 'h1'))
-        .then(() => I.dontSee('Iframe test', 'h1')));
-  });
+        .then(() => I.dontSee('Iframe test', 'h1')))
+  })
 
   describe('#dragSlider', () => {
     it('should drag scrubber to given position', async () => {
-      await I.amOnPage('/form/page_slider');
-      await I.seeElementInDOM('#slidecontainer input');
-      const before = await I.grabValueFrom('#slidecontainer input');
-      await I.dragSlider('#slidecontainer input', 20);
-      const after = await I.grabValueFrom('#slidecontainer input');
-      assert.notEqual(before, after);
-    });
-  });
+      await I.amOnPage('/form/page_slider')
+      await I.seeElementInDOM('#slidecontainer input')
+      const before = await I.grabValueFrom('#slidecontainer input')
+      await I.dragSlider('#slidecontainer input', 20)
+      const after = await I.grabValueFrom('#slidecontainer input')
+      assert.notEqual(before, after)
+    })
+  })
 
   describe('#uncheckOption', () => {
     it('should uncheck option that is currently checked', async () => {
-      await I.amOnPage('/info');
-      await I.uncheckOption('interesting');
-      await I.dontSeeCheckboxIsChecked('interesting');
-    });
+      await I.amOnPage('/info')
+      await I.uncheckOption('interesting')
+      await I.dontSeeCheckboxIsChecked('interesting')
+    })
 
     it('should NOT uncheck option that is NOT currently checked', async () => {
-      await I.amOnPage('/info');
-      await I.uncheckOption('interesting');
+      await I.amOnPage('/info')
+      await I.uncheckOption('interesting')
       // Unchecking again should not affect the current 'unchecked' status
-      await I.uncheckOption('interesting');
-      await I.dontSeeCheckboxIsChecked('interesting');
-    });
-  });
+      await I.uncheckOption('interesting')
+      await I.dontSeeCheckboxIsChecked('interesting')
+    })
+  })
 
   describe('#usePlaywrightTo', () => {
     it('should return title', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       const title = await I.usePlaywrightTo('test', async ({ page }) => {
-        return page.title();
-      });
-      assert.equal('TestEd Beta 2.0', title);
-    });
+        return page.title()
+      })
+      assert.equal('TestEd Beta 2.0', title)
+    })
 
     it('should pass expected parameters', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       const params = await I.usePlaywrightTo('test', async params => {
-        return params;
-      });
-      expect(params.page).to.exist;
-      expect(params.browserContext).to.exist;
-      expect(params.browser).to.exist;
-    });
-  });
+        return params
+      })
+      expect(params.page).to.exist
+      expect(params.browserContext).to.exist
+      expect(params.browser).to.exist
+    })
+  })
 
   describe('#mockRoute, #stopMockingRoute', () => {
     it('should mock a route', async () => {
-      await I.amOnPage('/form/fetch_call');
+      await I.amOnPage('/form/fetch_call')
       await I.mockRoute('https://reqres.in/api/comments/1', route => {
         route.fulfill({
           status: 200,
           headers: { 'Access-Control-Allow-Origin': '*' },
           contentType: 'application/json',
           body: '{"name": "this was mocked" }',
-        });
-      });
-      await I.click('GET COMMENTS');
-      await I.see('this was mocked');
-      await I.stopMockingRoute('https://reqres.in/api/comments/1');
-      await I.click('GET COMMENTS');
-      await I.see('data');
-      await I.dontSee('this was mocked');
-    });
-  });
+        })
+      })
+      await I.click('GET COMMENTS')
+      await I.see('this was mocked')
+      await I.stopMockingRoute('https://reqres.in/api/comments/1')
+      await I.click('GET COMMENTS')
+      await I.see('data')
+      await I.dontSee('this was mocked')
+    })
+  })
 
   describe('#makeApiRequest', () => {
     it('should make 3rd party API request', async () => {
-      const response = await I.makeApiRequest('get', 'https://reqres.in/api/users?page=2');
-      expect(response.status()).to.equal(200);
-      expect(await response.json()).to.include.keys(['page']);
-    });
+      const response = await I.makeApiRequest('get', 'https://reqres.in/api/users?page=2')
+      expect(response.status()).to.equal(200)
+      expect(await response.json()).to.include.keys(['page'])
+    })
 
     it('should make local API request', async () => {
-      const response = await I.makeApiRequest('get', '/form/fetch_call');
-      expect(response.status()).to.equal(200);
-    });
+      const response = await I.makeApiRequest('get', '/form/fetch_call')
+      expect(response.status()).to.equal(200)
+    })
 
     it('should convert to axios response with onResponse hook', async () => {
-      let response;
-      I.config.onResponse = resp => (response = resp);
-      await I.makeApiRequest('get', 'https://reqres.in/api/users?page=2');
-      expect(response).to.be.ok;
-      expect(response.status).to.equal(200);
-      expect(response.data).to.include.keys(['page', 'total']);
-    });
-  });
+      let response
+      I.config.onResponse = resp => (response = resp)
+      await I.makeApiRequest('get', 'https://reqres.in/api/users?page=2')
+      expect(response).to.be.ok
+      expect(response.status).to.equal(200)
+      expect(response.data).to.include.keys(['page', 'total'])
+    })
+  })
 
   describe('#grabElementBoundingRect', () => {
     it('should get the element bounding rectangle', async () => {
-      await I.amOnPage('/image');
-      const size = await I.grabElementBoundingRect('#logo');
-      expect(size.x).is.greaterThan(39); // 40 or more
-      expect(size.y).is.greaterThan(39);
-      expect(size.width).is.greaterThan(0);
-      expect(size.height).is.greaterThan(0);
-      expect(size.width).to.eql(100);
-      expect(size.height).to.eql(100);
-    });
+      await I.amOnPage('/image')
+      const size = await I.grabElementBoundingRect('#logo')
+      expect(size.x).is.greaterThan(39) // 40 or more
+      expect(size.y).is.greaterThan(39)
+      expect(size.width).is.greaterThan(0)
+      expect(size.height).is.greaterThan(0)
+      expect(size.width).to.eql(100)
+      expect(size.height).to.eql(100)
+    })
 
     it('should get the element width', async () => {
-      await I.amOnPage('/image');
-      const width = await I.grabElementBoundingRect('#logo', 'width');
-      expect(width).is.greaterThan(0);
-      expect(width).to.eql(100);
-    });
+      await I.amOnPage('/image')
+      const width = await I.grabElementBoundingRect('#logo', 'width')
+      expect(width).is.greaterThan(0)
+      expect(width).to.eql(100)
+    })
 
     it('should get the element height', async () => {
-      await I.amOnPage('/image');
-      const height = await I.grabElementBoundingRect('#logo', 'height');
-      expect(height).is.greaterThan(0);
-      expect(height).to.eql(100);
-    });
-  });
+      await I.amOnPage('/image')
+      const height = await I.grabElementBoundingRect('#logo', 'height')
+      expect(height).is.greaterThan(0)
+      expect(height).to.eql(100)
+    })
+  })
 
   describe('#handleDownloads - with passed folder', () => {
     before(() => {
       // create download folder;
-      global.output_dir = path.join(`${__dirname}/../data/output`);
+      global.output_dir = path.join(`${__dirname}/../data/output`)
 
-      FS = new FileSystem();
-      FS._before();
-      FS.amInPath('output/downloadHere');
-    });
+      FS = new FileSystem()
+      FS._before()
+      FS.amInPath('output/downloadHere')
+    })
 
     it('should download file', async () => {
-      await I.amOnPage('/form/download');
-      await I.handleDownloads('downloadHere/avatar.jpg');
-      await I.click('Download file');
-      await FS.waitForFile('avatar.jpg', 5);
-    });
-  });
+      await I.amOnPage('/form/download')
+      await I.handleDownloads('downloadHere/avatar.jpg')
+      await I.click('Download file')
+      await FS.waitForFile('avatar.jpg', 5)
+    })
+  })
 
   describe('#handleDownloads - with default folder', () => {
     before(() => {
       // create download folder;
-      global.output_dir = path.join(`${__dirname}/../data/output`);
+      global.output_dir = path.join(`${__dirname}/../data/output`)
 
-      FS = new FileSystem();
-      FS._before();
-      FS.amInPath('output');
-    });
+      FS = new FileSystem()
+      FS._before()
+      FS.amInPath('output')
+    })
 
     it('should download file', async () => {
-      await I.amOnPage('/form/download');
-      await I.handleDownloads('avatar.jpg');
-      await I.click('Download file');
-      await FS.waitForFile('avatar.jpg', 5);
-    });
-  });
+      await I.amOnPage('/form/download')
+      await I.handleDownloads('avatar.jpg')
+      await I.click('Download file')
+      await FS.waitForFile('avatar.jpg', 5)
+    })
+  })
 
   describe('#waitForURL', () => {
     it('should wait for URL', () => {
-      I.amOnPage('/');
-      I.click('More info');
-      I.waitForURL('/info');
-      I.see('Information');
-    });
+      I.amOnPage('/')
+      I.click('More info')
+      I.waitForURL('/info')
+      I.see('Information')
+    })
 
     it('should wait for regex URL', () => {
-      I.amOnPage('/');
-      I.click('More info');
-      I.waitForURL(/info/);
-      I.see('Information');
-    });
-  });
-});
+      I.amOnPage('/')
+      I.click('More info')
+      I.waitForURL(/info/)
+      I.see('Information')
+    })
+  })
+})
 
-let remoteBrowser;
+let remoteBrowser
 async function createRemoteBrowser() {
   if (remoteBrowser) {
-    await remoteBrowser.close();
+    await remoteBrowser.close()
   }
   remoteBrowser = await playwright.chromium.launchServer({
     webSocket: true,
     // args: ['--no-sandbox', '--disable-setuid-sandbox'],
     headless: true,
-  });
+  })
   remoteBrowser.on('disconnected', () => {
-    remoteBrowser = null;
-  });
-  return remoteBrowser;
+    remoteBrowser = null
+  })
+  return remoteBrowser
 }
 
 describe('Playwright (remote browser) websocket', function () {
-  this.timeout(35000);
-  this.retries(1);
+  this.timeout(35000)
+  this.retries(1)
 
   const helperConfig = {
     chromium: {
@@ -1117,86 +1117,86 @@ describe('Playwright (remote browser) websocket', function () {
     waitForTimeout: 5000,
     waitForAction: 500,
     windowSize: '500x700',
-  };
+  }
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
-    I = new Playwright(helperConfig);
-    I._init();
-  });
+    global.codecept_dir = path.join(__dirname, '/../data')
+    I = new Playwright(helperConfig)
+    I._init()
+  })
 
   beforeEach(async () => {
     // Mimick remote session by creating another browser instance
-    const remoteBrowser = await createRemoteBrowser();
+    const remoteBrowser = await createRemoteBrowser()
     // I.isRunning = false;
     // Set websocket endpoint to other browser instance
-  });
+  })
 
   afterEach(async () => {
-    await I._after();
-    return remoteBrowser && remoteBrowser.close();
-  });
+    await I._after()
+    return remoteBrowser && remoteBrowser.close()
+  })
 
   describe('#_startBrowser', () => {
     it('should throw an exception when endpoint is unreachable', async () => {
-      I._setConfig({ ...helperConfig, chromium: { browserWSEndpoint: 'ws://unreachable/' } });
+      I._setConfig({ ...helperConfig, chromium: { browserWSEndpoint: 'ws://unreachable/' } })
       try {
-        await I._startBrowser();
-        throw Error('It should never get this far');
+        await I._startBrowser()
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot connect to websocket');
+        e.message.should.include('Cannot connect to websocket')
       }
-    });
+    })
 
     it('should connect to legacy API endpoint', async () => {
-      const wsEndpoint = await remoteBrowser.wsEndpoint();
-      I._setConfig({ ...helperConfig, chromium: { browserWSEndpoint: { wsEndpoint } } });
-      await I._before();
-      await I.amOnPage('/');
-      await I.see('Welcome to test app');
-    });
+      const wsEndpoint = await remoteBrowser.wsEndpoint()
+      I._setConfig({ ...helperConfig, chromium: { browserWSEndpoint: { wsEndpoint } } })
+      await I._before()
+      await I.amOnPage('/')
+      await I.see('Welcome to test app')
+    })
 
     it('should connect to remote browsers', async () => {
-      helperConfig.chromium.browserWSEndpoint = await remoteBrowser.wsEndpoint();
-      I._setConfig(helperConfig);
+      helperConfig.chromium.browserWSEndpoint = await remoteBrowser.wsEndpoint()
+      I._setConfig(helperConfig)
 
-      await I._before();
-      await I.amOnPage('/');
-      await I.see('Welcome to test app');
-    });
+      await I._before()
+      await I.amOnPage('/')
+      await I.see('Welcome to test app')
+    })
 
     it('should manage pages in remote browser', async () => {
-      helperConfig.chromium.browserWSEndpoint = await remoteBrowser.wsEndpoint();
-      I._setConfig(helperConfig);
+      helperConfig.chromium.browserWSEndpoint = await remoteBrowser.wsEndpoint()
+      I._setConfig(helperConfig)
 
-      await I._before();
-      assert.ok(I.isRemoteBrowser);
-      const context = await I.browserContext;
+      await I._before()
+      assert.ok(I.isRemoteBrowser)
+      const context = await I.browserContext
       // Session was cleared
-      let currentPages = await context.pages();
-      assert.equal(currentPages.length, 1);
+      let currentPages = await context.pages()
+      assert.equal(currentPages.length, 1)
 
-      let numPages = await I.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
+      let numPages = await I.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
 
-      await I.openNewTab();
+      await I.openNewTab()
 
-      numPages = await I.grabNumberOfOpenTabs();
-      assert.equal(numPages, 2);
+      numPages = await I.grabNumberOfOpenTabs()
+      assert.equal(numPages, 2)
 
-      await I._stopBrowser();
+      await I._stopBrowser()
 
-      currentPages = await context.pages();
-      assert.equal(currentPages.length, 0);
-    });
-  });
-});
+      currentPages = await context.pages()
+      assert.equal(currentPages.length, 0)
+    })
+  })
+})
 
 describe('Playwright - BasicAuth', function () {
-  this.timeout(35000);
+  this.timeout(35000)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Playwright({
       url: 'http://localhost:8000',
@@ -1211,37 +1211,37 @@ describe('Playwright - BasicAuth', function () {
       },
       defaultPopupAction: 'accept',
       basicAuth: { username: 'admin', password: 'admin' },
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(() => {
     webApiTests.init({
       I,
       siteUrl,
-    });
+    })
     return I._before().then(() => {
-      page = I.page;
-    });
-  });
+      page = I.page
+    })
+  })
 
   afterEach(() => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   describe('open page with provided basic auth', () => {
     it('should be authenticated ', async () => {
-      await I.amOnPage('/basic_auth');
-      await I.see('You entered admin as your password.');
-    });
-  });
-});
+      await I.amOnPage('/basic_auth')
+      await I.see('You entered admin as your password.')
+    })
+  })
+})
 
 describe('Playwright - Emulation', () => {
   before(() => {
-    const { devices } = require('playwright');
-    global.codecept_dir = path.join(__dirname, '/../data');
+    const { devices } = require('playwright')
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Playwright({
       url: 'http://localhost:8000',
@@ -1255,32 +1255,32 @@ describe('Playwright - Emulation', () => {
       chrome: {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       },
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(() => {
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(() => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('should open page as iPhone ', async () => {
-    await I.amOnPage('/');
-    const width = await I.executeScript('window.innerWidth');
-    assert.equal(width, 980);
-  });
-});
+    await I.amOnPage('/')
+    const width = await I.executeScript('window.innerWidth')
+    assert.equal(width, 980)
+  })
+})
 
 describe('Playwright - PERSISTENT', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Playwright({
       url: 'http://localhost:8000',
@@ -1294,30 +1294,30 @@ describe('Playwright - PERSISTENT', () => {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
         userDataDir: '/tmp/playwright-tmp',
       },
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(() => {
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(() => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('should launch a persistent context', async () => {
-    assert.equal(I._getType(), 'BrowserContext');
-  });
-});
+    assert.equal(I._getType(), 'BrowserContext')
+  })
+})
 
 describe('Playwright - Electron', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Playwright({
       waitForTimeout: 5000,
@@ -1328,71 +1328,71 @@ describe('Playwright - Electron', () => {
         executablePath: require('electron'),
         args: [path.join(codecept_dir, '/electron/')],
       },
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   describe('#amOnPage', () => {
     it('should throw an error', async () => {
       try {
-        await I.amOnPage('/');
-        throw Error('It should never get this far');
+        await I.amOnPage('/')
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot open pages inside an Electron container');
+        e.message.should.include('Cannot open pages inside an Electron container')
       }
-    });
-  });
+    })
+  })
 
   describe('#openNewTab', () => {
     it('should throw an error', async () => {
       try {
-        await I.openNewTab();
-        throw Error('It should never get this far');
+        await I.openNewTab()
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot open new tabs inside an Electron container');
+        e.message.should.include('Cannot open new tabs inside an Electron container')
       }
-    });
-  });
+    })
+  })
 
   describe('#switchToNextTab', () => {
     it('should throw an error', async () => {
       try {
-        await I.switchToNextTab();
-        throw Error('It should never get this far');
+        await I.switchToNextTab()
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot switch tabs inside an Electron container');
+        e.message.should.include('Cannot switch tabs inside an Electron container')
       }
-    });
-  });
+    })
+  })
 
   describe('#switchToPreviousTab', () => {
     it('should throw an error', async () => {
       try {
-        await I.switchToNextTab();
-        throw Error('It should never get this far');
+        await I.switchToNextTab()
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot switch tabs inside an Electron container');
+        e.message.should.include('Cannot switch tabs inside an Electron container')
       }
-    });
-  });
+    })
+  })
 
   describe('#closeCurrentTab', () => {
     it('should throw an error', async () => {
       try {
-        await I.closeCurrentTab();
-        throw Error('It should never get this far');
+        await I.closeCurrentTab()
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot close current tab inside an Electron container');
+        e.message.should.include('Cannot close current tab inside an Electron container')
       }
-    });
-  });
-});
+    })
+  })
+})
 
 describe('Playwright - Performance Metrics', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
-    global.output_dir = path.join(`${__dirname}/../data/output`);
+    global.codecept_dir = path.join(__dirname, '/../data')
+    global.output_dir = path.join(`${__dirname}/../data/output`)
 
     I = new Playwright({
       url: siteUrl,
@@ -1400,40 +1400,40 @@ describe('Playwright - Performance Metrics', () => {
       show: false,
       restart: true,
       browser: 'chromium',
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     webApiTests.init({
       I,
       siteUrl,
-    });
+    })
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(async () => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('grabs performance metrics', async () => {
-    await I.amOnPage('https://codecept.io');
-    const metrics = await I.grabMetrics();
-    expect(metrics.length).to.greaterThan(0);
-    expect(metrics[0].name).to.equal('Timestamp');
-  });
-});
+    await I.amOnPage('https://codecept.io')
+    const metrics = await I.grabMetrics()
+    expect(metrics.length).to.greaterThan(0)
+    expect(metrics[0].name).to.equal('Timestamp')
+  })
+})
 
 describe('Playwright - Video & Trace & HAR', () => {
-  const test = { title: 'a failed test', artifacts: {} };
+  const test = { title: 'a failed test', artifacts: {} }
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
-    global.output_dir = path.join(`${__dirname}/../data/output`);
+    global.codecept_dir = path.join(__dirname, '/../data')
+    global.output_dir = path.join(`${__dirname}/../data/output`)
 
     I = new Playwright({
       url: siteUrl,
@@ -1450,49 +1450,49 @@ describe('Playwright - Video & Trace & HAR', () => {
         },
       },
       recordHar: {},
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     webApiTests.init({
       I,
       siteUrl,
-    });
-    deleteDir(path.join(global.output_dir, 'video'));
-    deleteDir(path.join(global.output_dir, 'trace'));
-    deleteDir(path.join(global.output_dir, 'har'));
+    })
+    deleteDir(path.join(global.output_dir, 'video'))
+    deleteDir(path.join(global.output_dir, 'trace'))
+    deleteDir(path.join(global.output_dir, 'har'))
     return I._before(test).then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(async () => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('checks that video is recorded', async () => {
-    await I.amOnPage('/');
-    await I.dontSee('this should be an error');
-    await I.click('More info');
-    await I.dontSee('this should be an error');
-    await I._failed(test);
-    assert(test.artifacts);
-    expect(Object.keys(test.artifacts)).to.include('trace');
-    expect(Object.keys(test.artifacts)).to.include('video');
-    expect(Object.keys(test.artifacts)).to.include('har');
+    await I.amOnPage('/')
+    await I.dontSee('this should be an error')
+    await I.click('More info')
+    await I.dontSee('this should be an error')
+    await I._failed(test)
+    assert(test.artifacts)
+    expect(Object.keys(test.artifacts)).to.include('trace')
+    expect(Object.keys(test.artifacts)).to.include('video')
+    expect(Object.keys(test.artifacts)).to.include('har')
 
-    assert.ok(fs.existsSync(test.artifacts.trace));
-    expect(test.artifacts.video).to.include(path.join(global.output_dir, 'video'));
-    expect(test.artifacts.trace).to.include(path.join(global.output_dir, 'trace'));
-    expect(test.artifacts.har).to.include(path.join(global.output_dir, 'har'));
-  });
-});
+    assert.ok(fs.existsSync(test.artifacts.trace))
+    expect(test.artifacts.video).to.include(path.join(global.output_dir, 'video'))
+    expect(test.artifacts.trace).to.include(path.join(global.output_dir, 'trace'))
+    expect(test.artifacts.har).to.include(path.join(global.output_dir, 'har'))
+  })
+})
 describe('Playwright - HAR', () => {
   before(() => {
-    global.codecept_dir = path.join(process.cwd());
+    global.codecept_dir = path.join(process.cwd())
 
     I = new Playwright({
       url: siteUrl,
@@ -1500,64 +1500,64 @@ describe('Playwright - HAR', () => {
       show: false,
       restart: true,
       browser: 'chromium',
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     webApiTests.init({
       I,
       siteUrl,
-    });
+    })
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(async () => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('replay from HAR - non existing file', async () => {
     try {
-      await I.replayFromHar('./non-existing-file.har');
-      await I.amOnPage('https://demo.playwright.dev/api-mocking');
+      await I.replayFromHar('./non-existing-file.har')
+      await I.amOnPage('https://demo.playwright.dev/api-mocking')
     } catch (e) {
-      expect(e.message).to.include('cannot be found on local system');
+      expect(e.message).to.include('cannot be found on local system')
     }
-  });
+  })
 
   it('replay from HAR', async () => {
-    const harFile = './test/data/sandbox/testHar.har';
-    await I.replayFromHar(harFile);
-    await I.amOnPage('https://demo.playwright.dev/api-mocking');
-    await I.see('CodeceptJS');
-  });
+    const harFile = './test/data/sandbox/testHar.har'
+    await I.replayFromHar(harFile)
+    await I.amOnPage('https://demo.playwright.dev/api-mocking')
+    await I.see('CodeceptJS')
+  })
 
   describe('#grabWebElements, #grabWebElement', () => {
     it('should return an array of WebElement', async () => {
-      await I.amOnPage('/form/focus_blur_elements');
+      await I.amOnPage('/form/focus_blur_elements')
 
-      const webElements = await I.grabWebElements('#button');
-      assert.equal(webElements[0], "locator('#button').first()");
-      assert.isAbove(webElements.length, 0);
-    });
+      const webElements = await I.grabWebElements('#button')
+      assert.equal(webElements[0], "locator('#button').first()")
+      assert.isAbove(webElements.length, 0)
+    })
 
     it('should return a WebElement', async () => {
-      await I.amOnPage('/form/focus_blur_elements');
+      await I.amOnPage('/form/focus_blur_elements')
 
-      const webElement = await I.grabWebElement('#button');
-      assert.equal(webElement, "locator('#button').first()");
-    });
-  });
-});
+      const webElement = await I.grabWebElement('#button')
+      assert.equal(webElement, "locator('#button').first()")
+    })
+  })
+})
 
 describe('using data-testid attribute', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
-    global.output_dir = path.join(`${__dirname}/../data/output`);
+    global.codecept_dir = path.join(__dirname, '/../data')
+    global.output_dir = path.join(`${__dirname}/../data/output`)
 
     I = new Playwright({
       url: siteUrl,
@@ -1565,35 +1565,35 @@ describe('using data-testid attribute', () => {
       show: false,
       restart: true,
       browser: 'chromium',
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(async () => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('should find element by pw locator', async () => {
-    await I.amOnPage('/');
+    await I.amOnPage('/')
 
-    const webElements = await I.grabWebElements({ pw: '[data-testid="welcome"]' });
-    assert.equal(webElements[0]._selector, '[data-testid="welcome"] >> nth=0');
-    assert.equal(webElements.length, 1);
-  });
+    const webElements = await I.grabWebElements({ pw: '[data-testid="welcome"]' })
+    assert.equal(webElements[0]._selector, '[data-testid="welcome"] >> nth=0')
+    assert.equal(webElements.length, 1)
+  })
 
   it('should find element by h1[data-testid="welcome"]', async () => {
-    await I.amOnPage('/');
+    await I.amOnPage('/')
 
-    const webElements = await I.grabWebElements('h1[data-testid="welcome"]');
-    assert.equal(webElements[0]._selector, 'h1[data-testid="welcome"] >> nth=0');
-    assert.equal(webElements.length, 1);
-  });
-});
+    const webElements = await I.grabWebElements('h1[data-testid="welcome"]')
+    assert.equal(webElements[0]._selector, 'h1[data-testid="welcome"] >> nth=0')
+    assert.equal(webElements.length, 1)
+  })
+})

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -1,32 +1,32 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const assert = chai.assert;
-const path = require('path');
+const expect = chai.expect
+const assert = chai.assert
+const path = require('path')
 
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer')
 
-const fs = require('fs');
-const TestHelper = require('../support/TestHelper');
-const Puppeteer = require('../../lib/helper/Puppeteer');
+const fs = require('fs')
+const TestHelper = require('../support/TestHelper')
+const Puppeteer = require('../../lib/helper/Puppeteer')
 
-const AssertionFailedError = require('../../lib/assert/error');
-const webApiTests = require('./webapi');
-const Secret = require('../../lib/secret');
-const { deleteDir } = require('../../lib/utils');
-global.codeceptjs = require('../../lib');
+const AssertionFailedError = require('../../lib/assert/error')
+const webApiTests = require('./webapi')
+const Secret = require('../../lib/secret')
+const { deleteDir } = require('../../lib/utils')
+global.codeceptjs = require('../../lib')
 
-let I;
-let browser;
-let page;
-let FS;
-const siteUrl = TestHelper.siteUrl();
+let I
+let browser
+let page
+let FS
+const siteUrl = TestHelper.siteUrl()
 
 describe('Puppeteer - BasicAuth', function () {
-  this.timeout(10000);
+  this.timeout(10000)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Puppeteer({
       url: siteUrl,
@@ -39,44 +39,44 @@ describe('Puppeteer - BasicAuth', function () {
       },
       defaultPopupAction: 'accept',
       basicAuth: { username: 'admin', password: 'admin' },
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(() => {
     webApiTests.init({
       I,
       siteUrl,
-    });
+    })
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(() => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   describe('open page with provided basic auth', () => {
     it('should be authenticated ', async () => {
-      await I.amOnPage('/basic_auth');
-      await I.see('You entered admin as your password.');
-    });
+      await I.amOnPage('/basic_auth')
+      await I.see('You entered admin as your password.')
+    })
     it('should be authenticated on second run', async () => {
-      await I.amOnPage('/basic_auth');
-      await I.see('You entered admin as your password.');
-    });
-  });
-});
+      await I.amOnPage('/basic_auth')
+      await I.see('You entered admin as your password.')
+    })
+  })
+})
 
 describe('Puppeteer', function () {
-  this.timeout(35000);
-  this.retries(1);
+  this.timeout(35000)
+  this.retries(1)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
 
     I = new Puppeteer({
       url: siteUrl,
@@ -88,92 +88,92 @@ describe('Puppeteer', function () {
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
       },
       defaultPopupAction: 'accept',
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(() => {
     webApiTests.init({
       I,
       siteUrl,
-    });
+    })
     return I._before().then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(() => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   describe('Session', () => {
     it('should not fail for localStorage.clear() on about:blank', async () => {
-      I.options.restart = false;
+      I.options.restart = false
       return I.page
         .goto('about:blank')
         .then(() => I._after())
         .then(() => {
-          I.options.restart = true;
+          I.options.restart = true
         })
         .catch(e => {
-          I.options.restart = true;
-          throw new Error(e);
-        });
-    });
-  });
+          I.options.restart = true
+          throw new Error(e)
+        })
+    })
+  })
 
   describe('open page : #amOnPage', () => {
     it('should open main page of configured site', async () => {
-      await I.amOnPage('/');
-      const url = await page.url();
-      await url.should.eql(`${siteUrl}/`);
-    });
+      await I.amOnPage('/')
+      const url = await page.url()
+      await url.should.eql(`${siteUrl}/`)
+    })
     it('should open any page of configured site', async () => {
-      await I.amOnPage('/info');
-      const url = await page.url();
-      return url.should.eql(`${siteUrl}/info`);
-    });
+      await I.amOnPage('/info')
+      const url = await page.url()
+      return url.should.eql(`${siteUrl}/info`)
+    })
 
     it('should open absolute url', async () => {
-      await I.amOnPage(siteUrl);
-      const url = await page.url();
-      return url.should.eql(`${siteUrl}/`);
-    });
+      await I.amOnPage(siteUrl)
+      const url = await page.url()
+      return url.should.eql(`${siteUrl}/`)
+    })
 
     it('should be unauthenticated ', async () => {
       try {
-        await I.amOnPage('/basic_auth');
-        await I.dontSee('You entered admin as your password.');
+        await I.amOnPage('/basic_auth')
+        await I.dontSee('You entered admin as your password.')
       } catch (e) {
-        expect(e.message).to.eq('net::ERR_INVALID_AUTH_CREDENTIALS at http://localhost:8000/basic_auth');
+        expect(e.message).to.eq('net::ERR_INVALID_AUTH_CREDENTIALS at http://localhost:8000/basic_auth')
       }
-    });
-  });
+    })
+  })
 
   describe('grabDataFromPerformanceTiming', () => {
     it('should return data from performance timing', async () => {
-      await I.amOnPage('/');
-      const res = await I.grabDataFromPerformanceTiming();
-      expect(res).to.have.property('responseEnd');
-      expect(res).to.have.property('domInteractive');
-      expect(res).to.have.property('domContentLoadedEventEnd');
-      expect(res).to.have.property('loadEventEnd');
-    });
-  });
+      await I.amOnPage('/')
+      const res = await I.grabDataFromPerformanceTiming()
+      expect(res).to.have.property('responseEnd')
+      expect(res).to.have.property('domInteractive')
+      expect(res).to.have.property('domContentLoadedEventEnd')
+      expect(res).to.have.property('loadEventEnd')
+    })
+  })
 
-  webApiTests.tests();
+  webApiTests.tests()
 
   describe('#waitForFunction', () => {
     it('should wait for function returns true', () => {
-      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(() => window.__waitJs, 3));
-    });
+      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(() => window.__waitJs, 3))
+    })
 
     it('should pass arguments and wait for function returns true', () => {
-      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(varName => window[varName], ['__waitJs'], 3));
-    });
-  });
+      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(varName => window[varName], ['__waitJs'], 3))
+    })
+  })
 
   describe('#waitToHide', () => {
     it('should wait for hidden element', () => {
@@ -181,69 +181,69 @@ describe('Puppeteer', function () {
         .then(() => I.see('Step One Button'))
         .then(() => I.waitToHide('#step_1', 2))
         .then(() => I.dontSeeElement('#step_1'))
-        .then(() => I.dontSee('Step One Button'));
-    });
+        .then(() => I.dontSee('Step One Button'))
+    })
 
     it('should wait for hidden element by XPath', () => {
       return I.amOnPage('/form/wait_invisible')
         .then(() => I.see('Step One Button'))
         .then(() => I.waitToHide('//div[@id="step_1"]', 2))
         .then(() => I.dontSeeElement('//div[@id="step_1"]'))
-        .then(() => I.dontSee('Step One Button'));
-    });
-  });
+        .then(() => I.dontSee('Step One Button'))
+    })
+  })
 
   describe('#waitNumberOfVisibleElements', () => {
     it('should wait for a specified number of elements on the page', async () => {
       try {
-        await I.amOnPage('/info');
-        await I.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3);
+        await I.amOnPage('/info')
+        await I.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3)
       } catch (e) {
-        e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec');
+        e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec')
       }
-    });
+    })
 
     it('should wait for a specified number of elements on the page using a css selector', () =>
       I.amOnPage('/info')
         .then(() => I.waitNumberOfVisibleElements('#grab-multiple > a', 3))
         .then(() => I.waitNumberOfVisibleElements('#grab-multiple > a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec');
-        }));
+          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec')
+        }))
 
     it('should wait for a specified number of elements which are not yet attached to the DOM', () =>
       I.amOnPage('/form/wait_num_elements')
         .then(() => I.waitNumberOfVisibleElements('.title', 2, 3))
         .then(() => I.see('Hello'))
-        .then(() => I.see('World')));
+        .then(() => I.see('World')))
 
     it('should wait for 0 number of visible elements', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.waitNumberOfVisibleElements('#step_1', 0);
-    });
-  });
+      await I.amOnPage('/form/wait_invisible')
+      await I.waitNumberOfVisibleElements('#step_1', 0)
+    })
+  })
 
   describe('#moveCursorTo', () => {
     it('should trigger hover event', () =>
       I.amOnPage('/form/hover')
         .then(() => I.moveCursorTo('#hover'))
-        .then(() => I.see('Hovered', '#show')));
+        .then(() => I.see('Hovered', '#show')))
 
     it('should not trigger hover event because of the offset is beyond the element', () =>
       I.amOnPage('/form/hover')
         .then(() => I.moveCursorTo('#hover', 100, 100))
-        .then(() => I.dontSee('Hovered', '#show')));
-  });
+        .then(() => I.dontSee('Hovered', '#show')))
+  })
 
   describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', () =>
       I.amOnPage('/')
         .then(() => I.wait(1))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => expect(numPages).to.eq(1)));
+        .then(numPages => expect(numPages).to.eq(1)))
 
     it('should switch to next tab', () =>
       I.amOnPage('/info')
@@ -255,7 +255,7 @@ describe('Puppeteer', function () {
         .then(() => I.waitForNumberOfTabs(2))
         .then(() => I.seeCurrentUrlEquals('/login'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => expect(numPages).to.eq(2)));
+        .then(numPages => expect(numPages).to.eq(2)))
 
     it('should assert when there is no ability to switch to next tab', () =>
       I.amOnPage('/')
@@ -265,8 +265,8 @@ describe('Puppeteer', function () {
         .then(() => I.wait(2))
         .then(() => expect(true, 'Throw an error if it gets this far (which it should not)!').to.eq(false))
         .catch(e => {
-          expect(e.message).to.eq('There is no ability to switch to next tab with offset 2');
-        }));
+          expect(e.message).to.eq('There is no ability to switch to next tab with offset 2')
+        }))
 
     it('should close current tab', () =>
       I.amOnPage('/info')
@@ -280,7 +280,7 @@ describe('Puppeteer', function () {
         .then(() => I.wait(1))
         .then(() => I.seeInCurrentUrl('/info'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => expect(numPages).to.eq(1)));
+        .then(numPages => expect(numPages).to.eq(1)))
 
     it('should close other tabs', () =>
       I.amOnPage('/')
@@ -296,7 +296,7 @@ describe('Puppeteer', function () {
         .then(() => I.wait(1))
         .then(() => I.seeInCurrentUrl('/login'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => expect(numPages).to.eq(1)));
+        .then(numPages => expect(numPages).to.eq(1)))
 
     it('should open new tab', () =>
       I.amOnPage('/info')
@@ -304,7 +304,7 @@ describe('Puppeteer', function () {
         .then(() => I.wait(1))
         .then(() => I.seeInCurrentUrl('about:blank'))
         .then(() => I.grabNumberOfOpenTabs())
-        .then(numPages => expect(numPages).to.eq(2)));
+        .then(numPages => expect(numPages).to.eq(2)))
 
     it('should switch to previous tab', () =>
       I.amOnPage('/info')
@@ -313,7 +313,7 @@ describe('Puppeteer', function () {
         .then(() => I.seeInCurrentUrl('about:blank'))
         .then(() => I.switchToPreviousTab())
         .then(() => I.wait(2))
-        .then(() => I.seeInCurrentUrl('/info')));
+        .then(() => I.seeInCurrentUrl('/info')))
 
     it('should assert when there is no ability to switch to previous tab', () =>
       I.amOnPage('/info')
@@ -324,9 +324,9 @@ describe('Puppeteer', function () {
         .then(() => I.wait(2))
         .then(() => I.waitInUrl('/info'))
         .catch(e => {
-          expect(e.message).to.eq('There is no ability to switch to previous tab with offset 2');
-        }));
-  });
+          expect(e.message).to.eq('There is no ability to switch to previous tab with offset 2')
+        }))
+  })
 
   describe('popup : #acceptPopup, #seeInPopup, #cancelPopup, #grabPopupText', () => {
     it('should accept popup window', () =>
@@ -334,67 +334,67 @@ describe('Puppeteer', function () {
         .then(() => I.amAcceptingPopups())
         .then(() => I.click('Confirm'))
         .then(() => I.acceptPopup())
-        .then(() => I.see('Yes', '#result')));
+        .then(() => I.see('Yes', '#result')))
 
     it('should accept popup window (using default popup action type)', () =>
       I.amOnPage('/form/popup')
         .then(() => I.click('Confirm'))
         .then(() => I.acceptPopup())
-        .then(() => I.see('Yes', '#result')));
+        .then(() => I.see('Yes', '#result')))
 
     it('should cancel popup', () =>
       I.amOnPage('/form/popup')
         .then(() => I.amCancellingPopups())
         .then(() => I.click('Confirm'))
         .then(() => I.cancelPopup())
-        .then(() => I.see('No', '#result')));
+        .then(() => I.see('No', '#result')))
 
     it('should check text in popup', () =>
       I.amOnPage('/form/popup')
         .then(() => I.amCancellingPopups())
         .then(() => I.click('Alert'))
         .then(() => I.seeInPopup('Really?'))
-        .then(() => I.cancelPopup()));
+        .then(() => I.cancelPopup()))
 
     it('should grab text from popup', () =>
       I.amOnPage('/form/popup')
         .then(() => I.amCancellingPopups())
         .then(() => I.click('Alert'))
         .then(() => I.grabPopupText())
-        .then(text => assert.equal(text, 'Really?')));
+        .then(text => assert.equal(text, 'Really?')))
 
     it('should return null if no popup is visible (do not throw an error)', () =>
       I.amOnPage('/form/popup')
         .then(() => I.grabPopupText())
-        .then(text => assert.equal(text, null)));
-  });
+        .then(text => assert.equal(text, null)))
+  })
 
   describe('#seeNumberOfElements', () => {
-    it('should return 1 as count', () => I.amOnPage('/').then(() => I.seeNumberOfElements('#area1', 1)));
-  });
+    it('should return 1 as count', () => I.amOnPage('/').then(() => I.seeNumberOfElements('#area1', 1)))
+  })
 
   describe('#switchTo', () => {
     it('should switch reference to iframe content', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo('[name="content"]'))
         .then(() => I.see('Information'))
-        .then(() => I.see('Lots of valuable data here')));
+        .then(() => I.see('Lots of valuable data here')))
 
     it('should return error if iframe selector is invalid', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo('#invalidIframeSelector'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath');
-        }));
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath')
+        }))
 
     it('should return error if iframe selector is not iframe', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo('h1'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath');
-        }));
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath')
+        }))
 
     it('should return to parent frame given a null locator', () =>
       I.amOnPage('/iframe')
@@ -402,20 +402,20 @@ describe('Puppeteer', function () {
         .then(() => I.see('Information'))
         .then(() => I.see('Lots of valuable data here'))
         .then(() => I.switchTo(null))
-        .then(() => I.see('Iframe test')));
-  });
+        .then(() => I.see('Iframe test')))
+  })
 
   describe('#seeInSource, #grabSource', () => {
     it('should check for text to be in HTML source', () =>
       I.amOnPage('/')
         .then(() => I.seeInSource('<title>TestEd Beta 2.0</title>'))
-        .then(() => I.dontSeeInSource('<meta')));
+        .then(() => I.dontSeeInSource('<meta')))
 
     it('should grab the source', () =>
       I.amOnPage('/')
         .then(() => I.grabSource())
-        .then(source => assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')));
-  });
+        .then(source => assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')))
+  })
 
   describe('#seeTitleEquals', () => {
     it('should check that title is equal to provided one', () =>
@@ -424,10 +424,10 @@ describe('Puppeteer', function () {
         .then(() => I.seeTitleEquals('TestEd Beta 2.'))
         .then(() => assert.equal(true, false, 'Throw an error because it should not get this far!'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('expected web page title "TestEd Beta 2.0" to equal "TestEd Beta 2."');
-        }));
-  });
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('expected web page title "TestEd Beta 2.0" to equal "TestEd Beta 2."')
+        }))
+  })
 
   describe('#seeTextEquals', () => {
     it('should check text is equal to provided one', () =>
@@ -436,290 +436,290 @@ describe('Puppeteer', function () {
         .then(() => I.seeTextEquals('Welcome to test app', 'h1'))
         .then(() => assert.equal(true, false, 'Throw an error because it should not get this far!'))
         .catch(e => {
-          e.should.be.instanceOf(Error);
-          e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"');
-        }));
-  });
+          e.should.be.instanceOf(Error)
+          e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"')
+        }))
+  })
 
   describe('#_locateClickable', () => {
     it('should locate a button to click', () =>
       I.amOnPage('/form/checkbox')
         .then(() => I._locateClickable('Submit'))
         .then(res => {
-          res.length.should.be.equal(1);
-        }));
+          res.length.should.be.equal(1)
+        }))
 
     it('should not locate a non-existing checkbox using _locateClickable', () =>
       I.amOnPage('/form/checkbox')
         .then(() => I._locateClickable('I disagree'))
-        .then(res => res.length.should.be.equal(0)));
-  });
+        .then(res => res.length.should.be.equal(0)))
+  })
 
   describe('#_locateCheckable', () => {
     it('should locate a checkbox', () =>
       I.amOnPage('/form/checkbox')
         .then(() => I._locateCheckable('I Agree'))
-        .then(res => res.should.be.ok));
-  });
+        .then(res => res.should.be.ok))
+  })
 
   describe('#_locateFields', () => {
     it('should locate a field', () =>
       I.amOnPage('/form/field')
         .then(() => I._locateFields('Name'))
-        .then(res => res.length.should.be.equal(1)));
+        .then(res => res.length.should.be.equal(1)))
 
     it('should not locate a non-existing field', () =>
       I.amOnPage('/form/field')
         .then(() => I._locateFields('Mother-in-law'))
-        .then(res => res.length.should.be.equal(0)));
-  });
+        .then(res => res.length.should.be.equal(0)))
+  })
 
   describe('check fields: #seeInField, #seeCheckboxIsChecked, ...', () => {
     it('should throw error if field is not empty', () =>
       I.amOnPage('/form/empty')
         .then(() => I.seeInField('#empty_input', 'Ayayay'))
         .catch(e => {
-          e.should.be.instanceOf(AssertionFailedError);
-          e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"');
-        }));
+          e.should.be.instanceOf(AssertionFailedError)
+          e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"')
+        }))
 
     it('should check values in checkboxes', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.dontSeeInField('checkbox[]', 'not seen one');
-      await I.seeInField('checkbox[]', 'see test one');
-      await I.dontSeeInField('checkbox[]', 'not seen two');
-      await I.seeInField('checkbox[]', 'see test two');
-      await I.dontSeeInField('checkbox[]', 'not seen three');
-      await I.seeInField('checkbox[]', 'see test three');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.dontSeeInField('checkbox[]', 'not seen one')
+      await I.seeInField('checkbox[]', 'see test one')
+      await I.dontSeeInField('checkbox[]', 'not seen two')
+      await I.seeInField('checkbox[]', 'see test two')
+      await I.dontSeeInField('checkbox[]', 'not seen three')
+      await I.seeInField('checkbox[]', 'see test three')
+    })
 
     it('should check values are the secret type in checkboxes', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.dontSeeInField('checkbox[]', Secret.secret('not seen one'));
-      await I.seeInField('checkbox[]', Secret.secret('see test one'));
-      await I.dontSeeInField('checkbox[]', Secret.secret('not seen two'));
-      await I.seeInField('checkbox[]', Secret.secret('see test two'));
-      await I.dontSeeInField('checkbox[]', Secret.secret('not seen three'));
-      await I.seeInField('checkbox[]', Secret.secret('see test three'));
-    });
+      await I.amOnPage('/form/field_values')
+      await I.dontSeeInField('checkbox[]', Secret.secret('not seen one'))
+      await I.seeInField('checkbox[]', Secret.secret('see test one'))
+      await I.dontSeeInField('checkbox[]', Secret.secret('not seen two'))
+      await I.seeInField('checkbox[]', Secret.secret('see test two'))
+      await I.dontSeeInField('checkbox[]', Secret.secret('not seen three'))
+      await I.seeInField('checkbox[]', Secret.secret('see test three'))
+    })
 
     it('should check values with boolean', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('checkbox1', true);
-      await I.dontSeeInField('checkbox1', false);
-      await I.seeInField('checkbox2', false);
-      await I.dontSeeInField('checkbox2', true);
-      await I.seeInField('radio2', true);
-      await I.dontSeeInField('radio2', false);
-      await I.seeInField('radio3', false);
-      await I.dontSeeInField('radio3', true);
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('checkbox1', true)
+      await I.dontSeeInField('checkbox1', false)
+      await I.seeInField('checkbox2', false)
+      await I.dontSeeInField('checkbox2', true)
+      await I.seeInField('radio2', true)
+      await I.dontSeeInField('radio2', false)
+      await I.seeInField('radio3', false)
+      await I.dontSeeInField('radio3', true)
+    })
 
     it('should check values in radio', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('radio1', 'see test one');
-      await I.dontSeeInField('radio1', 'not seen one');
-      await I.dontSeeInField('radio1', 'not seen two');
-      await I.dontSeeInField('radio1', 'not seen three');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('radio1', 'see test one')
+      await I.dontSeeInField('radio1', 'not seen one')
+      await I.dontSeeInField('radio1', 'not seen two')
+      await I.dontSeeInField('radio1', 'not seen three')
+    })
 
     it('should check values in select', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('select1', 'see test one');
-      await I.dontSeeInField('select1', 'not seen one');
-      await I.dontSeeInField('select1', 'not seen two');
-      await I.dontSeeInField('select1', 'not seen three');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('select1', 'see test one')
+      await I.dontSeeInField('select1', 'not seen one')
+      await I.dontSeeInField('select1', 'not seen two')
+      await I.dontSeeInField('select1', 'not seen three')
+    })
 
     it('should check for empty select field', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.seeInField('select3', '');
-    });
+      await I.amOnPage('/form/field_values')
+      await I.seeInField('select3', '')
+    })
 
     it('should check for select multiple field', async () => {
-      await I.amOnPage('/form/field_values');
-      await I.dontSeeInField('select2', 'not seen one');
-      await I.seeInField('select2', 'see test one');
-      await I.dontSeeInField('select2', 'not seen two');
-      await I.seeInField('select2', 'see test two');
-      await I.dontSeeInField('select2', 'not seen three');
-      await I.seeInField('select2', 'see test three');
-    });
-  });
+      await I.amOnPage('/form/field_values')
+      await I.dontSeeInField('select2', 'not seen one')
+      await I.seeInField('select2', 'see test one')
+      await I.dontSeeInField('select2', 'not seen two')
+      await I.seeInField('select2', 'see test two')
+      await I.dontSeeInField('select2', 'not seen three')
+      await I.seeInField('select2', 'see test three')
+    })
+  })
 
   describe('#pressKey, #pressKeyDown, #pressKeyUp', () => {
     it('should be able to send special keys to element', async () => {
-      await I.amOnPage('/form/field');
-      await I.appendField('Name', '-');
+      await I.amOnPage('/form/field')
+      await I.appendField('Name', '-')
 
-      await I.pressKey(['Right Shift', 'Home']);
-      await I.pressKey('Delete');
+      await I.pressKey(['Right Shift', 'Home'])
+      await I.pressKey('Delete')
 
       // Sequence only executes up to first non-modifier key ('Digit1')
-      await I.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4']);
-      await I.pressKey('1');
-      await I.pressKey('2');
-      await I.pressKey('3');
-      await I.pressKey('ArrowLeft');
-      await I.pressKey('Left Arrow');
-      await I.pressKey('arrow_left');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('a');
-      await I.pressKey('KeyB');
-      await I.pressKeyUp('ShiftLeft');
-      await I.pressKey('C');
-      await I.seeInField('Name', '!ABC123');
-    });
+      await I.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4'])
+      await I.pressKey('1')
+      await I.pressKey('2')
+      await I.pressKey('3')
+      await I.pressKey('ArrowLeft')
+      await I.pressKey('Left Arrow')
+      await I.pressKey('arrow_left')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('a')
+      await I.pressKey('KeyB')
+      await I.pressKeyUp('ShiftLeft')
+      await I.pressKey('C')
+      await I.seeInField('Name', '!ABC123')
+    })
 
     it('should use modifier key based on operating system', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', 'value that is cleared using select all shortcut');
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', 'value that is cleared using select all shortcut')
 
-      await I.pressKey(['ControlOrCommand', 'a']);
-      await I.pressKey('Backspace');
-      await I.dontSeeInField('Name', 'value that is cleared using select all shortcut');
-    });
+      await I.pressKey(['ControlOrCommand', 'a'])
+      await I.pressKey('Backspace')
+      await I.dontSeeInField('Name', 'value that is cleared using select all shortcut')
+    })
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', '');
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', '')
 
-      await I.pressKey(';');
-      await I.pressKey(['Shift', ';']);
-      await I.pressKey(['Shift', 'Semicolon']);
-      await I.pressKey('=');
-      await I.pressKey(['Shift', '=']);
-      await I.pressKey(['Shift', 'Equal']);
-      await I.pressKey('*');
-      await I.pressKey(['Shift', '*']);
-      await I.pressKey(['Shift', 'Multiply']);
-      await I.pressKey('+');
-      await I.pressKey(['Shift', '+']);
-      await I.pressKey(['Shift', 'Add']);
-      await I.pressKey(',');
-      await I.pressKey(['Shift', ',']);
-      await I.pressKey(['Shift', 'Comma']);
-      await I.pressKey(['Shift', 'NumpadComma']);
-      await I.pressKey(['Shift', 'Separator']);
-      await I.pressKey('-');
-      await I.pressKey(['Shift', '-']);
-      await I.pressKey(['Shift', 'Subtract']);
-      await I.pressKey('.');
-      await I.pressKey(['Shift', '.']);
-      await I.pressKey(['Shift', 'Decimal']);
-      await I.pressKey(['Shift', 'Period']);
-      await I.pressKey('/');
-      await I.pressKey(['Shift', '/']);
-      await I.pressKey(['Shift', 'Divide']);
-      await I.pressKey(['Shift', 'Slash']);
+      await I.pressKey(';')
+      await I.pressKey(['Shift', ';'])
+      await I.pressKey(['Shift', 'Semicolon'])
+      await I.pressKey('=')
+      await I.pressKey(['Shift', '='])
+      await I.pressKey(['Shift', 'Equal'])
+      await I.pressKey('*')
+      await I.pressKey(['Shift', '*'])
+      await I.pressKey(['Shift', 'Multiply'])
+      await I.pressKey('+')
+      await I.pressKey(['Shift', '+'])
+      await I.pressKey(['Shift', 'Add'])
+      await I.pressKey(',')
+      await I.pressKey(['Shift', ','])
+      await I.pressKey(['Shift', 'Comma'])
+      await I.pressKey(['Shift', 'NumpadComma'])
+      await I.pressKey(['Shift', 'Separator'])
+      await I.pressKey('-')
+      await I.pressKey(['Shift', '-'])
+      await I.pressKey(['Shift', 'Subtract'])
+      await I.pressKey('.')
+      await I.pressKey(['Shift', '.'])
+      await I.pressKey(['Shift', 'Decimal'])
+      await I.pressKey(['Shift', 'Period'])
+      await I.pressKey('/')
+      await I.pressKey(['Shift', '/'])
+      await I.pressKey(['Shift', 'Divide'])
+      await I.pressKey(['Shift', 'Slash'])
 
-      await I.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?');
-    });
+      await I.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?')
+    })
 
     it('should show correct number key when Shift modifier is active', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', '');
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', '')
 
-      await I.pressKey('0');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('0');
-      await I.pressKey('Digit0');
-      await I.pressKey('Numpad0');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('0')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('0')
+      await I.pressKey('Digit0')
+      await I.pressKey('Numpad0')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('1');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('1');
-      await I.pressKey('Digit1');
-      await I.pressKey('Numpad1');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('1')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('1')
+      await I.pressKey('Digit1')
+      await I.pressKey('Numpad1')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('2');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('2');
-      await I.pressKey('Digit2');
-      await I.pressKey('Numpad2');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('2')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('2')
+      await I.pressKey('Digit2')
+      await I.pressKey('Numpad2')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('3');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('3');
-      await I.pressKey('Digit3');
-      await I.pressKey('Numpad3');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('3')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('3')
+      await I.pressKey('Digit3')
+      await I.pressKey('Numpad3')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('4');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('4');
-      await I.pressKey('Digit4');
-      await I.pressKey('Numpad4');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('4')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('4')
+      await I.pressKey('Digit4')
+      await I.pressKey('Numpad4')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('5');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('5');
-      await I.pressKey('Digit5');
-      await I.pressKey('Numpad5');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('5')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('5')
+      await I.pressKey('Digit5')
+      await I.pressKey('Numpad5')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('6');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('6');
-      await I.pressKey('Digit6');
-      await I.pressKey('Numpad6');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('6')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('6')
+      await I.pressKey('Digit6')
+      await I.pressKey('Numpad6')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('7');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('7');
-      await I.pressKey('Digit7');
-      await I.pressKey('Numpad7');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('7')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('7')
+      await I.pressKey('Digit7')
+      await I.pressKey('Numpad7')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('8');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('8');
-      await I.pressKey('Digit8');
-      await I.pressKey('Numpad8');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('8')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('8')
+      await I.pressKey('Digit8')
+      await I.pressKey('Numpad8')
+      await I.pressKeyUp('Shift')
 
-      await I.pressKey('9');
-      await I.pressKeyDown('Shift');
-      await I.pressKey('9');
-      await I.pressKey('Digit9');
-      await I.pressKey('Numpad9');
-      await I.pressKeyUp('Shift');
+      await I.pressKey('9')
+      await I.pressKeyDown('Shift')
+      await I.pressKey('9')
+      await I.pressKey('Digit9')
+      await I.pressKey('Numpad9')
+      await I.pressKeyUp('Shift')
 
-      await I.seeInField('Name', '0))01!!12@@23##34$$45%%56^^67&&78**89((9');
-    });
-  });
+      await I.seeInField('Name', '0))01!!12@@23##34$$45%%56^^67&&78**89((9')
+    })
+  })
 
   describe('#waitForEnabled', () => {
     it('should wait for input text field to be enabled', () =>
       I.amOnPage('/form/wait_enabled')
         .then(() => I.waitForEnabled('#text', 2))
         .then(() => I.fillField('#text', 'hello world'))
-        .then(() => I.seeInField('#text', 'hello world')));
+        .then(() => I.seeInField('#text', 'hello world')))
 
     it('should wait for input text field to be enabled by xpath', () =>
       I.amOnPage('/form/wait_enabled')
         .then(() => I.waitForEnabled("//*[@name = 'test']", 2))
         .then(() => I.fillField('#text', 'hello world'))
-        .then(() => I.seeInField('#text', 'hello world')));
+        .then(() => I.seeInField('#text', 'hello world')))
 
     it('should wait for a button to be enabled', () =>
       I.amOnPage('/form/wait_enabled')
         .then(() => I.waitForEnabled('#text', 2))
         .then(() => I.click('#button'))
-        .then(() => I.see('button was clicked', '#message')));
-  });
+        .then(() => I.see('button was clicked', '#message')))
+  })
 
   describe('#waitForText', () => {
     it('should wait for text after load body', async () => {
-      await I.amOnPage('/redirect_long');
-      await I.waitForText('Hi there and greetings!', 5);
-    });
-  });
+      await I.amOnPage('/redirect_long')
+      await I.waitForText('Hi there and greetings!', 5)
+    })
+  })
 
   describe('#waitForValue', () => {
     it('should wait for expected value for given locator', () =>
@@ -727,79 +727,79 @@ describe('Puppeteer', function () {
         .then(() => I.waitForValue('//input[@name= "rus"]', 'Верно'))
         .then(() => I.waitForValue('//input[@name= "rus"]', 'Верно3', 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec');
-        }));
+          e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec')
+        }))
 
     it('should wait for expected value for given css locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.seeInField('#text', 'Hamburg'))
         .then(() => I.waitForValue('#text', 'Brisbane', 2.5))
-        .then(() => I.seeInField('#text', 'Brisbane')));
+        .then(() => I.seeInField('#text', 'Brisbane')))
 
     it('should wait for expected value for given xpath locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.seeInField('#text', 'Hamburg'))
         .then(() => I.waitForValue('//input[@value = "Grüße aus Hamburg"]', 'Brisbane', 2.5))
-        .then(() => I.seeInField('#text', 'Brisbane')));
+        .then(() => I.seeInField('#text', 'Brisbane')))
 
     it('should only wait for one of the matching elements to contain the value given xpath locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.waitForValue('//input[@type = "text"]', 'Brisbane', 4))
         .then(() => I.seeInField('#text', 'Brisbane'))
-        .then(() => I.seeInField('#text2', 'London')));
+        .then(() => I.seeInField('#text2', 'London')))
 
     it('should only wait for one of the matching elements to contain the value given css locator', () =>
       I.amOnPage('/form/wait_value')
         .then(() => I.waitForValue('.inputbox', 'Brisbane', 4))
         .then(() => I.seeInField('#text', 'Brisbane'))
-        .then(() => I.seeInField('#text2', 'London')));
-  });
+        .then(() => I.seeInField('#text2', 'London')))
+  })
 
   describe('#grabHTMLFrom', () => {
     it('should grab inner html from an element using xpath query', () =>
       I.amOnPage('/')
         .then(() => I.grabHTMLFrom('//title'))
-        .then(html => assert.equal(html, 'TestEd Beta 2.0')));
+        .then(html => assert.equal(html, 'TestEd Beta 2.0')))
 
     it('should grab inner html from an element using id query', () =>
       I.amOnPage('/')
         .then(() => I.grabHTMLFrom('#area1'))
-        .then(html => assert.equal(html.trim(), '<a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>')));
+        .then(html => assert.equal(html.trim(), '<a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>')))
 
     it('should grab inner html from multiple elements', () =>
       I.amOnPage('/')
         .then(() => I.grabHTMLFromAll('//a'))
-        .then(html => assert.equal(html.length, 5)));
+        .then(html => assert.equal(html.length, 5)))
 
     it('should grab inner html from within an iframe', () =>
       I.amOnPage('/iframe')
         .then(() => I.switchTo({ frame: 'iframe' }))
         .then(() => I.grabHTMLFrom('#new-tab'))
-        .then(html => assert.equal(html.trim(), '<a href="/login" target="_blank">New tab</a>')));
-  });
+        .then(html => assert.equal(html.trim(), '<a href="/login" target="_blank">New tab</a>')))
+  })
 
   describe('#grabBrowserLogs', () => {
     it('should grab browser logs', () =>
       I.amOnPage('/')
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry');
+            console.log('Test log entry')
           }),
         )
         .then(() => I.grabBrowserLogs())
         .then(logs => {
-          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1);
-          assert.equal(matchingLogs.length, 1);
-        }));
+          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1)
+          assert.equal(matchingLogs.length, 1)
+        }))
 
     it('should grab browser logs across pages', () =>
       I.amOnPage('/')
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry 1');
+            console.log('Test log entry 1')
           }),
         )
         .then(() => I.openNewTab())
@@ -807,22 +807,22 @@ describe('Puppeteer', function () {
         .then(() => I.amOnPage('/info'))
         .then(() =>
           I.executeScript(() => {
-            console.log('Test log entry 2');
+            console.log('Test log entry 2')
           }),
         )
         .then(() => I.grabBrowserLogs())
         .then(logs => {
-          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1);
-          assert.equal(matchingLogs.length, 2);
-        }));
-  });
+          const matchingLogs = logs.filter(log => log.text().indexOf('Test log entry') > -1)
+          assert.equal(matchingLogs.length, 2)
+        }))
+  })
 
   describe('#dragAndDrop', () => {
     it('Drag item from source to target (no iframe) @dragNdrop', () =>
       I.amOnPage('http://jqueryui.com/resources/demos/droppable/default.html')
         .then(() => I.seeElementInDOM('#draggable'))
         .then(() => I.dragAndDrop('#draggable', '#droppable'))
-        .then(() => I.see('Dropped')));
+        .then(() => I.see('Dropped')))
 
     it('Drag and drop from within an iframe', () =>
       I.amOnPage('http://jqueryui.com/droppable')
@@ -830,8 +830,8 @@ describe('Puppeteer', function () {
         .then(() => I.switchTo('//iframe[@class="demo-frame"]'))
         .then(() => I.seeElementInDOM('#draggable'))
         .then(() => I.dragAndDrop('#draggable', '#droppable'))
-        .then(() => I.see('Dropped')));
-  });
+        .then(() => I.see('Dropped')))
+  })
 
   describe('#switchTo frame', () => {
     it('should switch to frame using name', () =>
@@ -840,7 +840,7 @@ describe('Puppeteer', function () {
         .then(() => I.dontSee('Information', 'h1'))
         .then(() => I.switchTo('iframe'))
         .then(() => I.see('Information', 'h1'))
-        .then(() => I.dontSee('Iframe test', 'h1')));
+        .then(() => I.dontSee('Iframe test', 'h1')))
 
     it('should switch to root frame', () =>
       I.amOnPage('/iframe')
@@ -850,7 +850,7 @@ describe('Puppeteer', function () {
         .then(() => I.see('Information', 'h1'))
         .then(() => I.dontSee('Iframe test', 'h1'))
         .then(() => I.switchTo())
-        .then(() => I.see('Iframe test', 'h1')));
+        .then(() => I.see('Iframe test', 'h1')))
 
     it('should switch to frame using frame number', () =>
       I.amOnPage('/iframe')
@@ -858,205 +858,205 @@ describe('Puppeteer', function () {
         .then(() => I.dontSee('Information', 'h1'))
         .then(() => I.switchTo(0))
         .then(() => I.see('Information', 'h1'))
-        .then(() => I.dontSee('Iframe test', 'h1')));
-  });
+        .then(() => I.dontSee('Iframe test', 'h1')))
+  })
 
   describe('#dragSlider', () => {
     it('should drag scrubber to given position', async () => {
-      await I.amOnPage('/form/page_slider');
-      await I.seeElementInDOM('#slidecontainer input');
-      const before = await I.grabValueFrom('#slidecontainer input');
-      await I.dragSlider('#slidecontainer input', 20);
-      const after = await I.grabValueFrom('#slidecontainer input');
-      assert.notEqual(before, after);
-    });
-  });
+      await I.amOnPage('/form/page_slider')
+      await I.seeElementInDOM('#slidecontainer input')
+      const before = await I.grabValueFrom('#slidecontainer input')
+      await I.dragSlider('#slidecontainer input', 20)
+      const after = await I.grabValueFrom('#slidecontainer input')
+      assert.notEqual(before, after)
+    })
+  })
 
   describe('#uncheckOption', () => {
     it('should uncheck option that is currently checked', async () => {
-      await I.amOnPage('/info');
-      await I.uncheckOption('interesting');
-      await I.dontSeeCheckboxIsChecked('interesting');
-    });
+      await I.amOnPage('/info')
+      await I.uncheckOption('interesting')
+      await I.dontSeeCheckboxIsChecked('interesting')
+    })
 
     it('should NOT uncheck option that is NOT currently checked', async () => {
-      await I.amOnPage('/info');
-      await I.uncheckOption('interesting');
+      await I.amOnPage('/info')
+      await I.uncheckOption('interesting')
       // Unchecking again should not affect the current 'unchecked' status
-      await I.uncheckOption('interesting');
-      await I.dontSeeCheckboxIsChecked('interesting');
-    });
-  });
+      await I.uncheckOption('interesting')
+      await I.dontSeeCheckboxIsChecked('interesting')
+    })
+  })
 
   describe('#grabElementBoundingRect', () => {
     it('should get the element bounding rectangle', async () => {
-      await I.amOnPage('/form/hidden');
-      const size = await I.grabElementBoundingRect('input[type=submit]');
-      expect(size.x).is.greaterThan(0);
-      expect(size.y).is.greaterThan(0);
-      expect(size.width).is.greaterThan(0);
-      expect(size.height).is.greaterThan(0);
-    });
+      await I.amOnPage('/form/hidden')
+      const size = await I.grabElementBoundingRect('input[type=submit]')
+      expect(size.x).is.greaterThan(0)
+      expect(size.y).is.greaterThan(0)
+      expect(size.width).is.greaterThan(0)
+      expect(size.height).is.greaterThan(0)
+    })
 
     it('should get the element width', async () => {
-      await I.amOnPage('/form/hidden');
-      const width = await I.grabElementBoundingRect('input[type=submit]', 'width');
-      expect(width).is.greaterThan(0);
-    });
+      await I.amOnPage('/form/hidden')
+      const width = await I.grabElementBoundingRect('input[type=submit]', 'width')
+      expect(width).is.greaterThan(0)
+    })
 
     it('should get the element height', async () => {
-      await I.amOnPage('/form/hidden');
-      const height = await I.grabElementBoundingRect('input[type=submit]', 'height');
-      expect(height).is.greaterThan(0);
-    });
-  });
+      await I.amOnPage('/form/hidden')
+      const height = await I.grabElementBoundingRect('input[type=submit]', 'height')
+      expect(height).is.greaterThan(0)
+    })
+  })
 
   describe('#waitForClickable', () => {
     it('should wait for clickable', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
-      await I.waitForClickable({ css: 'input#text' });
-    });
+      await I.amOnPage('/form/wait_for_clickable')
+      await I.waitForClickable({ css: 'input#text' })
+    })
 
     it('should wait for clickable by XPath', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
-      await I.waitForClickable({ xpath: './/input[@id="text"]' });
-    });
+      await I.amOnPage('/form/wait_for_clickable')
+      await I.waitForClickable({ xpath: './/input[@id="text"]' })
+    })
 
     it('should fail for disabled element', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
+      await I.amOnPage('/form/wait_for_clickable')
       await I.waitForClickable({ css: '#button' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {css: #button} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {css: #button} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for disabled element by XPath', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
+      await I.amOnPage('/form/wait_for_clickable')
       await I.waitForClickable({ xpath: './/button[@id="button"]' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {xpath: .//button[@id="button"]} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {xpath: .//button[@id="button"]} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by top', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
+      await I.amOnPage('/form/wait_for_clickable')
       await I.waitForClickable({ css: '#notInViewportTop' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {css: #notInViewportTop} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {css: #notInViewportTop} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by bottom', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
+      await I.amOnPage('/form/wait_for_clickable')
       await I.waitForClickable({ css: '#notInViewportBottom' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {css: #notInViewportBottom} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {css: #notInViewportBottom} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by left', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
+      await I.amOnPage('/form/wait_for_clickable')
       await I.waitForClickable({ css: '#notInViewportLeft' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {css: #notInViewportLeft} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {css: #notInViewportLeft} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by right', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
+      await I.amOnPage('/form/wait_for_clickable')
       await I.waitForClickable({ css: '#notInViewportRight' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {css: #notInViewportRight} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {css: #notInViewportRight} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for overlapping element', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
-      await I.waitForClickable({ css: '#div2_button' }, 0.1);
+      await I.amOnPage('/form/wait_for_clickable')
+      await I.waitForClickable({ css: '#div2_button' }, 0.1)
       await I.waitForClickable({ css: '#div1_button' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element {css: #div1_button} still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element {css: #div1_button} still not clickable after 0.1 sec')
+        })
+    })
 
     it('should pass if element change class', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
-      await I.click('button_save');
-      await I.waitForClickable('//button[@name="button_publish"]');
-    });
+      await I.amOnPage('/form/wait_for_clickable')
+      await I.click('button_save')
+      await I.waitForClickable('//button[@name="button_publish"]')
+    })
 
     xit('should fail if element change class and not clickable', async () => {
-      await I.amOnPage('/form/wait_for_clickable');
-      await I.click('button_save');
+      await I.amOnPage('/form/wait_for_clickable')
+      await I.click('button_save')
       await I.waitForClickable('//button[@name="button_publish"]', 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element //button[@name="button_publish"] still not clickable after 0.1 sec');
-        });
-    });
-  });
+          e.message.should.include('element //button[@name="button_publish"] still not clickable after 0.1 sec')
+        })
+    })
+  })
 
   describe('#usePuppeteerTo', () => {
     it('should return title', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       const title = await I.usePuppeteerTo('test', async ({ page }) => {
-        return page.title();
-      });
-      assert.equal('TestEd Beta 2.0', title);
-    });
-  });
+        return page.title()
+      })
+      assert.equal('TestEd Beta 2.0', title)
+    })
+  })
 
   describe('#mockRoute, #stopMockingRoute', () => {
     it('should mock a route', async () => {
-      await I.amOnPage('/form/fetch_call');
+      await I.amOnPage('/form/fetch_call')
       await I.mockRoute('https://reqres.in/api/comments/1', request => {
         request.respond({
           status: 200,
           headers: { 'Access-Control-Allow-Origin': '*' },
           contentType: 'application/json',
           body: '{"name": "this was mocked" }',
-        });
-      });
-      await I.click('GET COMMENTS');
-      await I.see('this was mocked');
-      await I.stopMockingRoute('https://reqres.in/api/comments/1');
-      await I.click('GET COMMENTS');
-      await I.see('data');
-      await I.dontSee('this was mocked');
-    });
-  });
-});
+        })
+      })
+      await I.click('GET COMMENTS')
+      await I.see('this was mocked')
+      await I.stopMockingRoute('https://reqres.in/api/comments/1')
+      await I.click('GET COMMENTS')
+      await I.see('data')
+      await I.dontSee('this was mocked')
+    })
+  })
+})
 
-let remoteBrowser;
+let remoteBrowser
 async function createRemoteBrowser() {
   remoteBrowser = await puppeteer.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
     headless: true,
-  });
-  return remoteBrowser;
+  })
+  return remoteBrowser
 }
 
 const helperConfig = {
@@ -1072,129 +1072,129 @@ const helperConfig = {
   waitForTimeout: 5000,
   waitForAction: 500,
   windowSize: '500x700',
-};
+}
 
 describe('Puppeteer (remote browser)', function () {
-  this.timeout(35000);
-  this.retries(1);
+  this.timeout(35000)
+  this.retries(1)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
-    I = new Puppeteer(helperConfig);
-    I._init();
-    return I._beforeSuite();
-  });
+    global.codecept_dir = path.join(__dirname, '/../data')
+    I = new Puppeteer(helperConfig)
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     // Mimick remote session by creating another browser instance
-    await createRemoteBrowser();
+    await createRemoteBrowser()
     // Set websocket endpoint to other browser instance
-    helperConfig.chrome.browserWSEndpoint = await remoteBrowser.wsEndpoint();
-    I._setConfig(helperConfig);
+    helperConfig.chrome.browserWSEndpoint = await remoteBrowser.wsEndpoint()
+    I._setConfig(helperConfig)
 
-    return I._before();
-  });
+    return I._before()
+  })
 
   afterEach(() => {
     return I._after().then(() => {
-      remoteBrowser && remoteBrowser.close();
-    });
-  });
+      remoteBrowser && remoteBrowser.close()
+    })
+  })
 
   describe('#_startBrowser', () => {
     it('should throw an exception when endpoint is unreachable', async () => {
-      helperConfig.chrome.browserWSEndpoint = 'ws://unreachable/';
-      I._setConfig(helperConfig);
+      helperConfig.chrome.browserWSEndpoint = 'ws://unreachable/'
+      I._setConfig(helperConfig)
       try {
-        await I._startBrowser();
-        throw Error('It should never get this far');
+        await I._startBrowser()
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('Cannot connect to websocket endpoint.\n\nPlease make sure remote browser is running and accessible.');
+        e.message.should.include('Cannot connect to websocket endpoint.\n\nPlease make sure remote browser is running and accessible.')
       }
-    });
+    })
 
     xit('should clear any prior existing pages on remote browser', async () => {
-      const remotePages = await remoteBrowser.pages();
-      assert.equal(remotePages.length, 1);
+      const remotePages = await remoteBrowser.pages()
+      assert.equal(remotePages.length, 1)
       for (let p = 1; p < 5; p++) {
-        await remoteBrowser.newPage();
+        await remoteBrowser.newPage()
       }
-      const existingPages = await remoteBrowser.pages();
-      assert.equal(existingPages.length, 5);
+      const existingPages = await remoteBrowser.pages()
+      assert.equal(existingPages.length, 5)
 
-      await I._startBrowser();
+      await I._startBrowser()
       // Session was cleared
-      let currentPages = await remoteBrowser.pages();
-      assert.equal(currentPages.length, 1);
+      let currentPages = await remoteBrowser.pages()
+      assert.equal(currentPages.length, 1)
 
-      let numPages = await I.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
+      let numPages = await I.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
 
-      await I.openNewTab();
+      await I.openNewTab()
 
-      numPages = await I.grabNumberOfOpenTabs();
-      assert.equal(numPages, 2);
+      numPages = await I.grabNumberOfOpenTabs()
+      assert.equal(numPages, 2)
 
-      await I._stopBrowser();
+      await I._stopBrowser()
 
-      currentPages = await remoteBrowser.pages();
-      assert.equal(currentPages.length, 0);
-    });
-  });
-});
+      currentPages = await remoteBrowser.pages()
+      assert.equal(currentPages.length, 0)
+    })
+  })
+})
 
 describe('Puppeteer - Trace', () => {
-  const test = { title: 'a failed test', artifacts: {} };
+  const test = { title: 'a failed test', artifacts: {} }
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
-    global.output_dir = path.join(`${__dirname}/../data/output`);
+    global.codecept_dir = path.join(__dirname, '/../data')
+    global.output_dir = path.join(`${__dirname}/../data/output`)
 
     I = new Puppeteer({
       url: siteUrl,
       windowSize: '500x700',
       show: false,
       trace: true,
-    });
-    I._init();
-    return I._beforeSuite();
-  });
+    })
+    I._init()
+    return I._beforeSuite()
+  })
 
   beforeEach(async () => {
     webApiTests.init({
       I,
       siteUrl,
-    });
-    deleteDir(path.join(global.output_dir, 'trace'));
+    })
+    deleteDir(path.join(global.output_dir, 'trace'))
     return I._before(test).then(() => {
-      page = I.page;
-      browser = I.browser;
-    });
-  });
+      page = I.page
+      browser = I.browser
+    })
+  })
 
   afterEach(async () => {
-    return I._after();
-  });
+    return I._after()
+  })
 
   it('checks that trace is recorded', async () => {
-    await I.amOnPage('/');
-    await I.dontSee('this should be an error');
-    await I.click('More info');
-    await I.dontSee('this should be an error');
-    await I._failed(test);
-    assert(test.artifacts);
-    expect(Object.keys(test.artifacts)).to.include('trace');
+    await I.amOnPage('/')
+    await I.dontSee('this should be an error')
+    await I.click('More info')
+    await I.dontSee('this should be an error')
+    await I._failed(test)
+    assert(test.artifacts)
+    expect(Object.keys(test.artifacts)).to.include('trace')
 
-    assert.ok(fs.existsSync(test.artifacts.trace));
-    expect(test.artifacts.trace).to.include(path.join(global.output_dir, 'trace'));
-  });
+    assert.ok(fs.existsSync(test.artifacts.trace))
+    expect(test.artifacts.trace).to.include(path.join(global.output_dir, 'trace'))
+  })
 
   describe('#grabWebElements', () => {
     it('should return an array of WebElement', async () => {
-      await I.amOnPage('/form/focus_blur_elements');
+      await I.amOnPage('/form/focus_blur_elements')
 
-      const webElements = await I.grabWebElements('#button');
-      assert.include(webElements[0].constructor.name, 'CdpElementHandle');
-      assert.isAbove(webElements.length, 0);
-    });
-  });
-});
+      const webElements = await I.grabWebElements('#button')
+      assert.include(webElements[0].constructor.name, 'CdpElementHandle')
+      assert.isAbove(webElements.length, 0)
+    })
+  })
+})

--- a/test/helper/TestCafe_test.js
+++ b/test/helper/TestCafe_test.js
@@ -74,7 +74,7 @@ describe('TestCafe', function () {
     })
 
     it('should pass arguments and wait for function returns true', () => {
-      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction((varName) => window[varName], ['__waitJs'], 3))
+      return I.amOnPage('/form/wait_js').then(() => I.waitForFunction(varName => window[varName], ['__waitJs'], 3))
     })
   })
 

--- a/test/helper/WebDriver.noSeleniumServer_test.js
+++ b/test/helper/WebDriver.noSeleniumServer_test.js
@@ -1,29 +1,29 @@
-const assert = require('assert');
+const assert = require('assert')
 
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
+const expect = chai.expect
 
-const path = require('path');
-const fs = require('fs');
+const path = require('path')
+const fs = require('fs')
 
-const TestHelper = require('../support/TestHelper');
-const WebDriver = require('../../lib/helper/WebDriver');
-const AssertionFailedError = require('../../lib/assert/error');
-const Secret = require('../../lib/secret');
-global.codeceptjs = require('../../lib');
+const TestHelper = require('../support/TestHelper')
+const WebDriver = require('../../lib/helper/WebDriver')
+const AssertionFailedError = require('../../lib/assert/error')
+const Secret = require('../../lib/secret')
+global.codeceptjs = require('../../lib')
 
-const siteUrl = TestHelper.siteUrl();
-let wd;
-const browserVersion = 'stable';
+const siteUrl = TestHelper.siteUrl()
+let wd
+const browserVersion = 'stable'
 describe('WebDriver - No Selenium server started', function () {
-  this.retries(1);
-  this.timeout(35000);
+  this.retries(1)
+  this.timeout(35000)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     try {
-      fs.unlinkSync(dataFile);
+      fs.unlinkSync(dataFile)
     } catch (err) {
       // continue regardless of error
     }
@@ -43,462 +43,462 @@ describe('WebDriver - No Selenium server started', function () {
       customLocatorStrategies: {
         customSelector: selector => ({ 'element-6066-11e4-a52e-4f735466cecf': `${selector}-foobar` }),
       },
-    });
-  });
+    })
+  })
 
   beforeEach(async () => {
-    this.wdBrowser = await wd._before();
-    return this.wdBrowser;
-  });
+    this.wdBrowser = await wd._before()
+    return this.wdBrowser
+  })
 
-  afterEach(async () => wd._after());
+  afterEach(async () => wd._after())
 
   describe('customLocatorStrategies', () => {
     it('should include the custom strategy', async () => {
-      expect(wd.customLocatorStrategies.customSelector).to.not.be.undefined;
-    });
+      expect(wd.customLocatorStrategies.customSelector).to.not.be.undefined
+    })
 
     it('should be added to the browser locator strategies', async () => {
-      expect(this.wdBrowser.addLocatorStrategy).to.not.be.undefined;
-    });
+      expect(this.wdBrowser.addLocatorStrategy).to.not.be.undefined
+    })
 
     it('throws on invalid custom selector', async () => {
       try {
-        await wd.waitForEnabled({ madeUpSelector: '#text' }, 2);
+        await wd.waitForEnabled({ madeUpSelector: '#text' }, 2)
       } catch (e) {
-        expect(e.message).to.include('Please define "customLocatorStrategies"');
+        expect(e.message).to.include('Please define "customLocatorStrategies"')
       }
-    });
-  });
+    })
+  })
 
   describe('open page : #amOnPage', () => {
     it('should open main page of configured site', async () => {
-      await wd.amOnPage('/');
-      const url = await wd.grabCurrentUrl();
-      url.should.eql(`${siteUrl}/`);
-    });
+      await wd.amOnPage('/')
+      const url = await wd.grabCurrentUrl()
+      url.should.eql(`${siteUrl}/`)
+    })
 
     it('should open any page of configured site', async () => {
-      await wd.amOnPage('/info');
-      const url = await wd.grabCurrentUrl();
-      url.should.eql(`${siteUrl}/info`);
-    });
+      await wd.amOnPage('/info')
+      const url = await wd.grabCurrentUrl()
+      url.should.eql(`${siteUrl}/info`)
+    })
 
     it('should open absolute url', async () => {
-      await wd.amOnPage(siteUrl);
-      const url = await wd.grabCurrentUrl();
-      url.should.eql(`${siteUrl}/`);
-    });
-  });
+      await wd.amOnPage(siteUrl)
+      const url = await wd.grabCurrentUrl()
+      url.should.eql(`${siteUrl}/`)
+    })
+  })
 
   describe('see text : #see', () => {
     it('should fail when text is not on site', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
 
       try {
-        await wd.see('Something incredible!');
+        await wd.see('Something incredible!')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('web page');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('web page')
       }
 
       try {
-        await wd.dontSee('Welcome');
+        await wd.dontSee('Welcome')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('web page');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('web page')
       }
-    });
-  });
+    })
+  })
 
   describe.skip('check fields: #seeInField, #seeCheckboxIsChecked, ...', () => {
     it('should throw error if field is not empty', async () => {
-      await wd.amOnPage('/form/empty');
+      await wd.amOnPage('/form/empty')
 
       try {
-        await wd.seeInField('#empty_input', 'Ayayay');
+        await wd.seeInField('#empty_input', 'Ayayay')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"')
       }
-    });
+    })
 
     it('should check values in checkboxes', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.dontSeeInField('checkbox[]', 'not seen one');
-      await wd.seeInField('checkbox[]', 'see test one');
-      await wd.dontSeeInField('checkbox[]', 'not seen two');
-      await wd.seeInField('checkbox[]', 'see test two');
-      await wd.dontSeeInField('checkbox[]', 'not seen three');
-      await wd.seeInField('checkbox[]', 'see test three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.dontSeeInField('checkbox[]', 'not seen one')
+      await wd.seeInField('checkbox[]', 'see test one')
+      await wd.dontSeeInField('checkbox[]', 'not seen two')
+      await wd.seeInField('checkbox[]', 'see test two')
+      await wd.dontSeeInField('checkbox[]', 'not seen three')
+      await wd.seeInField('checkbox[]', 'see test three')
+    })
 
     it('should check values are the secret type in checkboxes', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen one'));
-      await wd.seeInField('checkbox[]', Secret.secret('see test one'));
-      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen two'));
-      await wd.seeInField('checkbox[]', Secret.secret('see test two'));
-      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen three'));
-      await wd.seeInField('checkbox[]', Secret.secret('see test three'));
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen one'))
+      await wd.seeInField('checkbox[]', Secret.secret('see test one'))
+      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen two'))
+      await wd.seeInField('checkbox[]', Secret.secret('see test two'))
+      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen three'))
+      await wd.seeInField('checkbox[]', Secret.secret('see test three'))
+    })
 
     it('should check values with boolean', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('checkbox1', true);
-      await wd.dontSeeInField('checkbox1', false);
-      await wd.seeInField('checkbox2', false);
-      await wd.dontSeeInField('checkbox2', true);
-      await wd.seeInField('radio2', true);
-      await wd.dontSeeInField('radio2', false);
-      await wd.seeInField('radio3', false);
-      await wd.dontSeeInField('radio3', true);
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('checkbox1', true)
+      await wd.dontSeeInField('checkbox1', false)
+      await wd.seeInField('checkbox2', false)
+      await wd.dontSeeInField('checkbox2', true)
+      await wd.seeInField('radio2', true)
+      await wd.dontSeeInField('radio2', false)
+      await wd.seeInField('radio3', false)
+      await wd.dontSeeInField('radio3', true)
+    })
 
     it('should check values in radio', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('radio1', 'see test one');
-      await wd.dontSeeInField('radio1', 'not seen one');
-      await wd.dontSeeInField('radio1', 'not seen two');
-      await wd.dontSeeInField('radio1', 'not seen three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('radio1', 'see test one')
+      await wd.dontSeeInField('radio1', 'not seen one')
+      await wd.dontSeeInField('radio1', 'not seen two')
+      await wd.dontSeeInField('radio1', 'not seen three')
+    })
 
     it('should check values in select', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('select1', 'see test one');
-      await wd.dontSeeInField('select1', 'not seen one');
-      await wd.dontSeeInField('select1', 'not seen two');
-      await wd.dontSeeInField('select1', 'not seen three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('select1', 'see test one')
+      await wd.dontSeeInField('select1', 'not seen one')
+      await wd.dontSeeInField('select1', 'not seen two')
+      await wd.dontSeeInField('select1', 'not seen three')
+    })
 
     it('should check for empty select field', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('select3', '');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('select3', '')
+    })
 
     it('should check for select multiple field', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.dontSeeInField('select2', 'not seen one');
-      await wd.seeInField('select2', 'see test one');
-      await wd.dontSeeInField('select2', 'not seen two');
-      await wd.seeInField('select2', 'see test two');
-      await wd.dontSeeInField('select2', 'not seen three');
-      await wd.seeInField('select2', 'see test three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.dontSeeInField('select2', 'not seen one')
+      await wd.seeInField('select2', 'see test one')
+      await wd.dontSeeInField('select2', 'not seen two')
+      await wd.seeInField('select2', 'see test two')
+      await wd.dontSeeInField('select2', 'not seen three')
+      await wd.seeInField('select2', 'see test three')
+    })
 
     it('should return error when element has no value attribute', async () => {
-      await wd.amOnPage('https://codecept.io/quickstart');
+      await wd.amOnPage('https://codecept.io/quickstart')
 
       try {
-        await wd.seeInField('#search_input_react', 'WebDriver1');
+        await wd.seeInField('#search_input_react', 'WebDriver1')
       } catch (e) {
-        e.should.be.instanceOf(Error);
+        e.should.be.instanceOf(Error)
       }
-    });
-  });
+    })
+  })
 
   describe('Force Right Click: #forceRightClick', () => {
     it('it should forceRightClick', async () => {
-      await wd.amOnPage('/form/rightclick');
-      await wd.dontSee('right clicked');
-      await wd.forceRightClick('Lorem Ipsum');
-      await wd.see('right clicked');
-    });
+      await wd.amOnPage('/form/rightclick')
+      await wd.dontSee('right clicked')
+      await wd.forceRightClick('Lorem Ipsum')
+      await wd.see('right clicked')
+    })
 
     it('it should forceRightClick by locator', async () => {
-      await wd.amOnPage('/form/rightclick');
-      await wd.dontSee('right clicked');
-      await wd.forceRightClick('.context a');
-      await wd.see('right clicked');
-    });
+      await wd.amOnPage('/form/rightclick')
+      await wd.dontSee('right clicked')
+      await wd.forceRightClick('.context a')
+      await wd.see('right clicked')
+    })
 
     it('it should forceRightClick by locator and context', async () => {
-      await wd.amOnPage('/form/rightclick');
-      await wd.dontSee('right clicked');
-      await wd.forceRightClick('Lorem Ipsum', '.context');
-      await wd.see('right clicked');
-    });
-  });
+      await wd.amOnPage('/form/rightclick')
+      await wd.dontSee('right clicked')
+      await wd.forceRightClick('Lorem Ipsum', '.context')
+      await wd.see('right clicked')
+    })
+  })
 
   describe.skip('#pressKey, #pressKeyDown, #pressKeyUp', () => {
     it('should be able to send special keys to element', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.appendField('Name', '-');
+      await wd.amOnPage('/form/field')
+      await wd.appendField('Name', '-')
 
-      await wd.pressKey(['Right Shift', 'Home']);
-      await wd.pressKey('Delete');
+      await wd.pressKey(['Right Shift', 'Home'])
+      await wd.pressKey('Delete')
 
       // Sequence only executes up to first non-modifier key ('Digit1')
-      await wd.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4']);
-      await wd.pressKey('1');
-      await wd.pressKey('2');
-      await wd.pressKey('3');
-      await wd.pressKey('ArrowLeft');
-      await wd.pressKey('Left Arrow');
-      await wd.pressKey('arrow_left');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('a');
-      await wd.pressKey('KeyB');
-      await wd.pressKeyUp('ShiftLeft');
-      await wd.pressKey('C');
-      await wd.seeInField('Name', '!ABC123');
-    });
+      await wd.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4'])
+      await wd.pressKey('1')
+      await wd.pressKey('2')
+      await wd.pressKey('3')
+      await wd.pressKey('ArrowLeft')
+      await wd.pressKey('Left Arrow')
+      await wd.pressKey('arrow_left')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('a')
+      await wd.pressKey('KeyB')
+      await wd.pressKeyUp('ShiftLeft')
+      await wd.pressKey('C')
+      await wd.seeInField('Name', '!ABC123')
+    })
 
     it('should use modifier key based on operating system', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.fillField('Name', 'value that is cleared using select all shortcut');
+      await wd.amOnPage('/form/field')
+      await wd.fillField('Name', 'value that is cleared using select all shortcut')
 
-      await wd.pressKey(['CommandOrControl', 'A']);
-      await wd.pressKey('Backspace');
-      await wd.dontSeeInField('Name', 'value that is cleared using select all shortcut');
-    });
+      await wd.pressKey(['CommandOrControl', 'A'])
+      await wd.pressKey('Backspace')
+      await wd.dontSeeInField('Name', 'value that is cleared using select all shortcut')
+    })
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.fillField('Name', '');
+      await wd.amOnPage('/form/field')
+      await wd.fillField('Name', '')
 
-      await wd.pressKey(';');
-      await wd.pressKey(['Shift', ';']);
-      await wd.pressKey(['Shift', 'Semicolon']);
-      await wd.pressKey('=');
-      await wd.pressKey(['Shift', '=']);
-      await wd.pressKey(['Shift', 'Equal']);
-      await wd.pressKey('*');
-      await wd.pressKey(['Shift', '*']);
-      await wd.pressKey(['Shift', 'Multiply']);
-      await wd.pressKey('+');
-      await wd.pressKey(['Shift', '+']);
-      await wd.pressKey(['Shift', 'Add']);
-      await wd.pressKey(',');
-      await wd.pressKey(['Shift', ',']);
-      await wd.pressKey(['Shift', 'Comma']);
-      await wd.pressKey(['Shift', 'NumpadComma']);
-      await wd.pressKey(['Shift', 'Separator']);
-      await wd.pressKey('-');
-      await wd.pressKey(['Shift', '-']);
-      await wd.pressKey(['Shift', 'Subtract']);
-      await wd.pressKey('.');
-      await wd.pressKey(['Shift', '.']);
-      await wd.pressKey(['Shift', 'Decimal']);
-      await wd.pressKey(['Shift', 'Period']);
-      await wd.pressKey('/');
-      await wd.pressKey(['Shift', '/']);
-      await wd.pressKey(['Shift', 'Divide']);
-      await wd.pressKey(['Shift', 'Slash']);
+      await wd.pressKey(';')
+      await wd.pressKey(['Shift', ';'])
+      await wd.pressKey(['Shift', 'Semicolon'])
+      await wd.pressKey('=')
+      await wd.pressKey(['Shift', '='])
+      await wd.pressKey(['Shift', 'Equal'])
+      await wd.pressKey('*')
+      await wd.pressKey(['Shift', '*'])
+      await wd.pressKey(['Shift', 'Multiply'])
+      await wd.pressKey('+')
+      await wd.pressKey(['Shift', '+'])
+      await wd.pressKey(['Shift', 'Add'])
+      await wd.pressKey(',')
+      await wd.pressKey(['Shift', ','])
+      await wd.pressKey(['Shift', 'Comma'])
+      await wd.pressKey(['Shift', 'NumpadComma'])
+      await wd.pressKey(['Shift', 'Separator'])
+      await wd.pressKey('-')
+      await wd.pressKey(['Shift', '-'])
+      await wd.pressKey(['Shift', 'Subtract'])
+      await wd.pressKey('.')
+      await wd.pressKey(['Shift', '.'])
+      await wd.pressKey(['Shift', 'Decimal'])
+      await wd.pressKey(['Shift', 'Period'])
+      await wd.pressKey('/')
+      await wd.pressKey(['Shift', '/'])
+      await wd.pressKey(['Shift', 'Divide'])
+      await wd.pressKey(['Shift', 'Slash'])
 
-      await wd.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?');
-    });
+      await wd.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?')
+    })
 
     it('should show correct number key when Shift modifier is active', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.fillField('Name', '');
+      await wd.amOnPage('/form/field')
+      await wd.fillField('Name', '')
 
-      await wd.pressKey('0');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('0');
-      await wd.pressKey('Digit0');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('0')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('0')
+      await wd.pressKey('Digit0')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('1');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('1');
-      await wd.pressKey('Digit1');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('1')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('1')
+      await wd.pressKey('Digit1')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('2');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('2');
-      await wd.pressKey('Digit2');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('2')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('2')
+      await wd.pressKey('Digit2')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('3');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('3');
-      await wd.pressKey('Digit3');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('3')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('3')
+      await wd.pressKey('Digit3')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('4');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('4');
-      await wd.pressKey('Digit4');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('4')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('4')
+      await wd.pressKey('Digit4')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('5');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('5');
-      await wd.pressKey('Digit5');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('5')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('5')
+      await wd.pressKey('Digit5')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('6');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('6');
-      await wd.pressKey('Digit6');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('6')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('6')
+      await wd.pressKey('Digit6')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('7');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('7');
-      await wd.pressKey('Digit7');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('7')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('7')
+      await wd.pressKey('Digit7')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('8');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('8');
-      await wd.pressKey('Digit8');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('8')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('8')
+      await wd.pressKey('Digit8')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('9');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('9');
-      await wd.pressKey('Digit9');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('9')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('9')
+      await wd.pressKey('Digit9')
+      await wd.pressKeyUp('Shift')
 
-      await wd.seeInField('Name', '0))1!!2@@3##4$$5%%6^^7&&8**9((');
-    });
-  });
+      await wd.seeInField('Name', '0))1!!2@@3##4$$5%%6^^7&&8**9((')
+    })
+  })
 
   describe('#seeInSource, #grabSource', () => {
     it('should check for text to be in HTML source', async () => {
-      await wd.amOnPage('/');
-      await wd.seeInSource('<title>TestEd Beta 2.0</title>');
-      await wd.dontSeeInSource('<meta');
-    });
+      await wd.amOnPage('/')
+      await wd.seeInSource('<title>TestEd Beta 2.0</title>')
+      await wd.dontSeeInSource('<meta')
+    })
 
     it('should grab the source', async () => {
-      await wd.amOnPage('/');
-      const source = await wd.grabSource();
-      assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved');
-    });
+      await wd.amOnPage('/')
+      const source = await wd.grabSource()
+      assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')
+    })
 
     it('should grab the innerHTML for an element', async () => {
-      await wd.amOnPage('/');
-      const source = await wd.grabHTMLFrom('#area1');
+      await wd.amOnPage('/')
+      const source = await wd.grabHTMLFrom('#area1')
       assert.deepEqual(
         source,
         `
     <a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>
 `,
-      );
-    });
-  });
+      )
+    })
+  })
 
   describe('#seeTitleEquals', () => {
     it('should check that title is equal to provided one', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
 
       try {
-        await wd.seeTitleEquals('TestEd Beta 2.0');
-        await wd.seeTitleEquals('TestEd Beta 2.');
+        await wd.seeTitleEquals('TestEd Beta 2.0')
+        await wd.seeTitleEquals('TestEd Beta 2.')
       } catch (e) {
-        assert.equal(e.message, 'expected web page title to be TestEd Beta 2., but found TestEd Beta 2.0');
+        assert.equal(e.message, 'expected web page title to be TestEd Beta 2., but found TestEd Beta 2.0')
       }
-    });
-  });
+    })
+  })
 
   describe('#seeTextEquals', () => {
     it('should check text is equal to provided one', async () => {
-      await wd.amOnPage('/');
-      await wd.seeTextEquals('Welcome to test app!', 'h1');
+      await wd.amOnPage('/')
+      await wd.seeTextEquals('Welcome to test app!', 'h1')
 
       try {
-        await wd.seeTextEquals('Welcome to test app', 'h1');
-        assert.equal(true, false, 'Throw an error because it should not get this far!');
+        await wd.seeTextEquals('Welcome to test app', 'h1')
+        assert.equal(true, false, 'Throw an error because it should not get this far!')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"');
+        e.should.be.instanceOf(Error)
+        e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"')
         // e.should.be.instanceOf(AssertionFailedError);
       }
-    });
+    })
 
     it('should check text is not equal to empty string of element text', async () => {
-      await wd.amOnPage('https://codecept.io');
+      await wd.amOnPage('https://codecept.io')
 
       try {
-        await wd.seeTextEquals('', '.logo');
-        await wd.seeTextEquals('This is not empty', '.logo');
+        await wd.seeTextEquals('', '.logo')
+        await wd.seeTextEquals('This is not empty', '.logo')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.be.equal('expected element .logo "This is not empty" to equal ""');
+        e.should.be.instanceOf(Error)
+        e.message.should.be.equal('expected element .logo "This is not empty" to equal ""')
       }
-    });
-  });
+    })
+  })
 
   describe('#waitForFunction', () => {
     it('should wait for function returns true', async () => {
-      await wd.amOnPage('/form/wait_js');
-      await wd.waitForFunction(() => window.__waitJs, 3);
-    });
+      await wd.amOnPage('/form/wait_js')
+      await wd.waitForFunction(() => window.__waitJs, 3)
+    })
 
     it('should pass arguments and wait for function returns true', async () => {
-      await wd.amOnPage('/form/wait_js');
-      await wd.waitForFunction(varName => window[varName], ['__waitJs'], 3);
-    });
-  });
+      await wd.amOnPage('/form/wait_js')
+      await wd.waitForFunction(varName => window[varName], ['__waitJs'], 3)
+    })
+  })
 
   describe.skip('#waitForEnabled', () => {
     it('should wait for input text field to be enabled', async () => {
-      await wd.amOnPage('/form/wait_enabled');
-      await wd.waitForEnabled('#text', 2);
-      await wd.fillField('#text', 'hello world');
-      await wd.seeInField('#text', 'hello world');
-    });
+      await wd.amOnPage('/form/wait_enabled')
+      await wd.waitForEnabled('#text', 2)
+      await wd.fillField('#text', 'hello world')
+      await wd.seeInField('#text', 'hello world')
+    })
 
     it('should wait for input text field to be enabled by xpath', async () => {
-      await wd.amOnPage('/form/wait_enabled');
-      await wd.waitForEnabled("//*[@name = 'test']", 2);
-      await wd.fillField('#text', 'hello world');
-      await wd.seeInField('#text', 'hello world');
-    });
+      await wd.amOnPage('/form/wait_enabled')
+      await wd.waitForEnabled("//*[@name = 'test']", 2)
+      await wd.fillField('#text', 'hello world')
+      await wd.seeInField('#text', 'hello world')
+    })
 
     it('should wait for a button to be enabled', async () => {
-      await wd.amOnPage('/form/wait_enabled');
-      await wd.waitForEnabled('#text', 2);
-      await wd.click('#button');
-      await wd.see('button was clicked');
-    });
-  });
+      await wd.amOnPage('/form/wait_enabled')
+      await wd.waitForEnabled('#text', 2)
+      await wd.click('#button')
+      await wd.see('button was clicked')
+    })
+  })
 
   describe.skip('#waitForValue', () => {
     it('should wait for expected value for given locator', async () => {
-      await wd.amOnPage('/info');
-      await wd.waitForValue('//input[@name= "rus"]', 'Верно');
+      await wd.amOnPage('/info')
+      await wd.waitForValue('//input[@name= "rus"]', 'Верно')
 
       try {
-        await wd.waitForValue('//input[@name= "rus"]', 'Верно3', 0.1);
-        throw Error('It should never get this far');
+        await wd.waitForValue('//input[@name= "rus"]', 'Верно3', 0.1)
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec');
+        e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec')
       }
-    });
+    })
 
     it('should wait for expected value for given css locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.seeInField('#text', 'Hamburg');
-      await wd.waitForValue('#text', 'Brisbane', 2.5);
-      await wd.seeInField('#text', 'Brisbane');
-    });
+      await wd.amOnPage('/form/wait_value')
+      await wd.seeInField('#text', 'Hamburg')
+      await wd.waitForValue('#text', 'Brisbane', 2.5)
+      await wd.seeInField('#text', 'Brisbane')
+    })
 
     it('should wait for expected value for given xpath locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.seeInField('#text', 'Hamburg');
-      await wd.waitForValue('//input[@value = "Grüße aus Hamburg"]', 'Brisbane', 2.5);
-      await wd.seeInField('#text', 'Brisbane');
-    });
+      await wd.amOnPage('/form/wait_value')
+      await wd.seeInField('#text', 'Hamburg')
+      await wd.waitForValue('//input[@value = "Grüße aus Hamburg"]', 'Brisbane', 2.5)
+      await wd.seeInField('#text', 'Brisbane')
+    })
 
     it('should only wait for one of the matching elements to contain the value given xpath locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.waitForValue('//input[@type = "text"]', 'Brisbane', 4);
-      await wd.seeInField('#text', 'Brisbane');
-      await wd.seeInField('#text2', 'London');
-    });
+      await wd.amOnPage('/form/wait_value')
+      await wd.waitForValue('//input[@type = "text"]', 'Brisbane', 4)
+      await wd.seeInField('#text', 'Brisbane')
+      await wd.seeInField('#text2', 'London')
+    })
 
     it('should only wait for one of the matching elements to contain the value given css locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.waitForValue('.inputbox', 'Brisbane', 4);
-      await wd.seeInField('#text', 'Brisbane');
-      await wd.seeInField('#text2', 'London');
-    });
-  });
+      await wd.amOnPage('/form/wait_value')
+      await wd.waitForValue('.inputbox', 'Brisbane', 4)
+      await wd.seeInField('#text', 'Brisbane')
+      await wd.seeInField('#text2', 'London')
+    })
+  })
 
   describe('#waitNumberOfVisibleElements', () => {
     it('should wait for a specified number of elements on the page', () => {
@@ -507,24 +507,24 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3))
         .then(() => wd.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec');
-        });
-    });
+          e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec')
+        })
+    })
 
     it('should be no [object Object] in the error message', () => {
       return wd
         .amOnPage('/info')
         .then(() => wd.waitNumberOfVisibleElements({ css: '//div[@id = "grab-multiple"]//a' }, 3))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.not.include('[object Object]');
-        });
-    });
+          e.message.should.not.include('[object Object]')
+        })
+    })
 
     it('should wait for a specified number of elements on the page using a css selector', () => {
       return wd
@@ -532,21 +532,21 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.waitNumberOfVisibleElements('#grab-multiple > a', 3))
         .then(() => wd.waitNumberOfVisibleElements('#grab-multiple > a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec');
-        });
-    });
+          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec')
+        })
+    })
 
     it('should wait for a specified number of elements which are not yet attached to the DOM', () => {
       return wd
         .amOnPage('/form/wait_num_elements')
         .then(() => wd.waitNumberOfVisibleElements('.title', 2, 3))
         .then(() => wd.see('Hello'))
-        .then(() => wd.see('World'));
-    });
-  });
+        .then(() => wd.see('World'))
+    })
+  })
 
   describe('#waitForVisible', () => {
     it('should be no [object Object] in the error message', () => {
@@ -554,13 +554,13 @@ describe('WebDriver - No Selenium server started', function () {
         .amOnPage('/info')
         .then(() => wd.waitForVisible('//div[@id = "grab-multiple"]//a', 3))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.not.include('[object Object]');
-        });
-    });
-  });
+          e.message.should.not.include('[object Object]')
+        })
+    })
+  })
 
   describe('#waitForInvisible', () => {
     it('should be no [object Object] in the error message', () => {
@@ -568,53 +568,53 @@ describe('WebDriver - No Selenium server started', function () {
         .amOnPage('/info')
         .then(() => wd.waitForInvisible('//div[@id = "grab-multiple"]//a', 3))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.not.include('[object Object]');
-        });
-    });
+          e.message.should.not.include('[object Object]')
+        })
+    })
 
     it('should wait for a specified element to be invisible', () => {
       return wd
         .amOnPage('/form/wait_invisible')
         .then(() => wd.waitForInvisible('#step1', 3))
-        .then(() => wd.dontSeeElement('#step1'));
-    });
-  });
+        .then(() => wd.dontSeeElement('#step1'))
+    })
+  })
 
   describe('#moveCursorTo', () => {
     it('should trigger hover event', async () => {
-      await wd.amOnPage('/form/hover');
-      await wd.moveCursorTo('#hover');
-      await wd.see('Hovered', '#show');
-    });
+      await wd.amOnPage('/form/hover')
+      await wd.moveCursorTo('#hover')
+      await wd.see('Hovered', '#show')
+    })
 
     it('should not trigger hover event because of the offset is beyond the element', async () => {
-      await wd.amOnPage('/form/hover');
-      await wd.moveCursorTo('#hover', 100, 100);
-      await wd.dontSee('Hovered', '#show');
-    });
-  });
+      await wd.amOnPage('/form/hover')
+      await wd.moveCursorTo('#hover', 100, 100)
+      await wd.dontSee('Hovered', '#show')
+    })
+  })
 
   describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', async () => {
-      await wd.amOnPage('/');
-      const numPages = await wd.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
-    });
+      await wd.amOnPage('/')
+      const numPages = await wd.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
+    })
 
     it('should switch to next tab', async () => {
-      wd.amOnPage('/info');
-      const numPages = await wd.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
+      wd.amOnPage('/info')
+      const numPages = await wd.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
 
-      await wd.click('New tab');
-      await wd.switchToNextTab();
-      await wd.waitInUrl('/login');
-      const numPagesAfter = await wd.grabNumberOfOpenTabs();
-      assert.equal(numPagesAfter, 2);
-    });
+      await wd.click('New tab')
+      await wd.switchToNextTab()
+      await wd.waitInUrl('/login')
+      const numPagesAfter = await wd.grabNumberOfOpenTabs()
+      assert.equal(numPagesAfter, 2)
+    })
 
     it('should assert when there is no ability to switch to next tab', () => {
       return wd
@@ -624,9 +624,9 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.switchToNextTab(2))
         .then(() => assert.equal(true, false, 'Throw an error if it gets this far (which it should not)!'))
         .catch(e => {
-          assert.equal(e.message, 'There is no ability to switch to next tab with offset 2');
-        });
-    });
+          assert.equal(e.message, 'There is no ability to switch to next tab with offset 2')
+        })
+    })
 
     it('should close current tab', () => {
       return wd
@@ -638,8 +638,8 @@ describe('WebDriver - No Selenium server started', function () {
         .then(numPages => assert.equal(numPages, 2))
         .then(() => wd.closeCurrentTab())
         .then(() => wd.seeInCurrentUrl('/info'))
-        .then(() => wd.grabNumberOfOpenTabs());
-    });
+        .then(() => wd.grabNumberOfOpenTabs())
+    })
 
     it('should close other tabs', () => {
       return wd
@@ -652,8 +652,8 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.seeInCurrentUrl('/login'))
         .then(() => wd.closeOtherTabs())
         .then(() => wd.seeInCurrentUrl('/login'))
-        .then(() => wd.grabNumberOfOpenTabs());
-    });
+        .then(() => wd.grabNumberOfOpenTabs())
+    })
 
     it('should open new tab', () => {
       return wd
@@ -661,8 +661,8 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.openNewTab())
         .then(() => wd.waitInUrl('about:blank'))
         .then(() => wd.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 2));
-    });
+        .then(numPages => assert.equal(numPages, 2))
+    })
 
     it('should switch to previous tab', () => {
       return wd
@@ -670,8 +670,8 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.openNewTab())
         .then(() => wd.waitInUrl('about:blank'))
         .then(() => wd.switchToPreviousTab())
-        .then(() => wd.waitInUrl('/info'));
-    });
+        .then(() => wd.waitInUrl('/info'))
+    })
 
     it('should assert when there is no ability to switch to previous tab', () => {
       return wd
@@ -681,10 +681,10 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.switchToPreviousTab(2))
         .then(() => wd.waitInUrl('/info'))
         .catch(e => {
-          assert.equal(e.message, 'There is no ability to switch to previous tab with offset 2');
-        });
-    });
-  });
+          assert.equal(e.message, 'There is no ability to switch to previous tab with offset 2')
+        })
+    })
+  })
 
   describe('popup : #acceptPopup, #seeInPopup, #cancelPopup', () => {
     it('should accept popup window', () => {
@@ -692,40 +692,40 @@ describe('WebDriver - No Selenium server started', function () {
         .amOnPage('/form/popup')
         .then(() => wd.click('Confirm'))
         .then(() => wd.acceptPopup())
-        .then(() => wd.see('Yes', '#result'));
-    });
+        .then(() => wd.see('Yes', '#result'))
+    })
 
     it('should cancel popup', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.click('Confirm'))
         .then(() => wd.cancelPopup())
-        .then(() => wd.see('No', '#result'));
-    });
+        .then(() => wd.see('No', '#result'))
+    })
 
     it('should check text in popup', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.click('Alert'))
         .then(() => wd.seeInPopup('Really?'))
-        .then(() => wd.cancelPopup());
-    });
+        .then(() => wd.cancelPopup())
+    })
 
     it('should grab text from popup', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.click('Alert'))
         .then(() => wd.grabPopupText())
-        .then(text => assert.equal(text, 'Really?'));
-    });
+        .then(text => assert.equal(text, 'Really?'))
+    })
 
     it('should return null if no popup is visible (do not throw an error)', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.grabPopupText())
-        .then(text => assert.equal(text, null));
-    });
-  });
+        .then(text => assert.equal(text, null))
+    })
+  })
 
   describe('#waitForText', () => {
     it('should return error if not present', () => {
@@ -733,92 +733,92 @@ describe('WebDriver - No Selenium server started', function () {
         .amOnPage('/dynamic')
         .then(() => wd.waitForText('Nothing here', 1, '#text'))
         .catch(e => {
-          e.message.should.be.equal('element (#text) is not in DOM or there is no element(#text) with text "Nothing here" after 1 sec');
-        });
-    });
+          e.message.should.be.equal('element (#text) is not in DOM or there is no element(#text) with text "Nothing here" after 1 sec')
+        })
+    })
 
     it('should return error if waiting is too small', () => {
       return wd
         .amOnPage('/dynamic')
         .then(() => wd.waitForText('Dynamic text', 0.1))
         .catch(e => {
-          e.message.should.be.equal('element (body) is not in DOM or there is no element(body) with text "Dynamic text" after 0.1 sec');
-        });
-    });
-  });
+          e.message.should.be.equal('element (body) is not in DOM or there is no element(body) with text "Dynamic text" after 0.1 sec')
+        })
+    })
+  })
 
   describe('#seeNumberOfElements', () => {
     it('should return 1 as count', async () => {
-      await wd.amOnPage('/');
-      await wd.seeNumberOfElements('#area1', 1);
-    });
-  });
+      await wd.amOnPage('/')
+      await wd.seeNumberOfElements('#area1', 1)
+    })
+  })
 
   describe('#switchTo', () => {
     it('should switch reference to iframe content', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.switchTo('[name="content"]');
-      await wd.see('Information\nLots of valuable data here');
-    });
+      await wd.amOnPage('/iframe')
+      await wd.switchTo('[name="content"]')
+      await wd.see('Information\nLots of valuable data here')
+    })
 
     it('should return error if iframe selector is invalid', async () => {
-      await wd.amOnPage('/iframe');
+      await wd.amOnPage('/iframe')
 
       try {
-        await wd.switchTo('#invalidIframeSelector');
+        await wd.switchTo('#invalidIframeSelector')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath');
+        e.should.be.instanceOf(Error)
+        e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath')
       }
-    });
+    })
 
     it('should return error if iframe selector is not iframe', async () => {
-      await wd.amOnPage('/iframe');
+      await wd.amOnPage('/iframe')
 
       try {
-        await wd.switchTo('h1');
+        await wd.switchTo('h1')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.contain('no such frame');
+        e.should.be.instanceOf(Error)
+        e.message.should.contain('no such frame')
       }
-    });
+    })
 
     it('should return to parent frame given a null locator', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.switchTo('[name="content"]');
-      await wd.see('Information\nLots of valuable data here');
-      await wd.switchTo(null);
-      await wd.see('Iframe test');
-    });
-  });
+      await wd.amOnPage('/iframe')
+      await wd.switchTo('[name="content"]')
+      await wd.see('Information\nLots of valuable data here')
+      await wd.switchTo(null)
+      await wd.see('Iframe test')
+    })
+  })
 
   describe('click context', () => {
     it('should click on inner text', async () => {
-      await wd.amOnPage('/form/checkbox');
-      await wd.click('Submit', '//input[@type = "submit"]');
-      await wd.waitInUrl('/form/complex');
-    });
+      await wd.amOnPage('/form/checkbox')
+      await wd.click('Submit', '//input[@type = "submit"]')
+      await wd.waitInUrl('/form/complex')
+    })
 
     it('should click on input in inner element', async () => {
-      await wd.amOnPage('/form/checkbox');
-      await wd.click('Submit', '//form');
-      await wd.waitInUrl('/form/complex');
-    });
+      await wd.amOnPage('/form/checkbox')
+      await wd.click('Submit', '//form')
+      await wd.waitInUrl('/form/complex')
+    })
 
     it('should click by accessibility_id', async () => {
-      await wd.amOnPage('/info');
-      await wd.click('~index via aria-label');
-      await wd.see('Welcome to test app!');
-    });
-  });
+      await wd.amOnPage('/info')
+      await wd.click('~index via aria-label')
+      await wd.see('Welcome to test app!')
+    })
+  })
 
   describe('window size #resizeWindow', () => {
     it('should set initial window size', async () => {
-      await wd.amOnPage('/form/resize');
-      await wd.click('Window Size');
-      await wd.see('Height 700', '#height');
-      await wd.see('Width 500', '#width');
-    });
+      await wd.amOnPage('/form/resize')
+      await wd.click('Window Size')
+      await wd.see('Height 700', '#height')
+      await wd.see('Width 500', '#width')
+    })
 
     it('should set window size on new session', () => {
       return wd
@@ -834,415 +834,415 @@ describe('WebDriver - No Selenium server started', function () {
         .then(() => wd.amOnPage('/form/resize'))
         .then(() => wd.click('Window Size'))
         .then(() => wd.see('Height 700', '#height'))
-        .then(() => wd.see('Width 500', '#width'));
-    });
+        .then(() => wd.see('Width 500', '#width'))
+    })
 
     it('should resize window to specific dimensions', async () => {
-      await wd.amOnPage('/form/resize');
-      await wd.resizeWindow(950, 600);
-      await wd.click('Window Size');
-      await wd.see('Height 600', '#height');
-      await wd.see('Width 950', '#width');
-    });
+      await wd.amOnPage('/form/resize')
+      await wd.resizeWindow(950, 600)
+      await wd.click('Window Size')
+      await wd.see('Height 600', '#height')
+      await wd.see('Width 950', '#width')
+    })
 
     xit('should resize window to maximum screen dimensions', async () => {
-      await wd.amOnPage('/form/resize');
-      await wd.resizeWindow(500, 400);
-      await wd.click('Window Size');
-      await wd.see('Height 400', '#height');
-      await wd.see('Width 500', '#width');
-      await wd.resizeWindow('maximize');
-      await wd.click('Window Size');
-      await wd.dontSee('Height 400', '#height');
-      await wd.dontSee('Width 500', '#width');
-    });
-  });
+      await wd.amOnPage('/form/resize')
+      await wd.resizeWindow(500, 400)
+      await wd.click('Window Size')
+      await wd.see('Height 400', '#height')
+      await wd.see('Width 500', '#width')
+      await wd.resizeWindow('maximize')
+      await wd.click('Window Size')
+      await wd.dontSee('Height 400', '#height')
+      await wd.dontSee('Width 500', '#width')
+    })
+  })
 
   describe('SmartWait', () => {
-    before(() => (wd.options.smartWait = 3000));
-    after(() => (wd.options.smartWait = 0));
+    before(() => (wd.options.smartWait = 3000))
+    after(() => (wd.options.smartWait = 0))
 
     it('should wait for element to appear', async () => {
-      await wd.amOnPage('/form/wait_element');
-      await wd.dontSeeElement('h1');
-      await wd.seeElement('h1');
-    });
+      await wd.amOnPage('/form/wait_element')
+      await wd.dontSeeElement('h1')
+      await wd.seeElement('h1')
+    })
 
     it('should wait for clickable element appear', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSeeElement('#click');
-      await wd.click('#click');
-      await wd.see('Hi!');
-    });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSeeElement('#click')
+      await wd.click('#click')
+      await wd.see('Hi!')
+    })
 
     it('should wait for clickable context to appear', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSeeElement('#linkContext');
-      await wd.click('Hello world', '#linkContext');
-      await wd.see('Hi!');
-    });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSeeElement('#linkContext')
+      await wd.click('Hello world', '#linkContext')
+      await wd.see('Hi!')
+    })
 
     it('should wait for text context to appear', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSee('Hello world');
-      await wd.see('Hello world', '#linkContext');
-    });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSee('Hello world')
+      await wd.see('Hello world', '#linkContext')
+    })
 
     it('should work with grabbers', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSee('Hello world');
-      const res = await wd.grabAttributeFrom('#click', 'id');
-      assert.equal(res, 'click');
-    });
-  });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSee('Hello world')
+      const res = await wd.grabAttributeFrom('#click', 'id')
+      assert.equal(res, 'click')
+    })
+  })
 
   describe('#_locateClickable', () => {
     it('should locate a button to click', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateClickable('Submit');
-      res.length.should.be.equal(1);
-    });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateClickable('Submit')
+      res.length.should.be.equal(1)
+    })
 
     it('should not locate a non-existing checkbox', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateClickable('I disagree');
-      res.length.should.be.equal(0);
-    });
-  });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateClickable('I disagree')
+      res.length.should.be.equal(0)
+    })
+  })
 
   describe('#_locateCheckable', () => {
     it('should locate a checkbox', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateCheckable('I Agree');
-      res.length.should.be.equal(1);
-    });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateCheckable('I Agree')
+      res.length.should.be.equal(1)
+    })
 
     it('should not locate a non-existing checkbox', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateCheckable('I disagree');
-      res.length.should.be.equal(0);
-    });
-  });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateCheckable('I disagree')
+      res.length.should.be.equal(0)
+    })
+  })
 
   describe('#_locateFields', () => {
     it('should locate a field', async () => {
-      await wd.amOnPage('/form/field');
-      const res = await wd._locateFields('Name');
-      res.length.should.be.equal(1);
-    });
+      await wd.amOnPage('/form/field')
+      const res = await wd._locateFields('Name')
+      res.length.should.be.equal(1)
+    })
 
     it('should not locate a non-existing field', async () => {
-      await wd.amOnPage('/form/field');
-      const res = await wd._locateFields('Mother-in-law');
-      res.length.should.be.equal(0);
-    });
-  });
+      await wd.amOnPage('/form/field')
+      const res = await wd._locateFields('Mother-in-law')
+      res.length.should.be.equal(0)
+    })
+  })
 
   xdescribe('#grabBrowserLogs', () => {
     it('should grab browser logs', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
       await wd.executeScript(() => {
-        console.log('Test log entry');
-      });
-      const logs = await wd.grabBrowserLogs();
-      console.log('lololo', logs);
+        console.log('Test log entry')
+      })
+      const logs = await wd.grabBrowserLogs()
+      console.log('lololo', logs)
 
-      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1);
-      assert.equal(matchingLogs.length, 1);
-    });
+      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1)
+      assert.equal(matchingLogs.length, 1)
+    })
 
     it('should grab browser logs across pages', async () => {
-      wd.amOnPage('/');
+      wd.amOnPage('/')
       await wd.executeScript(() => {
-        console.log('Test log entry 1');
-      });
-      await wd.openNewTab();
-      await wd.amOnPage('/info');
+        console.log('Test log entry 1')
+      })
+      await wd.openNewTab()
+      await wd.amOnPage('/info')
       await wd.executeScript(() => {
-        console.log('Test log entry 2');
-      });
+        console.log('Test log entry 2')
+      })
 
-      const logs = await wd.grabBrowserLogs();
+      const logs = await wd.grabBrowserLogs()
 
-      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1);
-      assert.equal(matchingLogs.length, 2);
-    });
-  });
+      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1)
+      assert.equal(matchingLogs.length, 2)
+    })
+  })
 
   describe('#dragAndDrop', () => {
     it('Drag item from source to target (no iframe) @dragNdrop', async () => {
-      await wd.amOnPage('http://jqueryui.com/resources/demos/droppable/default.html');
-      await wd.seeElementInDOM('#draggable');
-      await wd.dragAndDrop('#draggable', '#droppable');
-      await wd.see('Dropped');
-    });
+      await wd.amOnPage('http://jqueryui.com/resources/demos/droppable/default.html')
+      await wd.seeElementInDOM('#draggable')
+      await wd.dragAndDrop('#draggable', '#droppable')
+      await wd.see('Dropped')
+    })
 
     it('Drag and drop from within an iframe', async () => {
-      await wd.amOnPage('http://jqueryui.com/droppable');
-      await wd.resizeWindow(700, 700);
-      await wd.switchTo('//iframe[@class="demo-frame"]');
-      await wd.seeElementInDOM('#draggable');
-      await wd.dragAndDrop('#draggable', '#droppable');
-      await wd.see('Dropped');
-    });
-  });
+      await wd.amOnPage('http://jqueryui.com/droppable')
+      await wd.resizeWindow(700, 700)
+      await wd.switchTo('//iframe[@class="demo-frame"]')
+      await wd.seeElementInDOM('#draggable')
+      await wd.dragAndDrop('#draggable', '#droppable')
+      await wd.see('Dropped')
+    })
+  })
 
   describe('#switchTo frame', () => {
     it('should switch to frame using name', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.see('Iframe test', 'h1');
-      await wd.dontSee('Information', 'h1');
-      await wd.switchTo('iframe');
-      await wd.see('Information', 'h1');
-      await wd.dontSee('Iframe test', 'h1');
-    });
+      await wd.amOnPage('/iframe')
+      await wd.see('Iframe test', 'h1')
+      await wd.dontSee('Information', 'h1')
+      await wd.switchTo('iframe')
+      await wd.see('Information', 'h1')
+      await wd.dontSee('Iframe test', 'h1')
+    })
 
     it('should switch to root frame', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.see('Iframe test', 'h1');
-      await wd.dontSee('Information', 'h1');
-      await wd.switchTo('iframe');
-      await wd.see('Information', 'h1');
-      await wd.dontSee('Iframe test', 'h1');
-      await wd.switchTo();
-      await wd.see('Iframe test', 'h1');
-    });
+      await wd.amOnPage('/iframe')
+      await wd.see('Iframe test', 'h1')
+      await wd.dontSee('Information', 'h1')
+      await wd.switchTo('iframe')
+      await wd.see('Information', 'h1')
+      await wd.dontSee('Iframe test', 'h1')
+      await wd.switchTo()
+      await wd.see('Iframe test', 'h1')
+    })
 
     it('should switch to frame using frame number', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.see('Iframe test', 'h1');
-      await wd.dontSee('Information', 'h1');
-      await wd.switchTo(0);
-      await wd.see('Information', 'h1');
-      await wd.dontSee('Iframe test', 'h1');
-    });
-  });
+      await wd.amOnPage('/iframe')
+      await wd.see('Iframe test', 'h1')
+      await wd.dontSee('Information', 'h1')
+      await wd.switchTo(0)
+      await wd.see('Information', 'h1')
+      await wd.dontSee('Iframe test', 'h1')
+    })
+  })
 
   describe.skip('#AttachFile', () => {
     it('should attach to regular input element', async () => {
-      await wd.amOnPage('/form/file');
-      await wd.attachFile('Avatar', './app/avatar.jpg');
-      await wd.seeInField('Avatar', 'avatar.jpg');
-    });
+      await wd.amOnPage('/form/file')
+      await wd.attachFile('Avatar', './app/avatar.jpg')
+      await wd.seeInField('Avatar', 'avatar.jpg')
+    })
 
     it('should attach to invisible input element', async () => {
-      await wd.amOnPage('/form/file');
-      await wd.attachFile('hidden', '/app/avatar.jpg');
-    });
-  });
+      await wd.amOnPage('/form/file')
+      await wd.attachFile('hidden', '/app/avatar.jpg')
+    })
+  })
 
   describe('#dragSlider', () => {
     it('should drag scrubber to given position', async () => {
-      await wd.amOnPage('/form/page_slider');
-      await wd.seeElementInDOM('#slidecontainer input');
+      await wd.amOnPage('/form/page_slider')
+      await wd.seeElementInDOM('#slidecontainer input')
 
-      const before = await wd.grabValueFrom('#slidecontainer input');
-      await wd.dragSlider('#slidecontainer input', 20);
-      const after = await wd.grabValueFrom('#slidecontainer input');
+      const before = await wd.grabValueFrom('#slidecontainer input')
+      await wd.dragSlider('#slidecontainer input', 20)
+      const after = await wd.grabValueFrom('#slidecontainer input')
 
-      assert.notEqual(before, after);
-    });
-  });
+      assert.notEqual(before, after)
+    })
+  })
 
   describe('#uncheckOption', () => {
     it('should uncheck option that is currently checked', async () => {
-      await wd.amOnPage('/info');
-      await wd.uncheckOption('interesting');
-      await wd.dontSeeCheckboxIsChecked('interesting');
-    });
+      await wd.amOnPage('/info')
+      await wd.uncheckOption('interesting')
+      await wd.dontSeeCheckboxIsChecked('interesting')
+    })
 
     it('should NOT uncheck option that is NOT currently checked', async () => {
-      await wd.amOnPage('/info');
-      await wd.uncheckOption('interesting');
+      await wd.amOnPage('/info')
+      await wd.uncheckOption('interesting')
       // Unchecking again should not affect the current 'unchecked' status
-      await wd.uncheckOption('interesting');
-      await wd.dontSeeCheckboxIsChecked('interesting');
-    });
-  });
+      await wd.uncheckOption('interesting')
+      await wd.dontSeeCheckboxIsChecked('interesting')
+    })
+  })
 
   describe('allow back and forth between handles: #grabAllWindowHandles #grabCurrentWindowHandle #switchToWindow', () => {
     it('should open main page of configured site, open a popup, switch to main page, then switch to popup, close popup, and go back to main page', async () => {
-      await wd.amOnPage('/');
-      const handleBeforePopup = await wd.grabCurrentWindowHandle();
-      const urlBeforePopup = await wd.grabCurrentUrl();
+      await wd.amOnPage('/')
+      const handleBeforePopup = await wd.grabCurrentWindowHandle()
+      const urlBeforePopup = await wd.grabCurrentUrl()
 
-      const allHandlesBeforePopup = await wd.grabAllWindowHandles();
-      allHandlesBeforePopup.length.should.eql(1);
+      const allHandlesBeforePopup = await wd.grabAllWindowHandles()
+      allHandlesBeforePopup.length.should.eql(1)
 
       await wd.executeScript(() => {
-        window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400');
-      });
+        window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400')
+      })
 
-      const allHandlesAfterPopup = await wd.grabAllWindowHandles();
-      allHandlesAfterPopup.length.should.eql(2);
+      const allHandlesAfterPopup = await wd.grabAllWindowHandles()
+      allHandlesAfterPopup.length.should.eql(2)
 
-      await wd.switchToWindow(allHandlesAfterPopup[1]);
-      const urlAfterPopup = await wd.grabCurrentUrl();
-      urlAfterPopup.should.eql('https://www.w3schools.com/');
+      await wd.switchToWindow(allHandlesAfterPopup[1])
+      const urlAfterPopup = await wd.grabCurrentUrl()
+      urlAfterPopup.should.eql('https://www.w3schools.com/')
 
-      handleBeforePopup.should.eql(allHandlesAfterPopup[0]);
-      await wd.switchToWindow(handleBeforePopup);
-      const currentURL = await wd.grabCurrentUrl();
-      currentURL.should.eql(urlBeforePopup);
+      handleBeforePopup.should.eql(allHandlesAfterPopup[0])
+      await wd.switchToWindow(handleBeforePopup)
+      const currentURL = await wd.grabCurrentUrl()
+      currentURL.should.eql(urlBeforePopup)
 
-      await wd.switchToWindow(allHandlesAfterPopup[1]);
-      const urlAfterSwitchBack = await wd.grabCurrentUrl();
-      urlAfterSwitchBack.should.eql('https://www.w3schools.com/');
-      await wd.closeCurrentTab();
+      await wd.switchToWindow(allHandlesAfterPopup[1])
+      const urlAfterSwitchBack = await wd.grabCurrentUrl()
+      urlAfterSwitchBack.should.eql('https://www.w3schools.com/')
+      await wd.closeCurrentTab()
 
-      const allHandlesAfterPopupClosed = await wd.grabAllWindowHandles();
-      allHandlesAfterPopupClosed.length.should.eql(1);
-      const currentWindowHandle = await wd.grabCurrentWindowHandle();
-      currentWindowHandle.should.eql(handleBeforePopup);
-    });
-  });
+      const allHandlesAfterPopupClosed = await wd.grabAllWindowHandles()
+      allHandlesAfterPopupClosed.length.should.eql(1)
+      const currentWindowHandle = await wd.grabCurrentWindowHandle()
+      currentWindowHandle.should.eql(handleBeforePopup)
+    })
+  })
 
   describe('#waitForClickable', () => {
     it('should wait for clickable', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
-      await wd.waitForClickable({ css: 'input#text' });
-    });
+      await wd.amOnPage('/form/wait_for_clickable')
+      await wd.waitForClickable({ css: 'input#text' })
+    })
 
     it('should wait for clickable by XPath', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
-      await wd.waitForClickable({ xpath: './/input[@id="text"]' });
-    });
+      await wd.amOnPage('/form/wait_for_clickable')
+      await wd.waitForClickable({ xpath: './/input[@id="text"]' })
+    })
 
     it('should fail for disabled element', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#button' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #button still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #button still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for disabled element by XPath', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ xpath: './/button[@id="button"]' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element .//button[@id="button"] still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element .//button[@id="button"] still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by top', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportTop' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportTop still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportTop still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by bottom', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportBottom' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportBottom still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportBottom still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by left', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportLeft' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportLeft still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportLeft still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by right', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportRight' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportRight still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportRight still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for overlapping element', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
-      await wd.waitForClickable({ css: '#div2_button' }, 0.1);
+      await wd.amOnPage('/form/wait_for_clickable')
+      await wd.waitForClickable({ css: '#div2_button' }, 0.1)
       await wd
         .waitForClickable({ css: '#div1_button' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #div1_button still not clickable after 0.1 sec');
-        });
-    });
-  });
+          e.message.should.include('element #div1_button still not clickable after 0.1 sec')
+        })
+    })
+  })
 
   describe('#grabElementBoundingRect', () => {
     it('should get the element size', async () => {
-      await wd.amOnPage('/form/hidden');
-      const size = await wd.grabElementBoundingRect('input[type=submit]');
-      expect(size.x).is.greaterThan(0);
-      expect(size.y).is.greaterThan(0);
-      expect(size.width).is.greaterThan(0);
-      expect(size.height).is.greaterThan(0);
-    });
+      await wd.amOnPage('/form/hidden')
+      const size = await wd.grabElementBoundingRect('input[type=submit]')
+      expect(size.x).is.greaterThan(0)
+      expect(size.y).is.greaterThan(0)
+      expect(size.width).is.greaterThan(0)
+      expect(size.height).is.greaterThan(0)
+    })
 
     it('should get the element width', async () => {
-      await wd.amOnPage('/form/hidden');
-      const width = await wd.grabElementBoundingRect('input[type=submit]', 'width');
-      expect(width).is.greaterThan(0);
-    });
+      await wd.amOnPage('/form/hidden')
+      const width = await wd.grabElementBoundingRect('input[type=submit]', 'width')
+      expect(width).is.greaterThan(0)
+    })
 
     it('should get the element height', async () => {
-      await wd.amOnPage('/form/hidden');
-      const height = await wd.grabElementBoundingRect('input[type=submit]', 'height');
-      expect(height).is.greaterThan(0);
-    });
-  });
+      await wd.amOnPage('/form/hidden')
+      const height = await wd.grabElementBoundingRect('input[type=submit]', 'height')
+      expect(height).is.greaterThan(0)
+    })
+  })
 
   describe('#scrollIntoView', () => {
     it.skip('should scroll element into viewport', async () => {
-      await wd.amOnPage('/form/scroll_into_view');
-      const element = await wd.browser.$('#notInViewportByDefault');
-      expect(await element.isDisplayedInViewport()).to.be.false;
-      await wd.scrollIntoView('#notInViewportByDefault');
-      expect(await element.isDisplayedInViewport()).to.be.true;
-    });
-  });
+      await wd.amOnPage('/form/scroll_into_view')
+      const element = await wd.browser.$('#notInViewportByDefault')
+      expect(await element.isDisplayedInViewport()).to.be.false
+      await wd.scrollIntoView('#notInViewportByDefault')
+      expect(await element.isDisplayedInViewport()).to.be.true
+    })
+  })
 
   describe('#useWebDriverTo', () => {
     it('should return title', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
       const title = await wd.useWebDriverTo('test', async ({ browser }) => {
-        return browser.getTitle();
-      });
-      assert.equal('TestEd Beta 2.0', title);
-    });
-  });
-});
+        return browser.getTitle()
+      })
+      assert.equal('TestEd Beta 2.0', title)
+    })
+  })
+})
 
 describe('WebDriver - Basic Authentication', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     try {
-      fs.unlinkSync(dataFile);
+      fs.unlinkSync(dataFile)
     } catch (err) {
       // continue regardless of error
     }
@@ -1261,19 +1261,19 @@ describe('WebDriver - Basic Authentication', () => {
           args: ['--headless', '--disable-gpu', '--window-size=1280,1024'],
         },
       },
-    });
-  });
+    })
+  })
 
   beforeEach(async () => {
-    await wd._before();
-  });
+    await wd._before()
+  })
 
-  afterEach(() => wd._after());
+  afterEach(() => wd._after())
 
   describe('open page : #amOnPage', () => {
     it('should be authenticated', async () => {
-      await wd.amOnPage('/basic_auth');
-      await wd.see('You entered admin as your password.');
-    });
-  });
-});
+      await wd.amOnPage('/basic_auth')
+      await wd.see('You entered admin as your password.')
+    })
+  })
+})

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -1,31 +1,31 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const assert = chai.assert;
-const path = require('path');
-const fs = require('fs');
+const expect = chai.expect
+const assert = chai.assert
+const path = require('path')
+const fs = require('fs')
 
-const TestHelper = require('../support/TestHelper');
-const WebDriver = require('../../lib/helper/WebDriver');
-const AssertionFailedError = require('../../lib/assert/error');
-const webApiTests = require('./webapi');
-const Secret = require('../../lib/secret');
-global.codeceptjs = require('../../lib');
+const TestHelper = require('../support/TestHelper')
+const WebDriver = require('../../lib/helper/WebDriver')
+const AssertionFailedError = require('../../lib/assert/error')
+const webApiTests = require('./webapi')
+const Secret = require('../../lib/secret')
+global.codeceptjs = require('../../lib')
 
-const siteUrl = TestHelper.siteUrl();
-let wd;
+const siteUrl = TestHelper.siteUrl()
+let wd
 
-console.log('Connecting to Selenium Server', TestHelper.seleniumAddress());
-process.env.isSelenium = 'true';
+console.log('Connecting to Selenium Server', TestHelper.seleniumAddress())
+process.env.isSelenium = 'true'
 
 describe('WebDriver', function () {
-  this.retries(1);
-  this.timeout(35000);
+  this.retries(1)
+  this.timeout(35000)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     try {
-      fs.unlinkSync(dataFile);
+      fs.unlinkSync(dataFile)
     } catch (err) {
       // continue regardless of error
     }
@@ -46,471 +46,471 @@ describe('WebDriver', function () {
       customLocatorStrategies: {
         customSelector: selector => ({ 'element-6066-11e4-a52e-4f735466cecf': `${selector}-foobar` }),
       },
-    });
-  });
+    })
+  })
 
   beforeEach(async () => {
-    webApiTests.init({ I: wd, siteUrl });
-    this.wdBrowser = await wd._before();
-    return this.wdBrowser;
-  });
+    webApiTests.init({ I: wd, siteUrl })
+    this.wdBrowser = await wd._before()
+    return this.wdBrowser
+  })
 
-  afterEach(async () => wd._after());
+  afterEach(async () => wd._after())
 
   // load common test suite
-  webApiTests.tests();
+  webApiTests.tests()
 
   describe('customLocatorStrategies', () => {
     it('should locate through custom selector', async () => {
-      const el = await this.wdBrowser.custom$('customSelector', '.test');
-      expect(el.elementId).to.equal('.test-foobar');
-    });
+      const el = await this.wdBrowser.custom$('customSelector', '.test')
+      expect(el.elementId).to.equal('.test-foobar')
+    })
 
     it('should include the custom strategy', async () => {
-      expect(wd.customLocatorStrategies.customSelector).to.not.be.undefined;
-    });
+      expect(wd.customLocatorStrategies.customSelector).to.not.be.undefined
+    })
 
     it('should be added to the browser locator strategies', async () => {
-      expect(this.wdBrowser.addLocatorStrategy).to.not.be.undefined;
-    });
+      expect(this.wdBrowser.addLocatorStrategy).to.not.be.undefined
+    })
 
     it('throws on invalid custom selector', async () => {
       try {
-        await wd.waitForEnabled({ madeUpSelector: '#text' }, 2);
+        await wd.waitForEnabled({ madeUpSelector: '#text' }, 2)
       } catch (e) {
-        expect(e.message).to.include('Please define "customLocatorStrategies"');
+        expect(e.message).to.include('Please define "customLocatorStrategies"')
       }
-    });
-  });
+    })
+  })
 
   describe('open page : #amOnPage', () => {
     it('should open main page of configured site', async () => {
-      await wd.amOnPage('/');
-      const url = await wd.grabCurrentUrl();
-      url.should.eql(`${siteUrl}/`);
-    });
+      await wd.amOnPage('/')
+      const url = await wd.grabCurrentUrl()
+      url.should.eql(`${siteUrl}/`)
+    })
 
     it('should open any page of configured site', async () => {
-      await wd.amOnPage('/info');
-      const url = await wd.grabCurrentUrl();
-      url.should.eql(`${siteUrl}/info`);
-    });
+      await wd.amOnPage('/info')
+      const url = await wd.grabCurrentUrl()
+      url.should.eql(`${siteUrl}/info`)
+    })
 
     it('should open absolute url', async () => {
-      await wd.amOnPage(siteUrl);
-      const url = await wd.grabCurrentUrl();
-      url.should.eql(`${siteUrl}/`);
-    });
-  });
+      await wd.amOnPage(siteUrl)
+      const url = await wd.grabCurrentUrl()
+      url.should.eql(`${siteUrl}/`)
+    })
+  })
 
   describe('see text : #see', () => {
     it('should fail when text is not on site', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
 
       try {
-        await wd.see('Something incredible!');
+        await wd.see('Something incredible!')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('web page');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('web page')
       }
 
       try {
-        await wd.dontSee('Welcome');
+        await wd.dontSee('Welcome')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.include('web page');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.include('web page')
       }
-    });
-  });
+    })
+  })
 
   describe('check fields: #seeInField, #seeCheckboxIsChecked, ...', () => {
     it('should throw error if field is not empty', async () => {
-      await wd.amOnPage('/form/empty');
+      await wd.amOnPage('/form/empty')
 
       try {
-        await wd.seeInField('#empty_input', 'Ayayay');
+        await wd.seeInField('#empty_input', 'Ayayay')
       } catch (e) {
-        e.should.be.instanceOf(AssertionFailedError);
-        e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"');
+        e.should.be.instanceOf(AssertionFailedError)
+        e.inspect().should.be.equal('expected fields by #empty_input to include "Ayayay"')
       }
-    });
+    })
 
     it('should check values in checkboxes', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.dontSeeInField('checkbox[]', 'not seen one');
-      await wd.seeInField('checkbox[]', 'see test one');
-      await wd.dontSeeInField('checkbox[]', 'not seen two');
-      await wd.seeInField('checkbox[]', 'see test two');
-      await wd.dontSeeInField('checkbox[]', 'not seen three');
-      await wd.seeInField('checkbox[]', 'see test three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.dontSeeInField('checkbox[]', 'not seen one')
+      await wd.seeInField('checkbox[]', 'see test one')
+      await wd.dontSeeInField('checkbox[]', 'not seen two')
+      await wd.seeInField('checkbox[]', 'see test two')
+      await wd.dontSeeInField('checkbox[]', 'not seen three')
+      await wd.seeInField('checkbox[]', 'see test three')
+    })
 
     it('should check values are the secret type in checkboxes', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen one'));
-      await wd.seeInField('checkbox[]', Secret.secret('see test one'));
-      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen two'));
-      await wd.seeInField('checkbox[]', Secret.secret('see test two'));
-      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen three'));
-      await wd.seeInField('checkbox[]', Secret.secret('see test three'));
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen one'))
+      await wd.seeInField('checkbox[]', Secret.secret('see test one'))
+      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen two'))
+      await wd.seeInField('checkbox[]', Secret.secret('see test two'))
+      await wd.dontSeeInField('checkbox[]', Secret.secret('not seen three'))
+      await wd.seeInField('checkbox[]', Secret.secret('see test three'))
+    })
 
     it('should check values with boolean', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('checkbox1', true);
-      await wd.dontSeeInField('checkbox1', false);
-      await wd.seeInField('checkbox2', false);
-      await wd.dontSeeInField('checkbox2', true);
-      await wd.seeInField('radio2', true);
-      await wd.dontSeeInField('radio2', false);
-      await wd.seeInField('radio3', false);
-      await wd.dontSeeInField('radio3', true);
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('checkbox1', true)
+      await wd.dontSeeInField('checkbox1', false)
+      await wd.seeInField('checkbox2', false)
+      await wd.dontSeeInField('checkbox2', true)
+      await wd.seeInField('radio2', true)
+      await wd.dontSeeInField('radio2', false)
+      await wd.seeInField('radio3', false)
+      await wd.dontSeeInField('radio3', true)
+    })
 
     it('should check values in radio', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('radio1', 'see test one');
-      await wd.dontSeeInField('radio1', 'not seen one');
-      await wd.dontSeeInField('radio1', 'not seen two');
-      await wd.dontSeeInField('radio1', 'not seen three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('radio1', 'see test one')
+      await wd.dontSeeInField('radio1', 'not seen one')
+      await wd.dontSeeInField('radio1', 'not seen two')
+      await wd.dontSeeInField('radio1', 'not seen three')
+    })
 
     it('should check values in select', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('select1', 'see test one');
-      await wd.dontSeeInField('select1', 'not seen one');
-      await wd.dontSeeInField('select1', 'not seen two');
-      await wd.dontSeeInField('select1', 'not seen three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('select1', 'see test one')
+      await wd.dontSeeInField('select1', 'not seen one')
+      await wd.dontSeeInField('select1', 'not seen two')
+      await wd.dontSeeInField('select1', 'not seen three')
+    })
 
     it('should check for empty select field', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.seeInField('select3', '');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.seeInField('select3', '')
+    })
 
     it('should check for select multiple field', async () => {
-      await wd.amOnPage('/form/field_values');
-      await wd.dontSeeInField('select2', 'not seen one');
-      await wd.seeInField('select2', 'see test one');
-      await wd.dontSeeInField('select2', 'not seen two');
-      await wd.seeInField('select2', 'see test two');
-      await wd.dontSeeInField('select2', 'not seen three');
-      await wd.seeInField('select2', 'see test three');
-    });
+      await wd.amOnPage('/form/field_values')
+      await wd.dontSeeInField('select2', 'not seen one')
+      await wd.seeInField('select2', 'see test one')
+      await wd.dontSeeInField('select2', 'not seen two')
+      await wd.seeInField('select2', 'see test two')
+      await wd.dontSeeInField('select2', 'not seen three')
+      await wd.seeInField('select2', 'see test three')
+    })
 
     it('should return error when element has no value attribute', async () => {
-      await wd.amOnPage('https://codecept.io/quickstart');
+      await wd.amOnPage('https://codecept.io/quickstart')
 
       try {
-        await wd.seeInField('#search_input_react', 'WebDriver1');
+        await wd.seeInField('#search_input_react', 'WebDriver1')
       } catch (e) {
-        e.should.be.instanceOf(Error);
+        e.should.be.instanceOf(Error)
       }
-    });
-  });
+    })
+  })
 
   describe('Force Right Click: #forceRightClick', () => {
     it('it should forceRightClick', async () => {
-      await wd.amOnPage('/form/rightclick');
-      await wd.dontSee('right clicked');
-      await wd.forceRightClick('Lorem Ipsum');
-      await wd.see('right clicked');
-    });
+      await wd.amOnPage('/form/rightclick')
+      await wd.dontSee('right clicked')
+      await wd.forceRightClick('Lorem Ipsum')
+      await wd.see('right clicked')
+    })
 
     it('it should forceRightClick by locator', async () => {
-      await wd.amOnPage('/form/rightclick');
-      await wd.dontSee('right clicked');
-      await wd.forceRightClick('.context a');
-      await wd.see('right clicked');
-    });
+      await wd.amOnPage('/form/rightclick')
+      await wd.dontSee('right clicked')
+      await wd.forceRightClick('.context a')
+      await wd.see('right clicked')
+    })
 
     it('it should forceRightClick by locator and context', async () => {
-      await wd.amOnPage('/form/rightclick');
-      await wd.dontSee('right clicked');
-      await wd.forceRightClick('Lorem Ipsum', '.context');
-      await wd.see('right clicked');
-    });
-  });
+      await wd.amOnPage('/form/rightclick')
+      await wd.dontSee('right clicked')
+      await wd.forceRightClick('Lorem Ipsum', '.context')
+      await wd.see('right clicked')
+    })
+  })
 
   describe('#pressKey, #pressKeyDown, #pressKeyUp', () => {
     it('should be able to send special keys to element', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.appendField('Name', '-');
+      await wd.amOnPage('/form/field')
+      await wd.appendField('Name', '-')
 
-      await wd.pressKey(['Right Shift', 'Home']);
-      await wd.pressKey('Delete');
+      await wd.pressKey(['Right Shift', 'Home'])
+      await wd.pressKey('Delete')
 
       // Sequence only executes up to first non-modifier key ('Digit1')
-      await wd.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4']);
-      await wd.pressKey('1');
-      await wd.pressKey('2');
-      await wd.pressKey('3');
-      await wd.pressKey('ArrowLeft');
-      await wd.pressKey('Left Arrow');
-      await wd.pressKey('arrow_left');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('a');
-      await wd.pressKey('KeyB');
-      await wd.pressKeyUp('ShiftLeft');
-      await wd.pressKey('C');
-      await wd.seeInField('Name', '!ABC123');
-    });
+      await wd.pressKey(['SHIFT_RIGHT', 'Digit1', 'Digit4'])
+      await wd.pressKey('1')
+      await wd.pressKey('2')
+      await wd.pressKey('3')
+      await wd.pressKey('ArrowLeft')
+      await wd.pressKey('Left Arrow')
+      await wd.pressKey('arrow_left')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('a')
+      await wd.pressKey('KeyB')
+      await wd.pressKeyUp('ShiftLeft')
+      await wd.pressKey('C')
+      await wd.seeInField('Name', '!ABC123')
+    })
 
     it('should use modifier key based on operating system', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.fillField('Name', 'value that is cleared using select all shortcut');
+      await wd.amOnPage('/form/field')
+      await wd.fillField('Name', 'value that is cleared using select all shortcut')
 
-      await wd.pressKey(['CommandOrControl', 'A']);
-      await wd.pressKey('Backspace');
-      await wd.dontSeeInField('Name', 'value that is cleared using select all shortcut');
-    });
+      await wd.pressKey(['CommandOrControl', 'A'])
+      await wd.pressKey('Backspace')
+      await wd.dontSeeInField('Name', 'value that is cleared using select all shortcut')
+    })
 
     it('should show correct numpad or punctuation key when Shift modifier is active', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.fillField('Name', '');
+      await wd.amOnPage('/form/field')
+      await wd.fillField('Name', '')
 
-      await wd.pressKey(';');
-      await wd.pressKey(['Shift', ';']);
-      await wd.pressKey(['Shift', 'Semicolon']);
-      await wd.pressKey('=');
-      await wd.pressKey(['Shift', '=']);
-      await wd.pressKey(['Shift', 'Equal']);
-      await wd.pressKey('*');
-      await wd.pressKey(['Shift', '*']);
-      await wd.pressKey(['Shift', 'Multiply']);
-      await wd.pressKey('+');
-      await wd.pressKey(['Shift', '+']);
-      await wd.pressKey(['Shift', 'Add']);
-      await wd.pressKey(',');
-      await wd.pressKey(['Shift', ',']);
-      await wd.pressKey(['Shift', 'Comma']);
-      await wd.pressKey(['Shift', 'NumpadComma']);
-      await wd.pressKey(['Shift', 'Separator']);
-      await wd.pressKey('-');
-      await wd.pressKey(['Shift', '-']);
-      await wd.pressKey(['Shift', 'Subtract']);
-      await wd.pressKey('.');
-      await wd.pressKey(['Shift', '.']);
-      await wd.pressKey(['Shift', 'Decimal']);
-      await wd.pressKey(['Shift', 'Period']);
-      await wd.pressKey('/');
-      await wd.pressKey(['Shift', '/']);
-      await wd.pressKey(['Shift', 'Divide']);
-      await wd.pressKey(['Shift', 'Slash']);
+      await wd.pressKey(';')
+      await wd.pressKey(['Shift', ';'])
+      await wd.pressKey(['Shift', 'Semicolon'])
+      await wd.pressKey('=')
+      await wd.pressKey(['Shift', '='])
+      await wd.pressKey(['Shift', 'Equal'])
+      await wd.pressKey('*')
+      await wd.pressKey(['Shift', '*'])
+      await wd.pressKey(['Shift', 'Multiply'])
+      await wd.pressKey('+')
+      await wd.pressKey(['Shift', '+'])
+      await wd.pressKey(['Shift', 'Add'])
+      await wd.pressKey(',')
+      await wd.pressKey(['Shift', ','])
+      await wd.pressKey(['Shift', 'Comma'])
+      await wd.pressKey(['Shift', 'NumpadComma'])
+      await wd.pressKey(['Shift', 'Separator'])
+      await wd.pressKey('-')
+      await wd.pressKey(['Shift', '-'])
+      await wd.pressKey(['Shift', 'Subtract'])
+      await wd.pressKey('.')
+      await wd.pressKey(['Shift', '.'])
+      await wd.pressKey(['Shift', 'Decimal'])
+      await wd.pressKey(['Shift', 'Period'])
+      await wd.pressKey('/')
+      await wd.pressKey(['Shift', '/'])
+      await wd.pressKey(['Shift', 'Divide'])
+      await wd.pressKey(['Shift', 'Slash'])
 
-      await wd.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?');
-    });
+      await wd.seeInField('Name', ';::=++***+++,<<<<-_-.>.>/?/?')
+    })
 
     it('should show correct number key when Shift modifier is active', async () => {
-      await wd.amOnPage('/form/field');
-      await wd.fillField('Name', '');
+      await wd.amOnPage('/form/field')
+      await wd.fillField('Name', '')
 
-      await wd.pressKey('0');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('0');
-      await wd.pressKey('Digit0');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('0')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('0')
+      await wd.pressKey('Digit0')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('1');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('1');
-      await wd.pressKey('Digit1');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('1')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('1')
+      await wd.pressKey('Digit1')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('2');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('2');
-      await wd.pressKey('Digit2');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('2')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('2')
+      await wd.pressKey('Digit2')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('3');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('3');
-      await wd.pressKey('Digit3');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('3')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('3')
+      await wd.pressKey('Digit3')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('4');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('4');
-      await wd.pressKey('Digit4');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('4')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('4')
+      await wd.pressKey('Digit4')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('5');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('5');
-      await wd.pressKey('Digit5');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('5')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('5')
+      await wd.pressKey('Digit5')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('6');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('6');
-      await wd.pressKey('Digit6');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('6')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('6')
+      await wd.pressKey('Digit6')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('7');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('7');
-      await wd.pressKey('Digit7');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('7')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('7')
+      await wd.pressKey('Digit7')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('8');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('8');
-      await wd.pressKey('Digit8');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('8')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('8')
+      await wd.pressKey('Digit8')
+      await wd.pressKeyUp('Shift')
 
-      await wd.pressKey('9');
-      await wd.pressKeyDown('Shift');
-      await wd.pressKey('9');
-      await wd.pressKey('Digit9');
-      await wd.pressKeyUp('Shift');
+      await wd.pressKey('9')
+      await wd.pressKeyDown('Shift')
+      await wd.pressKey('9')
+      await wd.pressKey('Digit9')
+      await wd.pressKeyUp('Shift')
 
-      await wd.seeInField('Name', '0))1!!2@@3##4$$5%%6^^7&&8**9((');
-    });
-  });
+      await wd.seeInField('Name', '0))1!!2@@3##4$$5%%6^^7&&8**9((')
+    })
+  })
 
   describe('#seeInSource, #grabSource', () => {
     it('should check for text to be in HTML source', async () => {
-      await wd.amOnPage('/');
-      await wd.seeInSource('<title>TestEd Beta 2.0</title>');
-      await wd.dontSeeInSource('<meta');
-    });
+      await wd.amOnPage('/')
+      await wd.seeInSource('<title>TestEd Beta 2.0</title>')
+      await wd.dontSeeInSource('<meta')
+    })
 
     it('should grab the source', async () => {
-      await wd.amOnPage('/');
-      const source = await wd.grabSource();
-      assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved');
-    });
+      await wd.amOnPage('/')
+      const source = await wd.grabSource()
+      assert.notEqual(source.indexOf('<title>TestEd Beta 2.0</title>'), -1, 'Source html should be retrieved')
+    })
 
     it('should grab the innerHTML for an element', async () => {
-      await wd.amOnPage('/');
-      const source = await wd.grabHTMLFrom('#area1');
+      await wd.amOnPage('/')
+      const source = await wd.grabHTMLFrom('#area1')
       assert.deepEqual(
         source,
         `
     <a href="/form/file" qa-id="test" qa-link="test"> Test Link </a>
 `,
-      );
-    });
-  });
+      )
+    })
+  })
 
   describe('#seeTitleEquals', () => {
     it('should check that title is equal to provided one', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
 
       try {
-        await wd.seeTitleEquals('TestEd Beta 2.0');
-        await wd.seeTitleEquals('TestEd Beta 2.');
+        await wd.seeTitleEquals('TestEd Beta 2.0')
+        await wd.seeTitleEquals('TestEd Beta 2.')
       } catch (e) {
-        assert.equal(e.message, 'expected web page title to be TestEd Beta 2., but found TestEd Beta 2.0');
+        assert.equal(e.message, 'expected web page title to be TestEd Beta 2., but found TestEd Beta 2.0')
       }
-    });
-  });
+    })
+  })
 
   describe('#seeTextEquals', () => {
     it('should check text is equal to provided one', async () => {
-      await wd.amOnPage('/');
-      await wd.seeTextEquals('Welcome to test app!', 'h1');
+      await wd.amOnPage('/')
+      await wd.seeTextEquals('Welcome to test app!', 'h1')
 
       try {
-        await wd.seeTextEquals('Welcome to test app', 'h1');
-        assert.equal(true, false, 'Throw an error because it should not get this far!');
+        await wd.seeTextEquals('Welcome to test app', 'h1')
+        assert.equal(true, false, 'Throw an error because it should not get this far!')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"');
+        e.should.be.instanceOf(Error)
+        e.message.should.be.equal('expected element h1 "Welcome to test app" to equal "Welcome to test app!"')
         // e.should.be.instanceOf(AssertionFailedError);
       }
-    });
+    })
 
     it('should check text is not equal to empty string of element text', async () => {
-      await wd.amOnPage('https://codecept.io');
+      await wd.amOnPage('https://codecept.io')
 
       try {
-        await wd.seeTextEquals('', '.logo');
-        await wd.seeTextEquals('This is not empty', '.logo');
+        await wd.seeTextEquals('', '.logo')
+        await wd.seeTextEquals('This is not empty', '.logo')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.be.equal('expected element .logo "This is not empty" to equal ""');
+        e.should.be.instanceOf(Error)
+        e.message.should.be.equal('expected element .logo "This is not empty" to equal ""')
       }
-    });
-  });
+    })
+  })
 
   describe('#waitForFunction', () => {
     it('should wait for function returns true', async () => {
-      await wd.amOnPage('/form/wait_js');
-      await wd.waitForFunction(() => window.__waitJs, 3);
-    });
+      await wd.amOnPage('/form/wait_js')
+      await wd.waitForFunction(() => window.__waitJs, 3)
+    })
 
     it('should pass arguments and wait for function returns true', async () => {
-      await wd.amOnPage('/form/wait_js');
-      await wd.waitForFunction(varName => window[varName], ['__waitJs'], 3);
-    });
-  });
+      await wd.amOnPage('/form/wait_js')
+      await wd.waitForFunction(varName => window[varName], ['__waitJs'], 3)
+    })
+  })
 
   describe('#waitForEnabled', () => {
     it('should wait for input text field to be enabled', async () => {
-      await wd.amOnPage('/form/wait_enabled');
-      await wd.waitForEnabled('#text', 2);
-      await wd.fillField('#text', 'hello world');
-      await wd.seeInField('#text', 'hello world');
-    });
+      await wd.amOnPage('/form/wait_enabled')
+      await wd.waitForEnabled('#text', 2)
+      await wd.fillField('#text', 'hello world')
+      await wd.seeInField('#text', 'hello world')
+    })
 
     it('should wait for input text field to be enabled by xpath', async () => {
-      await wd.amOnPage('/form/wait_enabled');
-      await wd.waitForEnabled("//*[@name = 'test']", 2);
-      await wd.fillField('#text', 'hello world');
-      await wd.seeInField('#text', 'hello world');
-    });
+      await wd.amOnPage('/form/wait_enabled')
+      await wd.waitForEnabled("//*[@name = 'test']", 2)
+      await wd.fillField('#text', 'hello world')
+      await wd.seeInField('#text', 'hello world')
+    })
 
     it('should wait for a button to be enabled', async () => {
-      await wd.amOnPage('/form/wait_enabled');
-      await wd.waitForEnabled('#text', 2);
-      await wd.click('#button');
-      await wd.see('button was clicked');
-    });
-  });
+      await wd.amOnPage('/form/wait_enabled')
+      await wd.waitForEnabled('#text', 2)
+      await wd.click('#button')
+      await wd.see('button was clicked')
+    })
+  })
 
   describe('#waitForValue', () => {
     it('should wait for expected value for given locator', async () => {
-      await wd.amOnPage('/info');
-      await wd.waitForValue('//input[@name= "rus"]', 'Верно');
+      await wd.amOnPage('/info')
+      await wd.waitForValue('//input[@name= "rus"]', 'Верно')
 
       try {
-        await wd.waitForValue('//input[@name= "rus"]', 'Верно3', 0.1);
-        throw Error('It should never get this far');
+        await wd.waitForValue('//input[@name= "rus"]', 'Верно3', 0.1)
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec');
+        e.message.should.include('element (//input[@name= "rus"]) is not in DOM or there is no element(//input[@name= "rus"]) with value "Верно3" after 0.1 sec')
       }
-    });
+    })
 
     it('should wait for expected value for given css locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.seeInField('#text', 'Hamburg');
-      await wd.waitForValue('#text', 'Brisbane', 2.5);
-      await wd.seeInField('#text', 'Brisbane');
-    });
+      await wd.amOnPage('/form/wait_value')
+      await wd.seeInField('#text', 'Hamburg')
+      await wd.waitForValue('#text', 'Brisbane', 2.5)
+      await wd.seeInField('#text', 'Brisbane')
+    })
 
     it('should wait for expected value for given xpath locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.seeInField('#text', 'Hamburg');
-      await wd.waitForValue('//input[@value = "Grüße aus Hamburg"]', 'Brisbane', 2.5);
-      await wd.seeInField('#text', 'Brisbane');
-    });
+      await wd.amOnPage('/form/wait_value')
+      await wd.seeInField('#text', 'Hamburg')
+      await wd.waitForValue('//input[@value = "Grüße aus Hamburg"]', 'Brisbane', 2.5)
+      await wd.seeInField('#text', 'Brisbane')
+    })
 
     it('should only wait for one of the matching elements to contain the value given xpath locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.waitForValue('//input[@type = "text"]', 'Brisbane', 4);
-      await wd.seeInField('#text', 'Brisbane');
-      await wd.seeInField('#text2', 'London');
-    });
+      await wd.amOnPage('/form/wait_value')
+      await wd.waitForValue('//input[@type = "text"]', 'Brisbane', 4)
+      await wd.seeInField('#text', 'Brisbane')
+      await wd.seeInField('#text2', 'London')
+    })
 
     it('should only wait for one of the matching elements to contain the value given css locator', async () => {
-      await wd.amOnPage('/form/wait_value');
-      await wd.waitForValue('.inputbox', 'Brisbane', 4);
-      await wd.seeInField('#text', 'Brisbane');
-      await wd.seeInField('#text2', 'London');
-    });
-  });
+      await wd.amOnPage('/form/wait_value')
+      await wd.waitForValue('.inputbox', 'Brisbane', 4)
+      await wd.seeInField('#text', 'Brisbane')
+      await wd.seeInField('#text2', 'London')
+    })
+  })
 
   describe('#waitNumberOfVisibleElements', () => {
     it('should wait for a specified number of elements on the page', () => {
@@ -519,24 +519,24 @@ describe('WebDriver', function () {
         .then(() => wd.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3))
         .then(() => wd.waitNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec');
-        });
-    });
+          e.message.should.include('The number of elements (//div[@id = "grab-multiple"]//a) is not 2 after 0.1 sec')
+        })
+    })
 
     it('should be no [object Object] in the error message', () => {
       return wd
         .amOnPage('/info')
         .then(() => wd.waitNumberOfVisibleElements({ css: '//div[@id = "grab-multiple"]//a' }, 3))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.not.include('[object Object]');
-        });
-    });
+          e.message.should.not.include('[object Object]')
+        })
+    })
 
     it('should wait for a specified number of elements on the page using a css selector', () => {
       return wd
@@ -544,21 +544,21 @@ describe('WebDriver', function () {
         .then(() => wd.waitNumberOfVisibleElements('#grab-multiple > a', 3))
         .then(() => wd.waitNumberOfVisibleElements('#grab-multiple > a', 2, 0.1))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec');
-        });
-    });
+          e.message.should.include('The number of elements (#grab-multiple > a) is not 2 after 0.1 sec')
+        })
+    })
 
     it('should wait for a specified number of elements which are not yet attached to the DOM', () => {
       return wd
         .amOnPage('/form/wait_num_elements')
         .then(() => wd.waitNumberOfVisibleElements('.title', 2, 3))
         .then(() => wd.see('Hello'))
-        .then(() => wd.see('World'));
-    });
-  });
+        .then(() => wd.see('World'))
+    })
+  })
 
   describe('#waitForVisible', () => {
     it('should be no [object Object] in the error message', () => {
@@ -566,13 +566,13 @@ describe('WebDriver', function () {
         .amOnPage('/info')
         .then(() => wd.waitForVisible('//div[@id = "grab-multiple"]//a', 3))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.not.include('[object Object]');
-        });
-    });
-  });
+          e.message.should.not.include('[object Object]')
+        })
+    })
+  })
 
   describe('#waitForInvisible', () => {
     it('should be no [object Object] in the error message', () => {
@@ -580,54 +580,54 @@ describe('WebDriver', function () {
         .amOnPage('/info')
         .then(() => wd.waitForInvisible('//div[@id = "grab-multiple"]//a', 3))
         .then(() => {
-          throw Error('It should never get this far');
+          throw Error('It should never get this far')
         })
         .catch(e => {
-          e.message.should.not.include('[object Object]');
-        });
-    });
+          e.message.should.not.include('[object Object]')
+        })
+    })
 
     it('should wait for a specified element to be invisible', () => {
       return wd
         .amOnPage('/form/wait_invisible')
         .then(() => wd.waitForInvisible('#step1', 3))
-        .then(() => wd.dontSeeElement('#step1'));
-    });
-  });
+        .then(() => wd.dontSeeElement('#step1'))
+    })
+  })
 
   describe('#moveCursorTo', () => {
     it('should trigger hover event', async () => {
-      await wd.amOnPage('/form/hover');
-      await wd.moveCursorTo('#hover');
-      await wd.see('Hovered', '#show');
-    });
+      await wd.amOnPage('/form/hover')
+      await wd.moveCursorTo('#hover')
+      await wd.see('Hovered', '#show')
+    })
 
     it('should not trigger hover event because of the offset is beyond the element', async () => {
-      await wd.amOnPage('/form/hover');
-      await wd.moveCursorTo('#hover', 100, 100);
-      await wd.dontSee('Hovered', '#show');
-    });
-  });
+      await wd.amOnPage('/form/hover')
+      await wd.moveCursorTo('#hover', 100, 100)
+      await wd.dontSee('Hovered', '#show')
+    })
+  })
 
   describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {
     it('should only have 1 tab open when the browser starts and navigates to the first page', async () => {
-      await wd.amOnPage('/');
-      const numPages = await wd.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
-    });
+      await wd.amOnPage('/')
+      const numPages = await wd.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
+    })
 
     it('should switch to next tab', async () => {
-      wd.amOnPage('/info');
-      const numPages = await wd.grabNumberOfOpenTabs();
-      assert.equal(numPages, 1);
+      wd.amOnPage('/info')
+      const numPages = await wd.grabNumberOfOpenTabs()
+      assert.equal(numPages, 1)
 
-      await wd.click('New tab');
-      await wd.waitForNumberOfTabs(2);
-      await wd.switchToNextTab();
-      await wd.waitInUrl('/login');
-      const numPagesAfter = await wd.grabNumberOfOpenTabs();
-      assert.equal(numPagesAfter, 2);
-    });
+      await wd.click('New tab')
+      await wd.waitForNumberOfTabs(2)
+      await wd.switchToNextTab()
+      await wd.waitInUrl('/login')
+      const numPagesAfter = await wd.grabNumberOfOpenTabs()
+      assert.equal(numPagesAfter, 2)
+    })
 
     it('should assert when there is no ability to switch to next tab', () => {
       return wd
@@ -637,9 +637,9 @@ describe('WebDriver', function () {
         .then(() => wd.switchToNextTab(2))
         .then(() => assert.equal(true, false, 'Throw an error if it gets this far (which it should not)!'))
         .catch(e => {
-          assert.equal(e.message, 'There is no ability to switch to next tab with offset 2');
-        });
-    });
+          assert.equal(e.message, 'There is no ability to switch to next tab with offset 2')
+        })
+    })
 
     it('should close current tab', () => {
       return wd
@@ -651,8 +651,8 @@ describe('WebDriver', function () {
         .then(numPages => assert.equal(numPages, 2))
         .then(() => wd.closeCurrentTab())
         .then(() => wd.seeInCurrentUrl('/info'))
-        .then(() => wd.grabNumberOfOpenTabs());
-    });
+        .then(() => wd.grabNumberOfOpenTabs())
+    })
 
     it('should close other tabs', () => {
       return wd
@@ -665,8 +665,8 @@ describe('WebDriver', function () {
         .then(() => wd.seeInCurrentUrl('/login'))
         .then(() => wd.closeOtherTabs())
         .then(() => wd.seeInCurrentUrl('/login'))
-        .then(() => wd.grabNumberOfOpenTabs());
-    });
+        .then(() => wd.grabNumberOfOpenTabs())
+    })
 
     it('should open new tab', () => {
       return wd
@@ -674,8 +674,8 @@ describe('WebDriver', function () {
         .then(() => wd.openNewTab())
         .then(() => wd.waitInUrl('about:blank'))
         .then(() => wd.grabNumberOfOpenTabs())
-        .then(numPages => assert.equal(numPages, 2));
-    });
+        .then(numPages => assert.equal(numPages, 2))
+    })
 
     it('should switch to previous tab', () => {
       return wd
@@ -683,8 +683,8 @@ describe('WebDriver', function () {
         .then(() => wd.openNewTab())
         .then(() => wd.waitInUrl('about:blank'))
         .then(() => wd.switchToPreviousTab())
-        .then(() => wd.waitInUrl('/info'));
-    });
+        .then(() => wd.waitInUrl('/info'))
+    })
 
     it('should assert when there is no ability to switch to previous tab', () => {
       return wd
@@ -694,10 +694,10 @@ describe('WebDriver', function () {
         .then(() => wd.switchToPreviousTab(2))
         .then(() => wd.waitInUrl('/info'))
         .catch(e => {
-          assert.equal(e.message, 'There is no ability to switch to previous tab with offset 2');
-        });
-    });
-  });
+          assert.equal(e.message, 'There is no ability to switch to previous tab with offset 2')
+        })
+    })
+  })
 
   describe('popup : #acceptPopup, #seeInPopup, #cancelPopup', () => {
     it('should accept popup window', () => {
@@ -705,40 +705,40 @@ describe('WebDriver', function () {
         .amOnPage('/form/popup')
         .then(() => wd.click('Confirm'))
         .then(() => wd.acceptPopup())
-        .then(() => wd.see('Yes', '#result'));
-    });
+        .then(() => wd.see('Yes', '#result'))
+    })
 
     it('should cancel popup', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.click('Confirm'))
         .then(() => wd.cancelPopup())
-        .then(() => wd.see('No', '#result'));
-    });
+        .then(() => wd.see('No', '#result'))
+    })
 
     it('should check text in popup', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.click('Alert'))
         .then(() => wd.seeInPopup('Really?'))
-        .then(() => wd.cancelPopup());
-    });
+        .then(() => wd.cancelPopup())
+    })
 
     it('should grab text from popup', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.click('Alert'))
         .then(() => wd.grabPopupText())
-        .then(text => assert.equal(text, 'Really?'));
-    });
+        .then(text => assert.equal(text, 'Really?'))
+    })
 
     it('should return null if no popup is visible (do not throw an error)', () => {
       return wd
         .amOnPage('/form/popup')
         .then(() => wd.grabPopupText())
-        .then(text => assert.equal(text, null));
-    });
-  });
+        .then(text => assert.equal(text, null))
+    })
+  })
 
   describe('#waitForText', () => {
     it('should return error if not present', () => {
@@ -746,92 +746,92 @@ describe('WebDriver', function () {
         .amOnPage('/dynamic')
         .then(() => wd.waitForText('Nothing here', 1, '#text'))
         .catch(e => {
-          e.message.should.be.equal('element (#text) is not in DOM or there is no element(#text) with text "Nothing here" after 1 sec');
-        });
-    });
+          e.message.should.be.equal('element (#text) is not in DOM or there is no element(#text) with text "Nothing here" after 1 sec')
+        })
+    })
 
     it('should return error if waiting is too small', () => {
       return wd
         .amOnPage('/dynamic')
         .then(() => wd.waitForText('Dynamic text', 0.1))
         .catch(e => {
-          e.message.should.be.equal('element (body) is not in DOM or there is no element(body) with text "Dynamic text" after 0.1 sec');
-        });
-    });
-  });
+          e.message.should.be.equal('element (body) is not in DOM or there is no element(body) with text "Dynamic text" after 0.1 sec')
+        })
+    })
+  })
 
   describe('#seeNumberOfElements', () => {
     it('should return 1 as count', async () => {
-      await wd.amOnPage('/');
-      await wd.seeNumberOfElements('#area1', 1);
-    });
-  });
+      await wd.amOnPage('/')
+      await wd.seeNumberOfElements('#area1', 1)
+    })
+  })
 
   describe('#switchTo', () => {
     it('should switch reference to iframe content', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.switchTo('[name="content"]');
-      await wd.see('Information\nLots of valuable data here');
-    });
+      await wd.amOnPage('/iframe')
+      await wd.switchTo('[name="content"]')
+      await wd.see('Information\nLots of valuable data here')
+    })
 
     it('should return error if iframe selector is invalid', async () => {
-      await wd.amOnPage('/iframe');
+      await wd.amOnPage('/iframe')
 
       try {
-        await wd.switchTo('#invalidIframeSelector');
+        await wd.switchTo('#invalidIframeSelector')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath');
+        e.should.be.instanceOf(Error)
+        e.message.should.be.equal('Element "#invalidIframeSelector" was not found by text|CSS|XPath')
       }
-    });
+    })
 
     it('should return error if iframe selector is not iframe', async () => {
-      await wd.amOnPage('/iframe');
+      await wd.amOnPage('/iframe')
 
       try {
-        await wd.switchTo('h1');
+        await wd.switchTo('h1')
       } catch (e) {
-        e.should.be.instanceOf(Error);
-        e.message.should.contain('no such frame');
+        e.should.be.instanceOf(Error)
+        e.message.should.contain('no such frame')
       }
-    });
+    })
 
     it('should return to parent frame given a null locator', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.switchTo('[name="content"]');
-      await wd.see('Information\nLots of valuable data here');
-      await wd.switchTo(null);
-      await wd.see('Iframe test');
-    });
-  });
+      await wd.amOnPage('/iframe')
+      await wd.switchTo('[name="content"]')
+      await wd.see('Information\nLots of valuable data here')
+      await wd.switchTo(null)
+      await wd.see('Iframe test')
+    })
+  })
 
   describe('click context', () => {
     it('should click on inner text', async () => {
-      await wd.amOnPage('/form/checkbox');
-      await wd.click('Submit', '//input[@type = "submit"]');
-      await wd.waitInUrl('/form/complex');
-    });
+      await wd.amOnPage('/form/checkbox')
+      await wd.click('Submit', '//input[@type = "submit"]')
+      await wd.waitInUrl('/form/complex')
+    })
 
     it('should click on input in inner element', async () => {
-      await wd.amOnPage('/form/checkbox');
-      await wd.click('Submit', '//form');
-      await wd.waitInUrl('/form/complex');
-    });
+      await wd.amOnPage('/form/checkbox')
+      await wd.click('Submit', '//form')
+      await wd.waitInUrl('/form/complex')
+    })
 
     it('should click by accessibility_id', async () => {
-      await wd.amOnPage('/info');
-      await wd.click('~index via aria-label');
-      await wd.see('Welcome to test app!');
-    });
-  });
+      await wd.amOnPage('/info')
+      await wd.click('~index via aria-label')
+      await wd.see('Welcome to test app!')
+    })
+  })
 
   describe('window size #resizeWindow', () => {
     it('should set initial window size', async () => {
-      await wd.amOnPage('/form/resize');
-      await wd.click('Window Size');
-      await wd.see('Height 700', '#height');
-      await wd.see('Width 500', '#width');
-    });
+      await wd.amOnPage('/form/resize')
+      await wd.click('Window Size')
+      await wd.see('Height 700', '#height')
+      await wd.see('Width 500', '#width')
+    })
 
     it('should set window size on new session', () => {
       return wd
@@ -847,415 +847,415 @@ describe('WebDriver', function () {
         .then(() => wd.amOnPage('/form/resize'))
         .then(() => wd.click('Window Size'))
         .then(() => wd.see('Height 700', '#height'))
-        .then(() => wd.see('Width 500', '#width'));
-    });
+        .then(() => wd.see('Width 500', '#width'))
+    })
 
     it('should resize window to specific dimensions', async () => {
-      await wd.amOnPage('/form/resize');
-      await wd.resizeWindow(950, 600);
-      await wd.click('Window Size');
-      await wd.see('Height 600', '#height');
-      await wd.see('Width 950', '#width');
-    });
+      await wd.amOnPage('/form/resize')
+      await wd.resizeWindow(950, 600)
+      await wd.click('Window Size')
+      await wd.see('Height 600', '#height')
+      await wd.see('Width 950', '#width')
+    })
 
     xit('should resize window to maximum screen dimensions', async () => {
-      await wd.amOnPage('/form/resize');
-      await wd.resizeWindow(500, 400);
-      await wd.click('Window Size');
-      await wd.see('Height 400', '#height');
-      await wd.see('Width 500', '#width');
-      await wd.resizeWindow('maximize');
-      await wd.click('Window Size');
-      await wd.dontSee('Height 400', '#height');
-      await wd.dontSee('Width 500', '#width');
-    });
-  });
+      await wd.amOnPage('/form/resize')
+      await wd.resizeWindow(500, 400)
+      await wd.click('Window Size')
+      await wd.see('Height 400', '#height')
+      await wd.see('Width 500', '#width')
+      await wd.resizeWindow('maximize')
+      await wd.click('Window Size')
+      await wd.dontSee('Height 400', '#height')
+      await wd.dontSee('Width 500', '#width')
+    })
+  })
 
   describe('SmartWait', () => {
-    before(() => (wd.options.smartWait = 3000));
-    after(() => (wd.options.smartWait = 0));
+    before(() => (wd.options.smartWait = 3000))
+    after(() => (wd.options.smartWait = 0))
 
     it('should wait for element to appear', async () => {
-      await wd.amOnPage('/form/wait_element');
-      await wd.dontSeeElement('h1');
-      await wd.seeElement('h1');
-    });
+      await wd.amOnPage('/form/wait_element')
+      await wd.dontSeeElement('h1')
+      await wd.seeElement('h1')
+    })
 
     it('should wait for clickable element appear', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSeeElement('#click');
-      await wd.click('#click');
-      await wd.see('Hi!');
-    });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSeeElement('#click')
+      await wd.click('#click')
+      await wd.see('Hi!')
+    })
 
     it('should wait for clickable context to appear', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSeeElement('#linkContext');
-      await wd.click('Hello world', '#linkContext');
-      await wd.see('Hi!');
-    });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSeeElement('#linkContext')
+      await wd.click('Hello world', '#linkContext')
+      await wd.see('Hi!')
+    })
 
     it('should wait for text context to appear', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSee('Hello world');
-      await wd.see('Hello world', '#linkContext');
-    });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSee('Hello world')
+      await wd.see('Hello world', '#linkContext')
+    })
 
     it('should work with grabbers', async () => {
-      await wd.amOnPage('/form/wait_clickable');
-      await wd.dontSee('Hello world');
-      const res = await wd.grabAttributeFrom('#click', 'id');
-      assert.equal(res, 'click');
-    });
-  });
+      await wd.amOnPage('/form/wait_clickable')
+      await wd.dontSee('Hello world')
+      const res = await wd.grabAttributeFrom('#click', 'id')
+      assert.equal(res, 'click')
+    })
+  })
 
   describe('#_locateClickable', () => {
     it('should locate a button to click', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateClickable('Submit');
-      res.length.should.be.equal(1);
-    });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateClickable('Submit')
+      res.length.should.be.equal(1)
+    })
 
     it('should not locate a non-existing checkbox', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateClickable('I disagree');
-      res.length.should.be.equal(0);
-    });
-  });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateClickable('I disagree')
+      res.length.should.be.equal(0)
+    })
+  })
 
   describe('#_locateCheckable', () => {
     it('should locate a checkbox', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateCheckable('I Agree');
-      res.length.should.be.equal(1);
-    });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateCheckable('I Agree')
+      res.length.should.be.equal(1)
+    })
 
     it('should not locate a non-existing checkbox', async () => {
-      await wd.amOnPage('/form/checkbox');
-      const res = await wd._locateCheckable('I disagree');
-      res.length.should.be.equal(0);
-    });
-  });
+      await wd.amOnPage('/form/checkbox')
+      const res = await wd._locateCheckable('I disagree')
+      res.length.should.be.equal(0)
+    })
+  })
 
   describe('#_locateFields', () => {
     it('should locate a field', async () => {
-      await wd.amOnPage('/form/field');
-      const res = await wd._locateFields('Name');
-      res.length.should.be.equal(1);
-    });
+      await wd.amOnPage('/form/field')
+      const res = await wd._locateFields('Name')
+      res.length.should.be.equal(1)
+    })
 
     it('should not locate a non-existing field', async () => {
-      await wd.amOnPage('/form/field');
-      const res = await wd._locateFields('Mother-in-law');
-      res.length.should.be.equal(0);
-    });
-  });
+      await wd.amOnPage('/form/field')
+      const res = await wd._locateFields('Mother-in-law')
+      res.length.should.be.equal(0)
+    })
+  })
 
   xdescribe('#grabBrowserLogs', () => {
     it('should grab browser logs', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
       await wd.executeScript(() => {
-        console.log('Test log entry');
-      });
-      const logs = await wd.grabBrowserLogs();
-      console.log('lololo', logs);
+        console.log('Test log entry')
+      })
+      const logs = await wd.grabBrowserLogs()
+      console.log('lololo', logs)
 
-      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1);
-      assert.equal(matchingLogs.length, 1);
-    });
+      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1)
+      assert.equal(matchingLogs.length, 1)
+    })
 
     it('should grab browser logs across pages', async () => {
-      wd.amOnPage('/');
+      wd.amOnPage('/')
       await wd.executeScript(() => {
-        console.log('Test log entry 1');
-      });
-      await wd.openNewTab();
-      await wd.amOnPage('/info');
+        console.log('Test log entry 1')
+      })
+      await wd.openNewTab()
+      await wd.amOnPage('/info')
       await wd.executeScript(() => {
-        console.log('Test log entry 2');
-      });
+        console.log('Test log entry 2')
+      })
 
-      const logs = await wd.grabBrowserLogs();
+      const logs = await wd.grabBrowserLogs()
 
-      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1);
-      assert.equal(matchingLogs.length, 2);
-    });
-  });
+      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1)
+      assert.equal(matchingLogs.length, 2)
+    })
+  })
 
   describe('#dragAndDrop', () => {
     it('Drag item from source to target (no iframe) @dragNdrop', async () => {
-      await wd.amOnPage('http://jqueryui.com/resources/demos/droppable/default.html');
-      await wd.seeElementInDOM('#draggable');
-      await wd.dragAndDrop('#draggable', '#droppable');
-      await wd.see('Dropped');
-    });
+      await wd.amOnPage('http://jqueryui.com/resources/demos/droppable/default.html')
+      await wd.seeElementInDOM('#draggable')
+      await wd.dragAndDrop('#draggable', '#droppable')
+      await wd.see('Dropped')
+    })
 
     it('Drag and drop from within an iframe', async () => {
-      await wd.amOnPage('http://jqueryui.com/droppable');
-      await wd.resizeWindow(700, 700);
-      await wd.switchTo('//iframe[@class="demo-frame"]');
-      await wd.seeElementInDOM('#draggable');
-      await wd.dragAndDrop('#draggable', '#droppable');
-      await wd.see('Dropped');
-    });
-  });
+      await wd.amOnPage('http://jqueryui.com/droppable')
+      await wd.resizeWindow(700, 700)
+      await wd.switchTo('//iframe[@class="demo-frame"]')
+      await wd.seeElementInDOM('#draggable')
+      await wd.dragAndDrop('#draggable', '#droppable')
+      await wd.see('Dropped')
+    })
+  })
 
   describe('#switchTo frame', () => {
     it('should switch to frame using name', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.see('Iframe test', 'h1');
-      await wd.dontSee('Information', 'h1');
-      await wd.switchTo('iframe');
-      await wd.see('Information', 'h1');
-      await wd.dontSee('Iframe test', 'h1');
-    });
+      await wd.amOnPage('/iframe')
+      await wd.see('Iframe test', 'h1')
+      await wd.dontSee('Information', 'h1')
+      await wd.switchTo('iframe')
+      await wd.see('Information', 'h1')
+      await wd.dontSee('Iframe test', 'h1')
+    })
 
     it('should switch to root frame', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.see('Iframe test', 'h1');
-      await wd.dontSee('Information', 'h1');
-      await wd.switchTo('iframe');
-      await wd.see('Information', 'h1');
-      await wd.dontSee('Iframe test', 'h1');
-      await wd.switchTo();
-      await wd.see('Iframe test', 'h1');
-    });
+      await wd.amOnPage('/iframe')
+      await wd.see('Iframe test', 'h1')
+      await wd.dontSee('Information', 'h1')
+      await wd.switchTo('iframe')
+      await wd.see('Information', 'h1')
+      await wd.dontSee('Iframe test', 'h1')
+      await wd.switchTo()
+      await wd.see('Iframe test', 'h1')
+    })
 
     it('should switch to frame using frame number', async () => {
-      await wd.amOnPage('/iframe');
-      await wd.see('Iframe test', 'h1');
-      await wd.dontSee('Information', 'h1');
-      await wd.switchTo(0);
-      await wd.see('Information', 'h1');
-      await wd.dontSee('Iframe test', 'h1');
-    });
-  });
+      await wd.amOnPage('/iframe')
+      await wd.see('Iframe test', 'h1')
+      await wd.dontSee('Information', 'h1')
+      await wd.switchTo(0)
+      await wd.see('Information', 'h1')
+      await wd.dontSee('Iframe test', 'h1')
+    })
+  })
 
   describe('#AttachFile', () => {
     it('should attach to regular input element', async () => {
-      await wd.amOnPage('/form/file');
-      await wd.attachFile('Avatar', './app/avatar.jpg');
-      await wd.seeInField('Avatar', 'avatar.jpg');
-    });
+      await wd.amOnPage('/form/file')
+      await wd.attachFile('Avatar', './app/avatar.jpg')
+      await wd.seeInField('Avatar', 'avatar.jpg')
+    })
 
     it('should attach to invisible input element', async () => {
-      await wd.amOnPage('/form/file');
-      await wd.attachFile('hidden', '/app/avatar.jpg');
-    });
-  });
+      await wd.amOnPage('/form/file')
+      await wd.attachFile('hidden', '/app/avatar.jpg')
+    })
+  })
 
   describe('#dragSlider', () => {
     it('should drag scrubber to given position', async () => {
-      await wd.amOnPage('/form/page_slider');
-      await wd.seeElementInDOM('#slidecontainer input');
+      await wd.amOnPage('/form/page_slider')
+      await wd.seeElementInDOM('#slidecontainer input')
 
-      const before = await wd.grabValueFrom('#slidecontainer input');
-      await wd.dragSlider('#slidecontainer input', 20);
-      const after = await wd.grabValueFrom('#slidecontainer input');
+      const before = await wd.grabValueFrom('#slidecontainer input')
+      await wd.dragSlider('#slidecontainer input', 20)
+      const after = await wd.grabValueFrom('#slidecontainer input')
 
-      assert.notEqual(before, after);
-    });
-  });
+      assert.notEqual(before, after)
+    })
+  })
 
   describe('#uncheckOption', () => {
     it('should uncheck option that is currently checked', async () => {
-      await wd.amOnPage('/info');
-      await wd.uncheckOption('interesting');
-      await wd.dontSeeCheckboxIsChecked('interesting');
-    });
+      await wd.amOnPage('/info')
+      await wd.uncheckOption('interesting')
+      await wd.dontSeeCheckboxIsChecked('interesting')
+    })
 
     it('should NOT uncheck option that is NOT currently checked', async () => {
-      await wd.amOnPage('/info');
-      await wd.uncheckOption('interesting');
+      await wd.amOnPage('/info')
+      await wd.uncheckOption('interesting')
       // Unchecking again should not affect the current 'unchecked' status
-      await wd.uncheckOption('interesting');
-      await wd.dontSeeCheckboxIsChecked('interesting');
-    });
-  });
+      await wd.uncheckOption('interesting')
+      await wd.dontSeeCheckboxIsChecked('interesting')
+    })
+  })
 
   describe('allow back and forth between handles: #grabAllWindowHandles #grabCurrentWindowHandle #switchToWindow', () => {
     it('should open main page of configured site, open a popup, switch to main page, then switch to popup, close popup, and go back to main page', async () => {
-      await wd.amOnPage('/');
-      const handleBeforePopup = await wd.grabCurrentWindowHandle();
-      const urlBeforePopup = await wd.grabCurrentUrl();
+      await wd.amOnPage('/')
+      const handleBeforePopup = await wd.grabCurrentWindowHandle()
+      const urlBeforePopup = await wd.grabCurrentUrl()
 
-      const allHandlesBeforePopup = await wd.grabAllWindowHandles();
-      allHandlesBeforePopup.length.should.eql(1);
+      const allHandlesBeforePopup = await wd.grabAllWindowHandles()
+      allHandlesBeforePopup.length.should.eql(1)
 
       await wd.executeScript(() => {
-        window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400');
-      });
+        window.open('https://www.w3schools.com/', 'new window', 'toolbar=yes,scrollbars=yes,resizable=yes,width=400,height=400')
+      })
 
-      const allHandlesAfterPopup = await wd.grabAllWindowHandles();
-      allHandlesAfterPopup.length.should.eql(2);
+      const allHandlesAfterPopup = await wd.grabAllWindowHandles()
+      allHandlesAfterPopup.length.should.eql(2)
 
-      await wd.switchToWindow(allHandlesAfterPopup[1]);
-      const urlAfterPopup = await wd.grabCurrentUrl();
-      urlAfterPopup.should.eql('https://www.w3schools.com/');
+      await wd.switchToWindow(allHandlesAfterPopup[1])
+      const urlAfterPopup = await wd.grabCurrentUrl()
+      urlAfterPopup.should.eql('https://www.w3schools.com/')
 
-      handleBeforePopup.should.eql(allHandlesAfterPopup[0]);
-      await wd.switchToWindow(handleBeforePopup);
-      const currentURL = await wd.grabCurrentUrl();
-      currentURL.should.eql(urlBeforePopup);
+      handleBeforePopup.should.eql(allHandlesAfterPopup[0])
+      await wd.switchToWindow(handleBeforePopup)
+      const currentURL = await wd.grabCurrentUrl()
+      currentURL.should.eql(urlBeforePopup)
 
-      await wd.switchToWindow(allHandlesAfterPopup[1]);
-      const urlAfterSwitchBack = await wd.grabCurrentUrl();
-      urlAfterSwitchBack.should.eql('https://www.w3schools.com/');
-      await wd.closeCurrentTab();
+      await wd.switchToWindow(allHandlesAfterPopup[1])
+      const urlAfterSwitchBack = await wd.grabCurrentUrl()
+      urlAfterSwitchBack.should.eql('https://www.w3schools.com/')
+      await wd.closeCurrentTab()
 
-      const allHandlesAfterPopupClosed = await wd.grabAllWindowHandles();
-      allHandlesAfterPopupClosed.length.should.eql(1);
-      const currentWindowHandle = await wd.grabCurrentWindowHandle();
-      currentWindowHandle.should.eql(handleBeforePopup);
-    });
-  });
+      const allHandlesAfterPopupClosed = await wd.grabAllWindowHandles()
+      allHandlesAfterPopupClosed.length.should.eql(1)
+      const currentWindowHandle = await wd.grabCurrentWindowHandle()
+      currentWindowHandle.should.eql(handleBeforePopup)
+    })
+  })
 
   describe('#waitForClickable', () => {
     it('should wait for clickable', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
-      await wd.waitForClickable({ css: 'input#text' });
-    });
+      await wd.amOnPage('/form/wait_for_clickable')
+      await wd.waitForClickable({ css: 'input#text' })
+    })
 
     it('should wait for clickable by XPath', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
-      await wd.waitForClickable({ xpath: './/input[@id="text"]' });
-    });
+      await wd.amOnPage('/form/wait_for_clickable')
+      await wd.waitForClickable({ xpath: './/input[@id="text"]' })
+    })
 
     it('should fail for disabled element', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#button' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #button still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #button still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for disabled element by XPath', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ xpath: './/button[@id="button"]' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element .//button[@id="button"] still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element .//button[@id="button"] still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by top', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportTop' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportTop still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportTop still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by bottom', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportBottom' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportBottom still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportBottom still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by left', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportLeft' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportLeft still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportLeft still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for element not in viewport by right', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
+      await wd.amOnPage('/form/wait_for_clickable')
       await wd
         .waitForClickable({ css: '#notInViewportRight' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #notInViewportRight still not clickable after 0.1 sec');
-        });
-    });
+          e.message.should.include('element #notInViewportRight still not clickable after 0.1 sec')
+        })
+    })
 
     it('should fail for overlapping element', async () => {
-      await wd.amOnPage('/form/wait_for_clickable');
-      await wd.waitForClickable({ css: '#div2_button' }, 0.1);
+      await wd.amOnPage('/form/wait_for_clickable')
+      await wd.waitForClickable({ css: '#div2_button' }, 0.1)
       await wd
         .waitForClickable({ css: '#div1_button' }, 0.1)
         .then(isClickable => {
-          if (isClickable) throw new Error('Element is clickable, but must be unclickable');
+          if (isClickable) throw new Error('Element is clickable, but must be unclickable')
         })
         .catch(e => {
-          e.message.should.include('element #div1_button still not clickable after 0.1 sec');
-        });
-    });
-  });
+          e.message.should.include('element #div1_button still not clickable after 0.1 sec')
+        })
+    })
+  })
 
   describe('#grabElementBoundingRect', () => {
     it('should get the element size', async () => {
-      await wd.amOnPage('/form/hidden');
-      const size = await wd.grabElementBoundingRect('input[type=submit]');
-      expect(size.x).is.greaterThan(0);
-      expect(size.y).is.greaterThan(0);
-      expect(size.width).is.greaterThan(0);
-      expect(size.height).is.greaterThan(0);
-    });
+      await wd.amOnPage('/form/hidden')
+      const size = await wd.grabElementBoundingRect('input[type=submit]')
+      expect(size.x).is.greaterThan(0)
+      expect(size.y).is.greaterThan(0)
+      expect(size.width).is.greaterThan(0)
+      expect(size.height).is.greaterThan(0)
+    })
 
     it('should get the element width', async () => {
-      await wd.amOnPage('/form/hidden');
-      const width = await wd.grabElementBoundingRect('input[type=submit]', 'width');
-      expect(width).is.greaterThan(0);
-    });
+      await wd.amOnPage('/form/hidden')
+      const width = await wd.grabElementBoundingRect('input[type=submit]', 'width')
+      expect(width).is.greaterThan(0)
+    })
 
     it('should get the element height', async () => {
-      await wd.amOnPage('/form/hidden');
-      const height = await wd.grabElementBoundingRect('input[type=submit]', 'height');
-      expect(height).is.greaterThan(0);
-    });
-  });
+      await wd.amOnPage('/form/hidden')
+      const height = await wd.grabElementBoundingRect('input[type=submit]', 'height')
+      expect(height).is.greaterThan(0)
+    })
+  })
 
   describe('#scrollIntoView', () => {
     it.skip('should scroll element into viewport', async () => {
-      await wd.amOnPage('/form/scroll_into_view');
-      const element = await wd.browser.$('#notInViewportByDefault');
-      expect(await element.isDisplayedInViewport()).to.be.false;
-      await wd.scrollIntoView('#notInViewportByDefault');
-      expect(await element.isDisplayedInViewport()).to.be.true;
-    });
-  });
+      await wd.amOnPage('/form/scroll_into_view')
+      const element = await wd.browser.$('#notInViewportByDefault')
+      expect(await element.isDisplayedInViewport()).to.be.false
+      await wd.scrollIntoView('#notInViewportByDefault')
+      expect(await element.isDisplayedInViewport()).to.be.true
+    })
+  })
 
   describe('#useWebDriverTo', () => {
     it('should return title', async () => {
-      await wd.amOnPage('/');
+      await wd.amOnPage('/')
       const title = await wd.useWebDriverTo('test', async ({ browser }) => {
-        return browser.getTitle();
-      });
-      assert.equal('TestEd Beta 2.0', title);
-    });
-  });
-});
+        return browser.getTitle()
+      })
+      assert.equal('TestEd Beta 2.0', title)
+    })
+  })
+})
 
 describe('WebDriver - Basic Authentication', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data');
+    global.codecept_dir = path.join(__dirname, '/../data')
     try {
-      fs.unlinkSync(dataFile);
+      fs.unlinkSync(dataFile)
     } catch (err) {
       // continue regardless of error
     }
@@ -1275,20 +1275,20 @@ describe('WebDriver - Basic Authentication', () => {
           args: ['--headless', '--disable-gpu', '--window-size=1280,1024'],
         },
       },
-    });
-  });
+    })
+  })
 
   beforeEach(async () => {
-    webApiTests.init({ I: wd, siteUrl });
-    await wd._before();
-  });
+    webApiTests.init({ I: wd, siteUrl })
+    await wd._before()
+  })
 
-  afterEach(() => wd._after());
+  afterEach(() => wd._after())
 
   describe('open page : #amOnPage', () => {
     it('should be authenticated', async () => {
-      await wd.amOnPage('/basic_auth');
-      await wd.see('You entered admin as your password.');
-    });
-  });
-});
+      await wd.amOnPage('/basic_auth')
+      await wd.see('You entered admin as your password.')
+    })
+  })
+})

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -749,6 +749,14 @@ module.exports.tests = function () {
       assert.equal(val, 'Welcome to test app!');
     });
 
+    it('should return empty string when the text of tag is an empty string', async function () {
+      if (isHelper('TestCafe')) this.skip();
+
+      await I.amOnPage('/info');
+      let val = await I.grabTextFrom('#p-no-text');
+      assert.equal(val, '');
+    });
+
     it('should grab html from page', async function () {
       if (isHelper('TestCafe')) this.skip();
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -1,767 +1,767 @@
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
-const assert = chai.assert;
-const path = require('path');
+const expect = chai.expect
+const assert = chai.assert
+const path = require('path')
 
-const dataFile = path.join(__dirname, '/../data/app/db');
-const formContents = require('../../lib/utils').test.submittedData(dataFile);
-const fileExists = require('../../lib/utils').fileExists;
-const secret = require('../../lib/secret').secret;
+const dataFile = path.join(__dirname, '/../data/app/db')
+const formContents = require('../../lib/utils').test.submittedData(dataFile)
+const fileExists = require('../../lib/utils').fileExists
+const secret = require('../../lib/secret').secret
 
-const Locator = require('../../lib/locator');
-const customLocators = require('../../lib/plugin/customLocator');
+const Locator = require('../../lib/locator')
+const customLocators = require('../../lib/plugin/customLocator')
 
-let originalLocators;
-let I;
-let data;
-let siteUrl;
+let originalLocators
+let I
+let data
+let siteUrl
 
 module.exports.init = function (testData) {
-  data = testData;
-};
+  data = testData
+}
 
 module.exports.tests = function () {
-  const isHelper = helperName => I.constructor.name === helperName;
+  const isHelper = helperName => I.constructor.name === helperName
 
   beforeEach(() => {
-    I = data.I;
-    siteUrl = data.siteUrl;
-    if (fileExists(dataFile)) require('fs').unlinkSync(dataFile);
-  });
+    I = data.I
+    siteUrl = data.siteUrl
+    if (fileExists(dataFile)) require('fs').unlinkSync(dataFile)
+  })
 
   describe('#saveElementScreenshot', () => {
     beforeEach(() => {
-      global.output_dir = path.join(global.codecept_dir, 'output');
-    });
+      global.output_dir = path.join(global.codecept_dir, 'output')
+    })
 
     it('should create a screenshot file in output dir of element', async () => {
-      await I.amOnPage('/form/field');
-      await I.seeElement("input[name='name']");
-      const sec = new Date().getUTCMilliseconds();
-      await I.saveElementScreenshot("input[name='name']", `element_screenshot_${sec}.png`);
-      assert.ok(fileExists(path.join(global.output_dir, `element_screenshot_${sec}.png`)), null, 'file does not exists');
-    });
-  });
+      await I.amOnPage('/form/field')
+      await I.seeElement("input[name='name']")
+      const sec = new Date().getUTCMilliseconds()
+      await I.saveElementScreenshot("input[name='name']", `element_screenshot_${sec}.png`)
+      assert.ok(fileExists(path.join(global.output_dir, `element_screenshot_${sec}.png`)), null, 'file does not exists')
+    })
+  })
 
   describe('current url : #seeInCurrentUrl, #seeCurrentUrlEquals, #grabCurrentUrl, ...', () => {
     it('should check for url fragment', async () => {
-      await I.amOnPage('/form/checkbox');
-      await I.seeInCurrentUrl('/form');
-      await I.dontSeeInCurrentUrl('/user');
-    });
+      await I.amOnPage('/form/checkbox')
+      await I.seeInCurrentUrl('/form')
+      await I.dontSeeInCurrentUrl('/user')
+    })
 
     it('should check for equality', async () => {
-      await I.amOnPage('/info');
-      await I.seeCurrentUrlEquals('/info');
-      await I.dontSeeCurrentUrlEquals('form');
-    });
+      await I.amOnPage('/info')
+      await I.seeCurrentUrlEquals('/info')
+      await I.dontSeeCurrentUrlEquals('form')
+    })
 
     it('should check for equality in absolute urls', async () => {
-      await I.amOnPage('/info');
-      await I.seeCurrentUrlEquals(`${siteUrl}/info`);
-      await I.dontSeeCurrentUrlEquals(`${siteUrl}/form`);
-    });
+      await I.amOnPage('/info')
+      await I.seeCurrentUrlEquals(`${siteUrl}/info`)
+      await I.dontSeeCurrentUrlEquals(`${siteUrl}/form`)
+    })
 
     it('should grab browser url', async () => {
-      await I.amOnPage('/info');
-      const url = await I.grabCurrentUrl();
-      assert.equal(url, `${siteUrl}/info`);
-    });
-  });
+      await I.amOnPage('/info')
+      const url = await I.grabCurrentUrl()
+      assert.equal(url, `${siteUrl}/info`)
+    })
+  })
 
   describe('#waitInUrl, #waitUrlEquals', () => {
     it('should wait part of the URL to match the expected', async () => {
       try {
-        await I.amOnPage('/info');
-        await I.waitInUrl('/info');
-        await I.waitInUrl('/info2', 0.1);
+        await I.amOnPage('/info')
+        await I.waitInUrl('/info')
+        await I.waitInUrl('/info2', 0.1)
       } catch (e) {
-        assert.include(e.message, `expected url to include /info2, but found ${siteUrl}/info`);
+        assert.include(e.message, `expected url to include /info2, but found ${siteUrl}/info`)
       }
-    });
+    })
 
     it('should wait for the entire URL to match the expected', async () => {
       try {
-        await I.amOnPage('/info');
-        await I.waitUrlEquals('/info');
-        await I.waitUrlEquals(`${siteUrl}/info`);
-        await I.waitUrlEquals('/info2', 0.1);
+        await I.amOnPage('/info')
+        await I.waitUrlEquals('/info')
+        await I.waitUrlEquals(`${siteUrl}/info`)
+        await I.waitUrlEquals('/info2', 0.1)
       } catch (e) {
-        assert.include(e.message, `expected url to be ${siteUrl}/info2, but found ${siteUrl}/info`);
+        assert.include(e.message, `expected url to be ${siteUrl}/info2, but found ${siteUrl}/info`)
       }
-    });
-  });
+    })
+  })
 
   describe('see text : #see', () => {
     it('should check text on site', async () => {
-      await I.amOnPage('/');
-      await I.see('Welcome to test app!');
-      await I.see('A wise man said: "debug!"');
-      await I.dontSee('Info');
-    });
+      await I.amOnPage('/')
+      await I.see('Welcome to test app!')
+      await I.see('A wise man said: "debug!"')
+      await I.dontSee('Info')
+    })
 
     it('should check text inside element', async () => {
-      await I.amOnPage('/');
-      await I.see('Welcome to test app!', 'h1');
-      await I.amOnPage('/info');
-      await I.see('valuable', { css: 'p' });
-      await I.see('valuable', '//p');
-      await I.dontSee('valuable', 'h1');
-    });
+      await I.amOnPage('/')
+      await I.see('Welcome to test app!', 'h1')
+      await I.amOnPage('/info')
+      await I.see('valuable', { css: 'p' })
+      await I.see('valuable', '//p')
+      await I.dontSee('valuable', 'h1')
+    })
 
     it('should verify non-latin chars', async () => {
-      await I.amOnPage('/info');
-      await I.see('на');
-      await I.see("Don't do that at home!", 'h3');
-      await I.see('Текст', 'p');
-    });
+      await I.amOnPage('/info')
+      await I.see('на')
+      await I.see("Don't do that at home!", 'h3')
+      await I.see('Текст', 'p')
+    })
 
     it('should verify text with &nbsp', async () => {
-      if (isHelper('TestCafe') || isHelper('WebDriver')) return;
-      await I.amOnPage('/');
-      await I.see('With special space chars');
-    });
-  });
+      if (isHelper('TestCafe') || isHelper('WebDriver')) return
+      await I.amOnPage('/')
+      await I.see('With special space chars')
+    })
+  })
 
   describe('see element : #seeElement, #seeElementInDOM, #dontSeeElement', () => {
     it('should check visible elements on page', async () => {
-      await I.amOnPage('/form/field');
-      await I.seeElement('input[name=name]');
-      await I.seeElement({ name: 'name' });
-      await I.seeElement('//input[@id="name"]');
-      await I.dontSeeElement('#something-beyond');
-      await I.dontSeeElement('//input[@id="something-beyond"]');
-      await I.dontSeeElement({ name: 'noname' });
-      await I.dontSeeElement('#noid');
-    });
+      await I.amOnPage('/form/field')
+      await I.seeElement('input[name=name]')
+      await I.seeElement({ name: 'name' })
+      await I.seeElement('//input[@id="name"]')
+      await I.dontSeeElement('#something-beyond')
+      await I.dontSeeElement('//input[@id="something-beyond"]')
+      await I.dontSeeElement({ name: 'noname' })
+      await I.dontSeeElement('#noid')
+    })
 
     it('should check elements are in the DOM', async () => {
-      await I.amOnPage('/form/field');
-      await I.seeElementInDOM('input[name=name]');
-      await I.seeElementInDOM('//input[@id="name"]');
-      await I.seeElementInDOM({ name: 'noname' });
-      await I.seeElementInDOM('#noid');
-      await I.dontSeeElementInDOM('#something-beyond');
-      await I.dontSeeElementInDOM('//input[@id="something-beyond"]');
-    });
+      await I.amOnPage('/form/field')
+      await I.seeElementInDOM('input[name=name]')
+      await I.seeElementInDOM('//input[@id="name"]')
+      await I.seeElementInDOM({ name: 'noname' })
+      await I.seeElementInDOM('#noid')
+      await I.dontSeeElementInDOM('#something-beyond')
+      await I.dontSeeElementInDOM('//input[@id="something-beyond"]')
+    })
 
     it('should check elements are visible on the page', async () => {
-      await I.amOnPage('/form/field');
-      await I.seeElementInDOM('input[name=email]');
-      await I.dontSeeElement('input[name=email]');
-      await I.dontSeeElement('#something-beyond');
-    });
-  });
+      await I.amOnPage('/form/field')
+      await I.seeElementInDOM('input[name=email]')
+      await I.dontSeeElement('input[name=email]')
+      await I.dontSeeElement('#something-beyond')
+    })
+  })
 
   describe('#seeNumberOfVisibleElements', () => {
     it('should check number of visible elements for given locator', async () => {
-      await I.amOnPage('/info');
-      await I.seeNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3);
-    });
-  });
+      await I.amOnPage('/info')
+      await I.seeNumberOfVisibleElements('//div[@id = "grab-multiple"]//a', 3)
+    })
+  })
 
   describe('#grabNumberOfVisibleElements', () => {
     it('should grab number of visible elements for given locator', async () => {
-      await I.amOnPage('/info');
-      const num = await I.grabNumberOfVisibleElements('//div[@id = "grab-multiple"]//a');
-      assert.equal(num, 3);
-    });
+      await I.amOnPage('/info')
+      const num = await I.grabNumberOfVisibleElements('//div[@id = "grab-multiple"]//a')
+      assert.equal(num, 3)
+    })
 
     it('should support locators like {xpath:"//div"}', async () => {
-      await I.amOnPage('/info');
+      await I.amOnPage('/info')
       const num = await I.grabNumberOfVisibleElements({
         xpath: '//div[@id = "grab-multiple"]//a',
-      });
-      assert.equal(num, 3);
-    });
+      })
+      assert.equal(num, 3)
+    })
 
     it('should grab number of visible elements for given css locator', async () => {
-      await I.amOnPage('/info');
-      const num = await I.grabNumberOfVisibleElements('[id=grab-multiple] a');
-      assert.equal(num, 3);
-    });
+      await I.amOnPage('/info')
+      const num = await I.grabNumberOfVisibleElements('[id=grab-multiple] a')
+      assert.equal(num, 3)
+    })
 
     it('should return 0 for non-existing elements', async () => {
-      await I.amOnPage('/info');
-      const num = await I.grabNumberOfVisibleElements('button[type=submit]');
-      assert.equal(num, 0);
-    });
+      await I.amOnPage('/info')
+      const num = await I.grabNumberOfVisibleElements('button[type=submit]')
+      assert.equal(num, 0)
+    })
 
     it('should honor visibility hidden style', async () => {
-      await I.amOnPage('/info');
-      const num = await I.grabNumberOfVisibleElements('.issue2928');
-      assert.equal(num, 1);
-    });
-  });
+      await I.amOnPage('/info')
+      const num = await I.grabNumberOfVisibleElements('.issue2928')
+      assert.equal(num, 1)
+    })
+  })
 
   describe('#seeInSource, #dontSeeInSource', () => {
     it('should check meta of a page', async () => {
-      await I.amOnPage('/info');
-      await I.seeInSource('<body>');
-      await I.dontSeeInSource('<meta>');
-      await I.seeInSource('Invisible text');
-      await I.seeInSource('content="text/html; charset=utf-8"');
-    });
-  });
+      await I.amOnPage('/info')
+      await I.seeInSource('<body>')
+      await I.dontSeeInSource('<meta>')
+      await I.seeInSource('Invisible text')
+      await I.seeInSource('content="text/html; charset=utf-8"')
+    })
+  })
 
   describe('#click', () => {
     it('should click by inner text', async () => {
-      await I.amOnPage('/');
-      await I.click('More info');
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.click('More info')
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should click by css', async () => {
-      await I.amOnPage('/');
-      await I.click('#link');
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.click('#link')
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should click by xpath', async () => {
-      await I.amOnPage('/');
-      await I.click('//a[@id="link"]');
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.click('//a[@id="link"]')
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should click by name', async () => {
-      await I.amOnPage('/form/button');
-      await I.click('btn0');
-      assert.equal(formContents('text'), 'val');
-    });
+      await I.amOnPage('/form/button')
+      await I.click('btn0')
+      assert.equal(formContents('text'), 'val')
+    })
 
     it('should click on context', async () => {
-      await I.amOnPage('/');
-      await I.click('More info', 'body>p');
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.click('More info', 'body>p')
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should not click wrong context', async () => {
-      let err = false;
-      await I.amOnPage('/');
+      let err = false
+      await I.amOnPage('/')
       try {
-        await I.click('More info', '#area1');
+        await I.click('More info', '#area1')
       } catch (e) {
-        err = true;
+        err = true
       }
 
-      assert.ok(err);
-    });
+      assert.ok(err)
+    })
 
     it('should should click by aria-label', async () => {
-      await I.amOnPage('/form/aria');
-      await I.click('get info');
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/form/aria')
+      await I.click('get info')
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should click link with inner span', async () => {
-      await I.amOnPage('/form/example7');
-      await I.click('Buy Chocolate Bar');
-      await I.seeCurrentUrlEquals('/');
-    });
+      await I.amOnPage('/form/example7')
+      await I.click('Buy Chocolate Bar')
+      await I.seeCurrentUrlEquals('/')
+    })
 
     it('should click link with xpath locator', async () => {
-      await I.amOnPage('/form/example7');
+      await I.amOnPage('/form/example7')
       await I.click({
         xpath: '(//*[@title = "Chocolate Bar"])[1]',
-      });
-      await I.seeCurrentUrlEquals('/');
-    });
-  });
+      })
+      await I.seeCurrentUrlEquals('/')
+    })
+  })
 
   describe('#forceClick', () => {
     beforeEach(function () {
-      if (isHelper('TestCafe')) this.skip();
-    });
+      if (isHelper('TestCafe')) this.skip()
+    })
 
     it('should forceClick by inner text', async () => {
-      await I.amOnPage('/');
-      await I.forceClick('More info');
-      if (isHelper('Puppeteer')) await I.waitForNavigation();
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.forceClick('More info')
+      if (isHelper('Puppeteer')) await I.waitForNavigation()
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should forceClick by css', async () => {
-      await I.amOnPage('/');
-      await I.forceClick('#link');
-      if (isHelper('Puppeteer')) await I.waitForNavigation();
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.forceClick('#link')
+      if (isHelper('Puppeteer')) await I.waitForNavigation()
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should forceClick by xpath', async () => {
-      await I.amOnPage('/');
-      await I.forceClick('//a[@id="link"]');
-      if (isHelper('Puppeteer')) await I.waitForNavigation();
-      await I.seeInCurrentUrl('/info');
-    });
+      await I.amOnPage('/')
+      await I.forceClick('//a[@id="link"]')
+      if (isHelper('Puppeteer')) await I.waitForNavigation()
+      await I.seeInCurrentUrl('/info')
+    })
 
     it('should forceClick on context', async () => {
-      await I.amOnPage('/');
-      await I.forceClick('More info', 'body>p');
-      if (isHelper('Puppeteer')) await I.waitForNavigation();
-      await I.seeInCurrentUrl('/info');
-    });
-  });
+      await I.amOnPage('/')
+      await I.forceClick('More info', 'body>p')
+      if (isHelper('Puppeteer')) await I.waitForNavigation()
+      await I.seeInCurrentUrl('/info')
+    })
+  })
 
   // Could not get double click to work
   describe('#doubleClick', () => {
     it('it should doubleClick', async () => {
-      await I.amOnPage('/form/doubleclick');
-      await I.dontSee('Done');
-      await I.doubleClick('#block');
-      await I.see('Done');
-    });
-  });
+      await I.amOnPage('/form/doubleclick')
+      await I.dontSee('Done')
+      await I.doubleClick('#block')
+      await I.see('Done')
+    })
+  })
 
   // rightClick does not seem to work either
   describe('#rightClick', () => {
     it('it should rightClick', async () => {
-      await I.amOnPage('/form/rightclick');
-      await I.dontSee('right clicked');
-      await I.rightClick('Lorem Ipsum');
-      await I.see('right clicked');
-    });
+      await I.amOnPage('/form/rightclick')
+      await I.dontSee('right clicked')
+      await I.rightClick('Lorem Ipsum')
+      await I.see('right clicked')
+    })
 
     it('it should rightClick by locator', async () => {
-      await I.amOnPage('/form/rightclick');
-      await I.dontSee('right clicked');
-      await I.rightClick('.context a');
-      await I.see('right clicked');
-    });
+      await I.amOnPage('/form/rightclick')
+      await I.dontSee('right clicked')
+      await I.rightClick('.context a')
+      await I.see('right clicked')
+    })
 
     it('it should rightClick by locator and context', async () => {
-      await I.amOnPage('/form/rightclick');
-      await I.dontSee('right clicked');
-      await I.rightClick('Lorem Ipsum', '.context');
-      await I.see('right clicked');
-    });
-  });
+      await I.amOnPage('/form/rightclick')
+      await I.dontSee('right clicked')
+      await I.rightClick('Lorem Ipsum', '.context')
+      await I.see('right clicked')
+    })
+  })
 
   describe('#checkOption', () => {
     it('should check option by css', async () => {
-      await I.amOnPage('/form/checkbox');
-      await I.checkOption('#checkin');
-      await I.click('Submit');
-      await I.wait(1);
-      assert.equal(formContents('terms'), 'agree');
-    });
+      await I.amOnPage('/form/checkbox')
+      await I.checkOption('#checkin')
+      await I.click('Submit')
+      await I.wait(1)
+      assert.equal(formContents('terms'), 'agree')
+    })
 
     it('should check option by strict locator', async () => {
-      await I.amOnPage('/form/checkbox');
+      await I.amOnPage('/form/checkbox')
       await I.checkOption({
         id: 'checkin',
-      });
-      await I.click('Submit');
-      assert.equal(formContents('terms'), 'agree');
-    });
+      })
+      await I.click('Submit')
+      assert.equal(formContents('terms'), 'agree')
+    })
 
     it('should check option by name', async () => {
-      await I.amOnPage('/form/checkbox');
-      await I.checkOption('terms');
-      await I.click('Submit');
-      assert.equal(formContents('terms'), 'agree');
-    });
+      await I.amOnPage('/form/checkbox')
+      await I.checkOption('terms')
+      await I.click('Submit')
+      assert.equal(formContents('terms'), 'agree')
+    })
 
     it('should check option by label', async () => {
-      await I.amOnPage('/form/checkbox');
-      await I.checkOption('I Agree');
-      await I.click('Submit');
-      assert.equal(formContents('terms'), 'agree');
-    });
+      await I.amOnPage('/form/checkbox')
+      await I.checkOption('I Agree')
+      await I.click('Submit')
+      assert.equal(formContents('terms'), 'agree')
+    })
 
     // TODO Having problems with functional style selectors in testcafe
     // cannot do Selector(css).find(elementByXPath(xpath))
     // testcafe always says "xpath is not defined"
     // const el = Selector(context).find(elementByXPath(Locator.checkable.byText(xpathLocator.literal(field))).with({ boundTestRun: this.t })).with({ boundTestRun: this.t });
     it.skip('should check option by context', async () => {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/example1');
-      await I.checkOption('Remember me next time', '.rememberMe');
-      await I.click('Login');
-      assert.equal(formContents('LoginForm').rememberMe, 1);
-    });
-  });
+      await I.amOnPage('/form/example1')
+      await I.checkOption('Remember me next time', '.rememberMe')
+      await I.click('Login')
+      assert.equal(formContents('LoginForm').rememberMe, 1)
+    })
+  })
 
   describe('#uncheckOption', () => {
     it('should uncheck option that is currently checked', async () => {
-      await I.amOnPage('/info');
-      await I.uncheckOption('interesting');
-      await I.dontSeeCheckboxIsChecked('interesting');
-    });
-  });
+      await I.amOnPage('/info')
+      await I.uncheckOption('interesting')
+      await I.dontSeeCheckboxIsChecked('interesting')
+    })
+  })
 
   describe('#selectOption', () => {
     it('should select option by css', async () => {
-      await I.amOnPage('/form/select');
-      await I.selectOption('form select[name=age]', 'adult');
-      await I.click('Submit');
-      assert.equal(formContents('age'), 'adult');
-    });
+      await I.amOnPage('/form/select')
+      await I.selectOption('form select[name=age]', 'adult')
+      await I.click('Submit')
+      assert.equal(formContents('age'), 'adult')
+    })
 
     it('should select option by name', async () => {
-      await I.amOnPage('/form/select');
-      await I.selectOption('age', 'adult');
-      await I.click('Submit');
-      assert.equal(formContents('age'), 'adult');
-    });
+      await I.amOnPage('/form/select')
+      await I.selectOption('age', 'adult')
+      await I.click('Submit')
+      assert.equal(formContents('age'), 'adult')
+    })
 
     it('should select option by label', async () => {
-      await I.amOnPage('/form/select');
-      await I.selectOption('Select your age', 'dead');
-      await I.click('Submit');
-      assert.equal(formContents('age'), 'dead');
-    });
+      await I.amOnPage('/form/select')
+      await I.selectOption('Select your age', 'dead')
+      await I.click('Submit')
+      assert.equal(formContents('age'), 'dead')
+    })
 
     it('should select option by label and option text', async () => {
-      await I.amOnPage('/form/select');
-      await I.selectOption('Select your age', '21-60');
-      await I.click('Submit');
-      assert.equal(formContents('age'), 'adult');
-    });
+      await I.amOnPage('/form/select')
+      await I.selectOption('Select your age', '21-60')
+      await I.click('Submit')
+      assert.equal(formContents('age'), 'adult')
+    })
 
     it('should select option by label and option text - with an onchange callback', async () => {
-      await I.amOnPage('/form/select_onchange');
-      await I.selectOption('Select a value', 'Option 2');
-      await I.click('Submit');
-      assert.equal(formContents('select'), 'option2');
-    });
+      await I.amOnPage('/form/select_onchange')
+      await I.selectOption('Select a value', 'Option 2')
+      await I.click('Submit')
+      assert.equal(formContents('select'), 'option2')
+    })
 
     // Could not get multiselect to work with testcafe
     it('should select multiple options', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/select_multiple');
-      await I.selectOption('What do you like the most?', ['Play Video Games', 'Have Sex']);
-      await I.click('Submit');
-      assert.deepEqual(formContents('like'), ['play', 'adult']);
-    });
+      await I.amOnPage('/form/select_multiple')
+      await I.selectOption('What do you like the most?', ['Play Video Games', 'Have Sex'])
+      await I.click('Submit')
+      assert.deepEqual(formContents('like'), ['play', 'adult'])
+    })
 
     it('should select option by label and option text with additional spaces', async () => {
-      await I.amOnPage('/form/select_additional_spaces');
-      await I.selectOption('Select your age', '21-60');
-      await I.click('Submit');
-      assert.equal(formContents('age'), 'adult');
-    });
-  });
+      await I.amOnPage('/form/select_additional_spaces')
+      await I.selectOption('Select your age', '21-60')
+      await I.click('Submit')
+      assert.equal(formContents('age'), 'adult')
+    })
+  })
 
   describe('#executeScript', () => {
     it('should execute synchronous script', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       await I.executeScript(() => {
-        document.getElementById('link').innerHTML = 'Appended';
-      });
-      await I.see('Appended', 'a');
-    });
+        document.getElementById('link').innerHTML = 'Appended'
+      })
+      await I.see('Appended', 'a')
+    })
 
     it('should return value from sync script', async () => {
-      await I.amOnPage('/');
-      const val = await I.executeScript(a => a + 5, 5);
-      assert.equal(val, 10);
-    });
+      await I.amOnPage('/')
+      const val = await I.executeScript(a => a + 5, 5)
+      assert.equal(val, 10)
+    })
 
     it('should return value from sync script in iframe', async function () {
       // TODO Not yet implemented
-      if (isHelper('TestCafe')) this.skip(); // TODO Not yet implemented
+      if (isHelper('TestCafe')) this.skip() // TODO Not yet implemented
 
-      await I.amOnPage('/iframe');
-      await I.switchTo({ css: 'iframe' });
-      const val = await I.executeScript(() => document.getElementsByTagName('h1')[0].innerText);
-      assert.equal(val, 'Information');
-    });
+      await I.amOnPage('/iframe')
+      await I.switchTo({ css: 'iframe' })
+      const val = await I.executeScript(() => document.getElementsByTagName('h1')[0].innerText)
+      assert.equal(val, 'Information')
+    })
 
     it('should execute async script', async function () {
-      if (isHelper('TestCafe')) this.skip(); // TODO Not yet implemented
-      if (isHelper('Playwright')) return; // It won't be implemented
+      if (isHelper('TestCafe')) this.skip() // TODO Not yet implemented
+      if (isHelper('Playwright')) return // It won't be implemented
 
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       const val = await I.executeAsyncScript((val, done) => {
         setTimeout(() => {
-          document.getElementById('link').innerHTML = val;
-          done(5);
-        }, 100);
-      }, 'Timeout');
-      assert.equal(val, 5);
-      await I.see('Timeout', 'a');
-    });
-  });
+          document.getElementById('link').innerHTML = val
+          done(5)
+        }, 100)
+      }, 'Timeout')
+      assert.equal(val, 5)
+      await I.see('Timeout', 'a')
+    })
+  })
 
   describe('#fillField, #appendField', () => {
     it('should fill input fields', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', 'Nothing special');
-      await I.click('Submit');
-      assert.equal(formContents('name'), 'Nothing special');
-    });
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', 'Nothing special')
+      await I.click('Submit')
+      assert.equal(formContents('name'), 'Nothing special')
+    })
 
     it('should fill input fields with secrets', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', secret('Something special'));
-      await I.click('Submit');
-      assert.equal(formContents('name'), 'Something special');
-    });
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', secret('Something special'))
+      await I.click('Submit')
+      assert.equal(formContents('name'), 'Something special')
+    })
 
     it('should fill field by css', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('#name', 'Nothing special');
-      await I.click('Submit');
-      assert.equal(formContents('name'), 'Nothing special');
-    });
+      await I.amOnPage('/form/field')
+      await I.fillField('#name', 'Nothing special')
+      await I.click('Submit')
+      assert.equal(formContents('name'), 'Nothing special')
+    })
 
     it('should fill field by strict locator', async () => {
-      await I.amOnPage('/form/field');
+      await I.amOnPage('/form/field')
       await I.fillField(
         {
           id: 'name',
         },
         'Nothing special',
-      );
-      await I.click('Submit');
-      assert.equal(formContents('name'), 'Nothing special');
-    });
+      )
+      await I.click('Submit')
+      assert.equal(formContents('name'), 'Nothing special')
+    })
 
     it('should fill field by name', async () => {
-      await I.amOnPage('/form/example1');
-      await I.fillField('LoginForm[username]', 'davert');
-      await I.fillField('LoginForm[password]', '123456');
-      await I.click('Login');
-      assert.equal(formContents('LoginForm').username, 'davert');
-      assert.equal(formContents('LoginForm').password, '123456');
-    });
+      await I.amOnPage('/form/example1')
+      await I.fillField('LoginForm[username]', 'davert')
+      await I.fillField('LoginForm[password]', '123456')
+      await I.click('Login')
+      assert.equal(formContents('LoginForm').username, 'davert')
+      assert.equal(formContents('LoginForm').password, '123456')
+    })
 
     it('should fill textarea by css', async () => {
-      await I.amOnPage('/form/textarea');
-      await I.fillField('textarea', 'Nothing special');
-      await I.click('Submit');
-      assert.equal(formContents('description'), 'Nothing special');
-    });
+      await I.amOnPage('/form/textarea')
+      await I.fillField('textarea', 'Nothing special')
+      await I.click('Submit')
+      assert.equal(formContents('description'), 'Nothing special')
+    })
 
     it('should fill textarea by label', async () => {
-      await I.amOnPage('/form/textarea');
-      await I.fillField('Description', 'Nothing special');
-      await I.click('Submit');
-      assert.equal(formContents('description'), 'Nothing special');
-    });
+      await I.amOnPage('/form/textarea')
+      await I.fillField('Description', 'Nothing special')
+      await I.click('Submit')
+      assert.equal(formContents('description'), 'Nothing special')
+    })
 
     it('should fill input by aria-label and aria-labelledby', async () => {
-      await I.amOnPage('/form/aria');
-      await I.fillField('My Address', 'Home Sweet Home');
-      await I.fillField('Phone', '123456');
-      await I.click('Submit');
-      assert.equal(formContents('my-form-phone'), '123456');
-      assert.equal(formContents('my-form-address'), 'Home Sweet Home');
-    });
+      await I.amOnPage('/form/aria')
+      await I.fillField('My Address', 'Home Sweet Home')
+      await I.fillField('Phone', '123456')
+      await I.click('Submit')
+      assert.equal(formContents('my-form-phone'), '123456')
+      assert.equal(formContents('my-form-address'), 'Home Sweet Home')
+    })
 
     it('should fill textarea by overwritting the existing value', async () => {
-      await I.amOnPage('/form/textarea');
-      await I.fillField('Description', 'Nothing special');
-      await I.fillField('Description', 'Some other text');
-      await I.click('Submit');
-      assert.equal(formContents('description'), 'Some other text');
-    });
+      await I.amOnPage('/form/textarea')
+      await I.fillField('Description', 'Nothing special')
+      await I.fillField('Description', 'Some other text')
+      await I.click('Submit')
+      assert.equal(formContents('description'), 'Some other text')
+    })
 
     it('should append field value', async () => {
-      await I.amOnPage('/form/field');
-      await I.appendField('Name', '_AND_NEW');
-      await I.click('Submit');
-      assert.equal(formContents('name'), 'OLD_VALUE_AND_NEW');
-    });
+      await I.amOnPage('/form/field')
+      await I.appendField('Name', '_AND_NEW')
+      await I.click('Submit')
+      assert.equal(formContents('name'), 'OLD_VALUE_AND_NEW')
+    })
 
     it.skip('should not fill invisible fields', async () => {
-      if (isHelper('Playwright')) return; // It won't be implemented
-      await I.amOnPage('/form/field');
+      if (isHelper('Playwright')) return // It won't be implemented
+      await I.amOnPage('/form/field')
       try {
-        I.fillField('email', 'test@1234');
+        I.fillField('email', 'test@1234')
       } catch (e) {
-        await assert.equal(e.message, 'Error: Field "email" was not found by text|CSS|XPath');
+        await assert.equal(e.message, 'Error: Field "email" was not found by text|CSS|XPath')
       }
-    });
-  });
+    })
+  })
 
   describe('#clearField', () => {
     it('should clear a given element', async () => {
-      await I.amOnPage('/form/field');
-      await I.fillField('#name', 'Nothing special');
-      await I.seeInField('#name', 'Nothing special');
-      await I.clearField('#name');
-      await I.dontSeeInField('#name', 'Nothing special');
-    });
+      await I.amOnPage('/form/field')
+      await I.fillField('#name', 'Nothing special')
+      await I.seeInField('#name', 'Nothing special')
+      await I.clearField('#name')
+      await I.dontSeeInField('#name', 'Nothing special')
+    })
 
     it('should clear field by name', async () => {
-      await I.amOnPage('/form/example1');
-      await I.clearField('LoginForm[username]');
-      await I.click('Login');
-      assert.equal(formContents('LoginForm').username, '');
-    });
+      await I.amOnPage('/form/example1')
+      await I.clearField('LoginForm[username]')
+      await I.click('Login')
+      assert.equal(formContents('LoginForm').username, '')
+    })
 
     it('should clear field by locator', async () => {
-      await I.amOnPage('/form/example1');
-      await I.clearField('#LoginForm_username');
-      await I.click('Login');
-      assert.equal(formContents('LoginForm').username, '');
-    });
-  });
+      await I.amOnPage('/form/example1')
+      await I.clearField('#LoginForm_username')
+      await I.click('Login')
+      assert.equal(formContents('LoginForm').username, '')
+    })
+  })
 
   describe('#type', () => {
     it('should type into a field', async function () {
-      if (isHelper('TestCafe')) this.skip();
-      await I.amOnPage('/form/field');
-      await I.click('Name');
+      if (isHelper('TestCafe')) this.skip()
+      await I.amOnPage('/form/field')
+      await I.click('Name')
 
-      await I.type('Type Test');
-      await I.seeInField('Name', 'Type Test');
+      await I.type('Type Test')
+      await I.seeInField('Name', 'Type Test')
 
-      await I.fillField('Name', '');
+      await I.fillField('Name', '')
 
-      await I.type(['T', 'y', 'p', 'e', '2']);
-      await I.seeInField('Name', 'Type2');
-    });
+      await I.type(['T', 'y', 'p', 'e', '2'])
+      await I.seeInField('Name', 'Type2')
+    })
 
     it('should use delay to slow down typing', async function () {
-      if (isHelper('TestCafe')) this.skip();
-      await I.amOnPage('/form/field');
-      await I.fillField('Name', '');
-      const time = Date.now();
-      await I.type('12345', 100);
-      await I.seeInField('Name', '12345');
-      assert(Date.now() - time > 500);
-    });
-  });
+      if (isHelper('TestCafe')) this.skip()
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', '')
+      const time = Date.now()
+      await I.type('12345', 100)
+      await I.seeInField('Name', '12345')
+      assert(Date.now() - time > 500)
+    })
+  })
 
   describe('check fields: #seeInField, #seeCheckboxIsChecked, ...', () => {
     it('should check for empty field', async () => {
-      await I.amOnPage('/form/empty');
-      await I.seeInField('#empty_input', '');
-    });
+      await I.amOnPage('/form/empty')
+      await I.seeInField('#empty_input', '')
+    })
 
     it('should check for empty textarea', async () => {
-      await I.amOnPage('/form/empty');
-      await I.seeInField('#empty_textarea', '');
-    });
+      await I.amOnPage('/form/empty')
+      await I.seeInField('#empty_textarea', '')
+    })
 
     it('should check field equals', async () => {
-      await I.amOnPage('/form/field');
-      await I.seeInField('Name', 'OLD_VALUE');
-      await I.seeInField('name', 'OLD_VALUE');
-      await I.seeInField('//input[@id="name"]', 'OLD_VALUE');
-      await I.dontSeeInField('//input[@id="name"]', 'NOtVALUE');
-    });
+      await I.amOnPage('/form/field')
+      await I.seeInField('Name', 'OLD_VALUE')
+      await I.seeInField('name', 'OLD_VALUE')
+      await I.seeInField('//input[@id="name"]', 'OLD_VALUE')
+      await I.dontSeeInField('//input[@id="name"]', 'NOtVALUE')
+    })
 
     it('should check textarea equals', async () => {
-      await I.amOnPage('/form/textarea');
-      await I.seeInField('Description', 'sunrise');
-      await I.seeInField('textarea', 'sunrise');
-      await I.seeInField('//textarea[@id="description"]', 'sunrise');
-      await I.dontSeeInField('//textarea[@id="description"]', 'sunset');
-    });
+      await I.amOnPage('/form/textarea')
+      await I.seeInField('Description', 'sunrise')
+      await I.seeInField('textarea', 'sunrise')
+      await I.seeInField('//textarea[@id="description"]', 'sunrise')
+      await I.dontSeeInField('//textarea[@id="description"]', 'sunset')
+    })
 
     it('should check checkbox is checked :)', async () => {
-      await I.amOnPage('/info');
-      await I.seeCheckboxIsChecked('input[type=checkbox]');
-    });
+      await I.amOnPage('/info')
+      await I.seeCheckboxIsChecked('input[type=checkbox]')
+    })
 
     it('should check checkbox is not checked', async () => {
-      await I.amOnPage('/form/checkbox');
-      await I.dontSeeCheckboxIsChecked('#checkin');
-    });
+      await I.amOnPage('/form/checkbox')
+      await I.dontSeeCheckboxIsChecked('#checkin')
+    })
 
     it('should match fields with the same name', async () => {
-      await I.amOnPage('/form/example20');
-      await I.seeInField("//input[@name='txtName'][2]", 'emma');
-      await I.seeInField("input[name='txtName']:nth-child(2)", 'emma');
-    });
-  });
+      await I.amOnPage('/form/example20')
+      await I.seeInField("//input[@name='txtName'][2]", 'emma')
+      await I.seeInField("input[name='txtName']:nth-child(2)", 'emma')
+    })
+  })
 
   describe('#grabTextFromAll, #grabHTMLFromAll, #grabValueFromAll, #grabAttributeFromAll', () => {
     it('should grab multiple texts from page', async () => {
-      await I.amOnPage('/info');
-      let vals = await I.grabTextFromAll('#grab-multiple a');
-      assert.equal(vals[0], 'First');
-      assert.equal(vals[1], 'Second');
-      assert.equal(vals[2], 'Third');
+      await I.amOnPage('/info')
+      let vals = await I.grabTextFromAll('#grab-multiple a')
+      assert.equal(vals[0], 'First')
+      assert.equal(vals[1], 'Second')
+      assert.equal(vals[2], 'Third')
 
-      await I.amOnPage('/info');
-      vals = await I.grabTextFromAll('#invalid-id a');
-      assert.equal(vals.length, 0);
-    });
+      await I.amOnPage('/info')
+      vals = await I.grabTextFromAll('#invalid-id a')
+      assert.equal(vals.length, 0)
+    })
 
     it('should grab multiple html from page', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/info');
-      let vals = await I.grabHTMLFromAll('#grab-multiple a');
-      assert.equal(vals[0], 'First');
-      assert.equal(vals[1], 'Second');
-      assert.equal(vals[2], 'Third');
+      await I.amOnPage('/info')
+      let vals = await I.grabHTMLFromAll('#grab-multiple a')
+      assert.equal(vals[0], 'First')
+      assert.equal(vals[1], 'Second')
+      assert.equal(vals[2], 'Third')
 
-      await I.amOnPage('/info');
-      vals = await I.grabHTMLFromAll('#invalid-id a');
-      assert.equal(vals.length, 0);
-    });
+      await I.amOnPage('/info')
+      vals = await I.grabHTMLFromAll('#invalid-id a')
+      assert.equal(vals.length, 0)
+    })
 
     it('should grab multiple attribute from element', async () => {
-      await I.amOnPage('/form/empty');
+      await I.amOnPage('/form/empty')
       const vals = await I.grabAttributeFromAll(
         {
           css: 'input',
         },
         'name',
-      );
-      assert.equal(vals[0], 'text');
-      assert.equal(vals[1], 'empty_input');
-    });
+      )
+      assert.equal(vals[0], 'text')
+      assert.equal(vals[1], 'empty_input')
+    })
 
     it('Should return empty array if no attribute found', async () => {
-      await I.amOnPage('/form/empty');
+      await I.amOnPage('/form/empty')
       const vals = await I.grabAttributeFromAll(
         {
           css: 'div',
         },
         'test',
-      );
-      assert.equal(vals.length, 0);
-    });
+      )
+      assert.equal(vals.length, 0)
+    })
 
     it('should grab values if multiple field matches', async () => {
-      await I.amOnPage('/form/hidden');
-      let vals = await I.grabValueFromAll('//form/input');
-      assert.equal(vals[0], 'kill_people');
-      assert.equal(vals[1], 'Submit');
+      await I.amOnPage('/form/hidden')
+      let vals = await I.grabValueFromAll('//form/input')
+      assert.equal(vals[0], 'kill_people')
+      assert.equal(vals[1], 'Submit')
 
-      vals = await I.grabValueFromAll("//form/input[@name='action']");
-      assert.equal(vals[0], 'kill_people');
-    });
+      vals = await I.grabValueFromAll("//form/input[@name='action']")
+      assert.equal(vals[0], 'kill_people')
+    })
 
     it('Should return empty array if no value found', async () => {
-      await I.amOnPage('/');
-      const vals = await I.grabValueFromAll('//form/input');
-      assert.equal(vals.length, 0);
-    });
-  });
+      await I.amOnPage('/')
+      const vals = await I.grabValueFromAll('//form/input')
+      assert.equal(vals.length, 0)
+    })
+  })
 
   describe('#grabTextFrom, #grabHTMLFrom, #grabValueFrom, #grabAttributeFrom', () => {
     it('should grab text from page', async () => {
-      await I.amOnPage('/');
-      let val = await I.grabTextFrom('h1');
-      assert.equal(val, 'Welcome to test app!');
+      await I.amOnPage('/')
+      let val = await I.grabTextFrom('h1')
+      assert.equal(val, 'Welcome to test app!')
 
-      val = await I.grabTextFrom('//h1');
-      assert.equal(val, 'Welcome to test app!');
-    });
+      val = await I.grabTextFrom('//h1')
+      assert.equal(val, 'Welcome to test app!')
+    })
 
     it('should return empty string when the text of tag is an empty string', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/info');
-      let val = await I.grabTextFrom('#p-no-text');
-      assert.equal(val, '');
-    });
+      await I.amOnPage('/info')
+      let val = await I.grabTextFrom('#p-no-text')
+      assert.equal(val, '')
+    })
 
     it('should grab html from page', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/info');
-      const val = await I.grabHTMLFrom('#grab-multiple');
+      await I.amOnPage('/info')
+      const val = await I.grabHTMLFrom('#grab-multiple')
       assert.equal(
         `
     <a id="first-link">First</a>
@@ -769,1044 +769,1044 @@ module.exports.tests = function () {
     <a id="third-link">Third</a>
 `,
         val,
-      );
-    });
+      )
+    })
 
     it('should grab value from field', async () => {
-      await I.amOnPage('/form/hidden');
-      let val = await I.grabValueFrom('#action');
-      assert.equal(val, 'kill_people');
-      val = await I.grabValueFrom("//form/input[@name='action']");
-      assert.equal(val, 'kill_people');
-      await I.amOnPage('/form/textarea');
-      val = await I.grabValueFrom('#description');
-      assert.equal(val, 'sunrise');
-      await I.amOnPage('/form/select');
-      val = await I.grabValueFrom('#age');
-      assert.equal(val, 'oldfag');
-    });
+      await I.amOnPage('/form/hidden')
+      let val = await I.grabValueFrom('#action')
+      assert.equal(val, 'kill_people')
+      val = await I.grabValueFrom("//form/input[@name='action']")
+      assert.equal(val, 'kill_people')
+      await I.amOnPage('/form/textarea')
+      val = await I.grabValueFrom('#description')
+      assert.equal(val, 'sunrise')
+      await I.amOnPage('/form/select')
+      val = await I.grabValueFrom('#age')
+      assert.equal(val, 'oldfag')
+    })
 
     it('should grab attribute from element', async () => {
-      await I.amOnPage('/search');
+      await I.amOnPage('/search')
       const val = await I.grabAttributeFrom(
         {
           css: 'form',
         },
         'method',
-      );
-      assert.equal(val, 'get');
-    });
+      )
+      assert.equal(val, 'get')
+    })
 
     it('should grab custom attribute from element', async () => {
-      await I.amOnPage('/form/example4');
+      await I.amOnPage('/form/example4')
       const val = await I.grabAttributeFrom(
         {
           css: '.navbar-toggle',
         },
         'data-toggle',
-      );
-      assert.equal(val, 'collapse');
-    });
-  });
+      )
+      assert.equal(val, 'collapse')
+    })
+  })
 
   describe('page title : #seeTitle, #dontSeeTitle, #grabTitle', () => {
     it('should check page title', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/');
-      await I.seeInTitle('TestEd Beta 2.0');
-      await I.dontSeeInTitle('Welcome to test app');
-      await I.amOnPage('/info');
-      await I.dontSeeInTitle('TestEd Beta 2.0');
-    });
+      await I.amOnPage('/')
+      await I.seeInTitle('TestEd Beta 2.0')
+      await I.dontSeeInTitle('Welcome to test app')
+      await I.amOnPage('/info')
+      await I.dontSeeInTitle('TestEd Beta 2.0')
+    })
 
     it('should grab page title', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/');
-      const val = await I.grabTitle();
-      assert.equal(val, 'TestEd Beta 2.0');
-    });
-  });
+      await I.amOnPage('/')
+      const val = await I.grabTitle()
+      assert.equal(val, 'TestEd Beta 2.0')
+    })
+  })
 
   describe('#attachFile', () => {
     it('should upload file located by CSS', async () => {
-      await I.amOnPage('/form/file');
-      await I.attachFile('#avatar', 'app/avatar.jpg');
-      await I.click('Submit');
-      await I.see('Thank you');
-      formContents().files.should.have.key('avatar');
-      formContents().files.avatar.name.should.eql('avatar.jpg');
-      formContents().files.avatar.type.should.eql('image/jpeg');
-    });
+      await I.amOnPage('/form/file')
+      await I.attachFile('#avatar', 'app/avatar.jpg')
+      await I.click('Submit')
+      await I.see('Thank you')
+      formContents().files.should.have.key('avatar')
+      formContents().files.avatar.name.should.eql('avatar.jpg')
+      formContents().files.avatar.type.should.eql('image/jpeg')
+    })
 
     it('should upload file located by label', async () => {
-      await I.amOnPage('/form/file');
-      await I.attachFile('Avatar', 'app/avatar.jpg');
-      await I.click('Submit');
-      await I.see('Thank you');
-      formContents().files.should.have.key('avatar');
-      formContents().files.avatar.name.should.eql('avatar.jpg');
-      formContents().files.avatar.type.should.eql('image/jpeg');
-    });
-  });
+      await I.amOnPage('/form/file')
+      await I.attachFile('Avatar', 'app/avatar.jpg')
+      await I.click('Submit')
+      await I.see('Thank you')
+      formContents().files.should.have.key('avatar')
+      formContents().files.avatar.name.should.eql('avatar.jpg')
+      formContents().files.avatar.type.should.eql('image/jpeg')
+    })
+  })
 
   describe('#saveScreenshot', () => {
     beforeEach(() => {
-      global.output_dir = path.join(global.codecept_dir, 'output');
-    });
+      global.output_dir = path.join(global.codecept_dir, 'output')
+    })
 
     it('should create a screenshot file in output dir', async () => {
-      const sec = new Date().getUTCMilliseconds();
-      await I.amOnPage('/');
-      await I.saveScreenshot(`screenshot_${sec}.png`);
-      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists');
-    });
+      const sec = new Date().getUTCMilliseconds()
+      await I.amOnPage('/')
+      await I.saveScreenshot(`screenshot_${sec}.png`)
+      assert.ok(fileExists(path.join(global.output_dir, `screenshot_${sec}.png`)), null, 'file does not exists')
+    })
 
     it('should create a full page screenshot file in output dir', async () => {
-      const sec = new Date().getUTCMilliseconds();
-      await I.amOnPage('/');
-      await I.saveScreenshot(`screenshot_full_${+sec}.png`, true);
-      assert.ok(fileExists(path.join(global.output_dir, `screenshot_full_${+sec}.png`)), null, 'file does not exists');
-    });
-  });
+      const sec = new Date().getUTCMilliseconds()
+      await I.amOnPage('/')
+      await I.saveScreenshot(`screenshot_full_${+sec}.png`, true)
+      assert.ok(fileExists(path.join(global.output_dir, `screenshot_full_${+sec}.png`)), null, 'file does not exists')
+    })
+  })
 
   describe('cookies : #setCookie, #clearCookies, #seeCookie, #waitForCookie', () => {
     it('should do all cookie stuff', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       await I.setCookie({
         name: 'auth',
         value: '123456',
         url: 'http://localhost',
-      });
-      await I.seeCookie('auth');
-      await I.dontSeeCookie('auuth');
+      })
+      await I.seeCookie('auth')
+      await I.dontSeeCookie('auuth')
 
-      const cookie = await I.grabCookie('auth');
-      assert.equal(cookie.value, '123456');
+      const cookie = await I.grabCookie('auth')
+      assert.equal(cookie.value, '123456')
 
-      await I.clearCookie('auth');
-      await I.dontSeeCookie('auth');
-    });
+      await I.clearCookie('auth')
+      await I.dontSeeCookie('auth')
+    })
 
     it('should grab all cookies', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       await I.setCookie({
         name: 'auth',
         value: '123456',
         url: 'http://localhost',
-      });
+      })
       await I.setCookie({
         name: 'user',
         value: 'davert',
         url: 'http://localhost',
-      });
+      })
 
-      const cookies = await I.grabCookie();
-      assert.equal(cookies.length, 2);
-      assert(cookies[0].name);
-      assert(cookies[0].value);
-    });
+      const cookies = await I.grabCookie()
+      assert.equal(cookies.length, 2)
+      assert(cookies[0].name)
+      assert(cookies[0].value)
+    })
 
     it('should clear all cookies', async () => {
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       await I.setCookie({
         name: 'auth',
         value: '123456',
         url: 'http://localhost',
-      });
-      await I.clearCookie();
-      await I.dontSeeCookie('auth');
-    });
+      })
+      await I.clearCookie()
+      await I.dontSeeCookie('auth')
+    })
 
     it('should wait for cookie and throw error when cookie not found', async () => {
-      if (isHelper('TestCafe')) return;
+      if (isHelper('TestCafe')) return
 
-      await I.amOnPage('https://google.com');
+      await I.amOnPage('https://google.com')
       try {
-        await I.waitForCookie('auth', 2);
+        await I.waitForCookie('auth', 2)
       } catch (e) {
-        assert.equal(e.message, 'Cookie auth is not found after 2s');
+        assert.equal(e.message, 'Cookie auth is not found after 2s')
       }
-    });
+    })
 
     it('should wait for cookie', async () => {
-      if (isHelper('TestCafe')) return;
+      if (isHelper('TestCafe')) return
 
-      await I.amOnPage('/');
+      await I.amOnPage('/')
       await I.setCookie({
         name: 'auth',
         value: '123456',
         url: 'http://localhost',
-      });
-      await I.waitForCookie('auth');
-    });
-  });
+      })
+      await I.waitForCookie('auth')
+    })
+  })
 
   describe('#waitForText', () => {
     it('should wait for text', async () => {
-      await I.amOnPage('/dynamic');
-      await I.dontSee('Dynamic text');
-      await I.waitForText('Dynamic text', 2);
-      await I.see('Dynamic text');
-    });
+      await I.amOnPage('/dynamic')
+      await I.dontSee('Dynamic text')
+      await I.waitForText('Dynamic text', 2)
+      await I.see('Dynamic text')
+    })
 
     it('should wait for text in context', async () => {
-      await I.amOnPage('/dynamic');
-      await I.dontSee('Dynamic text');
-      await I.waitForText('Dynamic text', 2, '#text');
-      await I.see('Dynamic text');
-    });
+      await I.amOnPage('/dynamic')
+      await I.dontSee('Dynamic text')
+      await I.waitForText('Dynamic text', 2, '#text')
+      await I.see('Dynamic text')
+    })
 
     it('should fail if no context', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      let failed = false;
-      await I.amOnPage('/dynamic');
-      await I.dontSee('Dynamic text');
+      let failed = false
+      await I.amOnPage('/dynamic')
+      await I.dontSee('Dynamic text')
       try {
-        await I.waitForText('Dynamic text', 1, '#fext');
+        await I.waitForText('Dynamic text', 1, '#fext')
       } catch (e) {
-        failed = true;
+        failed = true
       }
-      assert.ok(failed);
-    });
+      assert.ok(failed)
+    })
 
     it("should fail if text doesn't contain", async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      let failed = false;
-      await I.amOnPage('/dynamic');
+      let failed = false
+      await I.amOnPage('/dynamic')
       try {
-        await I.waitForText('Other text', 1);
+        await I.waitForText('Other text', 1)
       } catch (e) {
-        failed = true;
+        failed = true
       }
-      assert.ok(failed);
-    });
+      assert.ok(failed)
+    })
 
     it('should fail if text is not in element', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      let failed = false;
-      await I.amOnPage('/dynamic');
+      let failed = false
+      await I.amOnPage('/dynamic')
       try {
-        await I.waitForText('Other text', 1, '#text');
+        await I.waitForText('Other text', 1, '#text')
       } catch (e) {
-        failed = true;
+        failed = true
       }
-      assert.ok(failed);
-    });
+      assert.ok(failed)
+    })
 
     it('should wait for text after timeout', async () => {
-      await I.amOnPage('/timeout');
-      await I.dontSee('Timeout text');
-      await I.waitForText('Timeout text', 31, '#text');
-      await I.see('Timeout text');
-    });
+      await I.amOnPage('/timeout')
+      await I.dontSee('Timeout text')
+      await I.waitForText('Timeout text', 31, '#text')
+      await I.see('Timeout text')
+    })
 
     it('should wait for text located by XPath', async () => {
-      await I.amOnPage('/dynamic');
-      await I.dontSee('Dynamic text');
-      await I.waitForText('Dynamic text', 5, '//div[@id="text"]');
-    });
+      await I.amOnPage('/dynamic')
+      await I.dontSee('Dynamic text')
+      await I.waitForText('Dynamic text', 5, '//div[@id="text"]')
+    })
 
     it('should wait for text with double quotes', async () => {
-      await I.amOnPage('/');
-      await I.waitForText('said: "debug!"', 5);
-    });
+      await I.amOnPage('/')
+      await I.waitForText('said: "debug!"', 5)
+    })
 
     it('should throw error when text not found', async () => {
-      await I.amOnPage('/dynamic');
-      await I.dontSee('Dynamic text');
-      let failed = false;
+      await I.amOnPage('/dynamic')
+      await I.dontSee('Dynamic text')
+      let failed = false
       try {
-        await I.waitForText('Some text', 1, '//div[@id="text"]');
+        await I.waitForText('Some text', 1, '//div[@id="text"]')
       } catch (e) {
-        failed = true;
+        failed = true
       }
-      assert.ok(failed);
-    });
-  });
+      assert.ok(failed)
+    })
+  })
 
   describe('#waitForElement', () => {
     it('should wait for visible element', async () => {
-      await I.amOnPage('/form/wait_visible');
-      await I.dontSee('Step One Button');
-      await I.dontSeeElement('#step_1');
-      await I.waitForVisible('#step_1', 2);
-      await I.seeElement('#step_1');
-      await I.click('#step_1');
-      await I.waitForVisible('#step_2', 2);
-      await I.see('Step Two Button');
-    });
+      await I.amOnPage('/form/wait_visible')
+      await I.dontSee('Step One Button')
+      await I.dontSeeElement('#step_1')
+      await I.waitForVisible('#step_1', 2)
+      await I.seeElement('#step_1')
+      await I.click('#step_1')
+      await I.waitForVisible('#step_2', 2)
+      await I.see('Step Two Button')
+    })
 
     it('should wait for element in DOM', async () => {
-      await I.amOnPage('/form/wait_visible');
-      await I.waitForElement('#step_2');
-      await I.dontSeeElement('#step_2');
-      await I.seeElementInDOM('#step_2');
-    });
+      await I.amOnPage('/form/wait_visible')
+      await I.waitForElement('#step_2')
+      await I.dontSeeElement('#step_2')
+      await I.seeElementInDOM('#step_2')
+    })
 
     it('should wait for element by XPath', async () => {
-      await I.amOnPage('/form/wait_visible');
-      await I.waitForElement('//div[@id="step_2"]');
-      await I.dontSeeElement('//div[@id="step_2"]');
-      await I.seeElementInDOM('//div[@id="step_2"]');
-    });
+      await I.amOnPage('/form/wait_visible')
+      await I.waitForElement('//div[@id="step_2"]')
+      await I.dontSeeElement('//div[@id="step_2"]')
+      await I.seeElementInDOM('//div[@id="step_2"]')
+    })
 
     it('should wait for element to appear', async () => {
-      await I.amOnPage('/form/wait_element');
-      await I.dontSee('Hello');
-      await I.dontSeeElement('h1');
-      await I.waitForElement('h1', 2);
-      await I.see('Hello');
-    });
-  });
+      await I.amOnPage('/form/wait_element')
+      await I.dontSee('Hello')
+      await I.dontSeeElement('h1')
+      await I.waitForElement('h1', 2)
+      await I.see('Hello')
+    })
+  })
 
   describe('#waitForInvisible', () => {
     it('should wait for element to be invisible', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.see('Step One Button');
-      await I.seeElement('#step_1');
-      await I.waitForInvisible('#step_1', 2);
-      await I.dontSeeElement('#step_1');
-    });
+      await I.amOnPage('/form/wait_invisible')
+      await I.see('Step One Button')
+      await I.seeElement('#step_1')
+      await I.waitForInvisible('#step_1', 2)
+      await I.dontSeeElement('#step_1')
+    })
 
     it('should wait for element to be invisible by XPath', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.seeElement('//div[@id="step_1"]');
-      await I.waitForInvisible('//div[@id="step_1"]');
-      await I.dontSeeElement('//div[@id="step_1"]');
-      await I.seeElementInDOM('//div[@id="step_1"]');
-    });
+      await I.amOnPage('/form/wait_invisible')
+      await I.seeElement('//div[@id="step_1"]')
+      await I.waitForInvisible('//div[@id="step_1"]')
+      await I.dontSeeElement('//div[@id="step_1"]')
+      await I.seeElementInDOM('//div[@id="step_1"]')
+    })
 
     it('should wait for element to be removed', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.see('Step Two Button');
-      await I.seeElement('#step_2');
-      await I.waitForInvisible('#step_2', 2);
-      await I.dontSeeElement('#step_2');
-    });
+      await I.amOnPage('/form/wait_invisible')
+      await I.see('Step Two Button')
+      await I.seeElement('#step_2')
+      await I.waitForInvisible('#step_2', 2)
+      await I.dontSeeElement('#step_2')
+    })
 
     it('should wait for element to be removed by XPath', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.see('Step Two Button');
-      await I.seeElement('//div[@id="step_2"]');
-      await I.waitForInvisible('//div[@id="step_2"]', 2);
-      await I.dontSeeElement('//div[@id="step_2"]');
-    });
-  });
+      await I.amOnPage('/form/wait_invisible')
+      await I.see('Step Two Button')
+      await I.seeElement('//div[@id="step_2"]')
+      await I.waitForInvisible('//div[@id="step_2"]', 2)
+      await I.dontSeeElement('//div[@id="step_2"]')
+    })
+  })
 
   describe('#waitToHide', () => {
     it('should wait for element to be invisible', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.see('Step One Button');
-      await I.seeElement('#step_1');
-      await I.waitToHide('#step_1', 2);
-      await I.dontSeeElement('#step_1');
-    });
+      await I.amOnPage('/form/wait_invisible')
+      await I.see('Step One Button')
+      await I.seeElement('#step_1')
+      await I.waitToHide('#step_1', 2)
+      await I.dontSeeElement('#step_1')
+    })
 
     it('should wait for element to be invisible by XPath', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.seeElement('//div[@id="step_1"]');
-      await I.waitToHide('//div[@id="step_1"]');
-      await I.dontSeeElement('//div[@id="step_1"]');
-      await I.seeElementInDOM('//div[@id="step_1"]');
-    });
+      await I.amOnPage('/form/wait_invisible')
+      await I.seeElement('//div[@id="step_1"]')
+      await I.waitToHide('//div[@id="step_1"]')
+      await I.dontSeeElement('//div[@id="step_1"]')
+      await I.seeElementInDOM('//div[@id="step_1"]')
+    })
 
     it('should wait for element to be removed', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.see('Step Two Button');
-      await I.seeElement('#step_2');
-      await I.waitToHide('#step_2', 2);
-      await I.dontSeeElement('#step_2');
-    });
+      await I.amOnPage('/form/wait_invisible')
+      await I.see('Step Two Button')
+      await I.seeElement('#step_2')
+      await I.waitToHide('#step_2', 2)
+      await I.dontSeeElement('#step_2')
+    })
 
     it('should wait for element to be removed by XPath', async () => {
-      await I.amOnPage('/form/wait_invisible');
-      await I.see('Step Two Button');
-      await I.seeElement('//div[@id="step_2"]');
-      await I.waitToHide('//div[@id="step_2"]', 2);
-      await I.dontSeeElement('//div[@id="step_2"]');
-    });
-  });
+      await I.amOnPage('/form/wait_invisible')
+      await I.see('Step Two Button')
+      await I.seeElement('//div[@id="step_2"]')
+      await I.waitToHide('//div[@id="step_2"]', 2)
+      await I.dontSeeElement('//div[@id="step_2"]')
+    })
+  })
 
   describe('#waitForDetached', () => {
     it('should throw an error if the element still exists in DOM', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/wait_detached');
-      await I.see('Step One Button');
-      await I.seeElement('#step_1');
+      await I.amOnPage('/form/wait_detached')
+      await I.see('Step One Button')
+      await I.seeElement('#step_1')
 
       try {
-        await I.waitForDetached('#step_1', 2);
-        throw Error('Should not get this far');
+        await I.waitForDetached('#step_1', 2)
+        throw Error('Should not get this far')
       } catch (err) {
-        err.message.should.include('still on page after');
+        err.message.should.include('still on page after')
       }
-    });
+    })
 
     it('should throw an error if the element still exists in DOM by XPath', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/wait_detached');
-      await I.see('Step One Button');
-      await I.seeElement('#step_1');
+      await I.amOnPage('/form/wait_detached')
+      await I.see('Step One Button')
+      await I.seeElement('#step_1')
 
       try {
-        await I.waitForDetached('#step_1', 2);
-        throw Error('Should not get this far');
+        await I.waitForDetached('#step_1', 2)
+        throw Error('Should not get this far')
       } catch (err) {
-        err.message.should.include('still on page after');
+        err.message.should.include('still on page after')
       }
-    });
+    })
 
     it('should wait for element to be removed from DOM', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/wait_detached');
-      await I.see('Step Two Button');
-      await I.seeElement('#step_2');
-      await I.waitForDetached('#step_2', 2);
-      await I.dontSeeElementInDOM('#step_2');
-    });
+      await I.amOnPage('/form/wait_detached')
+      await I.see('Step Two Button')
+      await I.seeElement('#step_2')
+      await I.waitForDetached('#step_2', 2)
+      await I.dontSeeElementInDOM('#step_2')
+    })
 
     it('should wait for element to be removed from DOM by XPath', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/wait_detached');
-      await I.seeElement('//div[@id="step_2"]');
-      await I.waitForDetached('//div[@id="step_2"]');
-      await I.dontSeeElement('//div[@id="step_2"]');
-      await I.dontSeeElementInDOM('//div[@id="step_2"]');
-    });
-  });
+      await I.amOnPage('/form/wait_detached')
+      await I.seeElement('//div[@id="step_2"]')
+      await I.waitForDetached('//div[@id="step_2"]')
+      await I.dontSeeElement('//div[@id="step_2"]')
+      await I.dontSeeElementInDOM('//div[@id="step_2"]')
+    })
+  })
 
   describe('within tests', () => {
-    afterEach(() => I._withinEnd());
+    afterEach(() => I._withinEnd())
 
     it('should execute within block', async () => {
-      await I.amOnPage('/form/example4');
-      await I.seeElement('#navbar-collapse-menu');
+      await I.amOnPage('/form/example4')
+      await I.seeElement('#navbar-collapse-menu')
       I._withinBegin('#register')
         .then(() => I.see('E-Mail'))
         .then(() => I.dontSee('Toggle navigation'))
-        .then(() => I.dontSeeElement('#navbar-collapse-menu'));
-    });
+        .then(() => I.dontSeeElement('#navbar-collapse-menu'))
+    })
 
     it('should respect form fields inside within block ', async () => {
-      let rethrow;
+      let rethrow
 
-      await I.amOnPage('/form/example4');
-      await I.seeElement('#navbar-collapse-menu');
-      await I.see('E-Mail');
-      await I.see('Hasło');
-      await I.fillField('Hasło', '12345');
-      await I.seeInField('Hasło', '12345');
-      await I.checkOption('terms');
-      await I.seeCheckboxIsChecked('terms');
+      await I.amOnPage('/form/example4')
+      await I.seeElement('#navbar-collapse-menu')
+      await I.see('E-Mail')
+      await I.see('Hasło')
+      await I.fillField('Hasło', '12345')
+      await I.seeInField('Hasło', '12345')
+      await I.checkOption('terms')
+      await I.seeCheckboxIsChecked('terms')
       I._withinBegin({ css: '.form-group' })
         .then(() => I.see('E-Mail'))
         .then(() => I.dontSee('Hasło'))
-        .then(() => I.dontSeeElement('#navbar-collapse-menu'));
+        .then(() => I.dontSeeElement('#navbar-collapse-menu'))
 
       try {
-        await I.dontSeeCheckboxIsChecked('terms');
+        await I.dontSeeCheckboxIsChecked('terms')
       } catch (err) {
-        if (!err) assert.fail('seen checkbox');
+        if (!err) assert.fail('seen checkbox')
       }
 
       try {
-        await I.seeInField('Hasło', '12345');
+        await I.seeInField('Hasło', '12345')
       } catch (err) {
-        if (!err) assert.fail('seen field');
+        if (!err) assert.fail('seen field')
       }
 
-      if (rethrow) throw rethrow;
-    });
+      if (rethrow) throw rethrow
+    })
 
     it('should execute within block 2', async () => {
-      await I.amOnPage('/form/example4');
-      await I.fillField('Hasło', '12345');
+      await I.amOnPage('/form/example4')
+      await I.fillField('Hasło', '12345')
       I._withinBegin({ xpath: '//div[@class="form-group"][2]' })
         .then(() => I.dontSee('E-Mail'))
         .then(() => I.see('Hasło'))
         .then(() => I.grabTextFrom('label'))
         .then(label => assert.equal(label, 'Hasło'))
         .then(() => I.grabValueFrom('input'))
-        .then(input => assert.equal(input, '12345'));
-    });
+        .then(input => assert.equal(input, '12345'))
+    })
 
     it('within should respect context in see', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/example4');
-      await I.see('Rejestracja', 'fieldset');
+      await I.amOnPage('/form/example4')
+      await I.see('Rejestracja', 'fieldset')
       I._withinBegin({ css: '.navbar-header' })
         .then(() => I.see('Rejestracja', '.container fieldset'))
-        .then(() => I.see('Toggle navigation', '.container fieldset'));
-    });
+        .then(() => I.see('Toggle navigation', '.container fieldset'))
+    })
 
     it('within should respect context in see when using nested frames', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/iframe_nested');
+      await I.amOnPage('/iframe_nested')
       await I._withinBegin({
         frame: ['#wrapperId', '[name=content]'],
-      });
+      })
 
       try {
-        await I.see('Kill & Destroy');
+        await I.see('Kill & Destroy')
       } catch (err) {
-        if (!err) assert.fail('seen "Kill & Destroy"');
+        if (!err) assert.fail('seen "Kill & Destroy"')
       }
 
       try {
-        await I.dontSee('Nested Iframe test');
+        await I.dontSee('Nested Iframe test')
       } catch (err) {
-        if (!err) assert.fail('seen "Nested Iframe test"');
+        if (!err) assert.fail('seen "Nested Iframe test"')
       }
 
       try {
-        await I.dontSee('Iframe test');
+        await I.dontSee('Iframe test')
       } catch (err) {
-        if (!err) assert.fail('seen "Iframe test"');
+        if (!err) assert.fail('seen "Iframe test"')
       }
-    });
+    })
 
     it('within should respect context in see when using frame', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/iframe');
+      await I.amOnPage('/iframe')
       await I._withinBegin({
         frame: '#number-frame-1234',
-      });
+      })
 
       try {
-        await I.see('Information');
+        await I.see('Information')
       } catch (err) {
-        if (!err) assert.fail('seen "Information"');
+        if (!err) assert.fail('seen "Information"')
       }
-    });
+    })
 
     it('within should respect context in see when using frame with strict locator', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/iframe');
+      await I.amOnPage('/iframe')
       await I._withinBegin({
         frame: { css: '#number-frame-1234' },
-      });
+      })
 
       try {
-        await I.see('Information');
+        await I.see('Information')
       } catch (err) {
-        if (!err) assert.fail('seen "Information"');
+        if (!err) assert.fail('seen "Information"')
       }
-    });
-  });
+    })
+  })
 
   describe('scroll: #scrollTo, #scrollPageToTop, #scrollPageToBottom', () => {
     it('should scroll inside an iframe', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/iframe');
-      await I.resizeWindow(500, 700);
-      await I.switchTo(0);
+      await I.amOnPage('/iframe')
+      await I.resizeWindow(500, 700)
+      await I.switchTo(0)
 
-      const { x, y } = await I.grabPageScrollPosition();
-      await I.scrollTo('.sign');
+      const { x, y } = await I.grabPageScrollPosition()
+      await I.scrollTo('.sign')
 
-      const { x: afterScrollX, y: afterScrollY } = await I.grabPageScrollPosition();
-      assert.notEqual(afterScrollY, y);
-      assert.equal(afterScrollX, x);
-    });
+      const { x: afterScrollX, y: afterScrollY } = await I.grabPageScrollPosition()
+      assert.notEqual(afterScrollY, y)
+      assert.equal(afterScrollX, x)
+    })
 
     it('should scroll to an element', async () => {
-      await I.amOnPage('/form/scroll');
-      await I.resizeWindow(500, 700);
-      const { y } = await I.grabPageScrollPosition();
-      await I.scrollTo('.section3 input[name="test"]');
+      await I.amOnPage('/form/scroll')
+      await I.resizeWindow(500, 700)
+      const { y } = await I.grabPageScrollPosition()
+      await I.scrollTo('.section3 input[name="test"]')
 
-      const { y: afterScrollY } = await I.grabPageScrollPosition();
-      assert.notEqual(afterScrollY, y);
-    });
+      const { y: afterScrollY } = await I.grabPageScrollPosition()
+      assert.notEqual(afterScrollY, y)
+    })
 
     it('should scroll to coordinates', async () => {
-      await I.amOnPage('/form/scroll');
-      await I.resizeWindow(500, 700);
-      await I.scrollTo(50, 70);
+      await I.amOnPage('/form/scroll')
+      await I.resizeWindow(500, 700)
+      await I.scrollTo(50, 70)
 
-      const { x: afterScrollX, y: afterScrollY } = await I.grabPageScrollPosition();
-      assert.equal(afterScrollX, 50);
-      assert.equal(afterScrollY, 70);
-    });
+      const { x: afterScrollX, y: afterScrollY } = await I.grabPageScrollPosition()
+      assert.equal(afterScrollX, 50)
+      assert.equal(afterScrollY, 70)
+    })
 
     it('should scroll to bottom of page', async () => {
-      await I.amOnPage('/form/scroll');
-      await I.resizeWindow(500, 700);
-      const { y } = await I.grabPageScrollPosition();
-      await I.scrollPageToBottom();
+      await I.amOnPage('/form/scroll')
+      await I.resizeWindow(500, 700)
+      const { y } = await I.grabPageScrollPosition()
+      await I.scrollPageToBottom()
 
-      const { y: afterScrollY } = await I.grabPageScrollPosition();
-      assert.notEqual(afterScrollY, y);
-      assert.notEqual(afterScrollY, 0);
-    });
+      const { y: afterScrollY } = await I.grabPageScrollPosition()
+      assert.notEqual(afterScrollY, y)
+      assert.notEqual(afterScrollY, 0)
+    })
 
     it('should scroll to top of page', async () => {
-      await I.amOnPage('/form/scroll');
-      await I.resizeWindow(500, 700);
-      await I.scrollPageToBottom();
-      const { y } = await I.grabPageScrollPosition();
-      await I.scrollPageToTop();
+      await I.amOnPage('/form/scroll')
+      await I.resizeWindow(500, 700)
+      await I.scrollPageToBottom()
+      const { y } = await I.grabPageScrollPosition()
+      await I.scrollPageToTop()
 
-      const { y: afterScrollY } = await I.grabPageScrollPosition();
-      assert.notEqual(afterScrollY, y);
-      assert.equal(afterScrollY, 0);
-    });
-  });
+      const { y: afterScrollY } = await I.grabPageScrollPosition()
+      assert.notEqual(afterScrollY, y)
+      assert.equal(afterScrollY, 0)
+    })
+  })
 
   describe('#grabCssPropertyFrom', () => {
     it('should grab css property for given element', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/doubleclick');
-      const css = await I.grabCssPropertyFrom('#block', 'height');
-      assert.equal(css, '100px');
-    });
+      await I.amOnPage('/form/doubleclick')
+      const css = await I.grabCssPropertyFrom('#block', 'height')
+      assert.equal(css, '100px')
+    })
 
     it('should grab camelcased css properies', async () => {
-      if (isHelper('TestCafe')) return;
+      if (isHelper('TestCafe')) return
 
-      await I.amOnPage('/form/doubleclick');
-      const css = await I.grabCssPropertyFrom('#block', 'user-select');
-      assert.equal(css, 'text');
-    });
+      await I.amOnPage('/form/doubleclick')
+      const css = await I.grabCssPropertyFrom('#block', 'user-select')
+      assert.equal(css, 'text')
+    })
 
     it('should grab multiple values if more than one matching element found', async () => {
-      if (isHelper('TestCafe')) return;
+      if (isHelper('TestCafe')) return
 
-      await I.amOnPage('/info');
-      const css = await I.grabCssPropertyFromAll('.span', 'height');
-      assert.equal(css[0], '12px');
-      assert.equal(css[1], '15px');
-    });
-  });
+      await I.amOnPage('/info')
+      const css = await I.grabCssPropertyFromAll('.span', 'height')
+      assert.equal(css[0], '12px')
+      assert.equal(css[1], '15px')
+    })
+  })
 
   describe('#seeAttributesOnElements', () => {
     it('should check attributes values for given element', async function () {
-      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip();
+      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip()
 
       try {
-        await I.amOnPage('/info');
+        await I.amOnPage('/info')
         await I.seeAttributesOnElements('//form', {
           method: 'post',
-        });
+        })
         await I.seeAttributesOnElements('//form', {
           method: 'get',
-        });
-        throw Error('It should never get this far');
+        })
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('all elements (//form) to have attributes {"method":"get"}');
+        e.message.should.include('all elements (//form) to have attributes {"method":"get"}')
       }
-    });
+    })
 
     it('should check href with slash', async function () {
-      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip();
+      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip()
 
       try {
-        await I.amOnPage('https://github.com/codeceptjs/CodeceptJS/');
+        await I.amOnPage('https://github.com/codeceptjs/CodeceptJS/')
         await I.seeAttributesOnElements(
           { css: 'a[href="/codeceptjs/CodeceptJS"]' },
           {
             href: '/codeceptjs/CodeceptJS',
           },
-        );
+        )
       } catch (e) {
-        e.message.should.include('all elements (a[href="/codeceptjs/CodeceptJS"]) to have attributes {"href":"/codeceptjs/CodeceptJS"}');
+        e.message.should.include('all elements (a[href="/codeceptjs/CodeceptJS"]) to have attributes {"href":"/codeceptjs/CodeceptJS"}')
       }
-    });
+    })
 
     it('should check attributes values for several elements', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
       try {
-        await I.amOnPage('/');
+        await I.amOnPage('/')
         await I.seeAttributesOnElements('a', {
           'qa-id': 'test',
           'qa-link': 'test',
-        });
+        })
         await I.seeAttributesOnElements('//div', {
           'qa-id': 'test',
-        });
+        })
         await I.seeAttributesOnElements('a', {
           'qa-id': 'test',
           href: '/info',
-        });
-        throw new Error('It should never get this far');
+        })
+        throw new Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('all elements (a) to have attributes {"qa-id":"test","href":"/info"}');
+        e.message.should.include('all elements (a) to have attributes {"qa-id":"test","href":"/info"}')
       }
-    });
+    })
 
     it('should return error when using non existing attribute', async function () {
-      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip();
+      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip()
 
       try {
-        await I.amOnPage('https://github.com/codeceptjs/CodeceptJS/');
+        await I.amOnPage('https://github.com/codeceptjs/CodeceptJS/')
         await I.seeAttributesOnElements(
           { css: 'a[href="/codeceptjs/CodeceptJS"]' },
           {
             disable: true,
           },
-        );
+        )
       } catch (e) {
-        e.message.should.include('expected all elements ({css: a[href="/codeceptjs/CodeceptJS"]}) to have attributes {"disable":true} "0" to equal "3"');
+        e.message.should.include('expected all elements ({css: a[href="/codeceptjs/CodeceptJS"]}) to have attributes {"disable":true} "0" to equal "3"')
       }
-    });
+    })
 
     it('should verify the boolean attribute', async function () {
-      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip();
+      if (isHelper('TestCafe') || isHelper('WebDriver')) this.skip()
 
       try {
-        await I.amOnPage('/');
+        await I.amOnPage('/')
         await I.seeAttributesOnElements('input', {
           disabled: true,
-        });
+        })
       } catch (e) {
-        e.message.should.include('expected all elements (input) to have attributes {"disabled":true} "0" to equal "1"');
+        e.message.should.include('expected all elements (input) to have attributes {"disabled":true} "0" to equal "1"')
       }
-    });
-  });
+    })
+  })
 
   describe('#seeCssPropertiesOnElements', () => {
     it('should check css property for given element', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
       try {
-        await I.amOnPage('/info');
+        await I.amOnPage('/info')
         await I.seeCssPropertiesOnElements('h4', {
           'font-weight': 300,
-        });
+        })
         await I.seeCssPropertiesOnElements('h3', {
           'font-weight': 'bold',
           display: 'block',
-        });
+        })
         await I.seeCssPropertiesOnElements('h3', {
           'font-weight': 'non-bold',
-        });
-        throw Error('It should never get this far');
+        })
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('expected all elements (h3) to have CSS property {"font-weight":"non-bold"}');
+        e.message.should.include('expected all elements (h3) to have CSS property {"font-weight":"non-bold"}')
       }
-    });
+    })
 
     it('should check css property for several elements', async function () {
-      if (isHelper('TestCafe') || process.env.BROWSER === 'firefox') this.skip();
+      if (isHelper('TestCafe') || process.env.BROWSER === 'firefox') this.skip()
 
       try {
-        await I.amOnPage('/');
+        await I.amOnPage('/')
         await I.seeCssPropertiesOnElements('a', {
           color: 'rgb(0, 0, 238)',
           cursor: 'pointer',
-        });
+        })
         await I.seeCssPropertiesOnElements('a', {
           color: '#0000EE',
           cursor: 'pointer',
-        });
+        })
         await I.seeCssPropertiesOnElements('//div', {
           display: 'block',
-        });
+        })
         await I.seeCssPropertiesOnElements('a', {
           'margin-top': '0em',
           cursor: 'pointer',
-        });
-        throw Error('It should never get this far');
+        })
+        throw Error('It should never get this far')
       } catch (e) {
-        e.message.should.include('expected all elements (a) to have CSS property {"margin-top":"0em","cursor":"pointer"}');
+        e.message.should.include('expected all elements (a) to have CSS property {"margin-top":"0em","cursor":"pointer"}')
       }
-    });
+    })
 
     it('should normalize css color properties for given element', async function () {
-      if (isHelper('TestCafe')) this.skip();
+      if (isHelper('TestCafe')) this.skip()
 
-      await I.amOnPage('/form/css_colors');
+      await I.amOnPage('/form/css_colors')
       await I.seeCssPropertiesOnElements('#namedColor', {
         'background-color': 'purple',
         color: 'yellow',
-      });
+      })
       await I.seeCssPropertiesOnElements('#namedColor', {
         'background-color': '#800080',
         color: '#ffff00',
-      });
+      })
 
       await I.seeCssPropertiesOnElements('#namedColor', {
         'background-color': 'rgb(128,0,128)',
         color: 'rgb(255,255,0)',
-      });
+      })
 
       await I.seeCssPropertiesOnElements('#namedColor', {
         'background-color': 'rgba(128,0,128,1)',
         color: 'rgba(255,255,0,1)',
-      });
-    });
-  });
+      })
+    })
+  })
 
   describe('#customLocators', () => {
     beforeEach(() => {
-      originalLocators = Locator.filters;
-      Locator.filters = [];
-    });
+      originalLocators = Locator.filters
+      Locator.filters = []
+    })
     afterEach(() => {
       // reset custom locators
-      Locator.filters = originalLocators;
-    });
+      Locator.filters = originalLocators
+    })
     it('should support xpath custom locator by default', async () => {
       customLocators({
         attribute: 'data-test-id',
         enabled: true,
-      });
-      await I.amOnPage('/form/custom_locator');
-      await I.dontSee('Step One Button');
-      await I.dontSeeElement('$step_1');
-      await I.waitForVisible('$step_1', 2);
-      await I.seeElement('$step_1');
-      await I.click('$step_1');
-      await I.waitForVisible('$step_2', 2);
-      await I.see('Step Two Button');
-    });
+      })
+      await I.amOnPage('/form/custom_locator')
+      await I.dontSee('Step One Button')
+      await I.dontSeeElement('$step_1')
+      await I.waitForVisible('$step_1', 2)
+      await I.seeElement('$step_1')
+      await I.click('$step_1')
+      await I.waitForVisible('$step_2', 2)
+      await I.see('Step Two Button')
+    })
     it('can use css strategy for custom locator', async () => {
       customLocators({
         attribute: 'data-test-id',
         enabled: true,
         strategy: 'css',
-      });
-      await I.amOnPage('/form/custom_locator');
-      await I.dontSee('Step One Button');
-      await I.dontSeeElement('$step_1');
-      await I.waitForVisible('$step_1', 2);
-      await I.seeElement('$step_1');
-      await I.click('$step_1');
-      await I.waitForVisible('$step_2', 2);
-      await I.see('Step Two Button');
-    });
+      })
+      await I.amOnPage('/form/custom_locator')
+      await I.dontSee('Step One Button')
+      await I.dontSeeElement('$step_1')
+      await I.waitForVisible('$step_1', 2)
+      await I.seeElement('$step_1')
+      await I.click('$step_1')
+      await I.waitForVisible('$step_2', 2)
+      await I.see('Step Two Button')
+    })
     it('can use xpath strategy for custom locator', async () => {
       customLocators({
         attribute: 'data-test-id',
         enabled: true,
         strategy: 'xpath',
-      });
-      await I.amOnPage('/form/custom_locator');
-      await I.dontSee('Step One Button');
-      await I.dontSeeElement('$step_1');
-      await I.waitForVisible('$step_1', 2);
-      await I.seeElement('$step_1');
-      await I.click('$step_1');
-      await I.waitForVisible('$step_2', 2);
-      await I.see('Step Two Button');
-    });
-  });
+      })
+      await I.amOnPage('/form/custom_locator')
+      await I.dontSee('Step One Button')
+      await I.dontSeeElement('$step_1')
+      await I.waitForVisible('$step_1', 2)
+      await I.seeElement('$step_1')
+      await I.click('$step_1')
+      await I.waitForVisible('$step_2', 2)
+      await I.see('Step Two Button')
+    })
+  })
 
   describe('#focus, #blur', () => {
     it('should focus a button, field and textarea', async () => {
-      await I.amOnPage('/form/focus_blur_elements');
+      await I.amOnPage('/form/focus_blur_elements')
 
-      await I.focus('#button');
-      await I.see('Button is focused', '#buttonMessage');
+      await I.focus('#button')
+      await I.see('Button is focused', '#buttonMessage')
 
-      await I.focus('#field');
-      await I.see('Button not focused', '#buttonMessage');
-      await I.see('Input field is focused', '#fieldMessage');
+      await I.focus('#field')
+      await I.see('Button not focused', '#buttonMessage')
+      await I.see('Input field is focused', '#fieldMessage')
 
-      await I.focus('#textarea');
-      await I.see('Button not focused', '#buttonMessage');
-      await I.see('Input field not focused', '#fieldMessage');
-      await I.see('Textarea is focused', '#textareaMessage');
-    });
+      await I.focus('#textarea')
+      await I.see('Button not focused', '#buttonMessage')
+      await I.see('Input field not focused', '#fieldMessage')
+      await I.see('Textarea is focused', '#textareaMessage')
+    })
 
     it('should blur focused button, field and textarea', async () => {
-      await I.amOnPage('/form/focus_blur_elements');
+      await I.amOnPage('/form/focus_blur_elements')
 
-      await I.focus('#button');
-      await I.see('Button is focused', '#buttonMessage');
-      await I.blur('#button');
-      await I.see('Button not focused', '#buttonMessage');
+      await I.focus('#button')
+      await I.see('Button is focused', '#buttonMessage')
+      await I.blur('#button')
+      await I.see('Button not focused', '#buttonMessage')
 
-      await I.focus('#field');
-      await I.see('Input field is focused', '#fieldMessage');
-      await I.blur('#field');
-      await I.see('Input field not focused', '#fieldMessage');
+      await I.focus('#field')
+      await I.see('Input field is focused', '#fieldMessage')
+      await I.blur('#field')
+      await I.see('Input field not focused', '#fieldMessage')
 
-      await I.focus('#textarea');
-      await I.see('Textarea is focused', '#textareaMessage');
-      await I.blur('#textarea');
-      await I.see('Textarea not focused', '#textareaMessage');
-    });
-  });
+      await I.focus('#textarea')
+      await I.see('Textarea is focused', '#textareaMessage')
+      await I.blur('#textarea')
+      await I.see('Textarea not focused', '#textareaMessage')
+    })
+  })
 
   describe('#startRecordingTraffic, #seeTraffic, #stopRecordingTraffic, #dontSeeTraffic, #grabRecordedNetworkTraffics', () => {
     beforeEach(function () {
-      if (isHelper('TestCafe') || process.env.isSelenium === 'true') this.skip();
-    });
+      if (isHelper('TestCafe') || process.env.isSelenium === 'true') this.skip()
+    })
 
     it('should throw error when calling seeTraffic before recording traffics', async () => {
       try {
-        I.amOnPage('https://codecept.io/');
-        await I.seeTraffic({ name: 'traffics', url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' });
+        I.amOnPage('https://codecept.io/')
+        await I.seeTraffic({ name: 'traffics', url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' })
       } catch (e) {
-        expect(e.message).to.equal('Failure in test automation. You use "I.seeTraffic", but "I.startRecordingTraffic" was never called before.');
+        expect(e.message).to.equal('Failure in test automation. You use "I.seeTraffic", but "I.startRecordingTraffic" was never called before.')
       }
-    });
+    })
 
     it('should throw error when calling seeTraffic but missing name', async () => {
       try {
-        I.amOnPage('https://codecept.io/');
-        await I.seeTraffic({ url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' });
+        I.amOnPage('https://codecept.io/')
+        await I.seeTraffic({ url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' })
       } catch (e) {
-        expect(e.message).to.equal('Missing required key "name" in object given to "I.seeTraffic".');
+        expect(e.message).to.equal('Missing required key "name" in object given to "I.seeTraffic".')
       }
-    });
+    })
 
     it('should throw error when calling seeTraffic but missing url', async () => {
       try {
-        I.amOnPage('https://codecept.io/');
-        await I.seeTraffic({ name: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' });
+        I.amOnPage('https://codecept.io/')
+        await I.seeTraffic({ name: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' })
       } catch (e) {
-        expect(e.message).to.equal('Missing required key "url" in object given to "I.seeTraffic".');
+        expect(e.message).to.equal('Missing required key "url" in object given to "I.seeTraffic".')
       }
-    });
+    })
 
     it('should flush the network traffics', async () => {
-      await I.startRecordingTraffic();
-      await I.amOnPage('https://codecept.io/');
-      await I.flushNetworkTraffics();
-      const traffics = await I.grabRecordedNetworkTraffics();
-      expect(traffics.length).to.equal(0);
-    });
+      await I.startRecordingTraffic()
+      await I.amOnPage('https://codecept.io/')
+      await I.flushNetworkTraffics()
+      const traffics = await I.grabRecordedNetworkTraffics()
+      expect(traffics.length).to.equal(0)
+    })
 
     it('should see recording traffics', async () => {
-      I.startRecordingTraffic();
-      I.amOnPage('https://codecept.io/');
-      await I.seeTraffic({ name: 'traffics', url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' });
-    });
+      I.startRecordingTraffic()
+      I.amOnPage('https://codecept.io/')
+      await I.seeTraffic({ name: 'traffics', url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' })
+    })
 
     it('should not see recording traffics', async () => {
-      I.startRecordingTraffic();
-      I.amOnPage('https://codecept.io/');
-      I.stopRecordingTraffic();
-      await I.dontSeeTraffic({ name: 'traffics', url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' });
-    });
+      I.startRecordingTraffic()
+      I.amOnPage('https://codecept.io/')
+      I.stopRecordingTraffic()
+      await I.dontSeeTraffic({ name: 'traffics', url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' })
+    })
 
     it('should not see recording traffics using regex url', async () => {
-      I.startRecordingTraffic();
-      I.amOnPage('https://codecept.io/');
-      I.stopRecordingTraffic();
-      await I.dontSeeTraffic({ name: 'traffics', url: /BC_LogoScreen_C.jpg/ });
-    });
+      I.startRecordingTraffic()
+      I.amOnPage('https://codecept.io/')
+      I.stopRecordingTraffic()
+      await I.dontSeeTraffic({ name: 'traffics', url: /BC_LogoScreen_C.jpg/ })
+    })
 
     it('should throw error when calling dontSeeTraffic but missing name', async () => {
-      I.startRecordingTraffic();
-      I.amOnPage('https://codecept.io/');
-      I.stopRecordingTraffic();
+      I.startRecordingTraffic()
+      I.amOnPage('https://codecept.io/')
+      I.stopRecordingTraffic()
       try {
-        await I.dontSeeTraffic({ url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' });
+        await I.dontSeeTraffic({ url: 'https://codecept.io/img/companies/BC_LogoScreen_C.jpg' })
       } catch (e) {
-        expect(e.message).to.equal('Missing required key "name" in object given to "I.dontSeeTraffic".');
+        expect(e.message).to.equal('Missing required key "name" in object given to "I.dontSeeTraffic".')
       }
-    });
+    })
 
     it('should throw error when calling dontSeeTraffic but missing url', async () => {
-      I.startRecordingTraffic();
-      I.amOnPage('https://codecept.io/');
-      I.stopRecordingTraffic();
+      I.startRecordingTraffic()
+      I.amOnPage('https://codecept.io/')
+      I.stopRecordingTraffic()
       try {
-        await I.dontSeeTraffic({ name: 'traffics' });
+        await I.dontSeeTraffic({ name: 'traffics' })
       } catch (e) {
-        expect(e.message).to.equal('Missing required key "url" in object given to "I.dontSeeTraffic".');
+        expect(e.message).to.equal('Missing required key "url" in object given to "I.dontSeeTraffic".')
       }
-    });
+    })
 
     it('should check traffics with more advanced params', async () => {
-      await I.startRecordingTraffic();
-      await I.amOnPage('https://openaI.com/blog/chatgpt');
-      const traffics = await I.grabRecordedNetworkTraffics();
+      await I.startRecordingTraffic()
+      await I.amOnPage('https://openaI.com/blog/chatgpt')
+      const traffics = await I.grabRecordedNetworkTraffics()
 
       for (const traffic of traffics) {
         if (traffic.url.includes('&width=')) {
           // new URL object
-          const currentUrl = new URL(traffic.url);
+          const currentUrl = new URL(traffic.url)
 
           // get access to URLSearchParams object
-          const searchParams = currentUrl.searchParams;
+          const searchParams = currentUrl.searchParams
 
           await I.seeTraffic({
             name: 'sentry event',
             url: currentUrl.origin + currentUrl.pathname,
             parameters: searchParams,
-          });
+          })
 
-          break;
+          break
         }
       }
-    });
+    })
 
     it.skip('should check traffics with more advanced post data', async () => {
-      await I.amOnPage('https://openaI.com/blog/chatgpt');
-      await I.startRecordingTraffic();
+      await I.amOnPage('https://openaI.com/blog/chatgpt')
+      await I.startRecordingTraffic()
       await I.seeTraffic({
         name: 'event',
         url: 'https://region1.google-analytics.com',
         requestPostData: {
           st: 2,
         },
-      });
-    });
-  });
+      })
+    })
+  })
 
   // the WS test website is not so stable. So we skip those tests for now.
   describe.skip('#startRecordingWebSocketMessages, #grabWebSocketMessages, #stopRecordingWebSocketMessages', () => {
     beforeEach(function () {
-      if (isHelper('TestCafe') || isHelper('WebDriver') || process.env.BROWSER === 'firefox') this.skip();
-    });
+      if (isHelper('TestCafe') || isHelper('WebDriver') || process.env.BROWSER === 'firefox') this.skip()
+    })
 
     it('should throw error when calling grabWebSocketMessages before startRecordingWebSocketMessages', () => {
       try {
-        I.amOnPage('https://websocketstest.com/');
-        I.waitForText('Work for You!');
-        I.grabWebSocketMessages();
+        I.amOnPage('https://websocketstest.com/')
+        I.waitForText('Work for You!')
+        I.grabWebSocketMessages()
       } catch (e) {
-        expect(e.message).to.equal('Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.');
+        expect(e.message).to.equal('Failure in test automation. You use "I.grabWebSocketMessages", but "I.startRecordingWebSocketMessages" was never called before.')
       }
-    });
+    })
 
     it('should flush the WS messages', async () => {
-      await I.startRecordingWebSocketMessages();
-      I.amOnPage('https://websocketstest.com/');
-      I.waitForText('Work for You!');
-      I.flushWebSocketMessages();
-      const wsMessages = I.grabWebSocketMessages();
-      expect(wsMessages.length).to.equal(0);
-    });
+      await I.startRecordingWebSocketMessages()
+      I.amOnPage('https://websocketstest.com/')
+      I.waitForText('Work for You!')
+      I.flushWebSocketMessages()
+      const wsMessages = I.grabWebSocketMessages()
+      expect(wsMessages.length).to.equal(0)
+    })
 
     it('should see recording WS messages', async () => {
-      await I.startRecordingWebSocketMessages();
-      await I.amOnPage('https://websocketstest.com/');
-      I.waitForText('Work for You!');
-      const wsMessages = await I.grabWebSocketMessages();
-      expect(wsMessages.length).to.greaterThan(0);
-    });
+      await I.startRecordingWebSocketMessages()
+      await I.amOnPage('https://websocketstest.com/')
+      I.waitForText('Work for You!')
+      const wsMessages = await I.grabWebSocketMessages()
+      expect(wsMessages.length).to.greaterThan(0)
+    })
 
     it('should not see recording WS messages', async () => {
-      await I.startRecordingWebSocketMessages();
-      await I.amOnPage('https://websocketstest.com/');
-      I.waitForText('Work for You!');
-      const wsMessages = I.grabWebSocketMessages();
-      await I.stopRecordingWebSocketMessages();
-      await I.amOnPage('https://websocketstest.com/');
-      I.waitForText('Work for You!');
-      const afterWsMessages = I.grabWebSocketMessages();
-      expect(wsMessages.length).to.equal(afterWsMessages.length);
-    });
-  });
-};
+      await I.startRecordingWebSocketMessages()
+      await I.amOnPage('https://websocketstest.com/')
+      I.waitForText('Work for You!')
+      const wsMessages = I.grabWebSocketMessages()
+      await I.stopRecordingWebSocketMessages()
+      await I.amOnPage('https://websocketstest.com/')
+      I.waitForText('Work for You!')
+      const afterWsMessages = I.grabWebSocketMessages()
+      expect(wsMessages.length).to.equal(afterWsMessages.length)
+    })
+  })
+}

--- a/test/plugin/plugin_test.js
+++ b/test/plugin/plugin_test.js
@@ -5,8 +5,7 @@ const { expect } = require('expect')
 const runner = path.join(__dirname, '../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '../acceptance')
 const codecept_run = `${runner} run`
-const config_run_config = (config, grep) =>
-  `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`
+const config_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`
 
 describe('CodeceptJS plugin', function () {
   this.timeout(30000)
@@ -15,7 +14,7 @@ describe('CodeceptJS plugin', function () {
     process.chdir(codecept_dir)
   })
 
-  it('should retry the await/non await steps', (done) => {
+  it('should retry the await/non await steps', done => {
     exec(`${config_run_config('codecept.Playwright.retryTo.js', '@plugin')} --verbose`, (err, stdout) => {
       const lines = stdout.split('\n')
       expect(lines).toEqual(expect.arrayContaining([expect.stringContaining('... Retrying')]))
@@ -24,7 +23,7 @@ describe('CodeceptJS plugin', function () {
     })
   })
 
-  it('should failed before the retryTo instruction', (done) => {
+  it('should failed before the retryTo instruction', done => {
     exec(`${config_run_config('codecept.Playwright.retryTo.js', 'Should be succeed')} --verbose`, (err, stdout) => {
       expect(stdout).toContain('locator.waitFor: Timeout 1000ms exceeded.')
       expect(stdout).toContain('[1] Error | Error: element (.nothing) still not visible after 1 sec')
@@ -33,30 +32,21 @@ describe('CodeceptJS plugin', function () {
     })
   })
 
-  it('should generate the coverage report', (done) => {
+  it('should generate the coverage report', done => {
     exec(`${config_run_config('codecept.Playwright.coverage.js', '@coverage')} --debug`, (err, stdout) => {
       const lines = stdout.split('\n')
-      expect(lines).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining('writing output/coverage'),
-          expect.stringContaining('generated coverage reports:'),
-          expect.stringContaining('output/coverage/index.html'),
-        ]),
-      )
+      expect(lines).toEqual(expect.arrayContaining([expect.stringContaining('writing output/coverage'), expect.stringContaining('generated coverage reports:'), expect.stringContaining('output/coverage/index.html')]))
       expect(err).toBeFalsy()
       done()
     })
   })
 
-  it('should retry to failure', (done) => {
-    exec(
-      `${config_run_config('codecept.Playwright.retryTo.js', 'Should fail after reached max retries')} --verbose`,
-      (err, stdout) => {
-        const lines = stdout.split('\n')
-        expect(lines).toEqual(expect.arrayContaining([expect.stringContaining('Custom pluginRetryTo Error')]))
-        expect(err).toBeTruthy()
-        done()
-      },
-    )
+  it('should retry to failure', done => {
+    exec(`${config_run_config('codecept.Playwright.retryTo.js', 'Should fail after reached max retries')} --verbose`, (err, stdout) => {
+      const lines = stdout.split('\n')
+      expect(lines).toEqual(expect.arrayContaining([expect.stringContaining('Custom pluginRetryTo Error')]))
+      expect(err).toBeTruthy()
+      done()
+    })
   })
 })

--- a/test/rest/ApiDataFactory_test.js
+++ b/test/rest/ApiDataFactory_test.js
@@ -38,7 +38,7 @@ describe('ApiDataFactory', function () {
     })
   })
 
-  beforeEach((done) => {
+  beforeEach(done => {
     try {
       fs.writeFileSync(dbFile, JSON.stringify(data))
     } catch (err) {
@@ -85,7 +85,7 @@ describe('ApiDataFactory', function () {
     it('should update request with onRequest', async () => {
       const I = new ApiDataFactory({
         endpoint: api_url,
-        onRequest: (request) => (request.data.author = 'Vasya'),
+        onRequest: request => (request.data.author = 'Vasya'),
         factories: {
           post: {
             factory: path.join(__dirname, '/../data/rest/posts_factory.js'),
@@ -108,7 +108,7 @@ describe('ApiDataFactory', function () {
               method: 'post',
               data: { author: 'Yorik', title: 'xxx', body: 'yyy' },
             }),
-            delete: (id) => ({ url: `/posts/${id}`, method: 'delete' }),
+            delete: id => ({ url: `/posts/${id}`, method: 'delete' }),
           },
         },
       })
@@ -135,13 +135,13 @@ describe('ApiDataFactory', function () {
       let resp = await I.restHelper.sendGetRequest('/posts')
       resp.data.length.should.eql(1)
       await I.haveMultiple('post', 3)
-      await new Promise((done) => {
+      await new Promise(done => {
         setTimeout(done, 500)
       })
       resp = await I.restHelper.sendGetRequest('/posts')
       resp.data.length.should.eql(4)
       await I._after()
-      await new Promise((done) => {
+      await new Promise(done => {
         setTimeout(done, 500)
       })
       resp = await I.restHelper.sendGetRequest('/posts')
@@ -182,7 +182,7 @@ describe('ApiDataFactory', function () {
       let resp = await I.restHelper.sendGetRequest('/posts')
       resp.data.length.should.eql(2)
       await I._after()
-      await new Promise((done) => {
+      await new Promise(done => {
         setTimeout(done, 500)
       })
       resp = await I.restHelper.sendGetRequest('/posts')

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -28,7 +28,7 @@ const data = {
 }
 
 describe('REST', () => {
-  beforeEach((done) => {
+  beforeEach(done => {
     I = new REST({
       endpoint: api_url,
       defaultHeaders: {
@@ -117,7 +117,7 @@ describe('REST', () => {
     })
 
     it('should update request with onRequest', async () => {
-      I.config.onRequest = (request) => (request.data = { name: 'Vasya' })
+      I.config.onRequest = request => (request.data = { name: 'Vasya' })
 
       const response = await I.sendPostRequest('/user', { name: 'john' })
       response.data.name.should.eql('Vasya')
@@ -306,7 +306,7 @@ describe('REST', () => {
 })
 
 describe('REST - Form upload', () => {
-  beforeEach((done) => {
+  beforeEach(done => {
     I = new REST({
       endpoint: 'http://the-internet.herokuapp.com/',
       maxUploadFileSize: 0.00008,

--- a/test/runner/bdd_test.js
+++ b/test/runner/bdd_test.js
@@ -5,14 +5,14 @@ const exec = require('child_process').exec
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox')
 const codecept_run = `${runner} run`
-const config_run_config = (config) => `${codecept_run} --config ${codecept_dir}/${config}`
+const config_run_config = config => `${codecept_run} --config ${codecept_dir}/${config}`
 
 describe('BDD Gherkin', () => {
   before(() => {
     process.chdir(codecept_dir)
   })
 
-  it('should run feature files', (done) => {
+  it('should run feature files', done => {
     exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout process"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Checkout process') // feature
@@ -30,7 +30,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should print substeps in debug mode', (done) => {
+  it('should print substeps in debug mode', done => {
     exec(config_run_config('codecept.bdd.js') + ' --debug --grep "Checkout process"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Checkout process') // feature
@@ -48,23 +48,20 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should print events in nodejs debug mode', (done) => {
-    exec(
-      `DEBUG=codeceptjs:* ${config_run_config('codecept.bdd.js')} --grep "Checkout products" --debug`,
-      (err, stdout, stderr) => {
-        //eslint-disable-line
-        stderr.should.include('Emitted | step.start (I add product "Harry Potter", 5)')
-        stdout.should.include('name            | category        | price')
-        stdout.should.include('Harry Potter    | Books           | 5')
-        stdout.should.include('iPhone 5        | Smartphones     | 1200 ')
-        stdout.should.include('Nuclear Bomb    | Weapons         | 100000')
-        assert(!err)
-        done()
-      },
-    )
+  it('should print events in nodejs debug mode', done => {
+    exec(`DEBUG=codeceptjs:* ${config_run_config('codecept.bdd.js')} --grep "Checkout products" --debug`, (err, stdout, stderr) => {
+      //eslint-disable-line
+      stderr.should.include('Emitted | step.start (I add product "Harry Potter", 5)')
+      stdout.should.include('name            | category        | price')
+      stdout.should.include('Harry Potter    | Books           | 5')
+      stdout.should.include('iPhone 5        | Smartphones     | 1200 ')
+      stdout.should.include('Nuclear Bomb    | Weapons         | 100000')
+      assert(!err)
+      done()
+    })
   })
 
-  it('should obfuscate secret substeps in debug mode', (done) => {
+  it('should obfuscate secret substeps in debug mode', done => {
     exec(config_run_config('codecept.bdd.js') + ' --debug --grep "Secrets"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Given I login') // feature
@@ -74,7 +71,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run feature with examples files', (done) => {
+  it('should run feature with examples files', done => {
     exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout examples"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include(' order discount {"price":"10","total":"10.0"}')
@@ -96,38 +93,32 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run feature with table and examples files', (done) => {
-    exec(
-      config_run_config('codecept.bdd.js') + ' --steps --grep "Include Examples in dataTtable placeholder"',
-      (err, stdout, stderr) => {
-        //eslint-disable-line
-        stdout.should.include('name            | Nuclear Bomb ')
-        stdout.should.include('price           | 20 ')
-        stdout.should.include('name            | iPhone 5 ')
-        stdout.should.include('price           | 10 ')
-        assert(!err)
-        done()
-      },
-    )
+  it('should run feature with table and examples files', done => {
+    exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Include Examples in dataTtable placeholder"', (err, stdout, stderr) => {
+      //eslint-disable-line
+      stdout.should.include('name            | Nuclear Bomb ')
+      stdout.should.include('price           | 20 ')
+      stdout.should.include('name            | iPhone 5 ')
+      stdout.should.include('price           | 10 ')
+      assert(!err)
+      done()
+    })
   })
 
-  it('should show data from examples in test title', (done) => {
-    exec(
-      config_run_config('codecept.bdd.js') + ' --steps --grep "Include Examples in dataTtable placeholder"',
-      (err, stdout, stderr) => {
-        //eslint-disable-line
-        stdout.should.include('order a product with discount - iPhone 5 - 10  @IncludeExamplesIndataTtable')
-        stdout.should.include('name            | Nuclear Bomb ')
-        stdout.should.include('price           | 20 ')
-        stdout.should.include('name            | iPhone 5 ')
-        stdout.should.include('price           | 10 ')
-        assert(!err)
-        done()
-      },
-    )
+  it('should show data from examples in test title', done => {
+    exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Include Examples in dataTtable placeholder"', (err, stdout, stderr) => {
+      //eslint-disable-line
+      stdout.should.include('order a product with discount - iPhone 5 - 10  @IncludeExamplesIndataTtable')
+      stdout.should.include('name            | Nuclear Bomb ')
+      stdout.should.include('price           | 20 ')
+      stdout.should.include('name            | iPhone 5 ')
+      stdout.should.include('price           | 10 ')
+      assert(!err)
+      done()
+    })
   })
 
-  it('should run feature with tables', (done) => {
+  it('should run feature with tables', done => {
     exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout products"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Given I have products in my cart')
@@ -141,7 +132,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run feature with tables contain long text', (done) => {
+  it('should run feature with tables contain long text', done => {
     exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout products"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Given I have products in my cart')
@@ -152,20 +143,18 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run feature with long strings', (done) => {
+  it('should run feature with long strings', done => {
     exec(config_run_config('codecept.bdd.js') + ' --steps --grep "Checkout string"', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Given I have product described as')
-      stdout.should.include(
-        'The goal of the product description is to provide the customer with enough information to compel them to want to buy the product immediately.',
-      )
+      stdout.should.include('The goal of the product description is to provide the customer with enough information to compel them to want to buy the product immediately.')
       stdout.should.include('Then my order amount is $582')
       assert(!err)
       done()
     })
   })
 
-  it('should run feature by file name', (done) => {
+  it('should run feature by file name', done => {
     exec(config_run_config('codecept.bdd.js') + ' --steps features/tables.feature', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Checkout product')
@@ -179,7 +168,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run feature by scenario name', (done) => {
+  it('should run feature by scenario name', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "checkout 3 products" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Checkout product')
@@ -193,7 +182,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run feature by tag name', (done) => {
+  it('should run feature by tag name', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "@important" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('I have product with $600 price in my cart')
@@ -206,7 +195,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run scenario by tag name', (done) => {
+  it('should run scenario by tag name', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "@very" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('I have product with $600 price in my cart')
@@ -219,7 +208,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run scenario outline by tag', (done) => {
+  it('should run scenario outline by tag', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "@user" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.not.include('0 passed')
@@ -229,7 +218,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run scenario and scenario outline by tags', (done) => {
+  it('should run scenario and scenario outline by tags', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "@user|@very" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.not.include('0 passed')
@@ -241,7 +230,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run scenario and scenario outline by tags', (done) => {
+  it('should run scenario and scenario outline by tags', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "@user|@very" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.not.include('0 passed')
@@ -253,7 +242,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should run not get stuck on failing step', (done) => {
+  it('should run not get stuck on failing step', done => {
     exec(config_run_config('codecept.bdd.js') + ' --grep "@fail" --steps', (err, stdout, stderr) => {
       //eslint-disable-line
       // stdout.should.include('Given I make a request (and it fails)');
@@ -265,7 +254,7 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should show all available steps', (done) => {
+  it('should show all available steps', done => {
     exec(`${runner} gherkin:steps --config ${codecept_dir}/codecept.bdd.js`, (err, stdout, stderr) => {
       //eslint-disable-line
       stdout.should.include('Gherkin')
@@ -279,12 +268,10 @@ describe('BDD Gherkin', () => {
     })
   })
 
-  it('should generate snippets for missing steps', (done) => {
-    exec(
-      `${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.dummy.bdd.js`,
-      (err, stdout, stderr) => {
-        //eslint-disable-line
-        stdout.should.include(`Given('I open a browser on a site', () => {
+  it('should generate snippets for missing steps', done => {
+    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.dummy.bdd.js`, (err, stdout, stderr) => {
+      //eslint-disable-line
+      stdout.should.include(`Given('I open a browser on a site', () => {
   // From "support/dummy.feature" {"line":4,"column":5}
   throw new Error('Not implemented yet');
 });
@@ -348,32 +335,28 @@ When(/^I define a step with a \\( paren and a "(.*?)" string$/, () => {
   // From "support/dummy.feature" {"line":16,"column":5}
   throw new Error('Not implemented yet');
 });`)
-        assert(!err)
-        done()
-      },
-    )
+      assert(!err)
+      done()
+    })
   })
 
-  it('should not generate duplicated steps', (done) => {
-    exec(
-      `${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.duplicate.bdd.js`,
-      (err, stdout, stderr) => {
-        //eslint-disable-line
-        assert.equal(stdout.match(/I open a browser on a site/g).length, 1)
-        assert(!err)
-        done()
-      },
-    )
+  it('should not generate duplicated steps', done => {
+    exec(`${runner} gherkin:snippets --dry-run --config ${codecept_dir}/codecept.duplicate.bdd.js`, (err, stdout, stderr) => {
+      //eslint-disable-line
+      assert.equal(stdout.match(/I open a browser on a site/g).length, 1)
+      assert(!err)
+      done()
+    })
   })
 
   describe('i18n', () => {
     const codecept_dir = path.join(__dirname, '/../data/sandbox/i18n')
-    const config_run_config = (config) => `${codecept_run} --config ${codecept_dir}/${config}`
+    const config_run_config = config => `${codecept_run} --config ${codecept_dir}/${config}`
 
     before(() => {
       process.chdir(codecept_dir)
     })
-    it('should run feature files in DE', (done) => {
+    it('should run feature files in DE', done => {
       exec(config_run_config('codecept.bdd.de.js') + ' --steps --grep "@i18n"', (err, stdout, stderr) => {
         //eslint-disable-line
         stdout.should.include('On Angenommen: ich habe ein produkt mit einem preis von 10$ in meinem warenkorb')

--- a/test/runner/before_failure_test.js
+++ b/test/runner/before_failure_test.js
@@ -7,7 +7,7 @@ const codecept_run = `${runner} run --config ${codecept_dir}/codecept.beforetest
 
 describe('Failure in before', function () {
   this.timeout(40000)
-  it('should skip tests that are skipped because of failure in before hook', (done) => {
+  it('should skip tests that are skipped because of failure in before hook', done => {
     exec(`${codecept_run}`, (err, stdout) => {
       stdout.should.include('First test will be passed @grep')
       stdout.should.include('Third test will be skipped @grep')
@@ -18,7 +18,7 @@ describe('Failure in before', function () {
     })
   })
 
-  it('should skip tests correctly with grep options', (done) => {
+  it('should skip tests correctly with grep options', done => {
     exec(`${codecept_run} --grep @grep`, (err, stdout) => {
       stdout.should.include('First test will be passed @grep')
       stdout.should.include('Third test will be skipped @grep')
@@ -28,7 +28,7 @@ describe('Failure in before', function () {
     })
   })
 
-  it('should trigger skipped events', (done) => {
+  it('should trigger skipped events', done => {
     exec(`DEBUG=codeceptjs:* ${codecept_run} --verbose`, (err, stdout, stderr) => {
       err.code.should.eql(1)
       stderr.should.include('Emitted | test.skipped')

--- a/test/runner/bootstrap_test.js
+++ b/test/runner/bootstrap_test.js
@@ -5,22 +5,20 @@ const exec = require('child_process').exec
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/bootstrap')
 const codecept_run = `${runner} run`
-const codecept_run_config = (config, grep) =>
-  `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep ${grep}` : ''}`
-const config_run_override = (config, override) =>
-  `${codecept_run} --config ${codecept_dir}/${config} --override '${JSON.stringify(override)}'`
+const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep ${grep}` : ''}`
+const config_run_override = (config, override) => `${codecept_run} --config ${codecept_dir}/${config} --override '${JSON.stringify(override)}'`
 
 describe('CodeceptJS Bootstrap and Teardown', () => {
   // success
-  it('should run bootstrap', (done) => {
+  it('should run bootstrap', done => {
     exec(codecept_run_config('bootstrap.conf.js', '@important'), (err, stdout) => {
       stdout.should.include('Filesystem') // feature
       stdout.should.include('I am bootstrap')
       stdout.should.include('I am teardown')
       const lines = stdout.split('\n')
-      const bootstrapIndex = lines.findIndex((l) => l === 'I am bootstrap')
-      const testIndex = lines.findIndex((l) => l.indexOf('Filesystem @main') === 0)
-      const teardownIndex = lines.findIndex((l) => l === 'I am teardown')
+      const bootstrapIndex = lines.findIndex(l => l === 'I am bootstrap')
+      const testIndex = lines.findIndex(l => l.indexOf('Filesystem @main') === 0)
+      const teardownIndex = lines.findIndex(l => l === 'I am teardown')
       assert(testIndex > bootstrapIndex, `${testIndex} (test) > ${bootstrapIndex} (bootstrap)`)
       assert(teardownIndex > testIndex, `${teardownIndex} (teardown) > ${testIndex} (test)`)
       assert(!err)
@@ -28,7 +26,7 @@ describe('CodeceptJS Bootstrap and Teardown', () => {
     })
   })
 
-  it('should run async bootstrap', (done) => {
+  it('should run async bootstrap', done => {
     exec(codecept_run_config('bootstrap.async.conf.js', '@important'), (err, stdout) => {
       stdout.should.include('Filesystem') // feature
       stdout.should.include('I am bootstrap')
@@ -36,9 +34,9 @@ describe('CodeceptJS Bootstrap and Teardown', () => {
       const lines = stdout.split('\n')
       const bootstrap0Index = lines.indexOf('I am 0 bootstrap')
       const teardown0Index = lines.indexOf('I am 0 teardown')
-      const bootstrapIndex = lines.findIndex((l) => l === 'I am bootstrap')
-      const testIndex = lines.findIndex((l) => l.indexOf('Filesystem @main') === 0)
-      const teardownIndex = lines.findIndex((l) => l === 'I am teardown')
+      const bootstrapIndex = lines.findIndex(l => l === 'I am bootstrap')
+      const testIndex = lines.findIndex(l => l.indexOf('Filesystem @main') === 0)
+      const teardownIndex = lines.findIndex(l => l === 'I am teardown')
       assert(bootstrap0Index < bootstrapIndex, `${bootstrap0Index} < ${bootstrapIndex} (bootstrap)`)
       assert(teardown0Index < teardownIndex, `${teardown0Index} < ${teardownIndex} (teardown)`)
       assert(testIndex > bootstrapIndex, `${testIndex} (test) > ${bootstrapIndex} (bootstrap)`)
@@ -49,7 +47,7 @@ describe('CodeceptJS Bootstrap and Teardown', () => {
   })
 
   // with teaedown - failed tests
-  it('should fail with code 1 when test failed and async bootstrap/teardown function with args', (done) => {
+  it('should fail with code 1 when test failed and async bootstrap/teardown function with args', done => {
     exec(config_run_override('bootstrap.async.conf.js', { tests: './failed_test.js' }), (err, stdout) => {
       assert(err)
       assert.equal(err.code, 1)
@@ -61,7 +59,7 @@ describe('CodeceptJS Bootstrap and Teardown', () => {
     })
   })
 
-  it('should fail with code 1 when test failed and async bootstrap/teardown function without args', (done) => {
+  it('should fail with code 1 when test failed and async bootstrap/teardown function without args', done => {
     exec(config_run_override('bootstrap.async.conf.js', { tests: './failed_test.js' }), (err, stdout) => {
       assert(err)
       assert.equal(err.code, 1)
@@ -74,7 +72,7 @@ describe('CodeceptJS Bootstrap and Teardown', () => {
   })
 
   // with teardown and fail bootstrap - teardown not call
-  it('should fail with code 1 when async bootstrap failed and not call teardown', (done) => {
+  it('should fail with code 1 when async bootstrap failed and not call teardown', done => {
     exec(codecept_run_config('without.args.failed.bootstrap.async.func.js'), (err, stdout) => {
       assert(err)
       assert.equal(err.code, 1)

--- a/test/runner/codecept_test.js
+++ b/test/runner/codecept_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const assert = require('assert')
@@ -10,14 +10,14 @@ const event = require('../../lib').event
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox')
 const codecept_run = `${runner} run`
-const codecept_run_config = (config) => `${codecept_run} --config ${codecept_dir}/${config}`
+const codecept_run_config = config => `${codecept_run} --config ${codecept_dir}/${config}`
 
 describe('CodeceptJS Runner', () => {
   before(() => {
     global.codecept_dir = path.join(__dirname, '/../data/sandbox')
   })
 
-  it('should be executed in current dir', (done) => {
+  it('should be executed in current dir', done => {
     process.chdir(codecept_dir)
     exec(codecept_run, (err, stdout) => {
       stdout.should.include('Filesystem') // feature
@@ -27,7 +27,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should be executed with glob', (done) => {
+  it('should be executed with glob', done => {
     process.chdir(codecept_dir)
     exec(codecept_run_config('codecept.glob.js'), (err, stdout) => {
       stdout.should.include('Filesystem') // feature
@@ -37,7 +37,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should be executed with config path', (done) => {
+  it('should be executed with config path', done => {
     process.chdir(__dirname)
     exec(`${codecept_run} -c ${codecept_dir}`, (err, stdout) => {
       stdout.should.include('Filesystem') // feature
@@ -47,7 +47,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should show failures and exit with 1 on fail', (done) => {
+  it('should show failures and exit with 1 on fail', done => {
     exec(codecept_run_config('codecept.failed.js'), (err, stdout) => {
       stdout.should.include('Not-A-Filesystem')
       stdout.should.include('file is not in dir')
@@ -56,7 +56,7 @@ describe('CodeceptJS Runner', () => {
       done()
     })
 
-    it('should except a directory glob pattern', (done) => {
+    it('should except a directory glob pattern', done => {
       process.chdir(codecept_dir)
       exec(`${codecept_run} "test-dir/*"`, (err, stdout) => {
         stdout.should.include('2 passed') // number of tests present in directory
@@ -66,7 +66,7 @@ describe('CodeceptJS Runner', () => {
   })
 
   describe('grep', () => {
-    it('filter by scenario tags', (done) => {
+    it('filter by scenario tags', done => {
       process.chdir(codecept_dir)
       exec(`${codecept_run} --grep @slow`, (err, stdout) => {
         stdout.should.include('Filesystem') // feature
@@ -76,7 +76,7 @@ describe('CodeceptJS Runner', () => {
       })
     })
 
-    it('filter by scenario tags #2', (done) => {
+    it('filter by scenario tags #2', done => {
       process.chdir(codecept_dir)
       exec(`${codecept_run} --grep @important`, (err, stdout) => {
         stdout.should.include('Filesystem') // feature
@@ -86,7 +86,7 @@ describe('CodeceptJS Runner', () => {
       })
     })
 
-    it('filter by feature tags', (done) => {
+    it('filter by feature tags', done => {
       process.chdir(codecept_dir)
       exec(`${codecept_run} --grep @main`, (err, stdout) => {
         stdout.should.include('Filesystem') // feature
@@ -97,7 +97,7 @@ describe('CodeceptJS Runner', () => {
     })
 
     describe('without "invert" option', () => {
-      it('should filter by scenario tags', (done) => {
+      it('should filter by scenario tags', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @1_grep`, (err, stdout) => {
           stdout.should.include('@feature_grep') // feature
@@ -108,7 +108,7 @@ describe('CodeceptJS Runner', () => {
         })
       })
 
-      it('should filter by scenario tags #2', (done) => {
+      it('should filter by scenario tags #2', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @2_grep`, (err, stdout) => {
           stdout.should.include('@feature_grep') // feature
@@ -119,7 +119,7 @@ describe('CodeceptJS Runner', () => {
         })
       })
 
-      it('should filter by feature tags', (done) => {
+      it('should filter by feature tags', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @feature_grep`, (err, stdout) => {
           stdout.should.include('@feature_grep') // feature
@@ -132,7 +132,7 @@ describe('CodeceptJS Runner', () => {
     })
 
     describe('with "invert" option', () => {
-      it('should filter by scenario tags', (done) => {
+      it('should filter by scenario tags', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @1_grep --invert`, (err, stdout) => {
           stdout.should.include('@feature_grep') // feature
@@ -143,7 +143,7 @@ describe('CodeceptJS Runner', () => {
         })
       })
 
-      it('should filter by scenario tags #2', (done) => {
+      it('should filter by scenario tags #2', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @2_grep --invert`, (err, stdout) => {
           stdout.should.include('@feature_grep') // feature
@@ -154,7 +154,7 @@ describe('CodeceptJS Runner', () => {
         })
       })
 
-      it('should filter by feature tags', (done) => {
+      it('should filter by feature tags', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @main --invert`, (err, stdout) => {
           stdout.should.include('@feature_grep') // feature
@@ -165,7 +165,7 @@ describe('CodeceptJS Runner', () => {
         })
       })
 
-      it('should filter by feature tags', (done) => {
+      it('should filter by feature tags', done => {
         process.chdir(codecept_dir)
         exec(`${codecept_run_config('codecept.grep.2.js')} --grep @feature_grep --invert`, (err, stdout) => {
           stdout.should.not.include('@feature_grep') // feature
@@ -178,7 +178,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should run hooks from suites', (done) => {
+  it('should run hooks from suites', done => {
     exec(codecept_run_config('codecept.testhooks.json'), (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
@@ -212,7 +212,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should run hooks from suites (in different order)', (done) => {
+  it('should run hooks from suites (in different order)', done => {
     exec(codecept_run_config('codecept.testhooks.different.order.json'), (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
@@ -232,22 +232,17 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should run different types of scenario', (done) => {
+  it('should run different types of scenario', done => {
     exec(codecept_run_config('codecept.testscenario.json'), (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
-      expect(lines).to.include.members([
-        'Test scenario types --',
-        "It's usual test",
-        "Test: I'm async/await test",
-        "Test: I'm asyncbrackets test",
-      ])
+      expect(lines).to.include.members(['Test scenario types --', "It's usual test", "Test: I'm async/await test", "Test: I'm asyncbrackets test"])
       stdout.should.include('OK  | 3 passed')
       assert(!err)
       done()
     })
   })
 
-  it('should run dynamic config', (done) => {
+  it('should run dynamic config', done => {
     exec(codecept_run_config('config.js'), (err, stdout) => {
       stdout.should.include('Filesystem') // feature
       assert(!err)
@@ -255,7 +250,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should run dynamic config with profile', (done) => {
+  it('should run dynamic config with profile', done => {
     exec(`${codecept_run_config('config.js')} --profile failed`, (err, stdout) => {
       stdout.should.include('FAILURES')
       stdout.should.not.include('I am bootstrap')
@@ -264,7 +259,7 @@ describe('CodeceptJS Runner', () => {
     })
   })
 
-  it('should exit code 1 when error in config', (done) => {
+  it('should exit code 1 when error in config', done => {
     exec(`${codecept_run_config('configs/codecept-invalid.config.js')} --profile failed`, (err, stdout, stderr) => {
       stdout.should.not.include('UnhandledPromiseRejectionWarning')
       stderr.should.not.include('UnhandledPromiseRejectionWarning')
@@ -278,7 +273,7 @@ describe('CodeceptJS Runner', () => {
     const moduleOutput = 'Module was required 1'
     const moduleOutput2 = 'Module was required 2'
 
-    it('should be executed with module when described', (done) => {
+    it('should be executed with module when described', done => {
       process.chdir(codecept_dir)
       exec(codecept_run_config('codecept.require.single.json'), (err, stdout) => {
         stdout.should.include(moduleOutput)
@@ -288,7 +283,7 @@ describe('CodeceptJS Runner', () => {
       })
     })
 
-    it('should be executed with several modules when described', (done) => {
+    it('should be executed with several modules when described', done => {
       process.chdir(codecept_dir)
       exec(codecept_run_config('codecept.require.several.json'), (err, stdout) => {
         stdout.should.include(moduleOutput)
@@ -298,7 +293,7 @@ describe('CodeceptJS Runner', () => {
       })
     })
 
-    it('should not be executed without module when not described', (done) => {
+    it('should not be executed without module when not described', done => {
       process.chdir(codecept_dir)
       exec(codecept_run_config('codecept.require.without.json'), (err, stdout) => {
         stdout.should.not.include(moduleOutput)
@@ -311,13 +306,13 @@ describe('CodeceptJS Runner', () => {
 })
 
 describe('Codeceptjs Events', () => {
-  it('should fire events with only passing tests', (done) => {
+  it('should fire events with only passing tests', done => {
     exec(`${codecept_run_config('codecept.testevents.js')} --grep @willpass`, (err, stdout) => {
       assert(!err)
       const eventMessages = stdout
         .split('\n')
-        .filter((text) => text.startsWith('Event:'))
-        .map((text) => text.replace(/^Event:/i, ''))
+        .filter(text => text.startsWith('Event:'))
+        .map(text => text.replace(/^Event:/i, ''))
 
       expect(eventMessages).to.deep.equal([
         event.all.before,
@@ -335,13 +330,13 @@ describe('Codeceptjs Events', () => {
     })
   })
 
-  it('should fire events with passing and failing tests', (done) => {
+  it('should fire events with passing and failing tests', done => {
     exec(codecept_run_config('codecept.testevents.js'), (err, stdout) => {
       assert(err)
       const eventMessages = stdout
         .split('\n')
-        .filter((text) => text.startsWith('Event:'))
-        .map((text) => text.replace(/^Event:/i, ''))
+        .filter(text => text.startsWith('Event:'))
+        .map(text => text.replace(/^Event:/i, ''))
 
       expect(eventMessages).to.deep.equal([
         event.all.before,

--- a/test/runner/comment_step_test.js
+++ b/test/runner/comment_step_test.js
@@ -5,8 +5,7 @@ const { expect } = require('expect')
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/commentStep')
 const codecept_run = `${runner} run`
-const config_run_config = (config, grep) =>
-  `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`
+const config_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`
 
 describe('CodeceptJS commentStep plugin', function () {
   this.timeout(3000)
@@ -15,7 +14,7 @@ describe('CodeceptJS commentStep plugin', function () {
     process.chdir(codecept_dir)
   })
 
-  it('should print nested steps when global var comments used', (done) => {
+  it('should print nested steps when global var comments used', done => {
     exec(`${config_run_config('codecept.conf.js', 'global var')} --debug`, (err, stdout) => {
       const lines = stdout.split('\n')
       expect(lines).toEqual(
@@ -33,7 +32,7 @@ describe('CodeceptJS commentStep plugin', function () {
     })
   })
 
-  it('should print nested steps when local var comments used', (done) => {
+  it('should print nested steps when local var comments used', done => {
     exec(`${config_run_config('codecept.conf.js', 'local var')} --debug`, (err, stdout) => {
       const lines = stdout.split('\n')
       expect(lines).toEqual(

--- a/test/runner/definitions_test.js
+++ b/test/runner/definitions_test.js
@@ -13,7 +13,7 @@ const pathOfJSDocDefinitions = path.join(pathToRootOfProject, 'typings/types.d.t
 const pathToTests = path.resolve(pathToRootOfProject, 'test')
 const pathToTypings = path.resolve(pathToRootOfProject, 'typings')
 
-import('chai').then((chai) => {
+import('chai').then(chai => {
   chai.use(require('chai-subset'))
   /** @type {Chai.ChaiPlugin */
   chai.use((chai, utils) => {
@@ -23,7 +23,7 @@ import('chai').then((chai) => {
       new chai.Assertion(project).to.be.instanceof(Project)
 
       let diagnostics = project.getPreEmitDiagnostics()
-      diagnostics = diagnostics.filter((diagnostic) => {
+      diagnostics = diagnostics.filter(diagnostic => {
         const filePath = diagnostic.getSourceFile().getFilePath()
         return filePath.startsWith(pathToTests) || filePath.startsWith(pathToTypings)
       })
@@ -49,7 +49,7 @@ describe('Definitions', function () {
   })
 
   describe('Static files', () => {
-    it('should have internal object that is available as variable codeceptjs', (done) => {
+    it('should have internal object that is available as variable codeceptjs', done => {
       exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
         const types = typesFrom(`${codecept_dir}/steps.d.ts`)
         types.should.be.valid
@@ -63,17 +63,14 @@ describe('Definitions', function () {
           { declarations: [{ name: 'config', type: 'typeof CodeceptJS.Config' }] },
           { declarations: [{ name: 'container', type: 'typeof CodeceptJS.Container' }] },
         ])
-        const codeceptjs = types
-          .getSourceFileOrThrow(pathOfStaticDefinitions)
-          .getVariableDeclarationOrThrow('codeceptjs')
-          .getStructure()
+        const codeceptjs = types.getSourceFileOrThrow(pathOfStaticDefinitions).getVariableDeclarationOrThrow('codeceptjs').getStructure()
         codeceptjs.type.should.equal('typeof CodeceptJS.index')
         done()
       })
     })
   })
 
-  it('def should create definition file', (done) => {
+  it('def should create definition file', done => {
     exec(`${runner} def ${codecept_dir}`, (err, stdout) => {
       stdout.should.include('Definitions were generated in steps.d.ts')
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
@@ -102,7 +99,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with correct page def', (done) => {
+  it('def should create definition file with correct page def', done => {
     exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, (err, stdout) => {
       stdout.should.include('Definitions were generated in steps.d.ts')
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
@@ -117,7 +114,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file given a config file', (done) => {
+  it('def should create definition file given a config file', done => {
     exec(`${runner} def --config ${codecept_dir}/../../codecept.ddt.js`, (err, stdout) => {
       stdout.should.include('Definitions were generated in steps.d.ts')
       const types = typesFrom(`${codecept_dir}/../../steps.d.ts`)
@@ -127,7 +124,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with support object', (done) => {
+  it('def should create definition file with support object', done => {
     exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
       types.should.be.valid
@@ -157,7 +154,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with inject which contains support objects', (done) => {
+  it('def should create definition file with inject which contains support objects', done => {
     exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
       types.should.be.valid
@@ -176,8 +173,8 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with inject which contains I object', (done) => {
-    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, (err) => {
+  it('def should create definition file with inject which contains I object', done => {
+    exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, err => {
       assert(!err)
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
       types.should.be.valid
@@ -196,7 +193,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with inject which contains I object from helpers', (done) => {
+  it('def should create definition file with inject which contains I object from helpers', done => {
     exec(`${runner} def --config ${codecept_dir}/codecept.inject.powi.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
       types.should.be.valid
@@ -212,7 +209,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with callback params', (done) => {
+  it('def should create definition file with callback params', done => {
     exec(`${runner} def --config ${codecept_dir}/codecept.inject.po.js`, () => {
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
       types.should.be.valid
@@ -228,7 +225,7 @@ describe('Definitions', function () {
     })
   })
 
-  it('def should create definition file with promise-based feature', (done) => {
+  it('def should create definition file with promise-based feature', done => {
     exec(`${runner} def --config ${codecept_dir}/codecept.promise.based.js`, (err, stdout) => {
       stdout.should.include('Definitions were generated in steps.d.ts')
       const types = typesFrom(`${codecept_dir}/steps.d.ts`)
@@ -287,12 +284,7 @@ function resolutionHost(moduleResolutionHost, getCompilerOptions) {
             failedLookupLocations: [],
           }
         } else {
-          result = ts.resolveTypeReferenceDirective(
-            typeDirectiveName,
-            containingFile,
-            compilerOptions,
-            moduleResolutionHost,
-          )
+          result = ts.resolveTypeReferenceDirective(typeDirectiveName, containingFile, compilerOptions, moduleResolutionHost)
         }
         if (result.resolvedTypeReferenceDirective) {
           resolvedTypeReferenceDirectives.push(result.resolvedTypeReferenceDirective)
@@ -326,12 +318,12 @@ function getExtends(node) {
     /** @type {import('ts-morph').Type} */
     result.properties = result.properties || []
     result.methods = result.methods || []
-    node.getExtends().map((symbol) =>
+    node.getExtends().map(symbol =>
       symbol
         .getType()
         .getProperties()
-        .forEach((symbol) => {
-          symbol.getDeclarations().forEach((declaration) => {
+        .forEach(symbol => {
+          symbol.getDeclarations().forEach(declaration => {
             const structure = declaration.getStructure()
             if (structure.kind === StructureKind.Method || structure.kind === StructureKind.MethodSignature) {
               result.methods.push(structure)
@@ -353,7 +345,7 @@ function getReturnStructure(node) {
   /** @type {import('ts-morph').Type} */
   const returnType = node.getSignature().getReturnType()
   const nodes = returnType.getSymbol().getDeclarations()
-  return nodes.map((node) => node.getStructure())
+  return nodes.map(node => node.getStructure())
 }
 
 /**

--- a/test/runner/dry_run_test.js
+++ b/test/runner/dry_run_test.js
@@ -1,70 +1,70 @@
-const path = require('path');
-const { expect } = require('expect');
-const exec = require('child_process').exec;
+const path = require('path')
+const { expect } = require('expect')
+const exec = require('child_process').exec
 
-const runner = path.join(__dirname, '/../../bin/codecept.js');
-const codecept_dir = path.join(__dirname, '/../data/sandbox');
-const codecept_run = `${runner} dry-run`;
-const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`;
-const char = require('figures').checkboxOff;
+const runner = path.join(__dirname, '/../../bin/codecept.js')
+const codecept_dir = path.join(__dirname, '/../data/sandbox')
+const codecept_run = `${runner} dry-run`
+const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`
+const char = require('figures').checkboxOff
 
 describe('dry-run command', () => {
   before(() => {
-    process.chdir(codecept_dir);
-  });
+    process.chdir(codecept_dir)
+  })
 
   it('should be executed with config path', done => {
-    process.chdir(__dirname);
+    process.chdir(__dirname)
     exec(`${codecept_run_config('codecept.js')}`, (err, stdout) => {
-      expect(stdout).toContain('Filesystem'); // feature
-      expect(stdout).toContain('check current dir'); // test name
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Filesystem') // feature
+      expect(stdout).toContain('check current dir') // test name
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should list all tests', done => {
-    process.chdir(__dirname);
+    process.chdir(__dirname)
     exec(`${codecept_run_config('codecept.js')}`, (err, stdout) => {
-      expect(stdout).toContain('Filesystem'); // feature
-      expect(stdout).toContain('check current dir'); // test name
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Filesystem') // feature
+      expect(stdout).toContain('check current dir') // test name
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should not run actual steps', done => {
     exec(`${codecept_run_config('codecept.flaky.js')}`, (err, stdout) => {
-      expect(stdout).toContain('Flaky'); // feature
-      expect(stdout).toContain('Not so flaky test'); // test name
-      expect(stdout).toContain('Old style flaky'); // test name
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Flaky') // feature
+      expect(stdout).toContain('Not so flaky test') // test name
+      expect(stdout).toContain('Old style flaky') // test name
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should not run helper hooks', done => {
     exec(`${codecept_run_config('codecept.testhooks.json')} --debug`, (err, stdout) => {
-      const lines = stdout.match(/\S.+/g);
+      const lines = stdout.match(/\S.+/g)
 
       expect(lines).not.toEqual(
         expect.arrayContaining(["Helper: I'm initialized", "Helper: I'm simple BeforeSuite hook", "Helper: I'm simple Before hook", "Helper: I'm simple After hook", "Helper: I'm simple AfterSuite hook"]),
-      );
+      )
 
-      expect(lines).toEqual(expect.arrayContaining(["Test: I'm simple BeforeSuite hook", "Test: I'm simple Before hook", "Test: I'm simple After hook", "Test: I'm simple AfterSuite hook"]));
+      expect(lines).toEqual(expect.arrayContaining(["Test: I'm simple BeforeSuite hook", "Test: I'm simple Before hook", "Test: I'm simple After hook", "Test: I'm simple AfterSuite hook"]))
 
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should display meta steps and substeps', done => {
     exec(`${codecept_run_config('configs/pageObjects/codecept.po.js')} --debug`, (err, stdout) => {
-      const lines = stdout.split('\n');
+      const lines = stdout.split('\n')
       expect(lines).toEqual(
         expect.arrayContaining([
           '  check current dir',
@@ -76,85 +76,85 @@ describe('dry-run command', () => {
           '      I see file "codecept.po.js"',
           '    I see file "codecept.po.js"',
         ]),
-      );
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      )
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should run feature files', done => {
     exec(codecept_run_config('codecept.bdd.js') + ' --steps --grep "Checkout process"', (err, stdout) => {
       //eslint-disable-line
-      expect(stdout).toContain('Checkout process'); // feature
-      expect(stdout).toContain('-- before checkout --');
-      expect(stdout).toContain('-- after checkout --');
+      expect(stdout).toContain('Checkout process') // feature
+      expect(stdout).toContain('-- before checkout --')
+      expect(stdout).toContain('-- after checkout --')
       // expect(stdout).toContain('In order to buy products'); // test name
-      expect(stdout).toContain('Given I have product with $600 price');
-      expect(stdout).toContain('And I have product with $1000 price');
-      expect(stdout).toContain('Then I should see that total number of products is 2');
-      expect(stdout).toContain('And my order amount is $1600');
-      expect(stdout).not.toContain('I add item 600'); // 'Given' actor's non-gherkin step check
-      expect(stdout).not.toContain('I see sum 1600'); // 'And' actor's non-gherkin step check
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Given I have product with $600 price')
+      expect(stdout).toContain('And I have product with $1000 price')
+      expect(stdout).toContain('Then I should see that total number of products is 2')
+      expect(stdout).toContain('And my order amount is $1600')
+      expect(stdout).not.toContain('I add item 600') // 'Given' actor's non-gherkin step check
+      expect(stdout).not.toContain('I see sum 1600') // 'And' actor's non-gherkin step check
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should run feature files with regex grep', done => {
     exec(codecept_run_config('codecept.bdd.js') + ' --steps --grep "(?=.*Checkout process)"', (err, stdout) => {
       //eslint-disable-line
-      expect(stdout).toContain('Checkout process'); // feature
-      expect(stdout).toContain('-- before checkout --');
-      expect(stdout).toContain('-- after checkout --');
+      expect(stdout).toContain('Checkout process') // feature
+      expect(stdout).toContain('-- before checkout --')
+      expect(stdout).toContain('-- after checkout --')
       // expect(stdout).toContain('In order to buy products'); // test name
-      expect(stdout).toContain('Given I have product with $600 price');
-      expect(stdout).toContain('And I have product with $1000 price');
-      expect(stdout).toContain('Then I should see that total number of products is 2');
-      expect(stdout).toContain('And my order amount is $1600');
-      expect(stdout).not.toContain('I add item 600'); // 'Given' actor's non-gherkin step check
-      expect(stdout).not.toContain('I see sum 1600'); // 'And' actor's non-gherkin step check
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Given I have product with $600 price')
+      expect(stdout).toContain('And I have product with $1000 price')
+      expect(stdout).toContain('Then I should see that total number of products is 2')
+      expect(stdout).toContain('And my order amount is $1600')
+      expect(stdout).not.toContain('I add item 600') // 'Given' actor's non-gherkin step check
+      expect(stdout).not.toContain('I see sum 1600') // 'And' actor's non-gherkin step check
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should print substeps in debug mode', done => {
     exec(codecept_run_config('codecept.bdd.js') + ' --debug --grep "Checkout process @important"', (err, stdout) => {
       //eslint-disable-line
-      expect(stdout).toContain('Checkout process'); // feature
+      expect(stdout).toContain('Checkout process') // feature
       // expect(stdout).toContain('In order to buy products'); // test name
-      expect(stdout).toContain('Given I have product with $600 price');
-      expect(stdout).toContain('I add item 600');
-      expect(stdout).toContain('And I have product with $1000 price');
-      expect(stdout).toContain('I add item 1000');
-      expect(stdout).toContain('Then I should see that total number of products is 2');
-      expect(stdout).toContain('I see num 2');
-      expect(stdout).toContain('And my order amount is $1600');
-      expect(stdout).toContain('I see sum 1600');
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(stdout).toContain('No tests were executed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Given I have product with $600 price')
+      expect(stdout).toContain('I add item 600')
+      expect(stdout).toContain('And I have product with $1000 price')
+      expect(stdout).toContain('I add item 1000')
+      expect(stdout).toContain('Then I should see that total number of products is 2')
+      expect(stdout).toContain('I see num 2')
+      expect(stdout).toContain('And my order amount is $1600')
+      expect(stdout).toContain('I see sum 1600')
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(stdout).toContain('No tests were executed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should run tests with different data', done => {
     exec(`${codecept_run_config('codecept.ddt.js')} --debug`, (err, stdout) => {
-      const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '');
-      expect(output).toContain('OK  | 11 passed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '')
+      expect(output).toContain('OK  | 11 passed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should work with inject() keyword', done => {
     exec(`${codecept_run_config('configs/pageObjects/codecept.inject.po.js', 'check current dir')} --debug`, (err, stdout) => {
-      const lines = stdout.split('\n');
-      expect(stdout).toContain('injected');
+      const lines = stdout.split('\n')
+      expect(stdout).toContain('injected')
       expect(lines).toEqual(
         expect.arrayContaining([
           '  check current dir',
@@ -166,42 +166,42 @@ describe('dry-run command', () => {
           '      I see file "codecept.po.js"',
           '    I see file "codecept.po.js"',
         ]),
-      );
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      )
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should inject page objects via proxy', done => {
     exec(`${codecept_run_config('../inject-fail-example')} --debug`, (err, stdout) => {
-      expect(stdout).toContain('newdomain');
-      expect(stdout).toContain('veni,vedi,vici');
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('newdomain')
+      expect(stdout).toContain('veni,vedi,vici')
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should enable all plugins in dry-mode when passing -p all', done => {
     exec(`${codecept_run_config('codecept.customLocator.js')} --verbose -p all`, (err, stdout) => {
-      expect(stdout).toContain('Plugins: screenshotOnFail, customLocator');
-      expect(stdout).toContain("I see element {xpath: .//*[@data-testid='COURSE']//a}");
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(stdout).toContain('--- DRY MODE: No tests were executed ---');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
+      expect(stdout).toContain('Plugins: screenshotOnFail, customLocator')
+      expect(stdout).toContain("I see element {xpath: .//*[@data-testid='COURSE']//a}")
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(stdout).toContain('--- DRY MODE: No tests were executed ---')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
 
   it('should enable a particular plugin in dry-mode when passing it to -p', done => {
     exec(`${codecept_run_config('codecept.customLocator.js')} --verbose -p customLocator`, (err, stdout) => {
-      expect(stdout).toContain('Plugins: customLocator');
-      expect(stdout).toContain("I see element {xpath: .//*[@data-testid='COURSE']//a}");
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(stdout).toContain('--- DRY MODE: No tests were executed ---');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
-});
+      expect(stdout).toContain('Plugins: customLocator')
+      expect(stdout).toContain("I see element {xpath: .//*[@data-testid='COURSE']//a}")
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(stdout).toContain('--- DRY MODE: No tests were executed ---')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
+})

--- a/test/runner/gherkin_test.js
+++ b/test/runner/gherkin_test.js
@@ -12,14 +12,8 @@ describe('gherkin bdd commands', () => {
     const codecept_dir_ts = path.join(codecept_dir, 'config_ts')
 
     beforeEach(() => {
-      fs.copyFileSync(
-        path.join(codecept_dir_js, 'codecept.conf.init.js'),
-        path.join(codecept_dir_js, 'codecept.conf.js'),
-      )
-      fs.copyFileSync(
-        path.join(codecept_dir_ts, 'codecept.conf.init.ts'),
-        path.join(codecept_dir_ts, 'codecept.conf.ts'),
-      )
+      fs.copyFileSync(path.join(codecept_dir_js, 'codecept.conf.init.js'), path.join(codecept_dir_js, 'codecept.conf.js'))
+      fs.copyFileSync(path.join(codecept_dir_ts, 'codecept.conf.init.ts'), path.join(codecept_dir_ts, 'codecept.conf.ts'))
     })
 
     afterEach(() => {
@@ -56,7 +50,7 @@ describe('gherkin bdd commands', () => {
         extension: 'ts',
       },
     ].forEach(({ codecept_dir_test, extension }) => {
-      it(`prepare CodeceptJS to run feature files (codecept.conf.${extension})`, (done) => {
+      it(`prepare CodeceptJS to run feature files (codecept.conf.${extension})`, done => {
         exec(`${runner} gherkin:init ${codecept_dir_test}`, (err, stdout) => {
           let dir = path.join(codecept_dir_test, 'features')
 

--- a/test/runner/help_test.js
+++ b/test/runner/help_test.js
@@ -5,7 +5,7 @@ const exec = require('child_process').exec
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 
 describe('help option', () => {
-  it('should print help message with --help option', (done) => {
+  it('should print help message with --help option', done => {
     exec(`${runner} --help`, (err, stdout) => {
       stdout.should.include('Usage:')
       stdout.should.include('Options:')
@@ -15,7 +15,7 @@ describe('help option', () => {
     })
   })
 
-  it('should print help message with -h option', (done) => {
+  it('should print help message with -h option', done => {
     exec(`${runner} -h`, (err, stdout) => {
       stdout.should.include('Usage:')
       stdout.should.include('Options:')
@@ -25,7 +25,7 @@ describe('help option', () => {
     })
   })
 
-  it('should print help message with no option', (done) => {
+  it('should print help message with no option', done => {
     exec(`${runner}`, (err, stdout) => {
       stdout.should.include('Usage:')
       stdout.should.include('Options:')

--- a/test/runner/init_test.js
+++ b/test/runner/init_test.js
@@ -36,10 +36,7 @@ describe('Init Command', function () {
   })
 
   it('should init Codecept with TypeScript REST JSONResponse English', async () => {
-    const result = await run(
-      [runner, 'init', codecept_dir],
-      ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y', ENTER, codecept_dir, ENTER, ENTER, ENTER, ENTER],
-    )
+    const result = await run([runner, 'init', codecept_dir], ['Y', ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y', ENTER, codecept_dir, ENTER, ENTER, ENTER, ENTER])
 
     result.should.include('Welcome to CodeceptJS initialization tool')
     result.should.include('It will prepare and configure a test environment for you')
@@ -59,10 +56,7 @@ describe('Init Command', function () {
   })
 
   it.skip('should init Codecept with JavaScript REST JSONResponse de-DE', async () => {
-    const result = await run(
-      [runner, 'init', codecept_dir],
-      [ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y', ENTER, codecept_dir, ENTER, DOWN, ENTER, ENTER, ENTER],
-    )
+    const result = await run([runner, 'init', codecept_dir], [ENTER, ENTER, DOWN, DOWN, DOWN, ENTER, 'y', ENTER, codecept_dir, ENTER, DOWN, ENTER, ENTER, ENTER])
 
     result.should.include('Welcome to CodeceptJS initialization tool')
     result.should.include('It will prepare and configure a test environment for you')

--- a/test/runner/interface_test.js
+++ b/test/runner/interface_test.js
@@ -5,14 +5,14 @@ const exec = require('child_process').exec
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox')
 const codecept_run = `${runner} run`
-const config_run_config = (config) => `${codecept_run} --config ${codecept_dir}/${config}`
+const config_run_config = config => `${codecept_run} --config ${codecept_dir}/${config}`
 
 describe('CodeceptJS Interface', () => {
   before(() => {
     process.chdir(codecept_dir)
   })
 
-  it('should rerun flaky tests', (done) => {
+  it('should rerun flaky tests', done => {
     exec(config_run_config('codecept.flaky.js'), (err, stdout) => {
       expect(stdout).toContain('Flaky') // feature
       expect(stdout).toContain('Not so flaky test') // test name
@@ -25,7 +25,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should rerun retried steps', (done) => {
+  it('should rerun retried steps', done => {
     exec(`${config_run_config('codecept.retry.json')} --grep @test1`, (err, stdout) => {
       expect(stdout).toContain('Retry') // feature
       expect(stdout).toContain('Retries: 4') // test name
@@ -34,7 +34,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should not propagate retries to non retried steps', (done) => {
+  it('should not propagate retries to non retried steps', done => {
     exec(`${config_run_config('codecept.retry.json')} --grep @test2 --verbose`, (err, stdout) => {
       expect(stdout).toContain('Retry') // feature
       expect(stdout).toContain('Retries: 1') // test name
@@ -42,7 +42,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should use retryFailedStep plugin for failed steps', (done) => {
+  it('should use retryFailedStep plugin for failed steps', done => {
     exec(`${config_run_config('codecept.retryFailed.json')} --grep @test1`, (err, stdout) => {
       expect(stdout).toContain('Retry') // feature
       expect(stdout).toContain('Retries: 5') // test name
@@ -51,7 +51,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should not retry wait* steps in retryFailedStep plugin', (done) => {
+  it('should not retry wait* steps in retryFailedStep plugin', done => {
     exec(`${config_run_config('codecept.retryFailed.json')} --grep @test2`, (err, stdout) => {
       expect(stdout).toContain('Retry') // feature
       expect(stdout).not.toContain('Retries: 5')
@@ -61,7 +61,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should not retry steps if retryFailedStep plugin disabled', (done) => {
+  it('should not retry steps if retryFailedStep plugin disabled', done => {
     exec(`${config_run_config('codecept.retryFailed.json')} --grep @test3`, (err, stdout) => {
       expect(stdout).toContain('Retry') // feature
       expect(stdout).not.toContain('Retries: 5')
@@ -71,7 +71,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should include grep option tests', (done) => {
+  it('should include grep option tests', done => {
     exec(config_run_config('codecept.grep.js'), (err, stdout) => {
       expect(stdout).toContain('Got login davert and password') // feature
       expect(stdout).not.toContain('Got changed login') // test name
@@ -80,7 +80,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should run tests with different data', (done) => {
+  it('should run tests with different data', done => {
     exec(config_run_config('codecept.ddt.js'), (err, stdout) => {
       const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '')
       expect(output).toContain(`Got login davert and password 123456
@@ -121,7 +121,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should run all tests with data of array by only', (done) => {
+  it('should run all tests with data of array by only', done => {
     exec(config_run_config('codecept.addt.js'), (err, stdout) => {
       const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '')
       expect(output).toContain('Got array item 1')
@@ -135,7 +135,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should run all tests with data of generator by only', (done) => {
+  it('should run all tests with data of generator by only', done => {
     exec(config_run_config('codecept.gddt.js'), (err, stdout) => {
       const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '')
       expect(output).toContain(`Got generator login nick
@@ -148,7 +148,7 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should provide skipped test for each entry of data', (done) => {
+  it('should provide skipped test for each entry of data', done => {
     exec(config_run_config('codecept.skip_ddt.json'), (err, stdout) => {
       const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '')
       expect(output).toContain('S Should add skip entry for each item | {"user":"bob"}')
@@ -161,26 +161,26 @@ describe('CodeceptJS Interface', () => {
     })
   })
 
-  it('should execute expected promise chain', (done) => {
+  it('should execute expected promise chain', done => {
     exec(`${codecept_run} --debug`, (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
       // before hooks
       const beforeStep = ['I am in path "."']
 
-      lines.filter((l) => beforeStep.indexOf(l) > -1).should.eql(beforeStep, 'check step hooks execution order')
+      lines.filter(l => beforeStep.indexOf(l) > -1).should.eql(beforeStep, 'check step hooks execution order')
 
       // steps order
       const step = ['I am in path "."', 'hello world', 'I see file "codecept.js"']
 
-      lines.filter((l) => step.indexOf(l) > -1).should.eql(step, 'check steps execution order')
+      lines.filter(l => step.indexOf(l) > -1).should.eql(step, 'check steps execution order')
 
       expect(err).toBeFalsy()
       done()
     })
   })
 
-  it('should display steps and artifacts & error log', (done) => {
+  it('should display steps and artifacts & error log', done => {
     exec(`${config_run_config('./configs/testArtifacts')} --debug`, (err, stdout) => {
       stdout.should.include('Scenario Steps:')
       stdout.should.include('Artifacts')

--- a/test/runner/list_test.js
+++ b/test/runner/list_test.js
@@ -6,7 +6,7 @@ const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox')
 
 describe('list commands', () => {
-  it('list should print actions', (done) => {
+  it('list should print actions', done => {
     exec(`${runner} list ${codecept_dir}`, (err, stdout) => {
       stdout.should.include('FileSystem') // helper name
       stdout.should.include('FileSystem I.amInPath(openPath)') // action name

--- a/test/runner/pageobject_test.js
+++ b/test/runner/pageobject_test.js
@@ -1,21 +1,21 @@
-const path = require('path');
-const exec = require('child_process').exec;
-const { expect } = require('expect');
+const path = require('path')
+const exec = require('child_process').exec
+const { expect } = require('expect')
 
-const runner = path.join(__dirname, '/../../bin/codecept.js');
-const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/pageObjects');
-const codecept_run = `${runner} run`;
-const config_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`;
+const runner = path.join(__dirname, '/../../bin/codecept.js')
+const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/pageObjects')
+const codecept_run = `${runner} run`
+const config_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} ${grep ? `--grep "${grep}"` : ''}`
 
 describe('CodeceptJS PageObject', () => {
   before(() => {
-    process.chdir(codecept_dir);
-  });
+    process.chdir(codecept_dir)
+  })
 
   describe('Failed PageObject', () => {
     it('should fail if page objects was failed', done => {
       exec(`${config_run_config('codecept.fail_po.js')} --debug`, (err, stdout) => {
-        const lines = stdout.split('\n');
+        const lines = stdout.split('\n')
         expect(lines).toEqual(
           expect.arrayContaining([
             expect.stringContaining('File notexistfile.js not found in'),
@@ -24,68 +24,68 @@ describe('CodeceptJS PageObject', () => {
             expect.stringContaining('- I.seeFile("codecept.class.js")'),
             expect.stringContaining('- I.amInPath(".")'),
           ]),
-        );
-        expect(stdout).toContain('FAIL  | 0 passed, 1 failed');
-        expect(err).toBeTruthy();
-        done();
-      });
-    });
-  });
+        )
+        expect(stdout).toContain('FAIL  | 0 passed, 1 failed')
+        expect(err).toBeTruthy()
+        done()
+      })
+    })
+  })
 
   describe('PageObject as Class', () => {
     it('should inject page objects by class', done => {
       exec(`${config_run_config('codecept.class.js', '@ClassPageObject')} --debug`, (err, stdout) => {
-        expect(stdout).not.toContain('classpage.type is not a function');
-        expect(stdout).toContain('On classpage: type "Class Page Type"');
-        expect(stdout).toContain('I print message "Class Page Type"');
-        expect(stdout).toContain('On classpage: purge domains');
-        expect(stdout).toContain('I print message "purgeDomains"');
-        expect(stdout).toContain('Class Page Type');
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
+        expect(stdout).not.toContain('classpage.type is not a function')
+        expect(stdout).toContain('On classpage: type "Class Page Type"')
+        expect(stdout).toContain('I print message "Class Page Type"')
+        expect(stdout).toContain('On classpage: purge domains')
+        expect(stdout).toContain('I print message "purgeDomains"')
+        expect(stdout).toContain('Class Page Type')
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
 
     it('should inject page objects by class which nested base clas', done => {
       exec(`${config_run_config('codecept.class.js', '@NestedClassPageObject')} --debug`, (err, stdout) => {
-        expect(stdout).not.toContain('classnestedpage.type is not a function');
-        expect(stdout).toContain('On classnestedpage: type "Nested Class Page Type"');
-        expect(stdout).toContain('user => User1');
-        expect(stdout).toContain('I print message "Nested Class Page Type"');
-        expect(stdout).toContain('On classnestedpage: purge domains');
-        expect(stdout).toContain('I print message "purgeDomains"');
-        expect(stdout).toContain('Nested Class Page Type');
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
+        expect(stdout).not.toContain('classnestedpage.type is not a function')
+        expect(stdout).toContain('On classnestedpage: type "Nested Class Page Type"')
+        expect(stdout).toContain('user => User1')
+        expect(stdout).toContain('I print message "Nested Class Page Type"')
+        expect(stdout).toContain('On classnestedpage: purge domains')
+        expect(stdout).toContain('I print message "purgeDomains"')
+        expect(stdout).toContain('Nested Class Page Type')
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
 
     it('should print pretty step log and pretty event log', done => {
       exec(`${config_run_config('codecept.logs.js', 'Print correct arg message')} --steps`, (err, stdout) => {
-        expect(stdout).toContain('I get humanize args Logs Page Value');
-        expect(stdout).toContain('Start event step: I get humanize args Logs Page Valu');
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
+        expect(stdout).toContain('I get humanize args Logs Page Value')
+        expect(stdout).toContain('Start event step: I get humanize args Logs Page Valu')
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
 
     it('should print pretty failed step log on stack trace', done => {
       exec(`${config_run_config('codecept.logs.js', 'Error print correct arg message')} --steps`, (err, stdout) => {
-        expect(stdout).toContain('I.errorMethodHumanizeArgs(Logs Page Value)');
-        expect(stdout).toContain('FAIL  | 0 passed, 1 failed');
-        expect(err).toBeTruthy();
-        done();
-      });
-    });
-  });
+        expect(stdout).toContain('I.errorMethodHumanizeArgs(Logs Page Value)')
+        expect(stdout).toContain('FAIL  | 0 passed, 1 failed')
+        expect(err).toBeTruthy()
+        done()
+      })
+    })
+  })
 
   describe('Show MetaSteps in Log', () => {
     it('should display meta steps and substeps', done => {
       exec(`${config_run_config('codecept.po.js')} --debug`, (err, stdout) => {
-        const lines = stdout.split('\n');
+        const lines = stdout.split('\n')
         expect(lines).toEqual(
           expect.arrayContaining([
             '  check current dir',
@@ -97,19 +97,19 @@ describe('CodeceptJS PageObject', () => {
             '      I see file "codecept.po.js"',
             '    I see file "codecept.po.js"',
           ]),
-        );
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
-  });
+        )
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
+  })
 
   describe('Inject PO in Test', () => {
     it('should work with inject() keyword', done => {
       exec(`${config_run_config('codecept.inject.po.js', 'check current dir')} --debug`, (err, stdout) => {
-        const lines = stdout.split('\n');
-        expect(stdout).toContain('injected');
+        const lines = stdout.split('\n')
+        expect(stdout).toContain('injected')
         expect(lines).toEqual(
           expect.arrayContaining([
             '  check current dir',
@@ -121,18 +121,18 @@ describe('CodeceptJS PageObject', () => {
             '      I see file "codecept.po.js"',
             '    I see file "codecept.po.js"',
           ]),
-        );
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
-  });
+        )
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
+  })
 
   describe('PageObject with context', () => {
     it('should work when used "this" context on method', done => {
       exec(`${config_run_config('codecept.inject.po.js', 'pageobject with context')} --debug`, (err, stdout) => {
-        const lines = stdout.split('\n');
+        const lines = stdout.split('\n')
         expect(lines).toEqual(
           expect.arrayContaining([
             '  pageobject with context',
@@ -144,33 +144,33 @@ describe('CodeceptJS PageObject', () => {
             '      I see file "codecept.po.js"',
             '    I see file "codecept.po.js"',
           ]),
-        );
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
-  });
+        )
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
+  })
 
   describe('Inject PO in another PO', () => {
     it('should inject page objects via proxy', done => {
       exec(`${config_run_config('../../../inject-fail-example')} --debug`, (err, stdout) => {
-        expect(stdout).toContain('newdomain');
-        expect(stdout).toContain('veni,vedi,vici');
-        expect(stdout).toContain('OK  | 1 passed');
-        expect(err).toBeFalsy();
-        done();
-      });
-    });
-  });
+        expect(stdout).toContain('newdomain')
+        expect(stdout).toContain('veni,vedi,vici')
+        expect(stdout).toContain('OK  | 1 passed')
+        expect(err).toBeFalsy()
+        done()
+      })
+    })
+  })
 
   it('built methods are still available custom I steps_file is added', done => {
     exec(`${config_run_config('codecept.class.js', '@CustomStepsBuiltIn')} --debug`, (err, stdout) => {
-      expect(stdout).toContain('Built in say');
-      expect(stdout).toContain('Say called from custom step');
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(err).toBeFalsy();
-      done();
-    });
-  });
-});
+      expect(stdout).toContain('Built in say')
+      expect(stdout).toContain('Say called from custom step')
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(err).toBeFalsy()
+      done()
+    })
+  })
+})

--- a/test/runner/retry_hooks_test.js
+++ b/test/runner/retry_hooks_test.js
@@ -4,13 +4,12 @@ const { codecept_dir, codecept_run } = require('./consts')
 
 const debug_this_test = false
 
-const config_run_config = (config, grep, verbose = false) =>
-  `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/retryHooks/${config} ${grep ? `--grep "${grep}"` : ''}`
+const config_run_config = (config, grep, verbose = false) => `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/retryHooks/${config} ${grep ? `--grep "${grep}"` : ''}`
 
 describe('CodeceptJS Retry Hooks', function () {
   this.timeout(10000)
-  ;['#Async ', '#Before ', '#BeforeSuite ', '#Helper '].forEach((retryHook) => {
-    it(`run ${retryHook} config`, (done) => {
+  ;['#Async ', '#Before ', '#BeforeSuite ', '#Helper '].forEach(retryHook => {
+    it(`run ${retryHook} config`, done => {
       exec(config_run_config('codecept.conf.js', retryHook), (err, stdout) => {
         debug_this_test && console.log(stdout)
         expect(stdout).toContain('1 passed')
@@ -18,8 +17,8 @@ describe('CodeceptJS Retry Hooks', function () {
       })
     })
   })
-  ;['#Before ', '#BeforeSuite '].forEach((retryHook) => {
-    it(`should ${retryHook} set hook retries from global config`, (done) => {
+  ;['#Before ', '#BeforeSuite '].forEach(retryHook => {
+    it(`should ${retryHook} set hook retries from global config`, done => {
       exec(config_run_config('codecept.retry.obj.conf.js', retryHook), (err, stdout) => {
         debug_this_test && console.log(stdout)
         expect(stdout).toContain('1 passed')
@@ -28,7 +27,7 @@ describe('CodeceptJS Retry Hooks', function () {
     })
   })
 
-  it('should finish if retry has not happened', (done) => {
+  it('should finish if retry has not happened', done => {
     exec(config_run_config('codecept.conf.js', '#FailBefore '), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('-- FAILURES')
@@ -38,7 +37,7 @@ describe('CodeceptJS Retry Hooks', function () {
     })
   })
 
-  it('should set global retry', (done) => {
+  it('should set global retry', done => {
     exec(config_run_config('codecept.retry.global.conf.js', '#globalRetry'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('1 passed')
@@ -46,7 +45,7 @@ describe('CodeceptJS Retry Hooks', function () {
     })
   })
 
-  it('should set global scenario retry', (done) => {
+  it('should set global scenario retry', done => {
     exec(config_run_config('codecept.retry.global.scenario.conf.js', '#globalScenarioRetry'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('1 passed')

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -1,258 +1,258 @@
-const assert = require('assert');
-const { expect } = require('expect');
-const path = require('path');
-const exec = require('child_process').exec;
+const assert = require('assert')
+const { expect } = require('expect')
+const path = require('path')
+const exec = require('child_process').exec
 
-const runner = path.join(__dirname, '/../../bin/codecept.js');
-const codecept_dir = path.join(__dirname, '/../data/sandbox');
-const codecept_run = `${runner} run-multiple --config ${codecept_dir}/codecept.multiple.js `;
+const runner = path.join(__dirname, '/../../bin/codecept.js')
+const codecept_dir = path.join(__dirname, '/../data/sandbox')
+const codecept_run = `${runner} run-multiple --config ${codecept_dir}/codecept.multiple.js `
 
 describe('CodeceptJS Multiple Runner', function () {
-  this.timeout(40000);
+  this.timeout(40000)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data/sandbox');
-  });
+    global.codecept_dir = path.join(__dirname, '/../data/sandbox')
+  })
 
   it('should execute one suite with browser', done => {
     exec(`${codecept_run}default:firefox`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('.default:firefox] print browser ');
-      stdout.should.not.include('.default:chrome] print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('.default:firefox] print browser ')
+      stdout.should.not.include('.default:chrome] print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should execute all suites', done => {
     exec(`${codecept_run}--all`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[1.default:chrome] print browser ');
-      stdout.should.include('[2.default:firefox] print browser ');
-      stdout.should.include('[3.mobile:android] print browser ');
-      stdout.should.include('[4.mobile:safari] print browser ');
-      stdout.should.include('[5.mobile:chrome] print browser ');
-      stdout.should.include('[6.mobile:safari] print browser ');
-      stdout.should.include('[7.grep:chrome] @grep print browser size ');
-      stdout.should.include('[8.grep:firefox] @grep print browser size ');
-      stdout.should.not.include('[7.grep:chrome] print browser ');
-      stdout.should.include('[1.default:chrome] @grep print browser size ');
-      stdout.should.include('[3.mobile:android] @grep print browser size ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[1.default:chrome] print browser ')
+      stdout.should.include('[2.default:firefox] print browser ')
+      stdout.should.include('[3.mobile:android] print browser ')
+      stdout.should.include('[4.mobile:safari] print browser ')
+      stdout.should.include('[5.mobile:chrome] print browser ')
+      stdout.should.include('[6.mobile:safari] print browser ')
+      stdout.should.include('[7.grep:chrome] @grep print browser size ')
+      stdout.should.include('[8.grep:firefox] @grep print browser size ')
+      stdout.should.not.include('[7.grep:chrome] print browser ')
+      stdout.should.include('[1.default:chrome] @grep print browser size ')
+      stdout.should.include('[3.mobile:android] @grep print browser size ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should replace parameters', done => {
     exec(`${codecept_run}grep --debug`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[1.grep:chrome]     › maximize');
-      stdout.should.include('[2.grep:firefox]     › 1200x840');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[1.grep:chrome]     › maximize')
+      stdout.should.include('[2.grep:firefox]     › 1200x840')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should execute multiple suites', done => {
     exec(`${codecept_run}mobile default `, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[1.mobile:android] print browser ');
-      stdout.should.include('[2.mobile:safari] print browser ');
-      stdout.should.include('[3.mobile:chrome] print browser ');
-      stdout.should.include('[4.mobile:safari] print browser ');
-      stdout.should.include('[5.default:chrome] print browser ');
-      stdout.should.include('[6.default:firefox] print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[1.mobile:android] print browser ')
+      stdout.should.include('[2.mobile:safari] print browser ')
+      stdout.should.include('[3.mobile:chrome] print browser ')
+      stdout.should.include('[4.mobile:safari] print browser ')
+      stdout.should.include('[5.default:chrome] print browser ')
+      stdout.should.include('[6.default:firefox] print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should execute multiple suites with selected browsers', done => {
     exec(`${codecept_run}mobile:safari default:chrome `, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[1.mobile:safari] print browser ');
-      stdout.should.include('[2.mobile:safari] print browser ');
-      stdout.should.include('[3.default:chrome] print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[1.mobile:safari] print browser ')
+      stdout.should.include('[2.mobile:safari] print browser ')
+      stdout.should.include('[3.default:chrome] print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should print steps', done => {
     exec(`${codecept_run}default --steps`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[2.default:firefox]   print browser ');
-      stdout.should.include('[2.default:firefox]     I print browser ');
-      stdout.should.include('[1.default:chrome]   print browser ');
-      stdout.should.include('[1.default:chrome]     I print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[2.default:firefox]   print browser ')
+      stdout.should.include('[2.default:firefox]     I print browser ')
+      stdout.should.include('[1.default:chrome]   print browser ')
+      stdout.should.include('[1.default:chrome]     I print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should pass grep to configuration', done => {
     exec(`${codecept_run}default --grep @grep`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[1.default:chrome] @grep print browser size');
-      stdout.should.include('[2.default:firefox] @grep print browser size');
-      stdout.should.not.include('[1.default:chrome] print browser ');
-      stdout.should.not.include('[2.default:firefox] print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[1.default:chrome] @grep print browser size')
+      stdout.should.include('[2.default:firefox] @grep print browser size')
+      stdout.should.not.include('[1.default:chrome] print browser ')
+      stdout.should.not.include('[2.default:firefox] print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should pass grep invert to configuration', done => {
     exec(`${codecept_run}default --grep @grep --invert`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.not.include('[1.default:chrome] @grep print browser size');
-      stdout.should.not.include('[2.default:firefox] @grep print browser size');
-      stdout.should.include('[1.default:chrome] print browser ');
-      stdout.should.include('[2.default:firefox] print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.not.include('[1.default:chrome] @grep print browser size')
+      stdout.should.not.include('[2.default:firefox] @grep print browser size')
+      stdout.should.include('[1.default:chrome] print browser ')
+      stdout.should.include('[2.default:firefox] print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should pass tests to configuration', done => {
     exec(`${codecept_run}test`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.include('[1.test:chrome] print browser size');
-      stdout.should.include('[2.test:firefox] print browser size');
-      stdout.should.include('[1.test:chrome] print browser ');
-      stdout.should.include('[2.test:firefox] print browser ');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.include('[1.test:chrome] print browser size')
+      stdout.should.include('[2.test:firefox] print browser size')
+      stdout.should.include('[1.test:chrome] print browser ')
+      stdout.should.include('[2.test:firefox] print browser ')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should run chunks', done => {
     exec(`${codecept_run}chunks`, (err, stdout) => {
-      stdout.should.include('CodeceptJS'); // feature
-      stdout.should.match(/chunks:chunk\d:dummy].+print browser/i);
-      stdout.should.match(/chunks:chunk\d:dummy].+@grep print browser size/i);
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('CodeceptJS') // feature
+      stdout.should.match(/chunks:chunk\d:dummy].+print browser/i)
+      stdout.should.match(/chunks:chunk\d:dummy].+@grep print browser size/i)
+      assert(!err)
+      done()
+    })
+  })
 
   it('should run features in parallel', done => {
-    process.chdir(codecept_dir);
+    process.chdir(codecept_dir)
     exec(`${runner} run-multiple --config codecept.multiple.features.js chunks --features  --grep '(?=.*)^(?!.*@fail)'`, (err, stdout) => {
-      stdout.should.match(/\[\d\.chunks:chunk\d:default\] Checkout examples process/);
+      stdout.should.match(/\[\d\.chunks:chunk\d:default\] Checkout examples process/)
       // stdout.should.not.match(/\[\d\.chunks:chunk\d:default\] Checkout examples process/)
-      stdout.should.match(/\[\d\.chunks:chunk\d:default\] Checkout string/);
+      stdout.should.match(/\[\d\.chunks:chunk\d:default\] Checkout string/)
       // stdout.should.not.match(/\[\d\.chunks:chunk\d:default\] Checkout string/)
-      stdout.should.match(/\[\d\.chunks:chunk\d:default\] {3}OK {2}\|/);
-      stdout.should.match(/\[\d\.chunks:chunk\d:default\] {3}OK {2}\|/);
-      stdout.should.not.include('@feature_grep');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.match(/\[\d\.chunks:chunk\d:default\] {3}OK {2}\|/)
+      stdout.should.match(/\[\d\.chunks:chunk\d:default\] {3}OK {2}\|/)
+      stdout.should.not.include('@feature_grep')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should run features & tests in parallel', done => {
-    process.chdir(codecept_dir);
+    process.chdir(codecept_dir)
     exec(`${runner} run-multiple --config codecept.multiple.features.js chunks --grep '(?=.*)^(?!.*@fail)'`, (err, stdout) => {
-      stdout.should.include('@feature_grep');
-      stdout.should.include('Checkout examples process');
-      stdout.should.include('Checkout string');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('@feature_grep')
+      stdout.should.include('Checkout examples process')
+      stdout.should.include('Checkout string')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should run only tests in parallel', done => {
-    process.chdir(codecept_dir);
+    process.chdir(codecept_dir)
     exec(`${runner} run-multiple --config codecept.multiple.features.js chunks --tests`, (err, stdout) => {
-      stdout.should.include('@feature_grep');
-      stdout.should.not.include('Checkout examples process');
-      stdout.should.not.include('Checkout string');
-      assert(!err);
-      done();
-    });
-  });
+      stdout.should.include('@feature_grep')
+      stdout.should.not.include('Checkout examples process')
+      stdout.should.not.include('Checkout string')
+      assert(!err)
+      done()
+    })
+  })
 
   it('should exit with non-zero code for failures during init process', done => {
-    process.chdir(codecept_dir);
+    process.chdir(codecept_dir)
     exec(`${runner} run-multiple --config codecept.multiple.initFailure.js default --all`, (err, stdout) => {
-      expect(err).not.toBeFalsy();
-      expect(err.code).toBe(1);
-      expect(stdout).toContain('Failed on FailureHelper');
-      done();
-    });
-  });
+      expect(err).not.toBeFalsy()
+      expect(err.code).toBe(1)
+      expect(stdout).toContain('Failed on FailureHelper')
+      done()
+    })
+  })
 
   it('should exit code 1 when error in config', done => {
-    process.chdir(codecept_dir);
+    process.chdir(codecept_dir)
     exec(`${runner} run-multiple --config configs/codecept-invalid.config.js default --all`, (err, stdout, stderr) => {
-      expect(stdout).not.toContain('UnhandledPromiseRejectionWarning');
-      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning');
-      expect(stdout).toContain('badFn is not defined');
-      expect(err).not.toBe(null);
-      done();
-    });
-  });
+      expect(stdout).not.toContain('UnhandledPromiseRejectionWarning')
+      expect(stderr).not.toContain('UnhandledPromiseRejectionWarning')
+      expect(stdout).toContain('badFn is not defined')
+      expect(err).not.toBe(null)
+      done()
+    })
+  })
 
   describe('bootstrapAll and teardownAll', () => {
-    const _codecept_run = `run-multiple --config ${codecept_dir}`;
+    const _codecept_run = `run-multiple --config ${codecept_dir}`
     it('should be executed from async function in config', done => {
       exec(`${runner} ${_codecept_run}/codecept.async.bootstrapall.multiple.code.js default`, (err, stdout) => {
-        stdout.should.include('CodeceptJS'); // feature
-        stdout.should.include('Results: inside Promise\n"event.multiple.before" is called');
-        stdout.should.include('"teardownAll" is called.');
-        assert(!err);
-        done();
-      });
-    });
+        stdout.should.include('CodeceptJS') // feature
+        stdout.should.include('Results: inside Promise\n"event.multiple.before" is called')
+        stdout.should.include('"teardownAll" is called.')
+        assert(!err)
+        done()
+      })
+    })
 
     it('should be executed from function in config', done => {
       exec(`${runner} ${_codecept_run}/codecept.bootstrapall.multiple.code.js default`, (err, stdout) => {
-        stdout.should.include('CodeceptJS'); // feature
-        stdout.should.include('"bootstrapAll" is called.');
-        stdout.should.include('"teardownAll" is called.');
-        assert(!err);
-        done();
-      });
-    });
-  });
+        stdout.should.include('CodeceptJS') // feature
+        stdout.should.include('"bootstrapAll" is called.')
+        stdout.should.include('"teardownAll" is called.')
+        assert(!err)
+        done()
+      })
+    })
+  })
 
   describe('with require parameter', () => {
-    const _codecept_run = `run-multiple --config ${codecept_dir}`;
-    const moduleOutput = 'Module was required 1';
-    const moduleOutput2 = 'Module was required 2';
+    const _codecept_run = `run-multiple --config ${codecept_dir}`
+    const moduleOutput = 'Module was required 1'
+    const moduleOutput2 = 'Module was required 2'
 
     it('should be executed with module when described', done => {
-      process.chdir(codecept_dir);
+      process.chdir(codecept_dir)
       exec(`${runner} ${_codecept_run}/codecept.require.multiple.single.json default`, (err, stdout) => {
-        stdout.should.include(moduleOutput);
-        stdout.should.not.include(moduleOutput2);
-        (stdout.match(new RegExp(moduleOutput, 'g')) || []).should.have.lengthOf(2);
-        assert(!err);
-        done();
-      });
-    });
+        stdout.should.include(moduleOutput)
+        stdout.should.not.include(moduleOutput2)
+        ;(stdout.match(new RegExp(moduleOutput, 'g')) || []).should.have.lengthOf(2)
+        assert(!err)
+        done()
+      })
+    })
 
     it('should be executed with several module when described', done => {
-      process.chdir(codecept_dir);
+      process.chdir(codecept_dir)
       exec(`${runner} ${_codecept_run}/codecept.require.multiple.several.js default`, (err, stdout) => {
-        stdout.should.include(moduleOutput);
-        stdout.should.include(moduleOutput2);
-        (stdout.match(new RegExp(moduleOutput, 'g')) || []).should.have.lengthOf(2);
-        (stdout.match(new RegExp(moduleOutput2, 'g')) || []).should.have.lengthOf(2);
-        assert(!err);
-        done();
-      });
-    });
+        stdout.should.include(moduleOutput)
+        stdout.should.include(moduleOutput2)
+        ;(stdout.match(new RegExp(moduleOutput, 'g')) || []).should.have.lengthOf(2)
+        ;(stdout.match(new RegExp(moduleOutput2, 'g')) || []).should.have.lengthOf(2)
+        assert(!err)
+        done()
+      })
+    })
 
     it('should not be executed without module when not described', done => {
-      process.chdir(codecept_dir);
+      process.chdir(codecept_dir)
       exec(`${runner} ${_codecept_run}/codecept.require.multiple.without.json default`, (err, stdout) => {
-        stdout.should.not.include(moduleOutput);
-        stdout.should.not.include(moduleOutput2);
-        assert(!err);
-        done();
-      });
-    });
-  });
-});
+        stdout.should.not.include(moduleOutput)
+        stdout.should.not.include(moduleOutput2)
+        assert(!err)
+        done()
+      })
+    })
+  })
+})

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -1,102 +1,102 @@
-const { expect } = require('expect');
-const { describe } = require('mocha');
-const path = require('path');
-const exec = require('child_process').exec;
-const semver = require('semver');
+const { expect } = require('expect')
+const { describe } = require('mocha')
+const path = require('path')
+const exec = require('child_process').exec
+const semver = require('semver')
 
-const runner = path.join(__dirname, '/../../bin/codecept.js');
-const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/run-rerun/');
-const codecept_run = `${runner} run-rerun`;
-const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} --grep "${grep || ''}"`;
+const runner = path.join(__dirname, '/../../bin/codecept.js')
+const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/run-rerun/')
+const codecept_run = `${runner} run-rerun`
+const codecept_run_config = (config, grep) => `${codecept_run} --config ${codecept_dir}/${config} --grep "${grep || ''}"`
 
 describe('run-rerun command', () => {
   before(() => {
-    process.chdir(codecept_dir);
-  });
+    process.chdir(codecept_dir)
+  })
 
   it('should display count of attemps', done => {
     exec(`${codecept_run_config('codecept.conf.js')} --debug`, (err, stdout) => {
-      const runs = stdout.split('Run Rerun - Command --');
+      const runs = stdout.split('Run Rerun - Command --')
       // check first run
-      expect(runs[1]).toContain('OK  | 1 passed');
+      expect(runs[1]).toContain('OK  | 1 passed')
       // expect(runs[1]).toContain('✔ OK')
 
       // check second run
-      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('OK  | 1 passed')
       // expect(runs[2]).toContain('✔ OK')
 
       // check third run
-      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('OK  | 1 passed')
       // expect(runs[2]).toContain('✔ OK')
 
-      expect(stdout).toContain('Process run 1 of max 3, success runs 1/3');
-      expect(stdout).toContain('Process run 2 of max 3, success runs 2/3');
-      expect(stdout).toContain('Process run 3 of max 3, success runs 3/3');
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(err).toBeNull();
-      done();
-    });
-  });
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/3')
+      expect(stdout).toContain('Process run 2 of max 3, success runs 2/3')
+      expect(stdout).toContain('Process run 3 of max 3, success runs 3/3')
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(err).toBeNull()
+      done()
+    })
+  })
 
   it('should display 2 success count of attemps', done => {
     exec(`${codecept_run_config('codecept.conf.min_less_max.js')} --debug`, (err, stdout) => {
-      const runs = stdout.split('Run Rerun - Command --');
+      const runs = stdout.split('Run Rerun - Command --')
 
       // check first run
-      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('OK  | 1 passed')
       // expect(runs[2]).toContain('✔ OK')
 
       // check second run
-      expect(runs[2]).toContain('OK  | 1 passed');
+      expect(runs[2]).toContain('OK  | 1 passed')
       // expect(runs[2]).toContain('✔ OK')
 
-      expect(stdout).toContain('Process run 1 of max 3, success runs 1/2');
-      expect(stdout).toContain('Process run 2 of max 3, success runs 2/2');
-      expect(stdout).not.toContain('Process run 3 of max 3');
-      expect(stdout).toContain('OK  | 1 passed');
-      expect(err).toBeNull();
-      done();
-    });
-  });
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/2')
+      expect(stdout).toContain('Process run 2 of max 3, success runs 2/2')
+      expect(stdout).not.toContain('Process run 3 of max 3')
+      expect(stdout).toContain('OK  | 1 passed')
+      expect(err).toBeNull()
+      done()
+    })
+  })
 
   it('should display error if minSuccess more than maxReruns', done => {
     exec(`${codecept_run_config('codecept.conf.min_more_max.js')} --debug`, (err, stdout) => {
-      expect(stdout).toContain('minSuccess must be less than maxReruns');
-      expect(err.code).toBe(1);
-      done();
-    });
-  });
+      expect(stdout).toContain('minSuccess must be less than maxReruns')
+      expect(err.code).toBe(1)
+      done()
+    })
+  })
 
   it('should display errors if test is fail always', done => {
     exec(`${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - Fail all attempt')} --debug`, (err, stdout) => {
-      expect(stdout).toContain('Fail run 1 of max 3, success runs 0/2');
-      expect(stdout).toContain('Fail run 2 of max 3, success runs 0/2');
-      expect(stdout).toContain('Fail run 3 of max 3, success runs 0/2');
-      expect(stdout).toContain('Flaky tests detected!');
-      expect(err.code).toBe(1);
-      done();
-    });
-  });
+      expect(stdout).toContain('Fail run 1 of max 3, success runs 0/2')
+      expect(stdout).toContain('Fail run 2 of max 3, success runs 0/2')
+      expect(stdout).toContain('Fail run 3 of max 3, success runs 0/2')
+      expect(stdout).toContain('Flaky tests detected!')
+      expect(err.code).toBe(1)
+      done()
+    })
+  })
 
   it('should display success run if test was fail one time of two attempts and 3 reruns', done => {
     exec(`FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - fail second test')} --debug`, (err, stdout) => {
-      expect(stdout).toContain('Process run 1 of max 3, success runs 1/2');
-      expect(stdout).toContain('Fail run 2 of max 3, success runs 1/2');
-      expect(stdout).toContain('Process run 3 of max 3, success runs 2/2');
-      expect(stdout).not.toContain('Flaky tests detected!');
-      expect(err).toBeNull();
-      done();
-    });
-  });
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/2')
+      expect(stdout).toContain('Fail run 2 of max 3, success runs 1/2')
+      expect(stdout).toContain('Process run 3 of max 3, success runs 2/2')
+      expect(stdout).not.toContain('Flaky tests detected!')
+      expect(err).toBeNull()
+      done()
+    })
+  })
 
   it('should throw exit code 1 if all tests were supposed to pass', done => {
     exec(`FAIL_ATTEMPT=0  ${codecept_run_config('codecept.conf.pass_all_test.js', '@RunRerun - fail second test')} --debug`, (err, stdout) => {
-      expect(stdout).toContain('Process run 1 of max 3, success runs 1/3');
-      expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3');
-      expect(stdout).toContain('Process run 3 of max 3, success runs 2/3');
-      expect(stdout).toContain('Flaky tests detected!');
-      expect(err.code).toBe(1);
-      done();
-    });
-  });
-});
+      expect(stdout).toContain('Process run 1 of max 3, success runs 1/3')
+      expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3')
+      expect(stdout).toContain('Process run 3 of max 3, success runs 2/3')
+      expect(stdout).toContain('Flaky tests detected!')
+      expect(err.code).toBe(1)
+      done()
+    })
+  })
+})

--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -6,7 +6,7 @@ const semver = require('semver')
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox')
 const codecept_run = `${runner} run-workers --config ${codecept_dir}/codecept.workers.conf.js `
-const codecept_run_glob = (config) => `${runner} run-workers --config ${codecept_dir}/${config} `
+const codecept_run_glob = config => `${runner} run-workers --config ${codecept_dir}/${config} `
 
 describe('CodeceptJS Workers Runner', function () {
   this.timeout(40000)

--- a/test/runner/scenario_stale_test.js
+++ b/test/runner/scenario_stale_test.js
@@ -5,14 +5,14 @@ const { exec } = require('child_process')
 const runner = path.join(__dirname, '/../../bin/codecept.js')
 const codecept_dir = path.join(__dirname, '/../data/sandbox')
 const codecept_run = `${runner} run`
-const config_run_config = (config) => `${codecept_run} --config ${codecept_dir}/${config}`
+const config_run_config = config => `${codecept_run} --config ${codecept_dir}/${config}`
 
 describe('Scenario termination check', () => {
   before(() => {
     process.chdir(codecept_dir)
   })
 
-  it('Should always fail and terminate', (done) => {
+  it('Should always fail and terminate', done => {
     exec(config_run_config('codecept.scenario-stale.js'), (err, stdout) => {
       expect(stdout).toContain('should not stale scenario error') // feature
       expect(err).toBeTruthy()

--- a/test/runner/session_test.js
+++ b/test/runner/session_test.js
@@ -13,7 +13,7 @@ describe('CodeceptJS session', function () {
     global.codecept_dir = path.join(__dirname, '/../data/sandbox')
   })
 
-  it('should run with 3 sessions', (done) => {
+  it('should run with 3 sessions', done => {
     exec(`${codecept_run} --steps --grep "@1"`, (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
@@ -22,24 +22,14 @@ describe('CodeceptJS session', function () {
       testStatus = list.pop()
       testStatus.should.include('OK')
       list.should.eql(
-        [
-          'I do "writing"',
-          'davert: I do "reading"',
-          'I do "playing"',
-          'john: I do "crying"',
-          'davert: I do "smiling"',
-          'I do "laughing"',
-          'mike: I do "spying"',
-          'john: I do "lying"',
-          'I do "waving"',
-        ],
+        ['I do "writing"', 'davert: I do "reading"', 'I do "playing"', 'john: I do "crying"', 'davert: I do "smiling"', 'I do "laughing"', 'mike: I do "spying"', 'john: I do "lying"', 'I do "waving"'],
         'check steps execution order',
       )
       done()
     })
   })
 
-  it('should run session defined before executing', (done) => {
+  it('should run session defined before executing', done => {
     exec(`${codecept_run} --steps --grep "@2"`, (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
@@ -48,23 +38,12 @@ describe('CodeceptJS session', function () {
       testStatus = list.pop()
       testStatus.should.include('OK')
 
-      list.should.eql(
-        [
-          'I do "writing"',
-          'I do "playing"',
-          'john: I do "crying"',
-          'davert: I do "smiling"',
-          'I do "laughing"',
-          'davert: I do "singing"',
-          'I do "waving"',
-        ],
-        'check steps execution order',
-      )
+      list.should.eql(['I do "writing"', 'I do "playing"', 'john: I do "crying"', 'davert: I do "smiling"', 'I do "laughing"', 'davert: I do "singing"', 'I do "waving"'], 'check steps execution order')
       done()
     })
   })
 
-  it('should run all session tests', (done) => {
+  it('should run all session tests', done => {
     exec(`${codecept_run} --steps`, (err, stdout) => {
       const lines = stdout.match(/\S.+/g)
       const testStatus = lines.pop()

--- a/test/runner/skip_test.js
+++ b/test/runner/skip_test.js
@@ -7,7 +7,7 @@ const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/skip')
 const codecept_run = `${runner} run --config ${codecept_dir}/codecept.conf.js `
 
 describe('Skip', () => {
-  it('should skip test with skip', (done) => {
+  it('should skip test with skip', done => {
     exec(`${codecept_run}`, (err, stdout) => {
       stdout.should.include('S @skip')
       stdout.should.include('S @skip with opts')
@@ -18,7 +18,7 @@ describe('Skip', () => {
     })
   })
 
-  it('should correctly pass custom opts for skip test', (done) => {
+  it('should correctly pass custom opts for skip test', done => {
     exec(`${codecept_run}`, (err, stdout) => {
       stdout.should.include('test @skip with opts was marked for skip with customOpts: "Custom options for skip"')
       assert(!err)

--- a/test/runner/step_timeout_test.js
+++ b/test/runner/step_timeout_test.js
@@ -4,13 +4,12 @@ const { codecept_dir, codecept_run } = require('./consts')
 
 const debug_this_test = false
 
-const config_run_config = (config, grep, verbose = false) =>
-  `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/step_timeout/${config} ${grep ? `--grep "${grep}"` : ''}`
+const config_run_config = (config, grep, verbose = false) => `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/step_timeout/${config} ${grep ? `--grep "${grep}"` : ''}`
 
 describe('CodeceptJS Steps', function () {
   this.timeout(5000)
 
-  it('should stop test, when step timeout exceeded', (done) => {
+  it('should stop test, when step timeout exceeded', done => {
     exec(config_run_config('codecept-1000.conf.js', 'Default command timeout'), (err, stdout) => {
       expect(stdout).toContain('Action exceededByTimeout: 1500 was interrupted on step timeout 1000ms')
       expect(stdout).toContain('0 passed, 1 failed')
@@ -20,7 +19,7 @@ describe('CodeceptJS Steps', function () {
     })
   })
 
-  it('should respect custom timeout with regex', (done) => {
+  it('should respect custom timeout with regex', done => {
     exec(config_run_config('codecept-1000.conf.js', 'Wait with longer timeout', debug_this_test), (err, stdout) => {
       expect(stdout).not.toContain('was interrupted on step timeout')
       expect(stdout).toContain('1 passed')
@@ -29,7 +28,7 @@ describe('CodeceptJS Steps', function () {
     })
   })
 
-  it('should respect custom timeout with full step name', (done) => {
+  it('should respect custom timeout with full step name', done => {
     exec(config_run_config('codecept-1000.conf.js', 'Wait with shorter timeout', debug_this_test), (err, stdout) => {
       expect(stdout).toContain('Action waitTadShorter: 750 was interrupted on step timeout 500ms')
       expect(stdout).toContain('0 passed, 1 failed')
@@ -38,7 +37,7 @@ describe('CodeceptJS Steps', function () {
     })
   })
 
-  it('should not stop test, when step not exceeded', (done) => {
+  it('should not stop test, when step not exceeded', done => {
     exec(config_run_config('codecept-2000.conf.js', 'Default command timeout'), (err, stdout) => {
       expect(stdout).not.toContain('was interrupted on step timeout')
       expect(stdout).toContain('1 passed')
@@ -47,7 +46,7 @@ describe('CodeceptJS Steps', function () {
     })
   })
 
-  it('should ignore timeout for steps with `wait*` prefix', (done) => {
+  it('should ignore timeout for steps with `wait*` prefix', done => {
     exec(config_run_config('codecept-1000.conf.js', 'Wait command timeout'), (err, stdout) => {
       expect(stdout).not.toContain('was interrupted on step timeout')
       expect(stdout).toContain('1 passed')
@@ -56,7 +55,7 @@ describe('CodeceptJS Steps', function () {
     })
   })
 
-  it('step timeout should work nicely with step retries', (done) => {
+  it('step timeout should work nicely with step retries', done => {
     exec(config_run_config('codecept-1000.conf.js', 'Rerun sleep'), (err, stdout) => {
       expect(stdout).not.toContain('was interrupted on step timeout')
       expect(stdout).toContain('1 passed')

--- a/test/runner/timeout_test.js
+++ b/test/runner/timeout_test.js
@@ -4,13 +4,12 @@ const { codecept_dir, codecept_run } = require('./consts')
 
 const debug_this_test = false
 
-const config_run_config = (config, grep, verbose = false) =>
-  `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/timeouts/${config} ${grep ? `--grep "${grep}"` : ''}`
+const config_run_config = (config, grep, verbose = false) => `${codecept_run} ${verbose || debug_this_test ? '--verbose' : ''} --config ${codecept_dir}/configs/timeouts/${config} ${grep ? `--grep "${grep}"` : ''}`
 
 describe('CodeceptJS Timeouts', function () {
   this.timeout(10000)
 
-  it('should stop test when timeout exceeded', (done) => {
+  it('should stop test when timeout exceeded', done => {
     exec(config_run_config('codecept.conf.js', 'timed out'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('Timeout 2s exceeded')
@@ -20,7 +19,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should take --no-timeouts option', (done) => {
+  it('should take --no-timeouts option', done => {
     exec(`${config_run_config('codecept.conf.js', 'timed out')} --no-timeouts`, (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('Timeouts were disabled')
@@ -31,7 +30,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should ignore timeouts if no timeout', (done) => {
+  it('should ignore timeouts if no timeout', done => {
     exec(config_run_config('codecept.conf.js', 'no timeout test'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).not.toContain('Timeout')
@@ -40,7 +39,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should use global timeouts if timeout is set', (done) => {
+  it('should use global timeouts if timeout is set', done => {
     exec(config_run_config('codecept.timeout.conf.js', 'no timeout test'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('Timeout 0.1')
@@ -49,7 +48,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should prefer step timeout', (done) => {
+  it('should prefer step timeout', done => {
     exec(config_run_config('codecept.conf.js', 'timeout step', true), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('was interrupted on step timeout 100ms')
@@ -58,7 +57,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should keep timeout with steps', (done) => {
+  it('should keep timeout with steps', done => {
     exec(config_run_config('codecept.timeout.conf.js', 'timeout step', true), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('was interrupted on step timeout 100ms')
@@ -67,7 +66,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should override timeout config from global object', (done) => {
+  it('should override timeout config from global object', done => {
     exec(config_run_config('codecept.timeout.obj.conf.js', '#first', false), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).toContain('Timeout 0.3s exceeded')
@@ -76,7 +75,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should override timeout config from global object but respect local value', (done) => {
+  it('should override timeout config from global object but respect local value', done => {
     exec(config_run_config('codecept.timeout.obj.conf.js', '#second'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).not.toContain('Timeout 0.3s exceeded')
@@ -86,7 +85,7 @@ describe('CodeceptJS Timeouts', function () {
     })
   })
 
-  it('should respect grep when overriding config from global config', (done) => {
+  it('should respect grep when overriding config from global config', done => {
     exec(config_run_config('codecept.timeout.obj.conf.js', '#fourth'), (err, stdout) => {
       debug_this_test && console.log(stdout)
       expect(stdout).not.toContain('Timeout 0.3s exceeded')

--- a/test/runner/todo_test.js
+++ b/test/runner/todo_test.js
@@ -7,7 +7,7 @@ const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/todo')
 const codecept_run = `${runner} run --config ${codecept_dir}/codecept.conf.js `
 
 describe('Todo', () => {
-  it('should skip test with todo', (done) => {
+  it('should skip test with todo', done => {
     exec(`${codecept_run}`, (err, stdout) => {
       stdout.should.include('S @todo')
       stdout.should.include('S @todo without function')
@@ -18,7 +18,7 @@ describe('Todo', () => {
     })
   })
 
-  it('should skip inject skipinfo to todo test', (done) => {
+  it('should skip inject skipinfo to todo test', done => {
     exec(`${codecept_run}`, (err, stdout) => {
       stdout.should.include('test @todo was marked for todo with message: Test not implemented!')
       stdout.should.include('test @todo without function was marked for todo with message: Test not implemented!')
@@ -28,7 +28,7 @@ describe('Todo', () => {
     })
   })
 
-  it('should correctly pass custom opts for todo test', (done) => {
+  it('should correctly pass custom opts for todo test', done => {
     exec(`${codecept_run}`, (err, stdout) => {
       stdout.should.include('test @todo with opts was marked for todo with customOpts: "Custom options for todo"')
       assert(!err)

--- a/test/runner/translation_test.js
+++ b/test/runner/translation_test.js
@@ -7,8 +7,8 @@ const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/translation'
 const codecept_run = `${runner} run --config ${codecept_dir}/codecept.conf.js `
 
 describe('Translation', () => {
-  it('Should run translated test file', (done) => {
-    exec(`${codecept_run}`, (err) => {
+  it('Should run translated test file', done => {
+    exec(`${codecept_run}`, err => {
       assert(!err)
       done()
     })

--- a/test/runner/within_test.js
+++ b/test/runner/within_test.js
@@ -15,42 +15,26 @@ describe('CodeceptJS within', function () {
     global.codecept_dir = path.join(__dirname, '/../data/sandbox')
   })
 
-  it('should execute if no generators', (done) => {
+  it('should execute if no generators', done => {
     exec(`${codecept_run} --debug`, (_err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
-      const withoutGeneratorList = grepLines(
-        lines,
-        'Check within without generator',
-        'Check within with generator. Yield is first in order',
-      )
+      const withoutGeneratorList = grepLines(lines, 'Check within without generator', 'Check within with generator. Yield is first in order')
       testStatus = withoutGeneratorList.pop()
       testStatus.should.include('OK')
       withoutGeneratorList.should.eql(
-        [
-          'I small promise ',
-          'I small promise was finished ',
-          'I hey! i am within begin. i get blabla ',
-          'Within "blabla" ""',
-          'I small promise ',
-          'I small promise was finished ',
-          'I oh! i am within end( ',
-        ],
+        ['I small promise ', 'I small promise was finished ', 'I hey! i am within begin. i get blabla ', 'Within "blabla" ""', 'I small promise ', 'I small promise was finished ', 'I oh! i am within end( '],
         'check steps execution order',
       )
       done()
     })
   })
 
-  it('should execute with async/await. Await is first in order', (done) => {
+  it('should execute with async/await. Await is first in order', done => {
     exec(`${codecept_run} --debug`, (_err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
-      const withGeneratorList = grepLines(
-        lines,
-        'Check within with async/await. Await is first in order',
-        'Check within with async/await. Await is second in order',
-      )
+      const withGeneratorList = grepLines(lines, 'Check within with async/await. Await is first in order', 'Check within with async/await. Await is second in order')
       testStatus = withGeneratorList.pop()
       testStatus.should.include('OK')
       withGeneratorList.should.eql(
@@ -74,15 +58,11 @@ describe('CodeceptJS within', function () {
     })
   })
 
-  it('should execute with async/await. Await is second in order', (done) => {
+  it('should execute with async/await. Await is second in order', done => {
     exec(`${codecept_run} --debug`, (_err, stdout) => {
       const lines = stdout.match(/\S.+/g)
 
-      const withGeneratorList = grepLines(
-        lines,
-        'Check within with async/await. Await is second in order',
-        '-- FAILURES:',
-      )
+      const withGeneratorList = grepLines(lines, 'Check within with async/await. Await is second in order', '-- FAILURES:')
       testStatus = withGeneratorList.pop()
       testStatus.should.include('OK')
       withGeneratorList.should.eql(

--- a/test/support/setup.js
+++ b/test/support/setup.js
@@ -1,3 +1,3 @@
-import('chai').then((chai) => {
+import('chai').then(chai => {
   chai.should()
 })

--- a/test/unit/actor_test.js
+++ b/test/unit/actor_test.js
@@ -1,32 +1,32 @@
-const path = require('path');
-const { expect } = require('expect');
+const path = require('path')
+const { expect } = require('expect')
 
-const actor = require('../../lib/actor');
-const container = require('../../lib/container');
-const recorder = require('../../lib/recorder');
-const event = require('../../lib/event');
-const store = require('../../lib/store');
+const actor = require('../../lib/actor')
+const container = require('../../lib/container')
+const recorder = require('../../lib/recorder')
+const event = require('../../lib/event')
+const store = require('../../lib/store')
 
-global.codecept_dir = path.join(__dirname, '/..');
-let I;
-let counter;
+global.codecept_dir = path.join(__dirname, '/..')
+let I
+let counter
 
 describe('Actor', () => {
   beforeEach(async () => {
-    counter = 0;
+    counter = 0
     container.clear(
       {
         MyHelper: {
           hello: () => 'hello world',
           bye: () => 'bye world',
           die: () => {
-            throw new Error('ups');
+            throw new Error('ups')
           },
           _hidden: () => 'hidden',
           failAfter: (i = 1) => {
-            counter++;
-            if (counter <= i) throw new Error('ups');
-            counter = 0;
+            counter++
+            if (counter <= i) throw new Error('ups')
+            counter = 0
           },
         },
         MyHelper2: {
@@ -35,135 +35,135 @@ describe('Actor', () => {
       },
       undefined,
       undefined,
-    );
-    store.actor = null;
-    container.translation().vocabulary.actions.hello = 'привет';
-    I = actor();
-    await container.started();
-    event.cleanDispatcher();
-  });
+    )
+    store.actor = null
+    container.translation().vocabulary.actions.hello = 'привет'
+    I = actor()
+    await container.started()
+    event.cleanDispatcher()
+  })
 
   it('should collect pageobject methods in actor', async () => {
     const poI = actor({
       customStep: () => {},
-    });
-    expect(poI).toHaveProperty('customStep');
-    expect(I).toHaveProperty('customStep');
-  });
+    })
+    expect(poI).toHaveProperty('customStep')
+    expect(I).toHaveProperty('customStep')
+  })
 
   it('should correct run step from Helper inside PageObject', () => {
     actor({
       customStep() {
-        return this.hello();
+        return this.hello()
       },
-    });
-    recorder.start();
-    const promise = I.customStep();
-    return promise.then(val => expect(val).toEqual('hello world'));
-  });
+    })
+    recorder.start()
+    const promise = I.customStep()
+    return promise.then(val => expect(val).toEqual('hello world'))
+  })
 
   it('should init pageobject methods as metastep', () => {
     actor({
       customStep: () => 3,
-    });
-    expect(I.customStep()).toEqual(3);
-  });
+    })
+    expect(I.customStep()).toEqual(3)
+  })
 
   it('should correct add translation for step from Helper', () => {
-    expect(I).toHaveProperty('привет');
-  });
+    expect(I).toHaveProperty('привет')
+  })
 
   it('should correct add translation for step from PageObject', async () => {
-    container.translation().vocabulary.actions.customStep = 'кастомный_шаг';
+    container.translation().vocabulary.actions.customStep = 'кастомный_шаг'
     actor({
       customStep: () => 3,
-    });
-    await container.started();
-    expect(I).toHaveProperty('кастомный_шаг');
-  });
+    })
+    await container.started()
+    expect(I).toHaveProperty('кастомный_шаг')
+  })
 
   it('should take all methods from helpers and built in', () => {
-    ['hello', 'bye', 'die', 'failAfter', 'say', 'retry', 'greeting'].forEach(key => {
-      expect(I).toHaveProperty(key);
-    });
-  });
+    ;['hello', 'bye', 'die', 'failAfter', 'say', 'retry', 'greeting'].forEach(key => {
+      expect(I).toHaveProperty(key)
+    })
+  })
 
   it('should return promise', () => {
-    recorder.start();
-    const promise = I.hello();
-    expect(promise).toBeInstanceOf(Promise);
-    return promise.then(val => expect(val).toEqual('hello world'));
-  });
+    recorder.start()
+    const promise = I.hello()
+    expect(promise).toBeInstanceOf(Promise)
+    return promise.then(val => expect(val).toEqual('hello world'))
+  })
 
   it('should produce step events', () => {
-    recorder.start();
-    let listeners = 0;
-    event.dispatcher.addListener(event.step.before, () => listeners++);
-    event.dispatcher.addListener(event.step.after, () => listeners++);
+    recorder.start()
+    let listeners = 0
+    event.dispatcher.addListener(event.step.before, () => listeners++)
+    event.dispatcher.addListener(event.step.after, () => listeners++)
     event.dispatcher.addListener(event.step.passed, step => {
-      listeners++;
-      expect(step.endTime).toBeTruthy();
-      expect(step.startTime).toBeTruthy();
-    });
+      listeners++
+      expect(step.endTime).toBeTruthy()
+      expect(step.startTime).toBeTruthy()
+    })
 
     return I.hello().then(() => {
-      expect(listeners).toEqual(3);
-    });
-  });
+      expect(listeners).toEqual(3)
+    })
+  })
 
   it('should retry failed step with #retry', () => {
-    recorder.start();
-    return I.retry({ retries: 2, minTimeout: 0 }).failAfter(1);
-  });
+    recorder.start()
+    return I.retry({ retries: 2, minTimeout: 0 }).failAfter(1)
+  })
 
   it('should retry once step with #retry', () => {
-    recorder.start();
-    return I.retry().failAfter(1);
-  });
+    recorder.start()
+    return I.retry().failAfter(1)
+  })
 
   it('should alway use the latest global retry options', () => {
-    recorder.start();
+    recorder.start()
     recorder.retry({
       retries: 0,
       minTimeout: 0,
       when: () => true,
-    });
+    })
     recorder.retry({
       retries: 1,
       minTimeout: 0,
       when: () => true,
-    });
-    I.hello(); // before fix: this changed the order of retries
-    return I.failAfter(1);
-  });
+    })
+    I.hello() // before fix: this changed the order of retries
+    return I.failAfter(1)
+  })
 
   it('should not delete a global retry option', () => {
-    recorder.start();
+    recorder.start()
     recorder.retry({
       retries: 2,
       minTimeout: 0,
       when: () => true,
-    });
-    I.retry(1).failAfter(1); // before fix: this changed the order of retries
-    return I.failAfter(2);
-  });
+    })
+    I.retry(1).failAfter(1) // before fix: this changed the order of retries
+    return I.failAfter(2)
+  })
 
   it('should print handle failed steps', () => {
-    recorder.start();
-    let listeners = 0;
-    event.dispatcher.addListener(event.step.before, () => listeners++);
-    event.dispatcher.addListener(event.step.after, () => listeners++);
+    recorder.start()
+    let listeners = 0
+    event.dispatcher.addListener(event.step.before, () => listeners++)
+    event.dispatcher.addListener(event.step.after, () => listeners++)
     event.dispatcher.addListener(event.step.failed, step => {
-      listeners++;
-      expect(step.endTime).toBeTruthy();
-      expect(step.startTime).toBeTruthy();
-    });
+      listeners++
+      expect(step.endTime).toBeTruthy()
+      expect(step.startTime).toBeTruthy()
+    })
 
     return I.die()
       .then(() => (listeners = 0))
       .catch(() => null)
       .then(() => {
-        expect(listeners).toEqual(3);
-      });
-  });
-});
+        expect(listeners).toEqual(3)
+      })
+  })
+})

--- a/test/unit/ai_test.js
+++ b/test/unit/ai_test.js
@@ -2,7 +2,7 @@ const AiAssistant = require('../../lib/ai')
 const config = require('../../lib/config')
 
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 

--- a/test/unit/assert_test.js
+++ b/test/unit/assert_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -1,25 +1,25 @@
-const Gherkin = require('@cucumber/gherkin');
-const Messages = require('@cucumber/messages');
+const Gherkin = require('@cucumber/gherkin')
+const Messages = require('@cucumber/messages')
 
-const chai = require('chai');
+const chai = require('chai')
 
-const expect = chai.expect;
+const expect = chai.expect
 
-const uuidFn = Messages.IdGenerator.uuid();
-const builder = new Gherkin.AstBuilder(uuidFn);
-const matcher = new Gherkin.GherkinClassicTokenMatcher();
+const uuidFn = Messages.IdGenerator.uuid()
+const builder = new Gherkin.AstBuilder(uuidFn)
+const matcher = new Gherkin.GherkinClassicTokenMatcher()
 
-const Config = require('../../lib/config');
-const { Given, When, And, Then, matchStep, clearSteps, defineParameterType } = require('../../lib/interfaces/bdd');
-const run = require('../../lib/interfaces/gherkin');
-const recorder = require('../../lib/recorder');
-const container = require('../../lib/container');
-const actor = require('../../lib/actor');
-const event = require('../../lib/event');
+const Config = require('../../lib/config')
+const { Given, When, And, Then, matchStep, clearSteps, defineParameterType } = require('../../lib/interfaces/bdd')
+const run = require('../../lib/interfaces/gherkin')
+const recorder = require('../../lib/recorder')
+const container = require('../../lib/container')
+const actor = require('../../lib/actor')
+const event = require('../../lib/event')
 
 class Color {
   constructor(name) {
-    this.name = name;
+    this.name = name
   }
 }
 
@@ -34,186 +34,186 @@ const text = `
     Given I have product with 600 price
     And I have product with 1000 price
     When I go to checkout process
-`;
+`
 
 const checkTestForErrors = test => {
   return new Promise((resolve, reject) => {
     test.fn(err => {
       if (err) {
-        return reject(err);
+        return reject(err)
       }
-      resolve();
-    });
-  });
-};
+      resolve()
+    })
+  })
+}
 
 describe('BDD', () => {
   beforeEach(() => {
-    clearSteps();
-    recorder.start();
-    container.create({});
-    Config.reset();
-  });
+    clearSteps()
+    recorder.start()
+    container.create({})
+    Config.reset()
+  })
 
   afterEach(() => {
-    container.clear();
-    recorder.stop();
-  });
+    container.clear()
+    recorder.stop()
+  })
 
   it('should parse gherkin input', () => {
-    const parser = new Gherkin.Parser(builder, matcher);
-    parser.stopAtFirstError = false;
-    const ast = parser.parse(text);
+    const parser = new Gherkin.Parser(builder, matcher)
+    parser.stopAtFirstError = false
+    const ast = parser.parse(text)
     // console.log('Feature', ast.feature);
     // console.log('Scenario', ast.feature.children);
     // console.log('Steps', ast.feature.children[0].steps[0]);
-    expect(ast.feature).is.ok;
-    expect(ast.feature.children).is.ok;
-    expect(ast.feature.children[0].scenario.steps).is.ok;
-  });
+    expect(ast.feature).is.ok
+    expect(ast.feature.children).is.ok
+    expect(ast.feature.children[0].scenario.steps).is.ok
+  })
 
   it('should load step definitions', () => {
-    Given('I am a bird', () => 1);
-    When('I fly over ocean', () => 2);
-    And(/^I fly over land$/i, () => 3);
-    Then(/I see (.*?)/, () => 4);
-    expect(1).is.equal(matchStep('I am a bird')());
-    expect(3).is.equal(matchStep('I Fly oVer Land')());
-    expect(4).is.equal(matchStep('I see ocean')());
-    expect(4).is.equal(matchStep('I see world')());
-  });
+    Given('I am a bird', () => 1)
+    When('I fly over ocean', () => 2)
+    And(/^I fly over land$/i, () => 3)
+    Then(/I see (.*?)/, () => 4)
+    expect(1).is.equal(matchStep('I am a bird')())
+    expect(3).is.equal(matchStep('I Fly oVer Land')())
+    expect(4).is.equal(matchStep('I see ocean')())
+    expect(4).is.equal(matchStep('I see world')())
+  })
 
   it('should fail on duplicate step definitions with option', () => {
     Config.append({
       gherkin: {
         avoidDuplicateSteps: true,
       },
-    });
+    })
 
-    let error = null;
+    let error = null
     try {
-      Given('I am a bird', () => 1);
-      Then('I am a bird', () => 1);
+      Given('I am a bird', () => 1)
+      Then('I am a bird', () => 1)
     } catch (err) {
-      error = err;
+      error = err
     } finally {
-      expect(!!error).is.true;
+      expect(!!error).is.true
     }
-  });
+  })
 
   it('should contain tags', async () => {
-    let sum = 0;
-    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)));
-    When('I go to checkout process', () => (sum += 10));
-    const suite = await run(text);
-    suite.tests[0].fn(() => {});
-    expect(suite.tests[0].tags).is.ok;
-    expect('@super').is.equal(suite.tests[0].tags[0]);
-  });
+    let sum = 0
+    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)))
+    When('I go to checkout process', () => (sum += 10))
+    const suite = await run(text)
+    suite.tests[0].fn(() => {})
+    expect(suite.tests[0].tags).is.ok
+    expect('@super').is.equal(suite.tests[0].tags[0])
+  })
 
   it('should load step definitions', done => {
-    let sum = 0;
-    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)));
-    When('I go to checkout process', () => (sum += 10));
-    const suite = run(text);
-    expect('checkout process').is.equal(suite.title);
+    let sum = 0
+    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)))
+    When('I go to checkout process', () => (sum += 10))
+    const suite = run(text)
+    expect('checkout process').is.equal(suite.title)
     suite.tests[0].fn(() => {
-      expect(suite.tests[0].steps).is.ok;
-      expect(1610).is.equal(sum);
-      done();
-    });
-  });
+      expect(suite.tests[0].steps).is.ok
+      expect(1610).is.equal(sum)
+      done()
+    })
+  })
 
   it('should allow failed steps', async () => {
-    let sum = 0;
-    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)));
-    When('I go to checkout process', () => expect(false).is.true);
-    const suite = run(text);
-    expect('checkout process').is.equal(suite.title);
+    let sum = 0
+    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)))
+    When('I go to checkout process', () => expect(false).is.true)
+    const suite = run(text)
+    expect('checkout process').is.equal(suite.title)
     try {
-      await checkTestForErrors(suite.tests[0]);
-      return Promise.reject(new Error('Test should have thrown with failed step, but did not'));
+      await checkTestForErrors(suite.tests[0])
+      return Promise.reject(new Error('Test should have thrown with failed step, but did not'))
     } catch (err) {
-      const errored = !!err;
-      expect(errored).is.true;
+      const errored = !!err
+      expect(errored).is.true
     }
-  });
+  })
 
   it('handles errors in steps', async () => {
-    let sum = 0;
-    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)));
+    let sum = 0
+    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)))
     When('I go to checkout process', () => {
-      throw new Error('errored step');
-    });
-    const suite = run(text);
-    expect('checkout process').is.equal(suite.title);
+      throw new Error('errored step')
+    })
+    const suite = run(text)
+    expect('checkout process').is.equal(suite.title)
     try {
-      await checkTestForErrors(suite.tests[0]);
-      return Promise.reject(new Error('Test should have thrown with error, but did not'));
+      await checkTestForErrors(suite.tests[0])
+      return Promise.reject(new Error('Test should have thrown with error, but did not'))
     } catch (err) {
-      const errored = !!err;
-      expect(errored).is.true;
+      const errored = !!err
+      expect(errored).is.true
     }
-  });
+  })
 
   it('handles async errors in steps', async () => {
-    let sum = 0;
-    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)));
-    When('I go to checkout process', () => Promise.reject(new Error('step failed')));
-    const suite = run(text);
-    expect('checkout process').is.equal(suite.title);
+    let sum = 0
+    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)))
+    When('I go to checkout process', () => Promise.reject(new Error('step failed')))
+    const suite = run(text)
+    expect('checkout process').is.equal(suite.title)
     try {
-      await checkTestForErrors(suite.tests[0]);
-      return Promise.reject(new Error('Test should have thrown with error, but did not'));
+      await checkTestForErrors(suite.tests[0])
+      return Promise.reject(new Error('Test should have thrown with error, but did not'))
     } catch (err) {
-      const errored = !!err;
-      expect(errored).is.true;
+      const errored = !!err
+      expect(errored).is.true
     }
-  });
+  })
 
   it('should work with async functions', done => {
-    let sum = 0;
-    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)));
+    let sum = 0
+    Given(/I have product with (\d+) price/, param => (sum += parseInt(param, 10)))
     When('I go to checkout process', async () => {
       return new Promise(checkoutDone => {
-        sum += 10;
-        setTimeout(checkoutDone, 0);
-      });
-    });
-    const suite = run(text);
-    expect('checkout process').is.equal(suite.title);
+        sum += 10
+        setTimeout(checkoutDone, 0)
+      })
+    })
+    const suite = run(text)
+    expect('checkout process').is.equal(suite.title)
     suite.tests[0].fn(() => {
-      expect(suite.tests[0].steps).is.ok;
-      expect(1610).is.equal(sum);
-      done();
-    });
-  });
+      expect(suite.tests[0].steps).is.ok
+      expect(1610).is.equal(sum)
+      done()
+    })
+  })
 
   it('should execute scenarios step-by-step ', async () => {
-    recorder.start();
-    printed = [];
+    recorder.start()
+    printed = []
     container.append({
       helpers: {
         simple: {
           do(...args) {
-            return Promise.resolve().then(() => printed.push(args.join(' ')));
+            return Promise.resolve().then(() => printed.push(args.join(' ')))
           },
         },
       },
-    });
-    I = actor();
-    let sum = 0;
+    })
+    I = actor()
+    let sum = 0
     Given(/I have product with (\d+) price/, price => {
-      I.do('add', (sum += parseInt(price, 10)));
-    });
+      I.do('add', (sum += parseInt(price, 10)))
+    })
     When('I go to checkout process', () => {
-      I.do('add finish checkout');
-    });
-    const suite = run(text);
+      I.do('add finish checkout')
+    })
+    const suite = run(text)
     suite.tests[0].fn(() => {
       recorder.promise().then(() => {
-        printed.should.include.members(['add 600', 'add 1600', 'add finish checkout']);
-        const lines = recorder.scheduled().split('\n');
+        printed.should.include.members(['add 600', 'add 1600', 'add finish checkout'])
+        const lines = recorder.scheduled().split('\n')
         lines.should.include.members([
           'do: "add", 600',
           'step passed',
@@ -226,17 +226,17 @@ describe('BDD', () => {
           'return result',
           'fire test.passed',
           'finish test',
-        ]);
-        done();
-      });
-    });
-  });
+        ])
+        done()
+      })
+    })
+  })
 
   it('should match step with params', () => {
-    Given('I am a {word}', param => param);
-    const fn = matchStep('I am a bird');
-    expect('bird').is.equal(fn.params[0]);
-  });
+    Given('I am a {word}', param => param)
+    const fn = matchStep('I am a bird')
+    expect('bird').is.equal(fn.params[0])
+  })
 
   it('should produce step events', done => {
     const text = `
@@ -244,34 +244,34 @@ describe('BDD', () => {
 
       Scenario:
         Then I emit step events
-    `;
-    Then('I emit step events', () => {});
-    let listeners = 0;
-    event.dispatcher.addListener(event.bddStep.before, () => listeners++);
-    event.dispatcher.addListener(event.bddStep.after, () => listeners++);
+    `
+    Then('I emit step events', () => {})
+    let listeners = 0
+    event.dispatcher.addListener(event.bddStep.before, () => listeners++)
+    event.dispatcher.addListener(event.bddStep.after, () => listeners++)
 
-    const suite = run(text);
+    const suite = run(text)
     suite.tests[0].fn(() => {
-      listeners.should.eql(2);
-      done();
-    });
-  });
+      listeners.should.eql(2)
+      done()
+    })
+  })
 
   it('should use shortened form for step definitions', () => {
-    let fn;
-    Given('I am a {word}', params => params[0]);
-    When('I have {int} wings and {int} eyes', params => params[0] + params[1]);
-    Given('I have ${int} in my pocket', params => params[0]); // eslint-disable-line no-template-curly-in-string
-    Given('I have also ${float} in my pocket', params => params[0]); // eslint-disable-line no-template-curly-in-string
-    fn = matchStep('I am a bird');
-    expect('bird').is.equal(fn(fn.params));
-    fn = matchStep('I have 2 wings and 2 eyes');
-    expect(4).is.equal(fn(fn.params));
-    fn = matchStep('I have $500 in my pocket');
-    expect(500).is.equal(fn(fn.params));
-    fn = matchStep('I have also $500.30 in my pocket');
-    expect(500.3).is.equal(fn(fn.params));
-  });
+    let fn
+    Given('I am a {word}', params => params[0])
+    When('I have {int} wings and {int} eyes', params => params[0] + params[1])
+    Given('I have ${int} in my pocket', params => params[0]) // eslint-disable-line no-template-curly-in-string
+    Given('I have also ${float} in my pocket', params => params[0]) // eslint-disable-line no-template-curly-in-string
+    fn = matchStep('I am a bird')
+    expect('bird').is.equal(fn(fn.params))
+    fn = matchStep('I have 2 wings and 2 eyes')
+    expect(4).is.equal(fn(fn.params))
+    fn = matchStep('I have $500 in my pocket')
+    expect(500).is.equal(fn(fn.params))
+    fn = matchStep('I have also $500.30 in my pocket')
+    expect(500.3).is.equal(fn(fn.params))
+  })
 
   it('should attach before hook for Background', finish => {
     const text = `
@@ -282,22 +282,22 @@ describe('BDD', () => {
 
       Scenario:
         Then I am shopping
-    `;
-    let sum = 0;
+    `
+    let sum = 0
     function incrementSum() {
-      sum++;
+      sum++
     }
-    Given('I am logged in as customer', incrementSum);
-    Then('I am shopping', incrementSum);
-    const suite = run(text);
-    const done = () => {};
+    Given('I am logged in as customer', incrementSum)
+    Then('I am shopping', incrementSum)
+    const suite = run(text)
+    const done = () => {}
 
-    suite._beforeEach.forEach(hook => hook.run(done));
+    suite._beforeEach.forEach(hook => hook.run(done))
     suite.tests[0].fn(() => {
-      expect(sum).is.equal(2);
-      finish();
-    });
-  });
+      expect(sum).is.equal(2)
+      finish()
+    })
+  })
 
   it('should execute scenario outlines', done => {
     const text = `
@@ -319,37 +319,37 @@ describe('BDD', () => {
       Examples:
         | price | total |
         | 20    | 18    |
-    `;
-    let cart = 0;
-    let sum = 0;
+    `
+    let cart = 0
+    let sum = 0
     Given('I have product with price {int}$ in my cart', price => {
-      cart = price;
-    });
+      cart = price
+    })
     Given('discount is {int} %', discount => {
-      cart -= (cart * discount) / 100;
-    });
+      cart -= (cart * discount) / 100
+    })
     Then('I should see price is {string} $', total => {
-      sum = parseInt(total, 10);
-    });
+      sum = parseInt(total, 10)
+    })
 
-    const suite = run(text);
+    const suite = run(text)
 
-    expect(suite.tests[0].tags).is.ok;
-    expect(['@awesome', '@cool', '@super']).is.deep.equal(suite.tests[0].tags);
-    expect(['@awesome', '@cool', '@super', '@exampleTag1', '@exampleTag2']).is.deep.equal(suite.tests[1].tags);
+    expect(suite.tests[0].tags).is.ok
+    expect(['@awesome', '@cool', '@super']).is.deep.equal(suite.tests[0].tags)
+    expect(['@awesome', '@cool', '@super', '@exampleTag1', '@exampleTag2']).is.deep.equal(suite.tests[1].tags)
 
-    expect(2).is.equal(suite.tests.length);
+    expect(2).is.equal(suite.tests.length)
     suite.tests[0].fn(() => {
-      expect(9).is.equal(cart);
-      expect(9).is.equal(sum);
+      expect(9).is.equal(cart)
+      expect(9).is.equal(sum)
 
       suite.tests[1].fn(() => {
-        expect(18).is.equal(cart);
-        expect(18).is.equal(sum);
-        done();
-      });
-    });
-  });
+        expect(18).is.equal(cart)
+        expect(18).is.equal(sum)
+        done()
+      })
+    })
+  })
 
   it('should provide a parsed DataTable', done => {
     const text = `
@@ -366,59 +366,59 @@ describe('BDD', () => {
         | label   | price  |
         | beer    | 9      |
         | cookies | 12     |
-    `;
+    `
 
-    let givenParsedRows;
-    let thenParsedRows;
+    let givenParsedRows
+    let thenParsedRows
 
     Given('I have the following products :', products => {
-      expect(products.rows.length).to.equal(3);
-      givenParsedRows = products.parse();
-    });
+      expect(products.rows.length).to.equal(3)
+      givenParsedRows = products.parse()
+    })
     Then('I should see the following products :', products => {
-      expect(products.rows.length).to.equal(3);
-      thenParsedRows = products.parse();
-    });
+      expect(products.rows.length).to.equal(3)
+      thenParsedRows = products.parse()
+    })
 
-    const suite = run(text);
+    const suite = run(text)
 
     const expectedParsedDataTable = [
       ['label', 'price'],
       ['beer', '9'],
       ['cookies', '12'],
-    ];
+    ]
 
     suite.tests[0].fn(() => {
-      expect(givenParsedRows.rawData).is.deep.equal(expectedParsedDataTable);
-      expect(thenParsedRows.rawData).is.deep.equal(expectedParsedDataTable);
-      done();
-    });
-  });
+      expect(givenParsedRows.rawData).is.deep.equal(expectedParsedDataTable)
+      expect(thenParsedRows.rawData).is.deep.equal(expectedParsedDataTable)
+      done()
+    })
+  })
 
   it('should match step with custom parameter type', done => {
     const colorType = {
       name: 'color',
       regexp: /red|blue|yellow/,
       transformer: s => new Color(s),
-    };
-    defineParameterType(colorType);
-    Given('I have a {color} label', color => color);
-    const fn = matchStep('I have a red label');
-    expect('red').is.equal(fn.params[0].name);
-    done();
-  });
+    }
+    defineParameterType(colorType)
+    Given('I have a {color} label', color => color)
+    const fn = matchStep('I have a red label')
+    expect('red').is.equal(fn.params[0].name)
+    done()
+  })
 
   it('should match step with async custom parameter type transformation', async () => {
     const colorType = {
       name: 'async_color',
       regexp: /red|blue|yellow/,
       transformer: async s => new Color(s),
-    };
-    defineParameterType(colorType);
-    Given('I have a {async_color} label', color => color);
-    const fn = matchStep('I have a blue label');
-    const color = await fn.params[0];
-    expect('blue').is.equal(color.name);
-    await Promise.resolve();
-  });
-});
+    }
+    defineParameterType(colorType)
+    Given('I have a {async_color} label', color => color)
+    const fn = matchStep('I have a blue label')
+    const color = await fn.params[0]
+    expect('blue').is.equal(color.name)
+    await Promise.resolve()
+  })
+})

--- a/test/unit/config_test.js
+++ b/test/unit/config_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 
@@ -21,7 +21,7 @@ describe('Config', () => {
   })
 
   it('should be completely reset', () => {
-    config.addHook((cfg) => {
+    config.addHook(cfg => {
       cfg.helpers.Puppeteer.show = true
     })
     config.create({
@@ -55,7 +55,7 @@ describe('Config', () => {
   })
 
   it('should use config hooks to enhance configs', () => {
-    config.addHook((cfg) => {
+    config.addHook(cfg => {
       cfg.additionalValue = true
     })
     const cfg = config.create({

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -1,109 +1,109 @@
-let expect;
+let expect
 import('chai').then(chai => {
-  expect = chai.expect;
-});
-const path = require('path');
+  expect = chai.expect
+})
+const path = require('path')
 
-const FileSystem = require('../../lib/helper/FileSystem');
-const actor = require('../../lib/actor');
-const container = require('../../lib/container');
+const FileSystem = require('../../lib/helper/FileSystem')
+const actor = require('../../lib/actor')
+const container = require('../../lib/container')
 
 describe('Container', () => {
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/..');
-    global.inject = container.support;
-    global.actor = actor;
-  });
+    global.codecept_dir = path.join(__dirname, '/..')
+    global.inject = container.support
+    global.actor = actor
+  })
 
   afterEach(() => {
-    container.clear();
-    ['I', 'dummy_page'].forEach(po => {
-      const name = require.resolve(path.join(__dirname, `../data/${po}`));
-      delete require.cache[name];
-    });
-  });
+    container.clear()
+    ;['I', 'dummy_page'].forEach(po => {
+      const name = require.resolve(path.join(__dirname, `../data/${po}`))
+      delete require.cache[name]
+    })
+  })
 
   describe('#translation', () => {
-    const Translation = require('../../lib/translation');
+    const Translation = require('../../lib/translation')
 
     it('should create empty translation', () => {
-      container.create({});
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.false;
-      expect(container.translation().actionAliasFor('see')).to.eql('see');
-    });
+      container.create({})
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.false
+      expect(container.translation().actionAliasFor('see')).to.eql('see')
+    })
 
     it('should create Russian translation', () => {
-      container.create({ translation: 'ru-RU' });
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.true;
-      expect(container.translation().I).to.eql('Я');
-      expect(container.translation().actionAliasFor('see')).to.eql('вижу');
-    });
+      container.create({ translation: 'ru-RU' })
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.true
+      expect(container.translation().I).to.eql('Я')
+      expect(container.translation().actionAliasFor('see')).to.eql('вижу')
+    })
 
     it('should create Italian translation', () => {
-      container.create({ translation: 'it-IT' });
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.true;
-      expect(container.translation().I).to.eql('io');
-      expect(container.translation().value('contexts').Feature).to.eql('Caratteristica');
-    });
+      container.create({ translation: 'it-IT' })
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.true
+      expect(container.translation().I).to.eql('io')
+      expect(container.translation().value('contexts').Feature).to.eql('Caratteristica')
+    })
 
     it('should create French translation', () => {
-      container.create({ translation: 'fr-FR' });
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.true;
-      expect(container.translation().I).to.eql('Je');
-      expect(container.translation().value('contexts').Feature).to.eql('Fonctionnalité');
-    });
+      container.create({ translation: 'fr-FR' })
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.true
+      expect(container.translation().I).to.eql('Je')
+      expect(container.translation().value('contexts').Feature).to.eql('Fonctionnalité')
+    })
 
     it('should create Portuguese translation', () => {
-      container.create({ translation: 'pt-BR' });
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.true;
-      expect(container.translation().I).to.eql('Eu');
-      expect(container.translation().value('contexts').Feature).to.eql('Funcionalidade');
-    });
+      container.create({ translation: 'pt-BR' })
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.true
+      expect(container.translation().I).to.eql('Eu')
+      expect(container.translation().value('contexts').Feature).to.eql('Funcionalidade')
+    })
 
     it('should load custom translation', () => {
-      container.create({ translation: 'my' });
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.true;
-    });
+      container.create({ translation: 'my' })
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.true
+    })
 
     it('should load no translation', () => {
-      container.create({});
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.false;
-    });
+      container.create({})
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.false
+    })
 
     it('should load custom translation with vocabularies', () => {
-      container.create({ translation: 'my', vocabularies: ['data/custom_vocabulary.json'] });
-      expect(container.translation()).to.be.instanceOf(Translation);
-      expect(container.translation().loaded).to.be.true;
-      const translation = container.translation();
-      expect(translation.actionAliasFor('say')).to.eql('arr');
-    });
-  });
+      container.create({ translation: 'my', vocabularies: ['data/custom_vocabulary.json'] })
+      expect(container.translation()).to.be.instanceOf(Translation)
+      expect(container.translation().loaded).to.be.true
+      const translation = container.translation()
+      expect(translation.actionAliasFor('say')).to.eql('arr')
+    })
+  })
 
   describe('#helpers', () => {
     beforeEach(() => {
       container.clear({
         helper1: { name: 'hello' },
         helper2: { name: 'world' },
-      });
-    });
+      })
+    })
 
-    it('should return all helper with no args', () => expect(container.helpers()).to.have.keys('helper1', 'helper2'));
+    it('should return all helper with no args', () => expect(container.helpers()).to.have.keys('helper1', 'helper2'))
 
     it('should return helper by name', () => {
-      expect(container.helpers('helper1')).is.ok;
-      expect(container.helpers('helper1').name).to.eql('hello');
-      expect(container.helpers('helper2')).is.ok;
-      expect(container.helpers('helper2').name).to.eql('world');
-      expect(!container.helpers('helper3')).is.ok;
-    });
-  });
+      expect(container.helpers('helper1')).is.ok
+      expect(container.helpers('helper1').name).to.eql('hello')
+      expect(container.helpers('helper2')).is.ok
+      expect(container.helpers('helper2').name).to.eql('world')
+      expect(!container.helpers('helper3')).is.ok
+    })
+  })
 
   describe('#support', () => {
     beforeEach(() => {
@@ -113,22 +113,22 @@ describe('Container', () => {
           support1: { name: 'hello' },
           support2: { name: 'world' },
         },
-      );
-    });
+      )
+    })
 
     it('should return all support objects', () => {
-      expect(container.support()).to.have.keys('support1', 'support2');
-    });
+      expect(container.support()).to.have.keys('support1', 'support2')
+    })
 
     it('should support object by name', () => {
-      expect(container.support('support1')).is.ok;
-      expect(container.support('support1').name).to.eql('hello');
-      expect(container.support('support2')).is.ok;
-      expect(container.support('support2').name).to.eql('world');
+      expect(container.support('support1')).is.ok
+      expect(container.support('support1').name).to.eql('hello')
+      expect(container.support('support2')).is.ok
+      expect(container.support('support2').name).to.eql('world')
 
-      expect(() => container.support('support3').name).to.throw(Error);
-    });
-  });
+      expect(() => container.support('support3').name).to.throw(Error)
+    })
+  })
 
   describe('#plugins', () => {
     beforeEach(() => {
@@ -139,19 +139,19 @@ describe('Container', () => {
           plugin1: { name: 'hello' },
           plugin2: { name: 'world' },
         },
-      );
-    });
+      )
+    })
 
-    it('should return all plugins', () => expect(container.plugins()).to.have.keys('plugin1', 'plugin2'));
+    it('should return all plugins', () => expect(container.plugins()).to.have.keys('plugin1', 'plugin2'))
 
     it('should get plugin by name', () => {
-      expect(container.plugins('plugin1')).is.ok;
-      expect(container.plugins('plugin1').name).is.eql('hello');
-      expect(container.plugins('plugin2')).is.ok;
-      expect(container.plugins('plugin2').name).is.eql('world');
-      expect(!container.plugins('plugin3')).is.ok;
-    });
-  });
+      expect(container.plugins('plugin1')).is.ok
+      expect(container.plugins('plugin1').name).is.eql('hello')
+      expect(container.plugins('plugin2')).is.ok
+      expect(container.plugins('plugin2').name).is.eql('world')
+      expect(!container.plugins('plugin3')).is.ok
+    })
+  })
 
   describe('#create', () => {
     it('should create container with helpers', () => {
@@ -162,53 +162,53 @@ describe('Container', () => {
           },
           FileSystem: {},
         },
-      };
-      container.create(config);
+      }
+      container.create(config)
       // custom helpers
-      expect(container.helpers('MyHelper')).is.ok;
-      expect(container.helpers('MyHelper').method()).to.eql('hello world');
+      expect(container.helpers('MyHelper')).is.ok
+      expect(container.helpers('MyHelper').method()).to.eql('hello world')
 
       // built-in helpers
-      expect(container.helpers('FileSystem')).is.ok;
-      expect(container.helpers('FileSystem')).to.be.instanceOf(FileSystem);
-    });
+      expect(container.helpers('FileSystem')).is.ok
+      expect(container.helpers('FileSystem')).to.be.instanceOf(FileSystem)
+    })
 
     it('should always create I', () => {
-      container.create({});
-      expect(container.support('I')).is.ok;
-    });
+      container.create({})
+      expect(container.support('I')).is.ok
+    })
 
     it('should load DI and return a reference to the module', () => {
       container.create({
         include: {
           dummyPage: './data/dummy_page',
         },
-      });
-      const dummyPage = require('../data/dummy_page');
-      expect(container.support('dummyPage').toString()).is.eql(dummyPage.toString());
-    });
+      })
+      const dummyPage = require('../data/dummy_page')
+      expect(container.support('dummyPage').toString()).is.eql(dummyPage.toString())
+    })
 
     it('should load I from path and execute', () => {
       container.create({
         include: {
           I: './data/I',
         },
-      });
-      expect(container.support('I')).is.ok;
-      expect(Object.keys(container.support('I'))).is.ok;
-      expect(Object.keys(container.support('I'))).to.include('_init');
-      expect(Object.keys(container.support('I'))).to.include('doSomething');
-    });
+      })
+      expect(container.support('I')).is.ok
+      expect(Object.keys(container.support('I'))).is.ok
+      expect(Object.keys(container.support('I'))).to.include('_init')
+      expect(Object.keys(container.support('I'))).to.include('doSomething')
+    })
 
     it('should load DI includes provided as require paths', () => {
       container.create({
         include: {
           dummyPage: './data/dummy_page',
         },
-      });
-      expect(container.support('dummyPage')).is.ok;
-      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
-    });
+      })
+      expect(container.support('dummyPage')).is.ok
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage')
+    })
 
     it('should load DI and inject I into PO', async () => {
       container.create({
@@ -216,12 +216,12 @@ describe('Container', () => {
           dummyPage: './data/dummy_page',
           I: './data/I',
         },
-      });
-      expect(container.support('dummyPage')).is.ok;
-      expect(container.support('I')).is.ok;
-      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
-      expect(container.support('dummyPage').getI()).to.have.keys('_init', 'doSomething');
-    });
+      })
+      expect(container.support('dummyPage')).is.ok
+      expect(container.support('I')).is.ok
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage')
+      expect(container.support('dummyPage').getI()).to.have.keys('_init', 'doSomething')
+    })
 
     it('should load DI and inject custom I into PO', () => {
       container.create({
@@ -229,11 +229,11 @@ describe('Container', () => {
           dummyPage: './data/dummy_page',
           I: './data/I',
         },
-      });
-      expect(container.support('dummyPage')).is.ok;
-      expect(container.support('I')).is.ok;
-      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
-    });
+      })
+      expect(container.support('dummyPage')).is.ok
+      expect(container.support('I')).is.ok
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage')
+    })
 
     it('should load DI includes provided as objects', () => {
       container.create({
@@ -242,10 +242,10 @@ describe('Container', () => {
             openDummyPage: () => 'dummy page opened',
           },
         },
-      });
-      expect(container.support('dummyPage')).is.ok;
-      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
-    });
+      })
+      expect(container.support('dummyPage')).is.ok
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage')
+    })
 
     it('should load DI includes provided as objects', () => {
       container.create({
@@ -254,11 +254,11 @@ describe('Container', () => {
             openDummyPage: () => 'dummy page opened',
           },
         },
-      });
-      expect(container.support('dummyPage')).is.ok;
-      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
-    });
-  });
+      })
+      expect(container.support('dummyPage')).is.ok
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage')
+    })
+  })
 
   describe('#append', () => {
     it('should be able to add new helper', () => {
@@ -266,26 +266,26 @@ describe('Container', () => {
         helpers: {
           FileSystem: {},
         },
-      };
-      container.create(config);
+      }
+      container.create(config)
       container.append({
         helpers: {
           AnotherHelper: { method: () => 'executed' },
         },
-      });
-      expect(container.helpers('FileSystem')).is.ok;
-      expect(container.helpers('FileSystem')).is.instanceOf(FileSystem);
+      })
+      expect(container.helpers('FileSystem')).is.ok
+      expect(container.helpers('FileSystem')).is.instanceOf(FileSystem)
 
-      expect(container.helpers('AnotherHelper')).is.ok;
-      expect(container.helpers('AnotherHelper').method()).is.eql('executed');
-    });
+      expect(container.helpers('AnotherHelper')).is.ok
+      expect(container.helpers('AnotherHelper').method()).is.eql('executed')
+    })
 
     it('should be able to add new support object', () => {
-      container.create({});
-      container.append({ support: { userPage: { login: '#login' } } });
-      expect(container.support('I')).is.ok;
-      expect(container.support('userPage')).is.ok;
-      expect(container.support('userPage').login).is.eql('#login');
-    });
-  });
-});
+      container.create({})
+      container.append({ support: { userPage: { login: '#login' } } })
+      expect(container.support('I')).is.ok
+      expect(container.support('userPage')).is.ok
+      expect(container.support('userPage').login).is.eql('#login')
+    })
+  })
+})

--- a/test/unit/heal_test.js
+++ b/test/unit/heal_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const heal = require('../../lib/heal')
@@ -103,7 +103,7 @@ describe('heal', () => {
     heal.addRecipe('reload', {
       priority: 10,
       steps: ['click'],
-      fn: async (opts) => {
+      fn: async opts => {
         passedOpts = opts
         return () => {
           isHealed = true

--- a/test/unit/html_test.js
+++ b/test/unit/html_test.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const cheerio = require('cheerio')
@@ -10,22 +10,7 @@ const { scanForErrorMessages, removeNonInteractiveElements, minifyHtml, splitByC
 
 const opts = {
   interactiveElements: ['a', 'input', 'button', 'select', 'textarea', 'label', 'option'],
-  allowedAttrs: [
-    'id',
-    'for',
-    'class',
-    'name',
-    'type',
-    'value',
-    'aria-labelledby',
-    'aria-label',
-    'label',
-    'placeholder',
-    'title',
-    'alt',
-    'src',
-    'role',
-  ],
+  allowedAttrs: ['id', 'for', 'class', 'name', 'type', 'value', 'aria-labelledby', 'aria-label', 'label', 'placeholder', 'title', 'alt', 'src', 'role'],
   allowedRoles: ['button', 'checkbox', 'search', 'textbox', 'tab'],
   textElements: ['label'],
 }

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const { DOMParser } = require('@xmldom/xmldom')

--- a/test/unit/output_test.js
+++ b/test/unit/output_test.js
@@ -1,6 +1,6 @@
 let chai
 let expect
-import('chai').then((_chai) => {
+import('chai').then(_chai => {
   chai = _chai
   expect = chai.expect
   chai.use(sinonChai)

--- a/test/unit/parser_test.js
+++ b/test/unit/parser_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const parser = require('../../lib/parser')
@@ -17,12 +17,7 @@ class Obj {
 
   method5({ locator, sec }) {}
 }
-const fixturesDestructuredArgs = [
-  'function namedFn({locator, sec}) {}',
-  'function * namedFn({locator, sec}) {}',
-  '({locator, sec}) => {}',
-  '({locator, sec}) => {}',
-]
+const fixturesDestructuredArgs = ['function namedFn({locator, sec}) {}', 'function * namedFn({locator, sec}) {}', '({locator, sec}) => {}', '({locator, sec}) => {}']
 
 describe('parser', () => {
   const obj = new Obj()
@@ -35,19 +30,14 @@ describe('parser', () => {
     it('should get params for async function', () => {
       expect(parser.getParamsToString(obj.method4)).to.eql('locator, context')
     })
-    fixturesDestructuredArgs.forEach((arg) => {
+    fixturesDestructuredArgs.forEach(arg => {
       it(`should get params for anonymous function with destructured args | ${arg}`, () => {
         expect(parser.getParams(arg)).to.eql(['locator', 'sec'])
       })
     })
 
     it('should get params for anonymous function with destructured args', () => {
-      expect(parser.getParams(({ locator, sec }, { first, second }) => {})).to.eql([
-        'locator',
-        'sec',
-        'first',
-        'second',
-      ])
+      expect(parser.getParams(({ locator, sec }, { first, second }) => {})).to.eql(['locator', 'sec', 'first', 'second'])
     })
 
     it('should get params for class method with destructured args', () => {

--- a/test/unit/recorder_test.js
+++ b/test/unit/recorder_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 
@@ -12,7 +12,7 @@ describe('Recorder', () => {
     expect(recorder.promise()).to.be.instanceof(Promise)
   })
 
-  it('should execute error handler on error', (done) => {
+  it('should execute error handler on error', done => {
     recorder.errHandler(() => done())
     recorder.throw(new Error('err'))
     recorder.catch()
@@ -74,13 +74,13 @@ describe('Recorder', () => {
       const errorText = 'noerror'
       recorder.retry({
         retries: 2,
-        when: (err) => {
+        when: err => {
           return err.message === errorText
         },
       })
       recorder.retry({
         retries: 2,
-        when: (err) => {
+        when: err => {
           return err.message === 'othererror'
         },
       })
@@ -105,7 +105,7 @@ describe('Recorder', () => {
       recorder.retry({ retries: 2 })
       recorder.retry({
         retries: 100,
-        when: (err) => {
+        when: err => {
           return err.message === errorText
         },
       })

--- a/test/unit/scenario_test.js
+++ b/test/unit/scenario_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const sinon = require('sinon')

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -7,7 +7,7 @@ const { secret } = require('../../lib/secret')
 
 let expect
 
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
   chai.use(require('chai-as-promised'))
 })
@@ -92,7 +92,7 @@ describe('Steps', () => {
     })
 
     describe('#isBDD', () => {
-      ;['Given', 'When', 'Then', 'And'].forEach((key) => {
+      ;['Given', 'When', 'Then', 'And'].forEach(key => {
         it(`[${key}] #isBdd should return true if it BDD style`, () => {
           const metaStep = new MetaStep(key, 'I need to open Google')
           expect(metaStep.isBDD()).to.be.true
@@ -106,7 +106,7 @@ describe('Steps', () => {
     })
 
     describe('#toString', () => {
-      ;['Given', 'When', 'Then', 'And'].forEach((key) => {
+      ;['Given', 'When', 'Then', 'And'].forEach(key => {
         it(`[${key}] should correct print BDD step`, () => {
           const metaStep = new MetaStep(key, 'I need to open Google')
           expect(metaStep.toString()).to.include(`${key} I need to open Google`)
@@ -127,7 +127,7 @@ describe('Steps', () => {
         const metaStep = new MetaStep('MyPage', 'clickByName')
         const msg = 'first message'
         const msg2 = 'second message'
-        const fn = (msg) => `result from callback = ${msg}`
+        const fn = msg => `result from callback = ${msg}`
         metaStep.run.bind(metaStep, fn)(msg, msg2)
         expect(metaStep.toString()).eql(`On MyPage: click by name "${msg}", "${msg2}"`)
       })
@@ -148,8 +148,8 @@ describe('Steps', () => {
       beforeEach(() => {
         metaStep = new MetaStep({ metaStepDoSomething: action }, 'metaStepDoSomething')
         asyncMetaStep = new MetaStep({ metaStepDoSomething: asyncAction }, 'metaStepDoSomething')
-        fn = (msg) => `result from callback = ${msg}`
-        asyncFn = async (msg) => `result from callback = ${msg}`
+        fn = msg => `result from callback = ${msg}`
+        asyncFn = async msg => `result from callback = ${msg}`
         boundedRun = metaStep.run.bind(metaStep, fn)
         boundedAsyncRun = metaStep.run.bind(metaStep, asyncFn)
       })

--- a/test/unit/ui_test.js
+++ b/test/unit/ui_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const Mocha = require('mocha/lib/mocha')
@@ -22,7 +22,7 @@ describe('ui', () => {
   describe('basic constants', () => {
     const constants = ['Before', 'Background', 'BeforeAll', 'After', 'AfterAll', 'Scenario', 'xScenario']
 
-    constants.forEach((c) => {
+    constants.forEach(c => {
       it(`context should contain ${c}`, () => expect(context[c]).is.ok)
     })
   })

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1,5 +1,5 @@
 let expect
-import('chai').then((chai) => {
+import('chai').then(chai => {
   expect = chai.expect
 })
 const os = require('os')
@@ -18,10 +18,8 @@ describe('utils', () => {
   describe('#getParamNames', () => {
     it('fn#1', () => expect(utils.getParamNames((a, b) => {})).eql(['a', 'b']))
     it('fn#2', () => expect(utils.getParamNames((I, userPage) => {})).eql(['I', 'userPage']))
-    it('should handle single-param arrow functions with omitted parens', () =>
-      expect(utils.getParamNames((I) => {})).eql(['I']))
-    it('should handle trailing comma', () =>
-      expect(utils.getParamNames((I, trailing, comma) => {})).eql(['I', 'trailing', 'comma']))
+    it('should handle single-param arrow functions with omitted parens', () => expect(utils.getParamNames(I => {})).eql(['I']))
+    it('should handle trailing comma', () => expect(utils.getParamNames((I, trailing, comma) => {})).eql(['I', 'trailing', 'comma']))
   })
 
   describe('#methodsOfObject', () => {
@@ -44,8 +42,7 @@ describe('utils', () => {
 
   describe('#beautify', () => {
     it('should beautify JS code', () => {
-      expect(utils.beautify('module.exports = function(a, b) { a++; b = a; if (a == b) { return 2 }};'))
-        .eql(`module.exports = function(a, b) {
+      expect(utils.beautify('module.exports = function(a, b) { a++; b = a; if (a == b) { return 2 }};')).eql(`module.exports = function(a, b) {
   a++;
   b = a;
   if (a == b) {
@@ -322,13 +319,9 @@ describe('utils', () => {
     })
 
     it('returns the given filename for absolute one', () => {
-      const _path = utils.screenshotOutputFolder(
-        '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace(/\//g, path.sep),
-      )
+      const _path = utils.screenshotOutputFolder('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace(/\//g, path.sep))
       if (os.platform() === 'win32') {
-        expect(_path).eql(
-          path.resolve(global.codecept_dir, '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'),
-        )
+        expect(_path).eql(path.resolve(global.codecept_dir, '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'))
       } else {
         expect(_path).eql('/Users/someuser/workbase/project1/test_output/screenshot1.failed.png')
       }
@@ -341,10 +334,7 @@ describe('utils', () => {
     })
 
     it('returns provide default require not found message', () => {
-      expect(() => utils.requireWithFallback('unexisting-package', 'unexisting-package2')).to.throw(
-        Error,
-        'Cannot find modules unexisting-package,unexisting-package2',
-      )
+      expect(() => utils.requireWithFallback('unexisting-package', 'unexisting-package2')).to.throw(Error, 'Cannot find modules unexisting-package,unexisting-package2')
     })
   })
 })

--- a/test/unit/worker_test.js
+++ b/test/unit/worker_test.js
@@ -1,54 +1,54 @@
-const path = require('path');
-const expect = require('chai').expect;
+const path = require('path')
+const expect = require('chai').expect
 
-const { Workers, event, recorder } = require('../../lib/index');
+const { Workers, event, recorder } = require('../../lib/index')
 
 describe('Workers', function () {
-  this.timeout(40000);
+  this.timeout(40000)
 
   before(() => {
-    global.codecept_dir = path.join(__dirname, '/../data/sandbox');
-  });
+    global.codecept_dir = path.join(__dirname, '/../data/sandbox')
+  })
 
   it('should run simple worker', done => {
     const workerConfig = {
       by: 'test',
       testConfig: './test/data/sandbox/codecept.workers.conf.js',
-    };
-    let passedCount = 0;
-    let failedCount = 0;
-    const workers = new Workers(2, workerConfig);
+    }
+    let passedCount = 0
+    let failedCount = 0
+    const workers = new Workers(2, workerConfig)
 
     workers.on(event.test.failed, () => {
-      failedCount += 1;
-    });
+      failedCount += 1
+    })
     workers.on(event.test.passed, () => {
-      passedCount += 1;
-    });
+      passedCount += 1
+    })
 
-    workers.run();
+    workers.run()
 
     workers.on(event.all.result, status => {
-      expect(status).equal(false);
-      expect(passedCount).equal(5);
-      expect(failedCount).equal(3);
-      done();
-    });
-  });
+      expect(status).equal(false)
+      expect(passedCount).equal(5)
+      expect(failedCount).equal(3)
+      done()
+    })
+  })
 
   it('should create worker by function', done => {
     const createTestGroups = () => {
-      const files = [[path.join(codecept_dir, '/custom-worker/base_test.worker.js')], [path.join(codecept_dir, '/custom-worker/custom_test.worker.js')]];
+      const files = [[path.join(codecept_dir, '/custom-worker/base_test.worker.js')], [path.join(codecept_dir, '/custom-worker/custom_test.worker.js')]]
 
-      return files;
-    };
+      return files
+    }
 
     const workerConfig = {
       by: createTestGroups,
       testConfig: './test/data/sandbox/codecept.customworker.js',
-    };
+    }
 
-    const workers = new Workers(-1, workerConfig);
+    const workers = new Workers(-1, workerConfig)
 
     for (const worker of workers.getWorkers()) {
       worker.addConfig({
@@ -58,27 +58,27 @@ describe('Workers', function () {
             require: './custom_worker_helper',
           },
         },
-      });
+      })
     }
 
-    workers.run();
+    workers.run()
 
     workers.on(event.all.result, status => {
-      expect(workers.getWorkers().length).equal(2);
-      expect(status).equal(true);
-      done();
-    });
-  });
+      expect(workers.getWorkers().length).equal(2)
+      expect(status).equal(true)
+      done()
+    })
+  })
 
   it('should run worker with custom config', done => {
     const workerConfig = {
       by: 'test',
       testConfig: './test/data/sandbox/codecept.customworker.js',
-    };
-    let passedCount = 0;
-    let failedCount = 0;
+    }
+    let passedCount = 0
+    let failedCount = 0
 
-    const workers = new Workers(2, workerConfig);
+    const workers = new Workers(2, workerConfig)
 
     for (const worker of workers.getWorkers()) {
       worker.addConfig({
@@ -88,39 +88,39 @@ describe('Workers', function () {
             require: './custom_worker_helper',
           },
         },
-      });
+      })
     }
 
-    workers.run();
+    workers.run()
 
     workers.on(event.test.failed, test => {
-      failedCount += 1;
-    });
+      failedCount += 1
+    })
     workers.on(event.test.passed, test => {
-      passedCount += 1;
-    });
+      passedCount += 1
+    })
 
     workers.on(event.all.result, status => {
-      expect(status).equal(false);
-      expect(passedCount).equal(3);
-      expect(failedCount).equal(2);
-      done();
-    });
-  });
+      expect(status).equal(false)
+      expect(passedCount).equal(3)
+      expect(failedCount).equal(2)
+      done()
+    })
+  })
 
   it('should able to add tests to each worker', done => {
     const workerConfig = {
       by: 'test',
       testConfig: './test/data/sandbox/codecept.customworker.js',
-    };
+    }
 
-    const workers = new Workers(-1, workerConfig);
+    const workers = new Workers(-1, workerConfig)
 
-    const workerOne = workers.spawn();
-    workerOne.addTestFiles([path.join(codecept_dir, '/custom-worker/base_test.worker.js')]);
+    const workerOne = workers.spawn()
+    workerOne.addTestFiles([path.join(codecept_dir, '/custom-worker/base_test.worker.js')])
 
-    const workerTwo = workers.spawn();
-    workerTwo.addTestFiles([path.join(codecept_dir, '/custom-worker/custom_test.worker.js')]);
+    const workerTwo = workers.spawn()
+    workerTwo.addTestFiles([path.join(codecept_dir, '/custom-worker/custom_test.worker.js')])
 
     for (const worker of workers.getWorkers()) {
       worker.addConfig({
@@ -130,32 +130,32 @@ describe('Workers', function () {
             require: './custom_worker_helper',
           },
         },
-      });
+      })
     }
 
-    workers.run();
+    workers.run()
 
     workers.on(event.all.result, status => {
-      expect(workers.getWorkers().length).equal(2);
-      expect(status).equal(true);
-      done();
-    });
-  });
+      expect(workers.getWorkers().length).equal(2)
+      expect(status).equal(true)
+      done()
+    })
+  })
 
   it('should able to add tests to using createGroupsOfTests', done => {
     const workerConfig = {
       by: 'test',
       testConfig: './test/data/sandbox/codecept.customworker.js',
-    };
+    }
 
-    const workers = new Workers(-1, workerConfig);
-    const testGroups = workers.createGroupsOfSuites(2);
+    const workers = new Workers(-1, workerConfig)
+    const testGroups = workers.createGroupsOfSuites(2)
 
-    const workerOne = workers.spawn();
-    workerOne.addTests(testGroups[0]);
+    const workerOne = workers.spawn()
+    workerOne.addTests(testGroups[0])
 
-    const workerTwo = workers.spawn();
-    workerTwo.addTests(testGroups[1]);
+    const workerTwo = workers.spawn()
+    workerTwo.addTests(testGroups[1])
 
     for (const worker of workers.getWorkers()) {
       worker.addConfig({
@@ -165,25 +165,25 @@ describe('Workers', function () {
             require: './custom_worker_helper',
           },
         },
-      });
+      })
     }
 
-    workers.run();
+    workers.run()
 
     workers.on(event.all.result, status => {
-      expect(workers.getWorkers().length).equal(2);
-      expect(status).equal(true);
-      done();
-    });
-  });
+      expect(workers.getWorkers().length).equal(2)
+      expect(status).equal(true)
+      done()
+    })
+  })
 
   it('Should able to pass data from workers to main thread and vice versa', done => {
     const workerConfig = {
       by: 'test',
       testConfig: './test/data/sandbox/codecept.customworker.js',
-    };
+    }
 
-    const workers = new Workers(2, workerConfig);
+    const workers = new Workers(2, workerConfig)
 
     for (const worker of workers.getWorkers()) {
       worker.addConfig({
@@ -193,47 +193,47 @@ describe('Workers', function () {
             require: './custom_worker_helper',
           },
         },
-      });
+      })
     }
 
-    workers.run();
-    recorder.add(() => share({ fromMain: true }));
+    workers.run()
+    recorder.add(() => share({ fromMain: true }))
 
     workers.on(event.all.result, status => {
-      expect(status).equal(true);
-      done();
-    });
-  });
+      expect(status).equal(true)
+      done()
+    })
+  })
 
   it('should propagate non test events', done => {
-    const messages = [];
+    const messages = []
 
     const createTestGroups = () => {
-      const files = [[path.join(codecept_dir, '/non-test-events-worker/non_test_event.worker.js')]];
+      const files = [[path.join(codecept_dir, '/non-test-events-worker/non_test_event.worker.js')]]
 
-      return files;
-    };
+      return files
+    }
 
     const workerConfig = {
       by: createTestGroups,
       testConfig: './test/data/sandbox/codecept.non-test-events-worker.js',
-    };
+    }
 
-    workers = new Workers(2, workerConfig);
+    workers = new Workers(2, workerConfig)
 
-    workers.run();
+    workers.run()
 
     workers.on('message', data => {
-      messages.push(data);
-    });
+      messages.push(data)
+    })
 
     workers.on(event.all.result, () => {
-      expect(messages.length).equal(2);
-      expect(messages[0]).equal('message 1');
-      expect(messages[1]).equal('message 2');
-      done();
-    });
-  });
+      expect(messages.length).equal(2)
+      expect(messages[0]).equal('message 1')
+      expect(messages[1]).equal('message 2')
+      done()
+    })
+  })
 
   it('should run worker with multiple config', done => {
     const workerConfig = {
@@ -241,9 +241,9 @@ describe('Workers', function () {
       testConfig: './test/data/sandbox/codecept.multiple.js',
       options: {},
       selectedRuns: ['mobile'],
-    };
+    }
 
-    const workers = new Workers(2, workerConfig);
+    const workers = new Workers(2, workerConfig)
 
     for (const worker of workers.getWorkers()) {
       worker.addConfig({
@@ -253,15 +253,15 @@ describe('Workers', function () {
             require: './custom_worker_helper',
           },
         },
-      });
+      })
     }
 
-    workers.run();
+    workers.run()
 
     workers.on(event.all.result, status => {
-      expect(workers.getWorkers().length).equal(8);
-      expect(status).equal(true);
-      done();
-    });
-  });
-});
+      expect(workers.getWorkers().length).equal(8)
+      expect(status).equal(true)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
## Motivation/Description of the PR
- When the element text is an empty string, just return the empty string instead of failing the tests
- Resolves #4487

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
