### PR TITLE
Remove double entry for fs-extra in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "figures": "3.2.0",
     "fn-args": "4.0.0",
     "fs-extra": "11.3.0",
-    "fs-extra": "11.2.0",
     "glob": "^11.0.1",
     "fuse.js": "^7.0.0",
     "html-minifier-terser": "7.2.0",


### PR DESCRIPTION
## Motivation/Description of the PR
- Remove double entry for fs-extra in package.json
- Resolves #4808

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
