### PR TITLE
fixed: #5205 correct typings for effect functions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -520,9 +520,9 @@ declare namespace CodeceptJS {
   }
 }
 
-type TryTo = <T>(fn: () => Promise<T> | T) => Promise<T | false>
-type HopeThat = <T>(fn: () => Promise<T> | T) => Promise<T | false>
-type RetryTo = <T>(fn: () => Promise<T> | T, retries?: number) => Promise<T>
+type TryTo = (fn: () => void) => Promise<boolean>
+type HopeThat = (fn: () => void) => Promise<boolean>
+type RetryTo = (fn: (tries: number) => Promise<void> | void, maxTries: number, pollInterval?: number) => Promise<boolean>
 
 // Globals
 declare const codecept_dir: string


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #5205 

Fixes for type definitions of the effect functions `tryTo`, `hopeThat`, and `retryTo`.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
