### PR TITLE
fix: wrong stats when running with workers

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -23,11 +23,36 @@ const Codecept = require(process.env.CODECEPT_CLASS_PATH || '../../codecept')
 const { options, tests, testRoot, workerIndex, poolMode } = workerData
 
 // hide worker output
-if (!options.debug && !options.verbose)
+// In pool mode, always hide worker output to prevent duplicate output
+// In regular mode, hide result output but allow step output in verbose/debug
+if (poolMode || (!options.debug && !options.verbose)) {
   process.stdout.write = string => {
     stdout += string
     return true
   }
+} else {
+  // In verbose/debug mode for test/suite modes, show step details
+  // but suppress individual worker result summaries to avoid duplicate output
+  const originalWrite = process.stdout.write
+  const originalConsoleLog = console.log
+
+  process.stdout.write = string => {
+    // Suppress individual worker result summaries and failure reports
+    if (string.includes('  FAIL  |') || string.includes('  OK  |') || string.includes('-- FAILURES:') || string.includes('AssertionError:') || string.includes('◯ File:') || string.includes('◯ Scenario Steps:')) {
+      return true
+    }
+    return originalWrite.call(process.stdout, string)
+  }
+
+  // Override console.log to catch result summaries
+  console.log = (...args) => {
+    const fullMessage = args.join(' ')
+    if (fullMessage.includes('  FAIL  |') || fullMessage.includes('  OK  |') || fullMessage.includes('-- FAILURES:')) {
+      return
+    }
+    return originalConsoleLog.apply(console, args)
+  }
+}
 
 const overrideConfigs = tryOrDefault(() => JSON.parse(options.override), {})
 

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -23,9 +23,22 @@ const Codecept = require(process.env.CODECEPT_CLASS_PATH || '../../codecept')
 const { options, tests, testRoot, workerIndex, poolMode } = workerData
 
 // hide worker output
-// In pool mode, always hide worker output to prevent duplicate output
+// In pool mode, only suppress output if debug is NOT enabled
 // In regular mode, hide result output but allow step output in verbose/debug
-if (poolMode || (!options.debug && !options.verbose)) {
+if (poolMode && !options.debug) {
+  // In pool mode without debug, suppress only result summaries and failures, but allow Scenario Steps
+  const originalWrite = process.stdout.write
+  process.stdout.write = string => {
+    // Always allow Scenario Steps output
+    if (string.includes('Scenario Steps:')) {
+      return originalWrite.call(process.stdout, string)
+    }
+    if (string.includes('  FAIL  |') || string.includes('  OK  |') || string.includes('-- FAILURES:') || string.includes('AssertionError:') || string.includes('◯ File:')) {
+      return true
+    }
+    return originalWrite.call(process.stdout, string)
+  }
+} else if (!poolMode && !options.debug && !options.verbose) {
   process.stdout.write = string => {
     stdout += string
     return true


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
