### PR TITLE
fix: adjust selector registration strategy to avoid false warnings in console

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -489,10 +489,10 @@ class Playwright extends Helper {
     // register an internal selector engine for reading value property of elements in a selector
     try {
       if (!defaultSelectorEnginesInitialized) {
+        defaultSelectorEnginesInitialized = true
         await playwright.selectors.register('__value', createValueEngine)
         await playwright.selectors.register('__disabled', createDisabledEngine)
         if (process.env.testIdAttribute) await playwright.selectors.setTestIdAttribute(process.env.testIdAttribute)
-        defaultSelectorEnginesInitialized = true
       }
 
       // Register all custom locator strategies from the global registry


### PR DESCRIPTION
## Motivation/Description of the PR
Since the last update, there are warnings in the console during the set-up of helper Playwright.
```
selectors.register: "__value" selector engine has been already registered
    at async Playwright._init (/Users/xxx/end-to-end-tests/node_modules/codeceptjs/lib/helper/Playwright.js:485:9) {
  name: 'Error'
}
```
I tried to investigate it may come from the following change #5090
Actually, the `_init` method is called twice (causing warning) and I guess there is a concurrent run. I think it's because of this call: https://github.com/codeceptjs/CodeceptJS/blob/bed491f48d3e6bd6f2c54442c4513093ab004aa1/lib/helper/Playwright.js#L363-L366
Note: this is a new behaviour has been introduced in the version 3.7.5 - version 3.7.4 called only once the `_init` method
**This PR doesn't fix the root cause, but prevent user to receive confused message when they run tests.**

Applicable helpers:

- [X] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
