### PR TITLE
Fix the package types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,19 @@
     "docs/webapi/**"
   ],
   "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "typings/index.d.ts",
   "exports": {
-    ".": "./lib/index.js",
+    ".": {
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "types": "./typings/index.d.ts"
+    },
     "./lib/*": "./lib/*.js",
     "./els": "./lib/els.js",
     "./effects": "./lib/effects.js",
     "./steps": "./lib/steps.js"
   },
-  "types": "typings/index.d.ts",
   "bin": {
     "codeceptjs": "./bin/codecept.js"
   },


### PR DESCRIPTION
## Motivation/Description of the PR

It's not possible to correctly build codeceptjs custom reporters after the package update.

The PR provides a correct `exports` field that no longer overrides `types` field and make possible to use types without collisions. 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
