### PR TITLE
fixed: typo in example of "retryTo" in lib/effects.js

### DIFF
--- a/lib/effects.js
+++ b/lib/effects.js
@@ -89,7 +89,7 @@ async function hopeThat(callback) {
  * - Restores the session state after each attempt, whether successful or not.
  *
  * @example
- * const { hopeThat } = require('codeceptjs/effects')
+ * const { retryTo } = require('codeceptjs/effects')
  * await retryTo((tries) => {
  *   if (tries < 3) {
  *     I.see('Non-existent element'); // Simulates a failure


### PR DESCRIPTION
## Motivation/Description of the PR

- fixed typo in `@example` documentation of effects/retryTo

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
