### PR TITLE
fix(utils): resolve command injection vulnerability in `emptyFolder` (3.x)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -476,7 +476,7 @@ module.exports.isNotSet = function (obj) {
   return false
 }
 
-module.exports.emptyFolder = async directoryPath => {
+module.exports.emptyFolder = directoryPath => {
   require('child_process').execSync(`rm -rf ${directoryPath}/*`)
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -477,7 +477,11 @@ module.exports.isNotSet = function (obj) {
 }
 
 module.exports.emptyFolder = directoryPath => {
-  require('child_process').execSync(`rm -rf ${directoryPath}/*`)
+  // Do not throw on non-existent directory, since it may be created later
+  if (!fs.existsSync(directoryPath)) return
+  for (const file of fs.readdirSync(directoryPath)) {
+    fs.rmSync(path.join(directoryPath, file), { recursive: true, force: true })
+  }
 }
 
 module.exports.printObjectProperties = obj => {


### PR DESCRIPTION
## Motivation/Description of the PR

This PR resolves a command injection vulnerability in the `emptyFolder` utility (on the `3.x` branch); see https://github.com/advisories/GHSA-34w8-mcwr-vg29.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)