### PR TITLE
fix : naming convention session / main erasing with long test.title/tags

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2377,15 +2377,16 @@ class Playwright extends Helper {
     if (this.options.recordVideo && this.page && this.page.video()) {
       test.artifacts.video = saveVideoForPage(this.page, `${test.title}.failed`)
       for (const sessionName in this.sessionPages) {
-        test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.failed`)
+        if (sessionName === '') continue
+        test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${sessionName}_${test.title}.failed`)
       }
     }
 
     if (this.options.trace) {
       test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.failed`)
       for (const sessionName in this.sessionPages) {
-        if (!this.sessionPages[sessionName].context) continue
-        test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.failed`)
+        if (!this.sessionPages[sessionName].context || sessionName === '') continue
+        test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context(), `${sessionName}_${test.title}.failed`)
       }
     }
 
@@ -2399,7 +2400,8 @@ class Playwright extends Helper {
       if (this.options.keepVideoForPassedTests) {
         test.artifacts.video = saveVideoForPage(this.page, `${test.title}.passed`)
         for (const sessionName of Object.keys(this.sessionPages)) {
-          test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${test.title}_${sessionName}.passed`)
+          if (sessionName === '') continue
+          test.artifacts[`video_${sessionName}`] = saveVideoForPage(this.sessionPages[sessionName], `${sessionName}_${test.title}.passed`)
         }
       } else {
         this.page
@@ -2414,8 +2416,8 @@ class Playwright extends Helper {
         if (this.options.trace) {
           test.artifacts.trace = await saveTraceForContext(this.browserContext, `${test.title}.passed`)
           for (const sessionName in this.sessionPages) {
-            if (!this.sessionPages[sessionName].context) continue
-            test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context, `${test.title}_${sessionName}.passed`)
+            if (!this.sessionPages[sessionName].context || sessionName === '') continue
+            test.artifacts[`trace_${sessionName}`] = await saveTraceForContext(this.sessionPages[sessionName].context(), `${sessionName}_${test.title}.passed`)
           }
         }
       } else {


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
 Solve issue in some use case where videos and traces of Playwright are not saved correctly when using multiple sessions

 fix : naming convention session / main erasing with long test.title/tags  
  --> file name of traces and video have title limited to 245 char and contains sessions name at end and test status, which in case of gherkin/bdd is not enough, the session name is truncated. Meaning all traces/videos of sessions are written to same file. Changed the naming to have the session before test title, therefore, having always a different file name

 fix: context is funtion in session and not property
   --> in the sessions iteration, the access to context is not a property but a function, it resulted in getting out of saving because no tracing property existed. Added the () to context usage for sessions loop
 
 fix : dual saving main session
  --> main session is also in the list of sessions, generating a Playwright error as the traces are already savec for the main session, and having 2 times the session saved. Added a check on session name to exclude it from the sessions loop.
 
 
- Resolves #4981 

Applicable helpers:

- [X] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
