### PR TITLE
feat(cli): make test file path hyperlink

### DIFF
--- a/lib/mocha/cli.js
+++ b/lib/mocha/cli.js
@@ -200,7 +200,7 @@ class Cli extends Base {
 
         // explicitly show file with error
         if (test.file) {
-          log += `\n${output.styles.basic(figures.circle)} ${output.styles.section('File:')} ${output.styles.basic(test.file)}\n`
+          log += `\n${output.styles.basic(figures.circle)} ${output.styles.section('File:')} file://${test.file}\n`
         }
 
         const steps = test.steps || (test.ctx && test.ctx.test.steps)


### PR DESCRIPTION
## Motivation/Description of the PR
- make test file path hyperlink so that we could click and visit the file directly.
<img width="191" height="141" alt="Screenshot 13" src="https://github.com/user-attachments/assets/a2a21480-00d8-4508-8bf6-d4bf5630e06a" />


Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
