### PR TITLE
fix: flaky UTs

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -29,8 +29,8 @@ if (poolMode && !options.debug) {
   // In pool mode without debug, suppress only result summaries and failures, but allow Scenario Steps
   const originalWrite = process.stdout.write
   process.stdout.write = string => {
-    // Always allow Scenario Steps output
-    if (string.includes('Scenario Steps:')) {
+    // Always allow Scenario Steps output (including the circle symbol)
+    if (string.includes('Scenario Steps:') || string.includes('◯ Scenario Steps:')) {
       return originalWrite.call(process.stdout, string)
     }
     if (string.includes('  FAIL  |') || string.includes('  OK  |') || string.includes('-- FAILURES:') || string.includes('AssertionError:') || string.includes('◯ File:')) {


### PR DESCRIPTION
## Motivation/Description of the PR
- fix flaky runner tests

```
  220 passing (4m)
  1 pending
  1 failing

  1) CodeceptJS Timeouts
       should stop test when timeout exceeded:
     Uncaught Error: expect(received).toContain(expected) // indexOf

Expected substring: "Timeout 1s exceeded"
Received string:    "CodeceptJS v3.7.5 #StandWithUkraine
Using test root \"/home/runner/work/CodeceptJS/CodeceptJS/test/data/sandbox/configs/timeouts\"·
timed out in 2s --·
  ✖ no timeout in 2009ms·
  ✖ timeout in 1 #fourth in 1000ms·
-- FAILURES:·
  1) timed out in 2s
       no timeout:······
  Timeout 2s exceeded (with Before hook)
  TestTimeoutError:·
      at /home/runner/work/CodeceptJS/CodeceptJS/lib/listener/globalTimeout.js:135:17
      at /home/runner/work/CodeceptJS/CodeceptJS/lib/recorder.js:299:16······
  ◯ File: file:///home/runner/work/CodeceptJS/CodeceptJS/test/data/sandbox/configs/timeouts/suite_timeout_test.js···
  ◯ Scenario Steps:
  ✖ I.waitForSleep(3000) at Test.<anonymous> (./suite_timeout_test.js:4:5)····
  2) timed out in 2s
       timeout in 1 #fourth:······
  Step I.waitForSleep(3000) timed out after 1s
  StepTimeoutError:·
      at /home/runner/work/CodeceptJS/CodeceptJS/lib/listener/globalTimeout.js:137:15
      at /home/runner/work/CodeceptJS/CodeceptJS/lib/recorder.js:299:16······
  ◯ File: file:///home/runner/work/CodeceptJS/CodeceptJS/test/data/sandbox/configs/timeouts/suite_timeout_test.js···
  ◯ Scenario Steps:
  ✖ I.waitForSleep(3000) at Test.<anonymous> (./suite_timeout_test.js:8:5)·····
  FAIL  | 0 passed, 2 failed   // 3s
Run with --verbose flag to see complete NodeJS stacktrace
"
      at /home/runner/work/CodeceptJS/CodeceptJS/test/runner/timeout_test.js:19:22
      at ChildProcess.exithandler (node:child_process:424:5)
      at ChildProcess.emit (node:events:519:28)
      at maybeClose (node:internal/child_process:1101:16)
      at ChildProcess._handle.onexit (node:internal/child_process:304:5)
```

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
