### PR TITLE
fix: undefined string when using ucfirst

### DIFF
--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -23,15 +23,23 @@ module.exports = async function (path, options) {
 
     if (options.verbose) output.level(3)
 
+    let addGlobalRetries
+
+    if (config.retry) {
+      addGlobalRetries = function retries() {}
+    }
+
     output.print('Starting interactive shell for current suite...')
     recorder.start()
     event.emit(event.suite.before, {
       fullTitle: () => 'Interactive Shell',
       tests: [],
+      retries: addGlobalRetries,
     })
     event.emit(event.test.before, {
       title: '',
       artifacts: {},
+      retries: addGlobalRetries,
     })
 
     const enabledHelpers = Container.helpers()

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,19 +94,19 @@ module.exports.template = function (template, data) {
 /**
  * Make first char uppercase.
  * @param {string} str
- * @returns {string}
+ * @returns {string | undefined}
  */
 module.exports.ucfirst = function (str) {
-  return str.charAt(0).toUpperCase() + str.substr(1)
+  if (str) return str.charAt(0).toUpperCase() + str.substr(1)
 }
 
 /**
  * Make first char lowercase.
  * @param {string} str
- * @returns {string}
+ * @returns {string | undefined}
  */
 module.exports.lcfirst = function (str) {
-  return str.charAt(0).toLowerCase() + str.substr(1)
+  if (str) return str.charAt(0).toLowerCase() + str.substr(1)
 }
 
 module.exports.chunkArray = function (arr, chunk) {

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -38,6 +38,10 @@ describe('utils', () => {
     it('should capitalize first letter', () => {
       expect(utils.ucfirst('hello')).equal('Hello')
     })
+
+    it('should handle the undefined', () => {
+      expect(utils.ucfirst()).to.be.undefined
+    })
   })
 
   describe('#beautify', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- fix: undefined string when using `ucfirst`
- fix: retries is not a function in shell command

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
