### PR TITLE
Bump wdio-docker-service to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "typedoc": "0.27.6",
     "typedoc-plugin-markdown": "4.4.1",
     "typescript": "5.7.3",
-    "wdio-docker-service": "1.5.0",
+    "wdio-docker-service": "3.2.1",
     "webdriverio": "9.7.2",
     "xml2js": "0.6.2",
     "xpath": "0.0.34"


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump wdio-docker-service to 3.2.1
- Resolves #4826 4826

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
