### PR TITLE
Fix: JSONResponse helper to preserve original onResponse behavior (Fixes #5042)

### DIFF
--- a/lib/helper/JSONResponse.js
+++ b/lib/helper/JSONResponse.js
@@ -72,10 +72,11 @@ class JSONResponse extends Helper {
     if (!this.helpers[this.options.requestHelper]) {
       throw new Error(`Error setting JSONResponse, helper ${this.options.requestHelper} is not enabled in config, helpers: ${Object.keys(this.helpers)}`)
     }
-    // connect to REST helper
+    const origOnResponse = this.helpers[this.options.requestHelper].config.onResponse;
     this.helpers[this.options.requestHelper].config.onResponse = response => {
-      this.response = response
-    }
+      this.response = response;
+      if (typeof origOnResponse === 'function') origOnResponse(response);
+    };
   }
 
   _before() {

--- a/test/unit/helper/json_response_onResponse_test.js
+++ b/test/unit/helper/json_response_onResponse_test.js
@@ -1,0 +1,68 @@
+const assert = require('assert')
+const REST = require('../../../lib/helper/REST')
+const Container = require('../../../lib/container')
+
+const TestHelper = require('../../support/TestHelper')
+const axios = require('axios')
+const fallBackURL = 'https://jsonplaceholder.typicode.com'
+//start the server using npm run test-server as in the package.json
+let api_url = TestHelper.jsonServerUrl()
+
+describe('REST onResponse Hook Wrapper', () => {
+  let rest
+
+  beforeEach(async () => {
+    Container.helpers({})
+    try {
+      await axios.get(`${api_url}`, { timeout: 1000 }) // Check if the server is reachable
+    } catch (e) {
+      api_url = fallBackURL // Fallback to alternative endpoint
+    }
+
+    rest = new REST({
+      endpoint: api_url,
+      onResponse: res => {
+        res.customFlag = true
+      },
+    })
+
+    rest._before()
+  })
+
+  afterEach(() => {
+    rest = null
+  })
+
+  it('should store response in this.response', async () => {
+    const response = await rest.sendGetRequest('/posts/1')
+    assert.ok(response, 'Expected response to be set on REST instance')
+    assert.equal(response.status, 200)
+  })
+
+  it('should call onResponse function and preserve modifications', async () => {
+    const response = await rest.sendGetRequest('/posts/1')
+    assert.ok(response.customFlag, 'Expected original onResponse to run and modify response')
+  })
+
+  it('should not fail if original onResponse is not set in the config', async () => {
+    const restNoHook = new REST({ endpoint: api_url })
+    restNoHook._before()
+
+    const response = await restNoHook.sendGetRequest('/posts/1')
+    assert.ok(response, 'Expected response to be returned')
+    assert.equal(response.status, 200)
+  })
+
+  it('should not throw if onResponse is not a function in the config', async () => {
+    const restInvalid = new REST({
+      endpoint: api_url,
+      onResponse: undefined,
+    })
+
+    restInvalid._before()
+
+    const response = await restInvalid.sendGetRequest('/posts/1')
+    assert.ok(response)
+    assert.equal(response.status, 200)
+  })
+})


### PR DESCRIPTION

## Motivation/Description of the PR
- Description of this PR, which problem it solves: Problem:
The current implementation overrides any custom onResponse handler that may have already been set in the user's configuration, causing their logic to be lost.

Suggested Fix:
Preserve the original onResponse handler by wrapping it, rather than replacing it:
- Resolves #issueId (if applicable): Fixes #5042

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
