### PR TITLE
fix: handle logging step

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,8 @@ module.exports = {
   store: require('./store'),
   /** @type {typeof CodeceptJS.Locator} */
   locator: require('./locator'),
+  /** @type {typeof CodeceptJS.Step} */
+  Step: require('./step'),
 
   heal: require('./heal'),
   ai: require('./ai'),

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,6 +1,7 @@
 const colors = require('chalk')
 const figures = require('figures')
 const { maskSensitiveData } = require('invisi-data')
+const Step = require('./step')
 
 const styles = {
   error: colors.bgRed.white.bold,
@@ -115,7 +116,7 @@ module.exports = {
       }
     }
 
-    try {
+    if (step instanceof Step) {
       let stepLine = step.toCliStyled()
       if (step.metaStep && outputLevel >= 1) {
         // this.stepShift += 2;
@@ -127,9 +128,11 @@ module.exports = {
 
       const _stepLine = isMaskedData() ? maskSensitiveData(stepLine) : stepLine
       print(' '.repeat(this.stepShift), truncate(_stepLine, this.spaceShift))
-    } catch (e) {
+    } else if (typeof step === 'string') {
       // sometimes the step is just the string, so we basically print it out
       print(step)
+    } else {
+      console.log(`Something went wrong with ${step}`)
     }
   },
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -115,17 +115,22 @@ module.exports = {
       }
     }
 
-    let stepLine = step.toCliStyled()
-    if (step.metaStep && outputLevel >= 1) {
-      // this.stepShift += 2;
-      stepLine = colors.dim(truncate(stepLine, this.spaceShift))
-    }
-    if (step.comment) {
-      stepLine += colors.grey(step.comment.split('\n').join('\n' + ' '.repeat(4)))
-    }
+    try {
+      let stepLine = step.toCliStyled()
+      if (step.metaStep && outputLevel >= 1) {
+        // this.stepShift += 2;
+        stepLine = colors.dim(truncate(stepLine, this.spaceShift))
+      }
+      if (step.comment) {
+        stepLine += colors.grey(step.comment.split('\n').join('\n' + ' '.repeat(4)))
+      }
 
-    const _stepLine = isMaskedData() ? maskSensitiveData(stepLine) : stepLine
-    print(' '.repeat(this.stepShift), truncate(_stepLine, this.spaceShift))
+      const _stepLine = isMaskedData() ? maskSensitiveData(stepLine) : stepLine
+      print(' '.repeat(this.stepShift), truncate(_stepLine, this.spaceShift))
+    } catch (e) {
+      // sometimes the step is just the string, so we basically print it out
+      print(step)
+    }
   },
 
   /** @namespace */

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ".": "./lib/index.js",
     "./els": "./lib/els.js",
     "./effects": "./lib/effects.js",
-    "./steps": "./lib/steps.js"
+    "./steps": "./lib/steps.js",
+    "./step": "./lib/step.js"
   },
   "types": "typings/index.d.ts",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     ".": "./lib/index.js",
     "./els": "./lib/els.js",
     "./effects": "./lib/effects.js",
-    "./steps": "./lib/steps.js",
-    "./step": "./lib/step.js"
+    "./steps": "./lib/steps.js"
   },
   "types": "typings/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Motivation/Description of the PR
- export step as public API so that it could be used in the custom helper, for instance our helper https://github.com/codeceptjs/expect-helper/blob/main/index.js#L51

```
const  Step = require('codeceptjs')
const step = new Step('I', `expect "${JSON.stringify(actualValue)}" to not equal "${JSON.stringify(expectedValue)}"`);
output.step(step)
```

- handle the case which the step is a string

```
    [1]  Error (Non-Terminated) | TypeError: step.toCliStyled is not a function | err => { step.status = 'failed' step.endTime = Dat...
    [1] Error | TypeError: step.toCliStyled is not a function undefined...
    [1] <teardown>  Stopping recording promises
    [2]  Starting recording promises

```


## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
