### PR TITLE
Bump @codeceptjs/expect-helper to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "devDependencies": {
     "@apollo/server": "^4",
-    "@codeceptjs/expect-helper": "^0.2.2",
+    "@codeceptjs/expect-helper": "^1.0.0",
     "@codeceptjs/mock-request": "0.3.1",
     "@eslint/eslintrc": "3.2.0",
     "@eslint/js": "9.19.0",

--- a/test/acceptance/codecept.Playwright.coverage.js
+++ b/test/acceptance/codecept.Playwright.coverage.js
@@ -24,7 +24,7 @@ module.exports.config = {
       outputPath: 'test/acceptance/output',
     },
     Expect: {
-      require: '@codeceptjs/expect-helper/index.cjs',
+      import: '@codeceptjs/expect-helper/index.cjs',
     },
   },
   include: {},

--- a/test/acceptance/codecept.Playwright.coverage.js
+++ b/test/acceptance/codecept.Playwright.coverage.js
@@ -24,7 +24,7 @@ module.exports.config = {
       outputPath: 'test/acceptance/output',
     },
     Expect: {
-      require: '@codeceptjs/expect-helper/index.js',
+      require: '@codeceptjs/expect-helper/index.cjs',
     },
   },
   include: {},

--- a/test/acceptance/codecept.Playwright.coverage.js
+++ b/test/acceptance/codecept.Playwright.coverage.js
@@ -24,7 +24,7 @@ module.exports.config = {
       outputPath: 'test/acceptance/output',
     },
     Expect: {
-      import: '@codeceptjs/expect-helper/index.cjs',
+      require: '@codeceptjs/expect-helper',
     },
   },
   include: {},

--- a/test/acceptance/codecept.Playwright.coverage.js
+++ b/test/acceptance/codecept.Playwright.coverage.js
@@ -24,7 +24,7 @@ module.exports.config = {
       outputPath: 'test/acceptance/output',
     },
     Expect: {
-      require: '@codeceptjs/expect-helper',
+      require: '@codeceptjs/expect-helper/index.js',
     },
   },
   include: {},

--- a/test/acceptance/codecept.Playwright.js
+++ b/test/acceptance/codecept.Playwright.js
@@ -23,7 +23,9 @@ module.exports.config = {
       require: '../support/ScreenshotSessionHelper.js',
       outputPath: 'test/acceptance/output',
     },
-    '@codeceptjs/expect-helper': {},
+    Expect: {
+      require: '@codeceptjs/expect-helper',
+    },
   },
   include: {},
   bootstrap: false,

--- a/test/data/sandbox/configs/custom-reporter-plugin/output/result.json
+++ b/test/data/sandbox/configs/custom-reporter-plugin/output/result.json
@@ -1,0 +1,67 @@
+{
+  "hasFailed": true,
+  "stats": {
+    "passes": 0,
+    "failures": 1,
+    "tests": 1,
+    "pending": 0,
+    "failedHooks": 0,
+    "start": "2025-03-03T04:55:55.785Z",
+    "end": "2025-03-03T04:55:55.796Z",
+    "duration": 11
+  },
+  "duration": 21,
+  "tests": [
+    {
+      "opts": {},
+      "tags": [],
+      "uid": "7NxSU6hWX0tj5d6GGxCtwSpDCOTsK3ggAD33fv7kzE",
+      "retries": -1,
+      "title": "test custom-reporter-plugin",
+      "state": "failed",
+      "notes": [],
+      "meta": {},
+      "artifacts": [],
+      "duration": 1,
+      "err": {
+        "stack": "AssertionError [ERR_ASSERTION]: \n    at FileSystem.seeFile (/Volumes/dev/external-repos/CodeceptJS/lib/helper/FileSystem.js:70:12)\n    at HelperStep.run (/Volumes/dev/external-repos/CodeceptJS/lib/step/helper.js:28:49)\n\n\n◯ File: /Volumes/dev/external-repos/CodeceptJS/test/data/sandbox/configs/custom-reporter-plugin/custom-reporter-plugin_test.js\n\n◯ Scenario Steps:\n✖ I.seeFile(\"this-file-should-not-exist.txt\") at Test.<anonymous> (./custom-reporter-plugin_test.js:13:5)\n✔ I.amInPath(\".\") at Test.<anonymous> (./custom-reporter-plugin_test.js:12:5)\n",
+        "message": "\n  File this-file-should-not-exist.txt not found in /Volumes/dev/external-repos/CodeceptJS/test/data/sandbox/configs/custom-reporter-plugin",
+        "actual": "false",
+        "expected": "true"
+      },
+      "parent": {
+        "title": "custom-reporter-plugin"
+      },
+      "steps": [
+        {
+          "opts": {},
+          "title": "seeFile",
+          "args": ["this-file-should-not-exist.txt"],
+          "status": "failed",
+          "startTime": 1740977755792,
+          "endTime": 1740977755793,
+          "parent": {}
+        },
+        {
+          "opts": {},
+          "title": "amInPath",
+          "args": ["."],
+          "status": "success",
+          "startTime": 1740977755792,
+          "endTime": 1740977755792,
+          "parent": {}
+        }
+      ]
+    }
+  ],
+  "failures": [
+    [],
+    [
+      "  %s) %s:\n%s\n%s\n",
+      1,
+      "custom-reporter-plugin\n       test custom-reporter-plugin",
+      "\n      \n  File this-file-should-not-exist.txt not found in /Volumes/dev/external-repos/CodeceptJS/test/data/sandbox/configs/custom-reporter-plugin\n      + expected - actual\n\n      -false\n      +true\n      ",
+      "  AssertionError [ERR_ASSERTION]: \n      at FileSystem.seeFile (/Volumes/dev/external-repos/CodeceptJS/lib/helper/FileSystem.js:70:12)\n      at HelperStep.run (/Volumes/dev/external-repos/CodeceptJS/lib/step/helper.js:28:49)\n  \n  \n  ◯ File: /Volumes/dev/external-repos/CodeceptJS/test/data/sandbox/configs/custom-reporter-plugin/custom-reporter-plugin_test.js\n  \n  ◯ Scenario Steps:\n  ✖ I.seeFile(\"this-file-should-not-exist.txt\") at Test.<anonymous> (./custom-reporter-plugin_test.js:13:5)\n  ✔ I.amInPath(\".\") at Test.<anonymous> (./custom-reporter-plugin_test.js:12:5)\n  "
+    ]
+  ]
+}


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump @codeceptjs/expect-helper to ^1.0.0
- Resolves #4869 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
