### PR TITLE
fixed: TS typings for Codecept and MainConfig

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -122,6 +122,7 @@ class Codecept {
   /**
    * Executes bootstrap.
    *
+   * @returns {Promise<void>}
    */
   async bootstrap() {
     return runHook(this.config.bootstrap, 'bootstrap')
@@ -129,7 +130,8 @@ class Codecept {
 
   /**
    * Executes teardown.
-
+   *
+   * @returns {Promise<void>}
    */
   async teardown() {
     return runHook(this.config.teardown, 'teardown')
@@ -262,6 +264,11 @@ class Codecept {
     })
   }
 
+  /**
+   * Returns the version string of CodeceptJS.
+   *
+   * @returns {string} The version string.
+   */
   static version() {
     return JSON.parse(readFileSync(`${__dirname}/../package.json`, 'utf8')).version
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -97,7 +97,7 @@ declare namespace CodeceptJS {
      * tests: 'tests/**.test.ts'
      * ```
      */
-    tests: string
+    tests: string | string[]
     /**
      * Where to store failure screenshots, artifacts, etc
      *
@@ -520,17 +520,16 @@ declare namespace CodeceptJS {
   }
 }
 
-type TryTo = <T>(fn: () => Promise<T> | T) => Promise<T | false>;
-type HopeThat = <T>(fn: () => Promise<T> | T) => Promise<T | false>;
-type RetryTo = <T>(fn: () => Promise<T> | T, retries?: number) => Promise<T>;
-
+type TryTo = <T>(fn: () => Promise<T> | T) => Promise<T | false>
+type HopeThat = <T>(fn: () => Promise<T> | T) => Promise<T | false>
+type RetryTo = <T>(fn: () => Promise<T> | T, retries?: number) => Promise<T>
 
 // Globals
 declare const codecept_dir: string
 declare const output_dir: string
-declare const tryTo: TryTo;
-declare const retryTo: RetryTo;
-declare const hopeThat: HopeThat;
+declare const tryTo: TryTo
+declare const retryTo: RetryTo
+declare const hopeThat: HopeThat
 
 declare const actor: CodeceptJS.actor
 declare const codecept_actor: CodeceptJS.actor
@@ -643,7 +642,7 @@ declare module '@codeceptjs/helper' {
 }
 
 declare module 'codeceptjs/effects' {
-  export const tryTo: TryTo;
-  export const retryTo: RetryTo;
-  export const hopeThat: HopeThat;
+  export const tryTo: TryTo
+  export const retryTo: RetryTo
+  export const hopeThat: HopeThat
 }


### PR DESCRIPTION
## Motivation/Description of the PR

This PR contains fixes for TypeScript types.

- in `MainConfig`, the option `tests` can be an array of strings.
- in `class Codecept`, the methods `bootstrap` and `teardown` will always return a promise.
- added jsdoc with types for static `Codecept.version`

The `npm run def` script has removed a few unrelated semicolons in `index.d.ts`.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
