### PR TITLE
resolve TypeScript path aliases from tsconfig.json

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -156,27 +156,32 @@ async function loadConfigFile(configFile) {
     try {
       // For .ts files, try to compile and load as JavaScript
       if (extensionName === '.ts') {
+        let transpileError = null
+        let tempFile = null
+        let allTempFiles = null
+        let fileMapping = null
+
         try {
           // Use the TypeScript transpilation utility
           const typescript = require('typescript')
-          const { tempFile, allTempFiles, fileMapping } = await transpileTypeScript(configFile, typescript)
+          const result = await transpileTypeScript(configFile, typescript)
+          tempFile = result.tempFile
+          allTempFiles = result.allTempFiles
+          fileMapping = result.fileMapping
 
-          try {
-            configModule = await import(tempFile)
-            cleanupTempFiles(allTempFiles)
-          } catch (err) {
+          configModule = await import(tempFile)
+          cleanupTempFiles(allTempFiles)
+        } catch (err) {
+          transpileError = err
+          if (fileMapping) {
             fixErrorStack(err, fileMapping)
+          }
+          if (allTempFiles) {
             cleanupTempFiles(allTempFiles)
-            throw err
           }
-        } catch (tsError) {
-          // If TypeScript compilation fails, fallback to ts-node
-          try {
-            require('ts-node/register')
-            configModule = require(configFile)
-          } catch (tsNodeError) {
-            throw new Error(`Failed to load TypeScript config: ${tsError.message}`)
-          }
+          // Throw immediately with the actual error - don't fall back to ts-node
+          // as it will mask the real error with "Unexpected token 'export'"
+          throw err
         }
       } else {
         // Try ESM import first for JS files

--- a/lib/utils/typescript.js
+++ b/lib/utils/typescript.js
@@ -118,20 +118,25 @@ const __dirname = __dirname_fn(__filename);
     // Transpile this file
     let jsContent = transpileTS(filePath)
 
-    // Find all relative TypeScript imports in this file
+    // Find all relative TypeScript imports in this file (both ESM imports and require() calls)
     const importRegex = /from\s+['"](\.[^'"]+?)(?:\.ts)?['"]/g
+    const requireRegex = /require\s*\(\s*['"](\.[^'"]+?)(?:\.ts)?['"]\s*\)/g
     let match
     const imports = []
 
     while ((match = importRegex.exec(jsContent)) !== null) {
-      imports.push(match[1])
+      imports.push({ path: match[1], type: 'import' })
+    }
+
+    while ((match = requireRegex.exec(jsContent)) !== null) {
+      imports.push({ path: match[1], type: 'require' })
     }
 
     // Get the base directory for this file
     const fileBaseDir = path.dirname(filePath)
 
     // Recursively transpile each imported TypeScript file
-    for (const relativeImport of imports) {
+    for (const { path: relativeImport } of imports) {
       let importedPath = path.resolve(fileBaseDir, relativeImport)
 
       // Handle .js extensions that might actually be .ts files
@@ -153,11 +158,17 @@ const __dirname = __dirname_fn(__filename);
         if (fs.existsSync(tsPath)) {
           importedPath = tsPath
         } else {
-          // Try .js extension as well
-          const jsPath = importedPath + '.js'
-          if (fs.existsSync(jsPath)) {
-            // Skip .js files, they don't need transpilation
-            continue
+          // Try index.ts for directory imports
+          const indexTsPath = path.join(importedPath, 'index.ts')
+          if (fs.existsSync(indexTsPath)) {
+            importedPath = indexTsPath
+          } else {
+            // Try .js extension as well
+            const jsPath = importedPath + '.js'
+            if (fs.existsSync(jsPath)) {
+              // Skip .js files, they don't need transpilation
+              continue
+            }
           }
         }
       }
@@ -181,13 +192,11 @@ const __dirname = __dirname_fn(__filename);
           if (transpiledFiles.has(tsVersion)) {
             const tempFile = transpiledFiles.get(tsVersion)
             const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
-            // Ensure the path starts with ./
             if (!relPath.startsWith('.')) {
               return `from './${relPath}'`
             }
             return `from '${relPath}'`
           }
-          // Keep .js extension as-is (might be a real .js file)
           return match
         }
 
@@ -198,18 +207,24 @@ const __dirname = __dirname_fn(__filename);
         if (transpiledFiles.has(tsPath)) {
           const tempFile = transpiledFiles.get(tsPath)
           const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
-          // Ensure the path starts with ./
           if (!relPath.startsWith('.')) {
             return `from './${relPath}'`
           }
           return `from '${relPath}'`
         }
 
-        // If the import doesn't have a standard module extension (.js, .mjs, .cjs, .json)
-        // add .js for ESM compatibility
-        // This handles cases where:
-        // 1. Import has no real extension (e.g., "./utils" or "./helper")
-        // 2. Import has a non-standard extension that's part of the name (e.g., "./abstract.helper")
+        // Try index.ts for directory imports
+        const indexTsPath = path.join(resolvedPath, 'index.ts')
+        if (transpiledFiles.has(indexTsPath)) {
+          const tempFile = transpiledFiles.get(indexTsPath)
+          const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
+          if (!relPath.startsWith('.')) {
+            return `from './${relPath}'`
+          }
+          return `from '${relPath}'`
+        }
+
+        // If the import doesn't have a standard module extension, add .js for ESM compatibility
         const standardExtensions = ['.js', '.mjs', '.cjs', '.json', '.node']
         const hasStandardExtension = standardExtensions.includes(originalExt.toLowerCase())
 
@@ -217,7 +232,40 @@ const __dirname = __dirname_fn(__filename);
           return match.replace(importPath, importPath + '.js')
         }
 
-        // Otherwise, keep the import as-is
+        return match
+      }
+    )
+
+    // Also rewrite require() calls to point to transpiled TypeScript files
+    jsContent = jsContent.replace(
+      /require\s*\(\s*['"](\.[^'"]+?)(?:\.ts)?['"]\s*\)/g,
+      (match, requirePath) => {
+        let resolvedPath = path.resolve(fileBaseDir, requirePath)
+
+        // Handle .js extension that might be .ts
+        if (resolvedPath.endsWith('.js')) {
+          const tsVersion = resolvedPath.replace(/\.js$/, '.ts')
+          if (transpiledFiles.has(tsVersion)) {
+            const tempFile = transpiledFiles.get(tsVersion)
+            const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
+            const finalPath = relPath.startsWith('.') ? relPath : './' + relPath
+            return `require('${finalPath}')`
+          }
+          return match
+        }
+
+        // Try with .ts extension
+        const tsPath = resolvedPath.endsWith('.ts') ? resolvedPath : resolvedPath + '.ts'
+
+        // If we transpiled this file, use the temp file
+        if (transpiledFiles.has(tsPath)) {
+          const tempFile = transpiledFiles.get(tsPath)
+          const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
+          const finalPath = relPath.startsWith('.') ? relPath : './' + relPath
+          return `require('${finalPath}')`
+        }
+
+        // Otherwise, keep the require as-is
         return match
       }
     )

--- a/lib/utils/typescript.js
+++ b/lib/utils/typescript.js
@@ -1,5 +1,60 @@
 import fs from 'fs'
 import path from 'path'
+import { pathToFileURL } from 'url'
+
+/**
+ * Load tsconfig.json if it exists
+ * @param {string} tsConfigPath - Path to tsconfig.json
+ * @returns {object|null} - Parsed tsconfig or null
+ */
+function loadTsConfig(tsConfigPath) {
+  if (!fs.existsSync(tsConfigPath)) {
+    return null
+  }
+
+  try {
+    const tsConfigContent = fs.readFileSync(tsConfigPath, 'utf8')
+    return JSON.parse(tsConfigContent)
+  } catch (err) {
+    return null
+  }
+}
+
+/**
+ * Resolve TypeScript path alias to actual file path
+ * @param {string} importPath - Import path with alias (e.g., '#config/urls')
+ * @param {object} tsConfig - Parsed tsconfig.json
+ * @param {string} configDir - Directory containing tsconfig.json
+ * @returns {string|null} - Resolved file path or null if not an alias
+ */
+function resolveTsPathAlias(importPath, tsConfig, configDir) {
+  if (!tsConfig || !tsConfig.compilerOptions || !tsConfig.compilerOptions.paths) {
+    return null
+  }
+
+  const paths = tsConfig.compilerOptions.paths
+
+  for (const [pattern, targets] of Object.entries(paths)) {
+    if (!targets || targets.length === 0) {
+      continue
+    }
+
+    const patternRegex = new RegExp(
+      '^' + pattern.replace(/\*/g, '(.*)') + '$'
+    )
+    const match = importPath.match(patternRegex)
+
+    if (match) {
+      const wildcard = match[1] || ''
+      const target = targets[0]
+      const resolvedTarget = target.replace(/\*/g, wildcard)
+
+      return path.resolve(configDir, resolvedTarget)
+    }
+  }
+
+  return null
+}
 
 /**
  * Transpile TypeScript files to ES modules with CommonJS shim support
@@ -108,6 +163,22 @@ const __dirname = __dirname_fn(__filename);
   const transpiledFiles = new Map()
   const baseDir = path.dirname(mainFilePath)
 
+  // Try to find tsconfig.json by walking up the directory tree
+  let tsConfigPath = path.join(baseDir, 'tsconfig.json')
+  let configDir = baseDir
+  let searchDir = baseDir
+
+  while (!fs.existsSync(tsConfigPath) && searchDir !== path.dirname(searchDir)) {
+    searchDir = path.dirname(searchDir)
+    tsConfigPath = path.join(searchDir, 'tsconfig.json')
+    if (fs.existsSync(tsConfigPath)) {
+      configDir = searchDir
+      break
+    }
+  }
+
+  const tsConfig = loadTsConfig(tsConfigPath)
+
   // Recursive function to transpile a file and all its TypeScript dependencies
   const transpileFileAndDeps = (filePath) => {
     // Already transpiled, skip
@@ -118,9 +189,9 @@ const __dirname = __dirname_fn(__filename);
     // Transpile this file
     let jsContent = transpileTS(filePath)
 
-    // Find all relative TypeScript imports in this file (both ESM imports and require() calls)
-    const importRegex = /from\s+['"](\.[^'"]+?)(?:\.ts)?['"]/g
-    const requireRegex = /require\s*\(\s*['"](\.[^'"]+?)(?:\.ts)?['"]\s*\)/g
+    // Find all TypeScript imports in this file (both ESM imports and require() calls)
+    const importRegex = /from\s+['"]([^'"]+?)['"]/g
+    const requireRegex = /require\s*\(\s*['"]([^'"]+?)['"]\s*\)/g
     let match
     const imports = []
 
@@ -136,8 +207,18 @@ const __dirname = __dirname_fn(__filename);
     const fileBaseDir = path.dirname(filePath)
 
     // Recursively transpile each imported TypeScript file
-    for (const { path: relativeImport } of imports) {
-      let importedPath = path.resolve(fileBaseDir, relativeImport)
+    for (const { path: importPath } of imports) {
+      let importedPath = importPath
+
+      // Check if this is a path alias
+      const resolvedAlias = resolveTsPathAlias(importPath, tsConfig, configDir)
+      if (resolvedAlias) {
+        importedPath = resolvedAlias
+      } else if (importPath.startsWith('.')) {
+        importedPath = path.resolve(fileBaseDir, importPath)
+      } else {
+        continue
+      }
 
       // Handle .js extensions that might actually be .ts files
       if (importedPath.endsWith('.js')) {
@@ -181,10 +262,33 @@ const __dirname = __dirname_fn(__filename);
 
     // After all dependencies are transpiled, rewrite imports in this file
     jsContent = jsContent.replace(
-      /from\s+['"](\.[^'"]+?)(?:\.ts)?['"]/g,
+      /from\s+['"]([^'"]+?)['"]/g,
       (match, importPath) => {
-        let resolvedPath = path.resolve(fileBaseDir, importPath)
+        let resolvedPath = importPath
         const originalExt = path.extname(importPath)
+
+        // Check if this is a path alias
+        const resolvedAlias = resolveTsPathAlias(importPath, tsConfig, configDir)
+        if (resolvedAlias) {
+          resolvedPath = resolvedAlias
+        } else if (importPath.startsWith('.')) {
+          resolvedPath = path.resolve(fileBaseDir, importPath)
+        } else {
+          return match
+        }
+
+        // If resolved path is a directory, try index.ts
+        if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isDirectory()) {
+          const indexPath = path.join(resolvedPath, 'index.ts')
+          if (fs.existsSync(indexPath) && transpiledFiles.has(indexPath)) {
+            const tempFile = transpiledFiles.get(indexPath)
+            const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
+            if (!relPath.startsWith('.')) {
+              return `from './${relPath}'`
+            }
+            return `from '${relPath}'`
+          }
+        }
 
         // Handle .js extension that might be .ts
         if (resolvedPath.endsWith('.js')) {
@@ -238,9 +342,19 @@ const __dirname = __dirname_fn(__filename);
 
     // Also rewrite require() calls to point to transpiled TypeScript files
     jsContent = jsContent.replace(
-      /require\s*\(\s*['"](\.[^'"]+?)(?:\.ts)?['"]\s*\)/g,
+      /require\s*\(\s*['"]([^'"]+?)['"]\s*\)/g,
       (match, requirePath) => {
-        let resolvedPath = path.resolve(fileBaseDir, requirePath)
+        let resolvedPath = requirePath
+
+        // Check if this is a path alias
+        const resolvedAlias = resolveTsPathAlias(requirePath, tsConfig, configDir)
+        if (resolvedAlias) {
+          resolvedPath = resolvedAlias
+        } else if (requirePath.startsWith('.')) {
+          resolvedPath = path.resolve(fileBaseDir, requirePath)
+        } else {
+          return match
+        }
 
         // Handle .js extension that might be .ts
         if (resolvedPath.endsWith('.js')) {
@@ -282,10 +396,13 @@ const __dirname = __dirname_fn(__filename);
   // Get the main transpiled file
   const tempJsFile = transpiledFiles.get(mainFilePath)
 
-  // Store all temp files for cleanup
+  // Convert to file:// URL for dynamic import() (required on Windows)
+  const tempFileUrl = pathToFileURL(tempJsFile).href
+
+  // Store all temp files for cleanup (keep as paths, not URLs)
   const allTempFiles = Array.from(transpiledFiles.values())
 
-  return { tempFile: tempJsFile, allTempFiles, fileMapping: transpiledFiles }
+  return { tempFile: tempFileUrl, allTempFiles, fileMapping: transpiledFiles }
 }
 
 /**

--- a/lib/utils/typescript.js
+++ b/lib/utils/typescript.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { loadConfig, createMatchPath } from 'tsconfig-paths'
 
 /**
  * Transpile TypeScript files to ES modules with CommonJS shim support
@@ -107,6 +108,53 @@ const __dirname = __dirname_fn(__filename);
   // Create a map to track transpiled files
   const transpiledFiles = new Map()
   const baseDir = path.dirname(mainFilePath)
+  const pathsMatcher = loadTsConfigPaths(baseDir)
+
+  /**
+   * Load tsconfig.json and create path matcher for resolving aliases
+   */
+  function loadTsConfigPaths(startDir) {
+    try {
+      let currentDir = startDir
+      let configPath = null
+      while (currentDir && currentDir !== path.parse(currentDir).root) {
+        const testPath = path.join(currentDir, 'tsconfig.json')
+        if (fs.existsSync(testPath)) {
+          configPath = testPath
+          break
+        }
+        currentDir = path.dirname(currentDir)
+      }
+
+      if (!configPath) return null
+
+      const configResult = loadConfig(configPath)
+
+      if (configResult.resultType !== 'success') return null
+
+      const { paths, absoluteBaseUrl } = configResult
+      if (!paths) return null
+
+      const matchPath = createMatchPath(
+        absoluteBaseUrl,
+        paths,
+        undefined,
+        false
+      )
+
+      return {
+        matchPath: (importPath) => {
+          for (const ext of ['.ts', '.tsx', '.js', '.jsx', '.json', '']) {
+            const resolved = matchPath(importPath + ext)
+            if (resolved) return resolved
+          }
+          return null
+        }
+      }
+    } catch (error) {
+      return null
+    }
+  }
 
   // Recursive function to transpile a file and all its TypeScript dependencies
   const transpileFileAndDeps = (filePath) => {
@@ -118,8 +166,7 @@ const __dirname = __dirname_fn(__filename);
     // Transpile this file
     let jsContent = transpileTS(filePath)
 
-    // Find all relative TypeScript imports in this file
-    const importRegex = /from\s+['"](\..+?)(?:\.ts)?['"]/g
+    const importRegex = /from\s+['"]([^'"]+?)['"]/g
     let match
     const imports = []
 
@@ -131,49 +178,112 @@ const __dirname = __dirname_fn(__filename);
     const fileBaseDir = path.dirname(filePath)
 
     // Recursively transpile each imported TypeScript file
-    for (const relativeImport of imports) {
-      let importedPath = path.resolve(fileBaseDir, relativeImport)
-
-      // Handle .js extensions that might actually be .ts files
-      if (importedPath.endsWith('.js')) {
-        const tsVersion = importedPath.replace(/\.js$/, '.ts')
-        if (fs.existsSync(tsVersion)) {
-          importedPath = tsVersion
-        }
+    for (const importPath of imports) {
+      if (importPath.startsWith('node:')) {
+        continue
       }
 
-      // Check for standard module extensions to determine if we should try adding .ts
-      const ext = path.extname(importedPath)
-      const standardExtensions = ['.js', '.mjs', '.cjs', '.json', '.node']
-      const hasStandardExtension = standardExtensions.includes(ext.toLowerCase())
+      if (importPath.startsWith('.')) {
+        let importedPath = path.resolve(fileBaseDir, importPath)
 
-      // If it doesn't end with .ts and doesn't have a standard extension, try adding .ts
-      if (!importedPath.endsWith('.ts') && !hasStandardExtension) {
-        const tsPath = importedPath + '.ts'
-        if (fs.existsSync(tsPath)) {
-          importedPath = tsPath
-        } else {
-          // Try .js extension as well
-          const jsPath = importedPath + '.js'
-          if (fs.existsSync(jsPath)) {
-            // Skip .js files, they don't need transpilation
-            continue
+        // Handle .js extensions that might actually be .ts files
+        if (importedPath.endsWith('.js')) {
+          const tsVersion = importedPath.replace(/\.js$/, '.ts')
+          if (fs.existsSync(tsVersion)) {
+            importedPath = tsVersion
           }
         }
+
+        // Check for standard module extensions to determine if we should try adding .ts
+        const ext = path.extname(importedPath)
+        const standardExtensions = ['.js', '.mjs', '.cjs', '.json', '.node']
+        const hasStandardExtension = standardExtensions.includes(ext.toLowerCase())
+
+        // If it doesn't end with .ts and doesn't have a standard extension, try adding .ts
+        if (!importedPath.endsWith('.ts') && !hasStandardExtension) {
+          const tsPath = importedPath + '.ts'
+          if (fs.existsSync(tsPath)) {
+            importedPath = tsPath
+          } else {
+            // Try .js extension as well
+            const jsPath = importedPath + '.js'
+            if (fs.existsSync(jsPath)) {
+              // Skip .js files, they don't need transpilation
+              continue
+            }
+          }
+        }
+
+        // If it's a TypeScript file, recursively transpile it and its dependencies
+        if (importedPath.endsWith('.ts') && fs.existsSync(importedPath)) {
+          transpileFileAndDeps(importedPath)
+        }
+
+        continue
       }
 
-      // If it's a TypeScript file, recursively transpile it and its dependencies
-      if (importedPath.endsWith('.ts') && fs.existsSync(importedPath)) {
-        transpileFileAndDeps(importedPath)
+      // Try to resolve as a path alias (non-relative import)
+      const resolvedAlias = pathsMatcher ? pathsMatcher.matchPath(importPath) : null
+      if (resolvedAlias) {
+        let importedPath = resolvedAlias
+
+        if (!importedPath.endsWith('.ts') && !path.extname(importedPath)) {
+          const tsPath = importedPath + '.ts'
+          if (fs.existsSync(tsPath)) {
+            importedPath = tsPath
+          }
+        }
+
+        if (importedPath.endsWith('.ts') && fs.existsSync(importedPath)) {
+          transpileFileAndDeps(importedPath)
+        }
+
+        continue
       }
     }
 
     // After all dependencies are transpiled, rewrite imports in this file
     jsContent = jsContent.replace(
-      /from\s+['"](\..+?)(?:\.ts)?['"]/g,
+      /from\s+['"]([^'"]+?)['"]/g,
       (match, importPath) => {
-        let resolvedPath = path.resolve(fileBaseDir, importPath)
         const originalExt = path.extname(importPath)
+
+        // Check if this is a path alias (non-relative import)
+        if (!importPath.startsWith('.')) {
+          const resolvedAlias = pathsMatcher ? pathsMatcher.matchPath(importPath) : null
+          if (resolvedAlias) {
+            let tsPath = resolvedAlias.endsWith('.ts') ? resolvedAlias : resolvedAlias + '.ts'
+
+            if (transpiledFiles.has(tsPath)) {
+              const tempFile = transpiledFiles.get(tsPath)
+              const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
+              if (!relPath.startsWith('.')) {
+                return `from './${relPath}'`
+              }
+              return `from '${relPath}'`
+            }
+
+            if (fs.existsSync(tsPath)) {
+              const jsPath = tsPath.replace(/\.ts$/, '.js')
+              const relPath = path.relative(fileBaseDir, jsPath).replace(/\\/g, '/')
+              if (!relPath.startsWith('.')) {
+                return `from './${relPath}'`
+              }
+              return `from '${relPath}'`
+            }
+          }
+
+          const standardExtensions = ['.js', '.mjs', '.cjs', '.json', '.node']
+          const hasStandardExtension = standardExtensions.includes(originalExt.toLowerCase())
+
+          if (!hasStandardExtension && !importPath.startsWith('node:')) {
+            return match.replace(importPath, importPath + '.js')
+          }
+
+          return match
+        }
+
+        let resolvedPath = path.resolve(fileBaseDir, importPath)
 
         // Handle .js extension that might be .ts
         if (resolvedPath.endsWith('.js')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs",
-  "version": "4.0.2-beta.17",
+  "version": "4.0.2-beta.19",
   "type": "module",
   "description": "Supercharged End 2 End Testing Framework for NodeJS",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "sinon-chai": "^4.0.1",
     "ts-morph": "27.0.2",
     "ts-node": "10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "tsd": "^0.33.0",
     "tsd-jsdoc": "2.5.0",
     "tsx": "^4.19.2",


### PR DESCRIPTION
## Summary
  Fixes [#5361](https://github.com/codeceptjs/CodeceptJS/issues/5361) - TypeScript path aliases now work in CodeceptJS 4.x

  ## Changes
  - Added `tsconfig-paths` dependency
  - Modified `lib/utils/typescript.js` to load `tsconfig.json` and resolve path aliases
  - Path aliases like `#config/*` are now converted to real paths during transpilation

  ## What was broken
  In CodeceptJS 4.x, imports like `import { X } from '#config/urls'` would fail because the custom transpiler didn't resolve aliases from tsconfig.json.

  ## What works now
  - Path aliases with any prefix (`#config/*`, `@config/*`, etc.)
  - Backward compatibility with relative imports
  - All external modules continue to work