### PR TITLE
chore: bump axios from 1.8.1 to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@xmldom/xmldom": "0.9.8",
     "acorn": "8.14.1",
     "arrify": "3.0.0",
-    "axios": "1.8.1",
+    "axios": "1.8.3",
     "chalk": "4.1.2",
     "cheerio": "^1.0.0",
     "commander": "11.1.0",


### PR DESCRIPTION
## Motivation/Description of the PR
- bump axios from 1.8.1 to 1.8.3
- Resolves #4482 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
