### PR TITLE
fixed: add typings for class Result

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -41,10 +41,16 @@ class Result {
       duration: 0,
     }
 
-    /** @type {CodeceptJS.Test[]} */
+    /**
+     * @type {CodeceptJS.Test[]}
+     * @private
+     */
     this._tests = []
 
-    /** @type {string[][]} */
+    /**
+     * @type {string[][]}
+     * @private
+     */
     this._failures = []
   }
 
@@ -63,35 +69,50 @@ class Result {
   }
 
   /**
-   * @returns {boolean} Whether this result contains any failed tests.
+   * Whether this result contains any failed tests.
+   *
+   * @type {boolean}
+   * @readonly
    */
   get hasFailed() {
     return this._stats.failures > 0
   }
 
   /**
-   * @returns {CodeceptJS.Test[]} All collected tests.
+   * All collected tests.
+   *
+   * @type {CodeceptJS.Test[]}
+   * @readonly
    */
   get tests() {
     return this._tests
   }
 
   /**
-   * @returns {string[][]} The failure reports (array aof strings per failed test).
+   * The failure reports (array of strings per failed test).
+   *
+   * @type {string[][]}
+   * @readonly
    */
   get failures() {
     return this._failures.filter(f => f && (!Array.isArray(f) || f.length > 0))
   }
 
   /**
-   * @returns {Stats} The test statistics.
+   * The test statistics.
+   *
+   * @type {Stats}
+   * @readonly
    */
   get stats() {
     return this._stats
   }
 
   /**
-   * @returns {Date} The start time of the test run.
+   * The start time of the test run.
+   *
+   * @type {Date}
+   * @readonly
    */
   get startTime() {
     return this._startTime
@@ -122,35 +143,50 @@ class Result {
   }
 
   /**
-   * @returns {boolean} Whether this result contains any failed tests.
+   * Whether this result contains any failed tests.
+   *
+   * @type {boolean}
+   * @readonly
    */
   get hasFailures() {
     return this.stats.failures > 0
   }
 
   /**
-   * @returns {number} The duration of the test run, in milliseconds.
+   * The duration of the test run, in milliseconds.
+   *
+   * @type {number}
+   * @readonly
    */
   get duration() {
     return this._endTime ? +this._endTime - +this._startTime : 0
   }
 
   /**
-   * @returns {CodeceptJS.Test[]} All failed tests.
+   * All failed tests.
+   *
+   * @type {CodeceptJS.Test[]}
+   * readonly
    */
   get failedTests() {
     return this._tests.filter(test => test.state === 'failed')
   }
 
   /**
-   * @returns {CodeceptJS.Test[]} All passed tests.
+   * All passed tests.
+   *
+   * @type {CodeceptJS.Test[]}
+   * @readonly
    */
   get passedTests() {
     return this._tests.filter(test => test.state === 'passed')
   }
 
   /**
-   * @returns {CodeceptJS.Test[]} All skipped tests.
+   * All skipped tests.
+   *
+   * @type {CodeceptJS.Test[]}
+   * @readonly
    */
   get skippedTests() {
     return this._tests.filter(test => test.state === 'skipped' || test.state === 'pending')

--- a/lib/result.js
+++ b/lib/result.js
@@ -3,22 +3,21 @@ const path = require('path')
 const { serializeTest } = require('./mocha/test')
 
 /**
- * Result of the test run
- *
- * @typedef {Object} Stats
- * @property {number} passes
- * @property {number} failures
- * @property {number} tests
- * @property {number} pending
- * @property {number} failedHooks
- * @property {Date} start
- * @property {Date} end
- * @property {number} duration
+ * @typedef {Object} Stats Statistics for a test result.
+ * @property {number} passes Number of passed tests.
+ * @property {number} failures Number of failed tests.
+ * @property {number} tests Total number of tests.
+ * @property {number} pending Number of pending tests.
+ * @property {number} failedHooks Number of failed hooks.
+ * @property {Date} start Start time of the test run.
+ * @property {Date} end End time of the test run.
+ * @property {number} duration Duration of the test run, in milliseconds.
+ */
+
+/**
+ * Result of a test run. Will be emitted for example in "event.all.result" events.
  */
 class Result {
-  /**
-   * Create Result of the test run
-   */
   constructor() {
     this._startTime = new Date()
     this._endTime = null
@@ -27,6 +26,9 @@ class Result {
     this.start()
   }
 
+  /**
+   * Resets all collected stats, tests, and failure reports.
+   */
   reset() {
     this._stats = {
       passes: 0,
@@ -42,40 +44,61 @@ class Result {
     /** @type {CodeceptJS.Test[]} */
     this._tests = []
 
-    /** @type {String[]} */
+    /** @type {string[][]} */
     this._failures = []
   }
 
+  /**
+   * Sets the start time to the current time.
+   */
   start() {
     this._startTime = new Date()
   }
 
+  /**
+   * Sets the end time to the current time.
+   */
   finish() {
     this._endTime = new Date()
   }
 
+  /**
+   * @returns {boolean} Whether this result contains any failed tests.
+   */
   get hasFailed() {
     return this._stats.failures > 0
   }
 
+  /**
+   * @returns {CodeceptJS.Test[]} All collected tests.
+   */
   get tests() {
     return this._tests
   }
 
+  /**
+   * @returns {string[][]} The failure reports (array aof strings per failed test).
+   */
   get failures() {
     return this._failures.filter(f => f && (!Array.isArray(f) || f.length > 0))
   }
 
+  /**
+   * @returns {Stats} The test statistics.
+   */
   get stats() {
     return this._stats
   }
 
+  /**
+   * @returns {Date} The start time of the test run.
+   */
   get startTime() {
     return this._startTime
   }
 
   /**
-   * Add test to result
+   * Adds a test to this result.
    *
    * @param {CodeceptJS.Test} test
    */
@@ -90,34 +113,52 @@ class Result {
   }
 
   /**
-   * Add failures to result
+   * Adds failure reports to this result.
    *
-   * @param {String[]} newFailures
+   * @param {string[][]} newFailures
    */
   addFailures(newFailures) {
     this._failures.push(...newFailures)
   }
 
+  /**
+   * @returns {boolean} Whether this result contains any failed tests.
+   */
   get hasFailures() {
     return this.stats.failures > 0
   }
 
+  /**
+   * @returns {number} The duration of the test run, in milliseconds.
+   */
   get duration() {
     return this._endTime ? +this._endTime - +this._startTime : 0
   }
 
+  /**
+   * @returns {CodeceptJS.Test[]} All failed tests.
+   */
   get failedTests() {
     return this._tests.filter(test => test.state === 'failed')
   }
 
+  /**
+   * @returns {CodeceptJS.Test[]} All passed tests.
+   */
   get passedTests() {
     return this._tests.filter(test => test.state === 'passed')
   }
 
+  /**
+   * @returns {CodeceptJS.Test[]} All skipped tests.
+   */
   get skippedTests() {
     return this._tests.filter(test => test.state === 'skipped' || test.state === 'pending')
   }
 
+  /**
+   * @returns {object} The JSON representation of this result.
+   */
   simplify() {
     return {
       hasFailed: this.hasFailed,
@@ -129,9 +170,9 @@ class Result {
   }
 
   /**
-   * Save result to json file
+   * Saves this result to a JSON file.
    *
-   * @param {string} fileName
+   * @param {string} [fileName] Path to the JSON file, relative to `output_dir`. Defaults to "result.json".
    */
   save(fileName) {
     if (!fileName) fileName = 'result.json'
@@ -139,9 +180,9 @@ class Result {
   }
 
   /**
-   * Add stats to result
+   * Adds stats to this result.
    *
-   * @param {object} newStats
+   * @param {Partial<Stats>} [newStats]
    */
   addStats(newStats = {}) {
     this._stats.passes += newStats.passes || 0


### PR DESCRIPTION
## Motivation/Description of the PR

This PR add JSDoc comments with type definitions to `class Result` (lib/result.js), which will be generated into `types.d.ts`.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
