### PR TITLE
Bugfix: Properly stop network traffic recording  

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2591,7 +2591,8 @@ class Puppeteer extends Helper {
    *
    * {{> stopRecordingTraffic }}
    */
-  stopRecordingTraffic() {
+  async stopRecordingTraffic() {
+    await this.page.setRequestInterception(false)
     stopRecordingTraffic.call(this)
   }
 

--- a/lib/helper/network/actions.js
+++ b/lib/helper/network/actions.js
@@ -1,68 +1,77 @@
-const assert = require('assert')
-const { isInTraffic, createAdvancedTestResults, getTrafficDump } = require('./utils')
+const assert = require('assert');
+const { isInTraffic, createAdvancedTestResults, getTrafficDump } = require('./utils');
 
 function dontSeeTraffic({ name, url }) {
   if (!this.recordedAtLeastOnce) {
-    throw new Error('Failure in test automation. You use "I.dontSeeTraffic", but "I.startRecordingTraffic" was never called before.')
+    throw new Error('Failure in test automation. You use "I.dontSeeTraffic", but "I.startRecordingTraffic" was never called before.');
   }
 
   if (!name) {
-    throw new Error('Missing required key "name" in object given to "I.dontSeeTraffic".')
+    throw new Error('Missing required key "name" in object given to "I.dontSeeTraffic".');
   }
 
   if (!url) {
-    throw new Error('Missing required key "url" in object given to "I.dontSeeTraffic".')
+    throw new Error('Missing required key "url" in object given to "I.dontSeeTraffic".');
   }
 
   if (isInTraffic.call(this, url)) {
-    assert.fail(`Traffic with name "${name}" (URL: "${url}') found, but was not expected to be found.`)
+    assert.fail(`Traffic with name "${name}" (URL: "${url}') found, but was not expected to be found.`);
   }
 }
 
-async function seeTraffic({ name, url, parameters, requestPostData, timeout = 10 }) {
+async function seeTraffic({
+  name, url, parameters, requestPostData, timeout = 10,
+}) {
   if (!name) {
-    throw new Error('Missing required key "name" in object given to "I.seeTraffic".')
+    throw new Error('Missing required key "name" in object given to "I.seeTraffic".');
   }
 
   if (!url) {
-    throw new Error('Missing required key "url" in object given to "I.seeTraffic".')
+    throw new Error('Missing required key "url" in object given to "I.seeTraffic".');
   }
 
   if (!this.recordedAtLeastOnce) {
-    throw new Error('Failure in test automation. You use "I.seeTraffic", but "I.startRecordingTraffic" was never called before.')
+    throw new Error('Failure in test automation. You use "I.seeTraffic", but "I.startRecordingTraffic" was never called before.');
   }
 
   for (let i = 0; i <= timeout * 2; i++) {
-    const found = isInTraffic.call(this, url, parameters)
+    const found = isInTraffic.call(this, url, parameters);
     if (found) {
-      return true
+      return true;
     }
-    await new Promise(done => {
-      setTimeout(done, 1000)
-    })
+    await new Promise((done) => {
+      setTimeout(done, 1000);
+    });
   }
 
   // check request post data
   if (requestPostData && isInTraffic.call(this, url)) {
-    const advancedTestResults = createAdvancedTestResults(url, requestPostData, this.requests)
+    const advancedTestResults = createAdvancedTestResults(url, requestPostData, this.requests);
 
-    assert.equal(advancedTestResults, true, `Traffic named "${name}" found correct URL ${url}, BUT the post data did not match:\n ${advancedTestResults}`)
+    assert.equal(advancedTestResults, true, `Traffic named "${name}" found correct URL ${url}, BUT the post data did not match:\n ${advancedTestResults}`);
   } else if (parameters && isInTraffic.call(this, url)) {
-    const advancedTestResults = createAdvancedTestResults(url, parameters, this.requests)
+    const advancedTestResults = createAdvancedTestResults(url, parameters, this.requests);
 
-    assert.fail(`Traffic named "${name}" found correct URL ${url}, BUT the query parameters did not match:\n` + `${advancedTestResults}`)
+    assert.fail(
+      `Traffic named "${name}" found correct URL ${url}, BUT the query parameters did not match:\n`
+      + `${advancedTestResults}`,
+    );
   } else {
-    assert.fail(`Traffic named "${name}" not found in recorded traffic within ${timeout} seconds.\n` + `Expected url: ${url}.\n` + `Recorded traffic:\n${getTrafficDump.call(this)}`)
+    assert.fail(
+      `Traffic named "${name}" not found in recorded traffic within ${timeout} seconds.\n`
+      + `Expected url: ${url}.\n`
+      + `Recorded traffic:\n${getTrafficDump.call(this)}`,
+    );
   }
 }
 
 async function grabRecordedNetworkTraffics() {
   if (!this.recordedAtLeastOnce) {
-    throw new Error('Failure in test automation. You use "I.grabRecordedNetworkTraffics", but "I.startRecordingTraffic" was never called before.')
+    throw new Error('Failure in test automation. You use "I.grabRecordedNetworkTraffics", but "I.startRecordingTraffic" was never called before.');
   }
 
-  const promises = this.requests.map(async request => {
-    const resp = await request.response
+  const promises = this.requests.map(async (request) => {
+    const resp = await request.response;
 
     if (!resp) {
       return {
@@ -72,13 +81,13 @@ async function grabRecordedNetworkTraffics() {
           statusText: '',
           body: '',
         },
-      }
+      };
     }
 
-    let body
+    let body;
     try {
       // There's no 'body' for some requests (redirect etc...)
-      body = JSON.parse((await resp.body()).toString())
+      body = JSON.parse((await resp.body()).toString());
     } catch (e) {
       // only interested in JSON, not HTML responses.
     }
@@ -90,21 +99,21 @@ async function grabRecordedNetworkTraffics() {
         statusText: resp.statusText(),
         body,
       },
-    }
-  })
-  return Promise.all(promises)
+    };
+  });
+  return Promise.all(promises);
 }
 
 function stopRecordingTraffic() {
   // @ts-ignore
-  this.page.removeAllListeners('request')
-  // @ts-ignore
-  this.page.removeAllListeners('requestfinished')
-  this.recording = false
+  this.page.removeAllListeners('request');
+   // @ts-ignore
+  this.page.removeAllListeners('requestfinished');
+  this.recording = false;
 }
 
 function flushNetworkTraffics() {
-  this.requests = []
+  this.requests = [];
 }
 
 module.exports = {
@@ -113,4 +122,4 @@ module.exports = {
   grabRecordedNetworkTraffics,
   stopRecordingTraffic,
   flushNetworkTraffics,
-}
+};

--- a/lib/helper/network/actions.js
+++ b/lib/helper/network/actions.js
@@ -1,77 +1,68 @@
-const assert = require('assert');
-const { isInTraffic, createAdvancedTestResults, getTrafficDump } = require('./utils');
+const assert = require('assert')
+const { isInTraffic, createAdvancedTestResults, getTrafficDump } = require('./utils')
 
 function dontSeeTraffic({ name, url }) {
   if (!this.recordedAtLeastOnce) {
-    throw new Error('Failure in test automation. You use "I.dontSeeTraffic", but "I.startRecordingTraffic" was never called before.');
+    throw new Error('Failure in test automation. You use "I.dontSeeTraffic", but "I.startRecordingTraffic" was never called before.')
   }
 
   if (!name) {
-    throw new Error('Missing required key "name" in object given to "I.dontSeeTraffic".');
+    throw new Error('Missing required key "name" in object given to "I.dontSeeTraffic".')
   }
 
   if (!url) {
-    throw new Error('Missing required key "url" in object given to "I.dontSeeTraffic".');
+    throw new Error('Missing required key "url" in object given to "I.dontSeeTraffic".')
   }
 
   if (isInTraffic.call(this, url)) {
-    assert.fail(`Traffic with name "${name}" (URL: "${url}') found, but was not expected to be found.`);
+    assert.fail(`Traffic with name "${name}" (URL: "${url}') found, but was not expected to be found.`)
   }
 }
 
-async function seeTraffic({
-  name, url, parameters, requestPostData, timeout = 10,
-}) {
+async function seeTraffic({ name, url, parameters, requestPostData, timeout = 10 }) {
   if (!name) {
-    throw new Error('Missing required key "name" in object given to "I.seeTraffic".');
+    throw new Error('Missing required key "name" in object given to "I.seeTraffic".')
   }
 
   if (!url) {
-    throw new Error('Missing required key "url" in object given to "I.seeTraffic".');
+    throw new Error('Missing required key "url" in object given to "I.seeTraffic".')
   }
 
-  if (!this.recording || !this.recordedAtLeastOnce) {
-    throw new Error('Failure in test automation. You use "I.seeTraffic", but "I.startRecordingTraffic" was never called before.');
+  if (!this.recordedAtLeastOnce) {
+    throw new Error('Failure in test automation. You use "I.seeTraffic", but "I.startRecordingTraffic" was never called before.')
   }
 
   for (let i = 0; i <= timeout * 2; i++) {
-    const found = isInTraffic.call(this, url, parameters);
+    const found = isInTraffic.call(this, url, parameters)
     if (found) {
-      return true;
+      return true
     }
-    await new Promise((done) => {
-      setTimeout(done, 1000);
-    });
+    await new Promise(done => {
+      setTimeout(done, 1000)
+    })
   }
 
   // check request post data
   if (requestPostData && isInTraffic.call(this, url)) {
-    const advancedTestResults = createAdvancedTestResults(url, requestPostData, this.requests);
+    const advancedTestResults = createAdvancedTestResults(url, requestPostData, this.requests)
 
-    assert.equal(advancedTestResults, true, `Traffic named "${name}" found correct URL ${url}, BUT the post data did not match:\n ${advancedTestResults}`);
+    assert.equal(advancedTestResults, true, `Traffic named "${name}" found correct URL ${url}, BUT the post data did not match:\n ${advancedTestResults}`)
   } else if (parameters && isInTraffic.call(this, url)) {
-    const advancedTestResults = createAdvancedTestResults(url, parameters, this.requests);
+    const advancedTestResults = createAdvancedTestResults(url, parameters, this.requests)
 
-    assert.fail(
-      `Traffic named "${name}" found correct URL ${url}, BUT the query parameters did not match:\n`
-      + `${advancedTestResults}`,
-    );
+    assert.fail(`Traffic named "${name}" found correct URL ${url}, BUT the query parameters did not match:\n` + `${advancedTestResults}`)
   } else {
-    assert.fail(
-      `Traffic named "${name}" not found in recorded traffic within ${timeout} seconds.\n`
-      + `Expected url: ${url}.\n`
-      + `Recorded traffic:\n${getTrafficDump.call(this)}`,
-    );
+    assert.fail(`Traffic named "${name}" not found in recorded traffic within ${timeout} seconds.\n` + `Expected url: ${url}.\n` + `Recorded traffic:\n${getTrafficDump.call(this)}`)
   }
 }
 
 async function grabRecordedNetworkTraffics() {
-  if (!this.recording || !this.recordedAtLeastOnce) {
-    throw new Error('Failure in test automation. You use "I.grabRecordedNetworkTraffics", but "I.startRecordingTraffic" was never called before.');
+  if (!this.recordedAtLeastOnce) {
+    throw new Error('Failure in test automation. You use "I.grabRecordedNetworkTraffics", but "I.startRecordingTraffic" was never called before.')
   }
 
-  const promises = this.requests.map(async (request) => {
-    const resp = await request.response;
+  const promises = this.requests.map(async request => {
+    const resp = await request.response
 
     if (!resp) {
       return {
@@ -81,13 +72,13 @@ async function grabRecordedNetworkTraffics() {
           statusText: '',
           body: '',
         },
-      };
+      }
     }
 
-    let body;
+    let body
     try {
       // There's no 'body' for some requests (redirect etc...)
-      body = JSON.parse((await resp.body()).toString());
+      body = JSON.parse((await resp.body()).toString())
     } catch (e) {
       // only interested in JSON, not HTML responses.
     }
@@ -99,19 +90,21 @@ async function grabRecordedNetworkTraffics() {
         statusText: resp.statusText(),
         body,
       },
-    };
-  });
-  return Promise.all(promises);
+    }
+  })
+  return Promise.all(promises)
 }
 
 function stopRecordingTraffic() {
   // @ts-ignore
-  this.page.removeAllListeners('request');
-  this.recording = false;
+  this.page.removeAllListeners('request')
+  // @ts-ignore
+  this.page.removeAllListeners('requestfinished')
+  this.recording = false
 }
 
 function flushNetworkTraffics() {
-  this.requests = [];
+  this.requests = []
 }
 
 module.exports = {
@@ -120,4 +113,4 @@ module.exports = {
   grabRecordedNetworkTraffics,
   stopRecordingTraffic,
   flushNetworkTraffics,
-};
+}

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -1703,6 +1703,16 @@ module.exports.tests = function () {
       expect(traffics.length).to.equal(0)
     })
 
+    it('should stop the network recording', async () => {
+      await I.startRecordingTraffic()
+      await I.amOnPage('https://codecept.io/')
+      await I.stopRecordingTraffic()
+      const traffics1 = await I.grabRecordedNetworkTraffics()
+      await I.amOnPage('https://codecept.io/')
+      const traffics2 = await I.grabRecordedNetworkTraffics()
+      expect(traffics2.length).to.equal(traffics1.length)
+    })
+
     it('should see recording traffics', async () => {
       I.startRecordingTraffic()
       I.amOnPage('https://codecept.io/')


### PR DESCRIPTION
### Context  
In the Playwright helper, `startRecordingTraffic()` attaches a listener on the `requestfinished` event to capture completed network requests.  
However, `stopRecordingTraffic()` was calling `removeAllListeners('request')`, which does not remove `requestfinished` listeners. This traffic is still recording event after the stopRecordingTraffic.  

Also, in `seeTraffic`, the condition was too strict: it required both `recording === true` *and* `recordedAtLeastOnce`. This prevented assertions on traffic after `stopRecordingTraffic()`.  

### Fix  
- Updated `stopRecordingTraffic()` to remove listeners for both `request` and `requestfinished`.  
  - Instead of changing the event listened to in `startRecordingTraffic()`, I chose to keep `requestfinished` and just ensure proper cleanup. This minimizes changes and avoids breaking compatibility.  
- Simplified `seeTraffic` condition: now it only checks `recordedAtLeastOnce`. Users can assert collected traffic even after recording is stopped.  

### Tests  
- Added a test ensuring that after calling `stopRecordingTraffic()`, new requests are no longer collected.  

### Impact  
- Keeps `actions.js` generic and safe.  
- No API changes.  
- Fixes stop recordings and makes `seeTraffic` usable after stopping traffic recording.  


Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
