### PR TITLE
feat: better I.grab logging in live interactive mode

### DIFF
--- a/lib/pause.js
+++ b/lib/pause.js
@@ -179,6 +179,7 @@ async function parseInput(cmd) {
         output.print(output.styles.debug(JSON.stringify(val, null, 2)))
       } catch (err) {
         output.print(output.styles.error(' ERROR '), 'Failed to stringify result:', err.message)
+        output.print(output.styles.error(' RAW VALUE '), String(val))
       }
     }
 

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -175,7 +175,7 @@ async function parseInput(cmd) {
       output.print(output.styles.success('  OK  '), cmd)
     }
     if (cmd?.startsWith('I.grab')) {
-      output.print(output.styles.debug(val))
+      output.print(output.styles.debug(JSON.stringify(val, null, 2)))
     }
 
     history.push(cmd) // add command to history when successful

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -175,7 +175,11 @@ async function parseInput(cmd) {
       output.print(output.styles.success('  OK  '), cmd)
     }
     if (cmd?.startsWith('I.grab')) {
-      output.print(output.styles.debug(JSON.stringify(val, null, 2)))
+      try {
+        output.print(output.styles.debug(JSON.stringify(val, null, 2)))
+      } catch (err) {
+        output.print(output.styles.error(' ERROR '), 'Failed to stringify result:', err.message)
+      }
     }
 
     history.push(cmd) // add command to history when successful


### PR DESCRIPTION
## Motivation/Description of the PR


Currently, the interactive shell mode with pause() resulting output like:
`[Object object]....` this is clearly not useful during live interactive mode when we're using:
 `I.grabBrowserLogs();`
 or
 `I.grabRecordedNetworkTraffics();`

By json stringify the value, we can safely see every type of output in the terminal session like following. 
![image](https://github.com/user-attachments/assets/5707f61c-e296-4bb0-8b75-ba44ceffe282)


- Resolves #issueId (if applicable).


Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
