### PR TITLE
adding support for the `But` keyword

### DIFF
--- a/lib/step/base.js
+++ b/lib/step/base.js
@@ -225,7 +225,7 @@ class Step {
     processingStep = this
 
     while (processingStep.metaStep) {
-      if (processingStep.metaStep.actor?.match(/^(Given|When|Then|And)/)) {
+      if (processingStep.metaStep.actor?.match(/^(Given|When|Then|And|But)/)) {
         hasBDD = true
         break
       } else {

--- a/lib/step/meta.js
+++ b/lib/step/meta.js
@@ -15,7 +15,7 @@ class MetaStep extends Step {
 
   /** @return {boolean} */
   isBDD() {
-    if (this.actor && this.actor.match && this.actor.match(/^(Given|When|Then|And)/)) {
+    if (this.actor && this.actor.match && this.actor.match(/^(Given|When|Then|And|But)/)) {
       return true
     }
     return false

--- a/test/data/sandbox/configs/html-reporter-plugin/features/html-reporter.feature
+++ b/test/data/sandbox/configs/html-reporter-plugin/features/html-reporter.feature
@@ -13,6 +13,7 @@ Feature: HTML Reporter BDD Test
     When I perform an action
     Then I should see the expected result
     And everything should work correctly
+    But I should see the expected result
 
   @regression @critical
   Scenario: Test with data table

--- a/test/runner/html-reporter-plugin_test.js
+++ b/test/runner/html-reporter-plugin_test.js
@@ -181,7 +181,7 @@ describe('CodeceptJS html-reporter-plugin', function () {
       expect(reportContent).toContain('data-type=')
 
       // Should contain scenario steps with proper keywords
-      expect(reportContent).toMatch(/Given|When|Then|And/)
+      expect(reportContent).toMatch(/Given|When|Then|And|But/)
 
       done()
     })

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -92,7 +92,7 @@ describe('Steps', () => {
     })
 
     describe('#isBDD', () => {
-      ;['Given', 'When', 'Then', 'And'].forEach(key => {
+      ;['Given', 'When', 'Then', 'And', 'But'].forEach(key => {
         it(`[${key}] #isBdd should return true if it BDD style`, () => {
           const metaStep = new MetaStep(key, 'I need to open Google')
           expect(metaStep.isBDD()).to.be.true


### PR DESCRIPTION
## Motivation/Description of the PR
- Fixes an issue where using the `But` keyword in gherkin would cause trouble printing the step name
- Resolves #5290

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
