### PR TITLE
fix: Make tests more stable by using google

### DIFF
--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -46,8 +46,8 @@ Scenario('screenshots reflect the current page of current session @Puppeteer @Pl
 })
 
 Scenario('Different cookies for different sessions @Playwright @Puppeteer', async ({ I }) => {
-  const cookiePage = 'https://www.microsoft.com/en-au/'
-  const cookieName = 'MUID'
+  const cookiePage = 'https://google.com/'
+  const cookieName = 'AEC'
   const cookies = {}
 
   I.amOnPage(cookiePage)
@@ -68,7 +68,7 @@ Scenario('Different cookies for different sessions @Playwright @Puppeteer', asyn
     cookies.mary = (await I.grabCookie(cookieName)).value
     I.say(`${cookieName}: ${cookies.mary}`)
   })
-  await I.seeInCurrentUrl('en-au')
+  await I.seeInCurrentUrl('google.com')
   assert(cookies.default)
   assert(cookies.john)
   assert(cookies.mary)


### PR DESCRIPTION
## Motivation/Description of the PR
- Make tests more stable by using google
- Resolves #4903 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
