### PR TITLE
Remove duplicate Playwright helper initialization (drop constructor setTimeout)

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -360,10 +360,6 @@ class Playwright extends Helper {
     // override defaults with config
     this._setConfig(config)
 
-    // Call _init() to register selector engines - use setTimeout to avoid blocking constructor
-    setTimeout(() => {
-      this._init().catch(console.error)
-    }, 0)
   }
 
   _validateConfig(config) {


### PR DESCRIPTION
# Playwright Helper: Remove duplicate async initialization causing race conditions

## Summary
This PR removes an unnecessary `setTimeout(... _init())` call from the `Playwright` helper constructor that caused `_init()` to run twice in parallel during framework bootstrap. Initialization is already performed by the CodeceptJS container (`container.createHelpers -> helper._init()`), so the deferred constructor call was redundant and risky.

## Background
After merging PR https://github.com/codeceptjs/CodeceptJS/pull/5089 (custom locator strategies + selector engine registration improvements), the constructor still contained (or reintroduced) an asynchronous fire‑and‑forget initialization pattern:

```js
setTimeout(() => this._init().catch(console.error), 0)
```

At runtime this led to two near-simultaneous executions:

1. Automatic container call: `global.createHelpers -> Playwright._init`
2. Deferred constructor invocation via `setTimeout`

Result: duplicate selector engine registration attempts and potential race conditions (especially if future logic adds non-idempotent side effects).

## Problem Details
Stack traces showed two `_init` executions for a single `codecept init` / test catalog discovery phase. Although selector engine registration was wrapped in `try/catch`, this produced noisy logs and increased risk of subtle state bugs (e.g. shared sets like `registeredCustomLocatorStrategies`).

## Changes
- Removed the deferred `setTimeout` call from the `Playwright` helper constructor.
- Relied solely on the container-managed `_init()` lifecycle.
- (No functional behavior loss: `_startBrowser()` already awaits `_init()` explicitly.)

## Rationale
- Avoid hidden async side effects inside the constructor.
- Make initialization order predictable and single-pass.
- Reduce noise (“already registered”) and eliminate potential race windows.

## What This Does NOT Change
- Public API of the Playwright helper.
- Custom locator strategy registration logic.
- Restart/session behavior.
- Trace/video/HAR setup.

## Reproduction Before Fix
1. Run a script that loads CodeceptJS programmatically (e.g. introspection or test discovery).
2. Observe duplicated `_init` stack traces and selector registration attempts.

## After Fix
Only one `_init` call—triggered by the container—appears in traces.

## Testing & Safety
- Manual verification: single `_init` invocation during bootstrap.
- Selector engines still registered once; no "already registered" warnings.
- No timing dependency detected that relied on the deferred microtask/macro task gap.

## Potential Follow-Up (Optional)
If future contributions add asynchronous prep stages that *must* be serialized:
- Introduce `_initialized` / `_initPromise` guards (idempotence) inside `_init()`.
- Add a small unit/integration test asserting single execution count.

## Migration
No action required for end users or plugin authors.

## Risk Assessment
Low. The removed code path was redundant; the retained path is the canonical lifecycle hook.

## Changelog Entry
Playwright Helper: Remove redundant deferred `_init()` invocation to prevent duplicate initialization and potential race conditions.

---

Applicable helpers:

- [x] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
