### PR TITLE
fix: handle missing opts in retryFailedStep plugin

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -108,6 +108,7 @@ module.exports = config => {
   event.dispatcher.on(event.test.before, test => {
     // pass disableRetryFailedStep is a preferred way to disable retries
     // test.disableRetryFailedStep is used for backward compatibility
+    if (!test.opts) test.opts = {}
     if (test.opts.disableRetryFailedStep || test.disableRetryFailedStep) {
       store.autoRetries = false
       return // disable retry when a test is not active

--- a/test/unit/plugin/retryFailedStep_interactive_shell_test.js
+++ b/test/unit/plugin/retryFailedStep_interactive_shell_test.js
@@ -1,0 +1,25 @@
+const assert = require('assert')
+const event = require('../../../lib/event')
+const retryFailedStep = require('../../../lib/plugin/retryFailedStep')
+
+describe('retryFailedStep plugin (interactive shell regression)', () => {
+  beforeEach(() => {
+    // Remove all listeners to avoid side effects
+    event.cleanDispatcher()
+    // Re-register plugin
+    retryFailedStep({ enabled: true })
+  })
+
+  it('should not throw when test.before is emitted without opts (interactive shell)', () => {
+    // Simulate the event as emitted by the interactive shell (no opts)
+    assert.doesNotThrow(() => {
+      event.dispatcher.emit(event.test.before, { title: 'Interactive', artifacts: {} })
+    })
+  })
+
+  it('should not throw when test.before is emitted with opts', () => {
+    assert.doesNotThrow(() => {
+      event.dispatcher.emit(event.test.before, { title: 'Normal', artifacts: {}, opts: {} })
+    })
+  })
+})


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #4844

Fixed by CoPilot GPT-4.1.
It fixes both issues mentioned in #4844
* `TypeError: Cannot read properties of undefined (reading 'disableRetryFailedStep')`
* Impossibility to run `I` method in the interactive mode

I checked that the new test fails as expected against the plugin without the fix.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [x] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
