### PR TITLE
fix: use platformName for mobile click detection instead of isW3C (Android touchClick bug)

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -995,7 +995,7 @@ class WebDriver extends Helper {
    * {{ react }}
    */
   async click(locator, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
+  const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick'
     const locateFn = prepareLocateFn.call(this, context)
 
     const res = await findClickable.call(this, locator, locateFn)
@@ -1214,7 +1214,7 @@ class WebDriver extends Helper {
    * {{> checkOption }}
    */
   async checkOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
+  const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick'
     const locateFn = prepareLocateFn.call(this, context)
 
     const res = await findCheckable.call(this, field, locateFn)
@@ -1234,7 +1234,7 @@ class WebDriver extends Helper {
    * {{> uncheckOption }}
    */
   async uncheckOption(field, context = null) {
-    const clickMethod = this.browser.isMobile && !this.browser.isW3C ? 'touchClick' : 'elementClick'
+  const clickMethod = this.browser.isMobile && this.browser.capabilities.platformName !== 'android' ? 'touchClick' : 'elementClick'
     const locateFn = prepareLocateFn.call(this, context)
 
     const res = await findCheckable.call(this, field, locateFn)


### PR DESCRIPTION


## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #4634 . The issue happens when using WebDriverIO 9.x, since https://github.com/webdriverio/webdriverio/pull/12987

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
