### PR TITLE
feat: shuffle test suite order in run command

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -164,6 +164,7 @@ program
   .option('--tests', 'run only JS test files and skip features')
   .option('--no-timeouts', 'disable all timeouts')
   .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
+  .option('--shuffle', 'Shuffle the order in which test files run')
 
   // mocha options
   .option('--colors', 'force enabling of colors')

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,6 +47,12 @@ Run single test with steps printed
 npx codeceptjs run github_test.js --steps
 ```
 
+Run test files in shuffled order
+
+```sh
+npx codeceptjs run --shuffle
+```
+
 Run single test in debug mode (see more in [debugging](#Debugging) section)
 
 ```sh

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -1,5 +1,6 @@
 const { existsSync, readFileSync } = require('fs')
 const { globSync } = require('glob')
+const shuffle = require('lodash.shuffle')
 const fsPath = require('path')
 const { resolve } = require('path')
 
@@ -179,6 +180,10 @@ class Codecept {
           }
         })
       }
+    }
+
+    if (this.opts.shuffle) {
+      this.testFiles = shuffle(this.testFiles)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "joi": "17.13.3",
     "js-beautify": "1.15.4",
     "lodash.clonedeep": "4.5.0",
+    "lodash.shuffle": "4.2.0",
     "lodash.merge": "4.6.2",
     "mkdirp": "3.0.1",
     "mocha": "11.6.0",


### PR DESCRIPTION
## Motivation/Description of the PR
Hello there.
Added an option to the run command that shuffles the order in which test suites are run.
Helpful if you want to make sure that your tests are not passing just because of a lucky side effect of a previous test.

Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [x] WebDriver
- [x] REST
- [x] FileHelper
- [x] Appium
- [x] TestCafe

Applicable plugins:

- [x] allure
- [x] autoDelay
- [x] autoLogin
- [x] customLocator
- [x] pauseOnFail
- [x] coverage
- [x] retryFailedStep
- [x] screenshotOnFail
- [x] selenoid
- [x] stepByStepReport
- [x] stepTimeout
- [x] wdio
- [x] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
