### PR TITLE
release 3.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 3.7.3
+
+❤️ Thanks all to those who contributed to make this release! ❤️
+
+🛩️ _Features_
+
+- feat(cli): improve info command to return installed browsers (#4890) - by @kobenguyent
+
+```
+➜  helloworld npx codeceptjs info
+Environment information:
+
+codeceptVersion:  "3.7.2"
+nodeInfo:  18.19.0
+osInfo:  macOS 14.4
+cpuInfo:  (8) x64 Apple M1 Pro
+osBrowsers:  "chrome: 133.0.6943.143, edge: 133.0.3065.92, firefox: not installed, safari: 17.4"
+playwrightBrowsers:  "chromium: 133.0.6943.16, firefox: 134.0, webkit: 18.2"
+helpers:  {
+"Playwright": {
+"url": "http://localhost",
+...
+```
+
+🐛 _Bug Fixes_
+
+- fix: resolving path inconsistency in container.js and appium.js (#4866) - by @mjalav
+- fix: broken screenshot links in mochawesome reports (#4889) - by @kobenguyent
+- some internal fixes to make UTs more stable by @thomashohn
+- dependencies upgrades by @thomashohn
+
 ## 3.7.2
 
 ❤️ Thanks all to those who contributed to make this release! ❤️

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "Supercharged End 2 End Testing Framework for NodeJS",
   "keywords": [
     "acceptance",


### PR DESCRIPTION
## 3.7.3

❤️ Thanks all to those who contributed to make this release! ❤️

🛩️ *Features*
* feat(cli): improve info command to return installed browsers (#4890) - by @kobenguyent

```
➜  helloworld npx codeceptjs info
Environment information:

codeceptVersion:  "3.7.2"
nodeInfo:  18.19.0
osInfo:  macOS 14.4
cpuInfo:  (8) x64 Apple M1 Pro
osBrowsers:  "chrome: 133.0.6943.143, edge: 133.0.3065.92, firefox: not installed, safari: 17.4"
playwrightBrowsers:  "chromium: 133.0.6943.16, firefox: 134.0, webkit: 18.2"
helpers:  {
"Playwright": {
"url": "http://localhost",
...
```

🐛 *Bug Fixes*
* fix: resolving path inconsistency in container.js and appium.js  (#4866) - by @mjalav
* fix: broken screenshot links in mochawesome reports (#4889) - by @kobenguyent
* some internal fixes to make UTs more stable by @thomashohn
* dependencies upgrades by @thomashohn
