### PR TITLE
Bump typedoc-plugin-markdown to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "tsd": "^0.31.0",
     "tsd-jsdoc": "2.5.0",
     "typedoc": "0.27.6",
-    "typedoc-plugin-markdown": "4.3.3",
+    "typedoc-plugin-markdown": "4.4.1",
     "typescript": "5.7.2",
     "wdio-docker-service": "1.5.0",
     "webdriverio": "8.40.6",


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump typedoc-plugin-markdown to 4.4.1
- Resolves #4705 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
