### PR TITLE
fixed: remove deprecated fs.rmdirSync with recursive option

### DIFF
--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -175,7 +175,7 @@ describe('CodeceptJS Workers Runner', function () {
     let createdOutput = false
 
     if (fs.existsSync(outputDir)) {
-      fs.rmdirSync(outputDir, { recursive: true })
+      fs.rmSync(outputDir, { recursive: true, force: true })
     }
 
     if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version')


### PR DESCRIPTION
## Motivation/Description of the PR

Node's `fs.rmdirSync` with "recursive" option is deprecated.

https://nodejs.org/api/deprecations.html#dep0147-fsrmdirpath--recursive-true-

This function was used once in the test file `test/runner/run_workers_test.js`.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
