### PR TITLE
fix:[iOS 17+] Appium should not overrride sauce:options cap with prefix

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -275,7 +275,7 @@ class Appium extends Webdriver {
     const _convertedCaps = {}
     for (const [key, value] of Object.entries(capabilities)) {
       if (!key.startsWith(vendorPrefix.appium)) {
-        if (key !== 'platformName' && key !== 'bstack:options') {
+        if (key !== 'platformName' && key !== 'bstack:options' && key !== 'sauce:options') {
           _convertedCaps[`${vendorPrefix.appium}:${key}`] = value
         } else {
           _convertedCaps[`${key}`] = value


### PR DESCRIPTION
## Motivation/Description of the PR
- [iOS 17+] Override of 'sauce:options' cap into 'appium:sauce:options' lead to error on start and does not allow to run tests on cloud provider: iOS 17 and above must be used with the W3C protocol and Appium 2. Visit https://docs.saucelabs.com/mobile-apps/automated-testing/appium/appium-2-migration/ to learn how to migrate to Appium 2.
- Preconditions: "codeceptjs": "^3.7.4", "webdriverio": "^9.19.2", cloud provider: SauceLabs
- Used settings
Appium: {
  "appiumV2": true,
  "protocol": "https",
  "host": "[ondemand.eu-central-1.saucelabs.com](http://ondemand.eu-central-1.saucelabs.com/)",
  "region": "eu",
  "port": 443,
  "path": "/wd/hub",
  "user": "mikhail.yesipchuk",
  "key": "...",
  "waitForTimeout": 5000,
  "smartWait": 3000,
  "app": "storage:filename=*.ipa",
  "platform": "iOS",
  "restart": false,
  "reuseSession": false,
  "desiredCapabilities": {
    "platformName": "iOS",
    "appium:app": "storage:filename=*.ipa",
    "appium:automationName": "XCUITest",
    "appium:platformVersion": "18",
    "appium:deviceName": "iPhone 1.*",
    "appium:language": "en",
    "appium:locale": "en_GB",
    "sauce:options": {
      "name": "Mobile Automation Test - iOS",
      "appiumVersion": "latest",
      "phoneOnly": true,
      "networkCapture": false,
    },
    "appium:noReset": true,
    "appium:fullReset": false,
    "appium:waitForIdleTimeout": 0,
    "appium:newCommandTimeout": 90,
    "appium:autoAcceptAlerts": true,
    "appium:useNewWDA": false
  }
}

<img width="1007" height="190" alt="Screenshot 2025-09-22 at 14 57 48" src="https://github.com/user-attachments/assets/085225b1-ce73-4ec0-8569-8941c3b37b01" />

Note: issue happens after update wdio from v8 to v9

Applicable helpers:
- [X] Appium

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)

Test run:
220 passing (4m)
  1 pending
  1 failing

1) CodeceptJS Workers Runner
       should run tests with pool mode:
     Uncaught Error: expect(received).toContain(expected) // indexOf

Expected substring: "Scenario Steps:"
Received string:    "CodeceptJS v3.7.5 #StandWithUkraine
