### PR TITLE
chore: Bump various minor versions to keeps deps updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "publish-beta": "./runok.js publish:next-beta-version"
   },
   "dependencies": {
-    "@codeceptjs/configure": "1.0.3",
+    "@codeceptjs/configure": "1.0.4",
     "@codeceptjs/helper": "2.0.4",
     "@cucumber/cucumber-expressions": "18",
     "@cucumber/gherkin": "32",
@@ -117,11 +117,11 @@
     "uuid": "11.1.0"
   },
   "optionalDependencies": {
-    "@codeceptjs/detox-helper": "1.1.7"
+    "@codeceptjs/detox-helper": "1.1.8"
   },
   "devDependencies": {
     "@apollo/server": "^4",
-    "@codeceptjs/expect-helper": "^1.0.1",
+    "@codeceptjs/expect-helper": "^1.0.2",
     "@codeceptjs/mock-request": "0.3.1",
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.23.0",
@@ -130,16 +130,16 @@
     "@pollyjs/core": "6.0.6",
     "@types/chai": "5.2.1",
     "@types/inquirer": "9.0.7",
-    "@types/node": "22.13.14",
+    "@types/node": "22.14.0",
     "@wdio/sauce-service": "9.12.2",
     "@wdio/selenium-standalone-service": "8.15.0",
-    "@wdio/utils": "9.12.1",
+    "@wdio/utils": "9.12.2",
     "@xmldom/xmldom": "0.9.8",
     "chai": "^4.0.0",
     "chai-as-promised": "7.1.2",
     "chai-subset": "1.6.0",
     "documentation": "14.0.3",
-    "electron": "35.1.1",
+    "electron": "35.1.3",
     "eslint": "^9.21.0",
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-mocha": "10.5.0",
@@ -155,7 +155,7 @@
     "json-server": "0.17.4",
     "playwright": "1.51.1",
     "prettier": "^3.3.2",
-    "puppeteer": "24.4.0",
+    "puppeteer": "24.5.0",
     "qrcode-terminal": "0.12.0",
     "rosie": "2.1.1",
     "runok": "0.9.3",
@@ -168,10 +168,10 @@
     "tsd": "^0.31.0",
     "tsd-jsdoc": "2.5.0",
     "typedoc": "0.28.1",
-    "typedoc-plugin-markdown": "4.6.0",
+    "typedoc-plugin-markdown": "4.6.1",
     "typescript": "5.8.2",
     "wdio-docker-service": "3.2.1",
-    "webdriverio": "9.12.1",
+    "webdriverio": "9.12.2",
     "xml2js": "0.6.2",
     "xpath": "0.0.34"
   },


### PR DESCRIPTION
## Motivation/Description of the PR
- Bump various minor versions to keeps deps updated
- Resolves #4949 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
