### PR TITLE
fix(playwright): relaunch browser correctly with `restart: 'session'` in `run-workers --by pool`

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -48,7 +48,9 @@ jobs:
         run: './bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug'
       - name: run chromium with restart==browser tests
         run: 'BROWSER_RESTART=browser ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug'
-      - name: run chromium with restart==session tests
+      - name: run chromium with restart==session tests on 2 workers split by pool
+        run: 'BROWSER_RESTART=session ./bin/codecept.js run-workers 2 -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug --by=pool'
+      - name: run chromium with restart==session tests and
         run: 'BROWSER_RESTART=session ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug'
       - name: run firefox tests
         run: 'BROWSER=firefox node ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug'

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1031,7 +1031,10 @@ class Playwright extends Helper {
     this.frame = null
     popupStore.clear()
     if (this.options.recordHar) await this.browserContext.close()
+    this.browserContext = null
     await this.browser.close()
+    this.browser = null
+    this.isRunning = false
   }
 
   async _evaluateHandeInContext(...args) {


### PR DESCRIPTION
## Description

This PR fixes a **pool-mode–specific** issue in the **Playwright helper** when `restart: 'session'` is enabled.

In `run-workers --by pool`, each test is executed via its **own** `codecept.run()` call. At the end of a test, `_finishTest()` triggers `_stopBrowser()`. However, `_stopBrowser()` left the helper’s internal state in an **inconsistent** condition (e.g. `isRunning` not reset, `browserContext` still referenced). On the subsequent test run, `_beforeSuite()` believed a browser was still active and **did not relaunch** it, leading to `page is null` / `waitForURL` errors.

This change ensures the helper’s state is **fully reset** when stopping the browser so that the next pool-assigned test relaunches cleanly.

---

## Scope / Affected configurations

- **Affected:** `run-workers --by pool` **with** Playwright helper configured as `restart: 'session'`.
- **Not affected:** legacy batch mode (single `codecept.run()`), `restart: false` / `'context'` (browser stays up), and `'browser'` (browser restart is expected every test).

Environment where reproduced: **CodeceptJS v3.7.5-beta.1** (Playwright helper).

---

## Why this didn’t break before

In **legacy batch mode**, a worker received a **batch** of tests and executed them in a **single** `codecept.run()` call. `_finishTest()` ran only **once** at the end of the batch, so the browser lifecycle remained consistent and the issue was masked.

With **pool mode**, each test gets its **own** `codecept.run()`. `_finishTest()` is invoked **after every test**, and because `_stopBrowser()` did not fully reset helper state, the **next** `codecept.run()` incorrectly assumed a live browser and skipped relaunch.

---

## Reproduction

**Setup**
- Playwright helper with `restart: 'session'`
- Execute with `run-workers --by pool`

**In code actions**
1. Start workers in pool mode.
2. First test runs.
3. `_finishTest()` calls `_stopBrowser()` at end of test.
4. Pool scheduler assigns a second test.
5. Second test begins.

**Observations**
- First test passes.
- Second test **does not** open a new browser/context.
- Steps fail with messages like:
  - `page is null, returning`
  - `Cannot read properties of undefined (reading 'waitForURL')`

---

## Fix

Ensure `_stopBrowser()` **fully resets** Playwright helper state so that `_beforeSuite()` (or the next test’s setup) reliably **relaunches** the browser in pool mode with `restart: 'session'`. Concretely:
- Set `isRunning = false`.
- Close and then null out `browserContext`.
- Close and then null out `browser`.

---

## Result

- With `restart: 'session'` in `run-workers --by pool`, each new test now **relaunches** a fresh browser/session as intended.
- Pool mode runs multiple tests sequentially **without** `page is null` failures.
- **Legacy batch mode** and other `restart` strategies remain **unchanged**.

---

## Risk / Compatibility

Low risk. The change is limited to the Playwright helper’s teardown path and only impacts flows that stop the browser. Normal runs and other restart strategies keep their current behavior.

---
Applicable helpers:

- [x] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
