### PR TITLE
fix(playwright): always use keyboard.type for strings, add national characters test

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1884,7 +1884,7 @@ class Playwright extends Helper {
       return
     }
 
-    // For array input, treat each as a key press to keep modified keys working.
+    // For array input, treat each as a key press to keep working combinations such as ['Control', 'A'] or ['T', 'e', 's', 't'].
     for (const key of keys) {
       await this.page.keyboard.press(key)
       if (delay) await this.wait(delay / 1000)

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1876,11 +1876,15 @@ class Playwright extends Helper {
    * {{> type }}
    */
   async type(keys, delay = null) {
+    // Always use page.keyboard.type for any string (including single character and national characters).
     if (!Array.isArray(keys)) {
       keys = keys.toString()
-      keys = keys.split('')
+      const typeDelay = typeof delay === 'number' ? delay : this.options.pressKeyDelay
+      await this.page.keyboard.type(keys, { delay: typeDelay })
+      return
     }
 
+    // For array input, treat each as a key press to keep modified keys working.
     for (const key of keys) {
       await this.page.keyboard.press(key)
       if (delay) await this.wait(delay / 1000)

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -713,6 +713,15 @@ describe('Playwright', function () {
     })
   })
 
+  describe('#type', () => {
+    it('should type national characters', async () => {
+      await I.amOnPage('/form/field')
+      await I.fillField('Name', '')
+      await I.type('Oprávněné')
+      await I.seeInField('Name', 'Oprávněné')
+    })
+  })
+
   describe('#waitForEnabled', () => {
     it('should wait for input text field to be enabled', () =>
       I.amOnPage('/form/wait_enabled')


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #5279

Fixed by help of VSCode's Copilot Claude Sonnet 4 and GPT-4.1.

Applicable helpers:

- [x] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
