### PR TITLE
chore(deps-dev): bump @codeceptjs/detox-helper to 1.1.7

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -15,32 +15,31 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - uses: shivammathur/setup-php@v2
-      with:
-        php-version: 7.4
-    - name: npm install
-      run: |
-        npm i --force && npm i puppeteer --force
-      env:
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-    - name: start a server
-      run: "php -S 127.0.0.1:8000 -t test/data/app &"
-    - uses: browser-actions/setup-chrome@v1
-    - run: chrome --version
-    - name: run tests
-      run:  "./bin/codecept.js run-workers 2 -c test/acceptance/codecept.Puppeteer.js --grep @Puppeteer --debug"
-    - name: run unit tests
-      run: ./node_modules/.bin/mocha test/helper/Puppeteer_test.js
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+      - name: npm install
+        run: |
+          npm i --force && npm i puppeteer --force
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+      - name: start a server
+        run: 'php -S 127.0.0.1:8000 -t test/data/app &'
+      - uses: browser-actions/setup-chrome@v1
+      - run: chrome --version
+      - name: run tests
+        run: './bin/codecept.js run-workers 2 -c test/acceptance/codecept.Puppeteer.js --grep @Puppeteer --debug'
+      - name: run unit tests
+        run: ./node_modules/.bin/mocha test/helper/Puppeteer_test.js

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "uuid": "11.1.0"
   },
   "optionalDependencies": {
-    "@codeceptjs/detox-helper": "1.1.5"
+    "@codeceptjs/detox-helper": "1.1.7"
   },
   "devDependencies": {
     "@apollo/server": "^4",


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump @codeceptjs/detox-helper to 1.1.7
- Resolves #4896 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
