### PR TITLE
 Fix "Chaining cycle detected for promise" error in Auth plugin

### DIFF
--- a/lib/plugin/auth.js
+++ b/lib/plugin/auth.js
@@ -350,7 +350,8 @@ export default function (config) {
           recorder.session.restore('auto login')
           recorder.session.restore('check login')
           section.end()
-          recorder.throw(err)
+          // Use regular throw instead of recorder.throw to avoid promise chaining cycle
+          throw err
         })
     })
     recorder.add(() => {


### PR DESCRIPTION
When using Data() with multiple values and session() inside tests, Auth plugin's retry logic created an infinite promise loop.

## Fix
Replaced `recorder.throw(err)` with `throw err` in auth.js:353 to break the chaining cycle.

https://github.com/codeceptjs/CodeceptJS/issues/5207