### PR TITLE
Rename variable for consistency in helper handling because supportedH…

### DIFF
--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -52,13 +52,13 @@ const defaultConfig = {
  *
  */
 module.exports = function (config) {
-  standardActingHelpers.push('REST')
+  const affectedHelpers = [...standardActingHelpers, 'REST']
   const helpers = Container.helpers()
   let helper
 
   config = Object.assign(defaultConfig, config)
 
-  for (const helperName of standardActingHelpers) {
+  for (const helperName of affectedHelpers) {
     if (Object.keys(helpers).indexOf(helperName) > -1) {
       helper = helpers[helperName]
     }

--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -52,13 +52,13 @@ const defaultConfig = {
  *
  */
 module.exports = function (config) {
-  supportedHelpers.push('REST')
+  standardActingHelpers.push('REST')
   const helpers = Container.helpers()
   let helper
 
   config = Object.assign(defaultConfig, config)
 
-  for (const helperName of supportedHelpers) {
+  for (const helperName of standardActingHelpers) {
     if (Object.keys(helpers).indexOf(helperName) > -1) {
       helper = helpers[helperName]
     }


### PR DESCRIPTION
…elpers is no longer available.

## Motivation/Description of the PR
- After going to CodeceptJS 3.7.0, I can't execute the tests with this error: 
```
Could not load plugin autoDelay from module './plugin/autoDelay':
supportedHelpers is not defined

```

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [X] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)

3 tests fail, but this looks more like an issue with running those tests using Windows.
