### PR TITLE
Add warning for ts-node/esm usage

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -19,7 +19,7 @@ import ActorFactory from './actor.js'
 import output from './output.js'
 import { emptyFolder } from './utils.js'
 import { initCodeceptGlobals } from './globals.js'
-import { validateTypeScriptSetup } from './utils/loaderCheck.js'
+import { validateTypeScriptSetup, getTSNodeESMWarning } from './utils/loaderCheck.js'
 import recorder from './recorder.js'
 
 import storeListener from './listener/store.js'
@@ -268,6 +268,12 @@ class Codecept {
     if (tsValidation.hasError) {
       output.error(tsValidation.message)
       process.exit(1)
+    }
+
+    // Show warning if ts-node/esm is being used
+    const tsWarning = getTSNodeESMWarning(this.requiringModules || [])
+    if (tsWarning) {
+      output.print(output.colors.yellow(tsWarning))
     }
 
     // Ensure translations are loaded for Gherkin features

--- a/lib/utils/loaderCheck.js
+++ b/lib/utils/loaderCheck.js
@@ -107,6 +107,26 @@ Note: TypeScript config files (codecept.conf.ts) and helpers are automatically
 }
 
 /**
+ * Get warning message if ts-node/esm is being used
+ * @param {string[]} requiredModules - Array of required modules from config
+ * @returns {string|null} Warning message or null
+ */
+export function getTSNodeESMWarning(requiredModules = []) {
+  if (!requiredModules.includes('ts-node/esm')) {
+    return null
+  }
+
+  return `
+⚠️  Warning: ts-node/esm with "module": "esnext" requires explicit file extensions in all imports.
+
+This is a known limitation. Use tsx/cjs instead to write imports without extensions.
+
+📚 Documentation: https://codecept.io/typescript
+
+`
+}
+
+/**
  * Check if user is trying to run TypeScript tests without proper loader
  * @param {string[]} testFiles - Array of test file paths
  * @param {string[]} requiredModules - Array of required modules from config

--- a/lib/utils/loaderCheck.js
+++ b/lib/utils/loaderCheck.js
@@ -121,6 +121,14 @@ export function getTSNodeESMWarning(requiredModules = []) {
 
 This is a known limitation. Use tsx/cjs instead to write imports without extensions.
 
+Examples:
+
+  ❌ Incorrect (will fail):
+     import loginPage from "./pages/Login";
+
+  ✅ Correct (must include .ts extension):
+     import loginPage from "./pages/Login.ts";
+
 📚 Documentation: https://codecept.io/typescript
 
 `


### PR DESCRIPTION
## Problem
When using `ts-node/esm` with `"module": "esnext"` in tsconfig.json, users get "Cannot find module" errors because imports without file extensions don't work.
This is a known limitation of `ts-node/esm`, not a bug in CodeceptJS, but users don't understand what's happening. https://github.com/codeceptjs/CodeceptJS/issues/5323

 ## Solution
  Add a warning message when `ts-node/esm` is detected in the config. The warning:
  - Explains the limitation clearly
  - Recommends `tsx/cjs` as an alternative
  - Links to documentation