### PR TITLE
Fix global timeout before suite

### DIFF
--- a/lib/listener/globalTimeout.js
+++ b/lib/listener/globalTimeout.js
@@ -20,14 +20,29 @@ module.exports = function () {
 
   // disable timeout for BeforeSuite/AfterSuite hooks
   // add separate configs to them?
+  // When a BeforeSuite/AfterSuite hook starts we want to disable the
+  // per-test timeout during that hook execution only. Previously the
+  // code cleared `suiteTimeout` permanently which caused the suite
+  // level timeout to be lost for subsequent tests. Save previous
+  // values and restore them when the hook finishes.
+  let __prevTimeout = undefined
+  let __prevSuiteTimeout = undefined
+
   event.dispatcher.on(event.hook.started, hook => {
-    if (hook instanceof BeforeSuiteHook) {
+    if (hook instanceof BeforeSuiteHook || hook instanceof AfterSuiteHook) {
+      __prevTimeout = timeout
+      // copy array to preserve original values
+      __prevSuiteTimeout = suiteTimeout.slice()
       timeout = null
       suiteTimeout = []
     }
-    if (hook instanceof AfterSuiteHook) {
-      timeout = null
-      suiteTimeout = []
+  })
+
+  event.dispatcher.on(event.hook.finished, hook => {
+    if (hook instanceof BeforeSuiteHook || hook instanceof AfterSuiteHook) {
+      // restore previously stored values
+      timeout = __prevTimeout
+      suiteTimeout = __prevSuiteTimeout.slice()
     }
   })
 

--- a/test/data/sandbox/configs/timeouts/beforeSuite_timeout_test.js
+++ b/test/data/sandbox/configs/timeouts/beforeSuite_timeout_test.js
@@ -1,0 +1,9 @@
+Feature('Timeout')
+
+BeforeSuite(() => {
+  // No stuff needed here to reproduce the issue
+})
+
+Scenario('enforce global timeout with BeforeSuite', ({ I }) => {
+  I.waitForSleep(4 * 1000)
+})

--- a/test/data/sandbox/configs/timeouts/beforeSuite_timeout_test.js
+++ b/test/data/sandbox/configs/timeouts/beforeSuite_timeout_test.js
@@ -1,4 +1,4 @@
-Feature('Timeout')
+Feature('Global Timeout with BeforeSuite')
 
 BeforeSuite(() => {
   // No stuff needed here to reproduce the issue

--- a/test/data/sandbox/configs/timeouts/codecept.beforeSuiteTimeout.conf.js
+++ b/test/data/sandbox/configs/timeouts/codecept.beforeSuiteTimeout.conf.js
@@ -6,7 +6,6 @@ exports.config = {
       require: './customHelper.js',
     },
   },
-  plugins: {},
-  name: 'my',
+  name: 'beforeSuiteTimeout',
   timeout: 2,
 }

--- a/test/data/sandbox/configs/timeouts/codecept.beforeSuiteTimeout.conf.js
+++ b/test/data/sandbox/configs/timeouts/codecept.beforeSuiteTimeout.conf.js
@@ -1,0 +1,12 @@
+exports.config = {
+  tests: './*_test.js',
+  output: './output',
+  helpers: {
+    CustomHelper: {
+      require: './customHelper.js',
+    },
+  },
+  plugins: {},
+  name: 'my',
+  timeout: 2,
+}

--- a/test/runner/timeout_test.js
+++ b/test/runner/timeout_test.js
@@ -100,4 +100,14 @@ describe('CodeceptJS Timeouts', function () {
       done()
     })
   })
+
+  it('should enforce global timeout even with BeforeSuite', done => {
+    exec(config_run_config('codecept.beforeSuiteTimeout.conf.js', 'enforce global timeout with BeforeSuite', true), (err, stdout) => {
+      debug_this_test && console.log(stdout)
+      expect(stdout).toContain('Timeout 2s exceeded')
+      expect(stdout).toContain('TestTimeoutError')
+      expect(err).toBeTruthy()
+      done()
+    })
+  })
 })


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #5265

Fixed by VSCode's Copilot "Claude Sonnet 4" + "GPT-4.1"
I checked that the newly added test fails as expected when the bug isn't fixed.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
