### PR TITLE
bugfix: prevent this error when running WebDriver without Bidi protocol: 'Error: Failed to execute WebDriver Bidi command "sessionSubscribe"'

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -491,7 +491,7 @@ class WebDriver extends Helper {
     }
     config.capabilities.browserName = config.browser || config.capabilities.browserName
 
-    // WebDriver Bidi Protocol. Default: false
+    // WebDriver Bidi Protocol. Default: true
     config.capabilities.webSocketUrl = config.bidiProtocol ?? config.capabilities.webSocketUrl ?? true
 
     config.capabilities.browserVersion = config.browserVersion || config.capabilities.browserVersion
@@ -629,7 +629,11 @@ class WebDriver extends Helper {
 
     this.browser.on('dialog', () => {})
 
-    await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
+    // Check for Bidi, because "sessionSubscribe" is an exclusive Bidi protocol feature. Otherwise, error will be thrown.
+    if (config.capabilities.webSocketUrl) {
+      await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
+    }
+
     this.browser.on('log.entryAdded', logEvents)
 
     return this.browser

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -632,9 +632,8 @@ class WebDriver extends Helper {
     // Check for Bidi, because "sessionSubscribe" is an exclusive Bidi protocol feature. Otherwise, error will be thrown.
     if (this.browser.capabilities && this.browser.capabilities.webSocketUrl) {
       await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
+      this.browser.on('log.entryAdded', logEvents)
     }
-
-    this.browser.on('log.entryAdded', logEvents)
 
     return this.browser
   }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -630,7 +630,7 @@ class WebDriver extends Helper {
     this.browser.on('dialog', () => {})
 
     // Check for Bidi, because "sessionSubscribe" is an exclusive Bidi protocol feature. Otherwise, error will be thrown.
-    if (config.capabilities.webSocketUrl) {
+    if (this.browser.capabilities && this.browser.capabilities.webSocketUrl) {
       await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
     }
 


### PR DESCRIPTION
…d "sessionSubscribe" as no Bidi session was established. Make sure you enable it by setting "webSocketUrl: true" in your capabilities and verify that your environment and browser supports it.' being printed to stdout when user deactivated Bidi protocol with "bidiProtocol" : false in Webdriver config.

## Motivation/Description of the PR

Situation:
- I use "WebDriver" against Selenoid
- Selenoid does not support Bidi protocol, because of reasons
- Since Bidi protocol active became the new default behavior in CodeceptJS recently, my tests time out when executed against Selenoid 😕
- Applying workaround "bidiProtocol" : "false" in WebDriver helper enables me to still run my test against Selenoid 🙂

Problem:
- BUT, you always see this annoying error in STDOUT and you don't have the power to prevent it: 😕
❌ "Error: Failed to execute WebDriver Bidi command "sessionSubscribe" as no Bidi session was established. Make sure you enable it by setting "webSocketUrl: true" in your capabilities and verify that your environment and browser supports it."

<img width="648" height="103" alt="image" src="https://github.com/user-attachments/assets/ff63455e-9a3d-4ae1-a2d0-792935f185bf" />

Solution presented in the pull-request:
- before
```
await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
```
- after
```
    // Check for Bidi, because "sessionSubscribe" is an exclusive Bidi protocol feature. Otherwise, error will be thrown.
    if (this.browser.capabilities && this.browser.capabilities.webSocketUrl) {
      await this.browser.sessionSubscribe({ events: ['log.entryAdded'] })
    }
```

## Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
