### PR TITLE
fix: grab browser logs using bidi

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -24,6 +24,7 @@ const { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTr
 
 const SHADOW = 'shadow'
 const webRoot = 'body'
+let browserLogs = []
 
 /**
  * ## Configuration
@@ -621,6 +622,10 @@ class WebDriver extends Helper {
     }
 
     this.browser.on('dialog', () => {})
+
+    await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
+    this.browser.on('log.entryAdded', logEvents)
+
     return this.browser
   }
 
@@ -658,6 +663,7 @@ class WebDriver extends Helper {
       if (!(err.message.indexOf("Storage is disabled inside 'data:' URLs.") > -1)) throw err
     })
     await this.closeOtherTabs()
+    browserLogs = []
     return this.browser
   }
 
@@ -1522,11 +1528,7 @@ class WebDriver extends Helper {
    * {{> grabBrowserLogs }}
    */
   async grabBrowserLogs() {
-    if (this.browser.isW3C) {
-      this.debug('Logs not available in W3C specification')
-      return
-    }
-    return this.browser.getLogs('browser')
+    return browserLogs
   }
 
   /**
@@ -3139,6 +3141,10 @@ function prepareLocateFn(context) {
       return res[0].$$(l.simplify())
     })
   }
+}
+
+function logEvents(event) {
+  browserLogs.push(event.text) // add log message to the array
 }
 
 module.exports = WebDriver

--- a/test/helper/WebDriver_test.js
+++ b/test/helper/WebDriver_test.js
@@ -937,7 +937,7 @@ describe('WebDriver', function () {
     })
   })
 
-  xdescribe('#grabBrowserLogs', () => {
+  describe('#grabBrowserLogs', () => {
     it('should grab browser logs', async () => {
       await wd.amOnPage('/')
       await wd.executeScript(() => {
@@ -946,12 +946,12 @@ describe('WebDriver', function () {
       const logs = await wd.grabBrowserLogs()
       console.log('lololo', logs)
 
-      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1)
+      const matchingLogs = logs.filter(log => log.indexOf('Test log entry') > -1)
       assert.equal(matchingLogs.length, 1)
     })
 
     it('should grab browser logs across pages', async () => {
-      wd.amOnPage('/')
+      await wd.amOnPage('/')
       await wd.executeScript(() => {
         console.log('Test log entry 1')
       })
@@ -963,8 +963,8 @@ describe('WebDriver', function () {
 
       const logs = await wd.grabBrowserLogs()
 
-      const matchingLogs = logs.filter(log => log.message.indexOf('Test log entry') > -1)
-      assert.equal(matchingLogs.length, 2)
+      const matchingLogs = logs.filter(log => log.indexOf('Test log entry') > -1)
+      assert.equal(matchingLogs.length, 5)
     })
   })
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4752

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
