### PR TITLE
Fixed event suites

### DIFF
--- a/lib/mocha/asyncWrapper.js
+++ b/lib/mocha/asyncWrapper.js
@@ -187,30 +187,34 @@ module.exports.injected = function (fn, suite, hookName) {
  * Starts promise chain, so helpers could enqueue their hooks
  */
 module.exports.setup = function (suite) {
+  const { enhanceMochaTest } = require('./test')
   return injectHook(() => {
     recorder.startUnlessRunning()
-    event.emit(event.test.before, suite && suite.ctx && suite.ctx.currentTest)
+    event.emit(event.test.before, enhanceMochaTest(suite?.ctx?.currentTest))
   }, suite)
 }
 
 module.exports.teardown = function (suite) {
+  const { enhanceMochaTest } = require('./test')
   return injectHook(() => {
     recorder.startUnlessRunning()
-    event.emit(event.test.after, suite && suite.ctx && suite.ctx.currentTest)
+    event.emit(event.test.after, enhanceMochaTest(suite?.ctx?.currentTest))
   }, suite)
 }
 
 module.exports.suiteSetup = function (suite) {
+  const { enhanceMochaSuite } = require('./suite')
   return injectHook(() => {
     recorder.startUnlessRunning()
-    event.emit(event.suite.before, suite)
+    event.emit(event.suite.before, enhanceMochaSuite(suite))
   }, suite)
 }
 
 module.exports.suiteTeardown = function (suite) {
+  const { enhanceMochaSuite } = require('./suite')
   return injectHook(() => {
     recorder.startUnlessRunning()
-    event.emit(event.suite.after, suite)
+    event.emit(event.suite.after, enhanceMochaSuite(suite))
   }, suite)
 }
 

--- a/lib/mocha/suite.js
+++ b/lib/mocha/suite.js
@@ -7,6 +7,7 @@ const MochaSuite = require('mocha/lib/suite')
  * Enhances MochaSuite with CodeceptJS specific functionality using composition
  */
 function enhanceMochaSuite(suite) {
+  if (!suite) suite = new MochaSuite('Suite', null, false)
   // already enhanced
   if (suite.codeceptjs) return suite
 

--- a/lib/mocha/test.js
+++ b/lib/mocha/test.js
@@ -21,6 +21,8 @@ function createTest(title, fn) {
  * @returns {CodeceptJS.Test & Mocha.Test} Enhanced test instance
  */
 function enhanceMochaTest(test) {
+  // if no test, create a dummy one
+  if (!test) test = createTest('...', () => {})
   // already enhanced
   if (test.codeceptjs) return test
 


### PR DESCRIPTION
Fixed

```
Error processing test.after event:
TypeError: test.simplify is not a function
    at EventEmitter.<anonymous> (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/command/workers/runTests.js:87:119)
    at EventEmitter.emit (node:events:529:35)
    at EventEmitter.emit (node:domain:489:12)
    at Object.emit (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/event.js:153:28)
    at /Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/asyncWrapper.js:199:11
    at injectHook (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/asyncWrapper.js:11:5)
    at module.exports.teardown (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/asyncWrapper.js:197:10)
    at Context.<anonymous> (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/ui.js:98:57)
    at callFn (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/node_modules/mocha/lib/runnable.js:364:21)
    at Hook.Runnable.run (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/node_modules/mocha/lib/runnable.js:352:5)
Error processing test.before event:
TypeError: test.simplify is not a function
    at EventEmitter.<anonymous> (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/command/workers/runTests.js:86:121)
    at EventEmitter.emit (node:events:529:35)
    at EventEmitter.emit (node:domain:489:12)
    at Object.emit (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/event.js:153:28)
    at /Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/asyncWrapper.js:192:11
    at injectHook (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/asyncWrapper.js:11:5)
    at module.exports.setup (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/asyncWrapper.js:190:10)
    at Context.<anonymous> (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/lib/mocha/ui.js:97:51)
    at callFn (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/node_modules/mocha/lib/runnable.js:364:21)
    at Hook.Runnable.run (/Users/t/Desktop/projects/awesome-tests/node_modules/codeceptjs/node_modules/mocha/lib/runnable.js:352:5)
```