### PR TITLE
Use own implementation of shuffle to remve lodash.shuffle dependency

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -194,20 +194,15 @@ class Codecept {
   }
 
   /**
-   * Fisher-Yates algorithm for shuffle
+   * Fisher–Yates shuffle (non-mutating)
    */
-  shuffle(arrayToShuffle) {
-    var i = arrayToShuffle.length,
-      j,
-      temp
-    while (--i > 0) {
-      j = Math.floor(Math.random() * (i + 1))
-      temp = arrayToShuffle[j]
-      arrayToShuffle[j] = arrayToShuffle[i]
-      arrayToShuffle[i] = temp
+  shuffle(array) {
+    const arr = [...array] // clone to avoid mutating input
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[arr[i], arr[j]] = [arr[j], arr[i]] // swap
     }
-
-    return arrayToShuffle
+    return arr
   }
 
   /**

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -1,6 +1,5 @@
 const { existsSync, readFileSync } = require('fs')
 const { globSync } = require('glob')
-const shuffle = require('lodash.shuffle')
 const fsPath = require('path')
 const { resolve } = require('path')
 
@@ -186,11 +185,26 @@ class Codecept {
     }
 
     if (this.opts.shuffle) {
-      this.testFiles = shuffle(this.testFiles)
+      this.shuffle(this.testFiles)
     }
 
     if (this.opts.shard) {
       this.testFiles = this._applySharding(this.testFiles, this.opts.shard)
+    }
+  }
+
+  /**
+   * Fisher-Yates algorithm for shuffle
+   */
+  shuffle(arrayToShuffle) {
+    var i = arrayToShuffle.length,
+      j,
+      temp
+    while (--i > 0) {
+      j = Math.floor(Math.random() * (i + 1))
+      temp = arrayToShuffle[j]
+      arrayToShuffle[j] = arrayToShuffle[i]
+      arrayToShuffle[i] = temp
     }
   }
 

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -185,7 +185,7 @@ class Codecept {
     }
 
     if (this.opts.shuffle) {
-      this.shuffle(this.testFiles)
+      this.testFiles = this.shuffle(this.testFiles)
     }
 
     if (this.opts.shard) {
@@ -206,6 +206,8 @@ class Codecept {
       arrayToShuffle[j] = arrayToShuffle[i]
       arrayToShuffle[i] = temp
     }
+
+    return arrayToShuffle
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "js-beautify": "1.15.4",
     "lodash.clonedeep": "4.5.0",
     "lodash.merge": "4.6.2",
-    "lodash.shuffle": "4.2.0",
     "mkdirp": "3.0.1",
     "mocha": "11.7.2",
     "monocart-coverage-reports": "2.12.9",


### PR DESCRIPTION
## Motivation/Description of the PR
- Remove use of lodash.shuffle unmaintained package
- Resolves #5264 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
