### PR TITLE
chore: bump webdriverio to 9.12.0 and friends

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@types/chai": "4.3.19",
     "@types/inquirer": "9.0.7",
     "@types/node": "22.13.0",
-    "@wdio/sauce-service": "9.10.1",
+    "@wdio/sauce-service": "9.12.0",
     "@wdio/selenium-standalone-service": "8.15.0",
     "@wdio/utils": "9.11.0",
     "@xmldom/xmldom": "0.9.7",
@@ -171,7 +171,7 @@
     "typedoc-plugin-markdown": "4.4.2",
     "typescript": "5.8.2",
     "wdio-docker-service": "3.2.1",
-    "webdriverio": "9.10.1",
+    "webdriverio": "9.12.0",
     "xml2js": "0.6.2",
     "xpath": "0.0.34"
   },


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump webdriverio to 9.12.0 and friends
- Resolves #4905

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
