### PR TITLE
Export container as named export for ESM

### DIFF
--- a/test/data/typescript-esm-exports/codecept.conf.ts
+++ b/test/data/typescript-esm-exports/codecept.conf.ts
@@ -1,0 +1,9 @@
+export const config: CodeceptJS.MainConfig = {
+  tests: "./*.ts",
+  output: "./output",
+  helpers: {
+    FileSystem: {},
+  },
+  name: "container-esm",
+  require: ["tsx/cjs"],
+};

--- a/test/data/typescript-esm-exports/package.json
+++ b/test/data/typescript-esm-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "container-esm",
+  "version": "1.0.0",
+  "private": true
+}

--- a/test/data/typescript-esm-exports/test-all-exports.ts
+++ b/test/data/typescript-esm-exports/test-all-exports.ts
@@ -1,0 +1,107 @@
+import {
+  container,
+  codecept,
+  output,
+  event,
+  recorder,
+  config,
+  actor,
+  helper,
+  pause,
+  within,
+  dataTable,
+  dataTableArgument,
+  store,
+  locator,
+  // Secret,
+  // secret,
+} from "codeceptjs";
+import { expect } from "chai";
+
+Feature("Import all exports from codeceptjs");
+
+Scenario("container should be importable as named export", () => {
+  expect(container).to.exist;
+  expect(container.helpers).to.be.a("function");
+
+  const helpers = container.helpers();
+  console.log("Available helpers:", Object.keys(helpers));
+});
+
+Scenario("codecept should be importable", () => {
+  expect(codecept).to.exist;
+});
+
+Scenario("output should be importable", () => {
+  expect(output).to.exist;
+  expect(output.print).to.be.a("function");
+  output.print("Testing output.print");
+});
+
+Scenario("event should be importable", () => {
+  expect(event).to.exist;
+  expect(event).to.be.an("object");
+  expect(event.dispatcher).to.exist;
+});
+
+Scenario("recorder should be importable", () => {
+  expect(recorder).to.exist;
+  expect(recorder).to.be.an("object");
+  expect(recorder.start).to.be.a("function");
+});
+
+Scenario("config should be importable", () => {
+  expect(config).to.exist;
+  expect(config.get).to.be.a("function");
+});
+
+Scenario("actor should be importable", () => {
+  expect(actor).to.exist;
+  expect(actor).to.be.a("function");
+});
+
+Scenario("helper should be importable", () => {
+  expect(helper).to.exist;
+});
+
+Scenario("pause should be importable", () => {
+  expect(pause).to.exist;
+});
+
+Scenario("within should be importable", () => {
+  expect(within).to.exist;
+  expect(within).to.be.a("function");
+});
+
+Scenario("dataTable should be importable", () => {
+  expect(dataTable).to.exist;
+});
+
+Scenario("dataTableArgument should be importable", () => {
+  expect(dataTableArgument).to.exist;
+});
+
+Scenario("store should be importable", () => {
+  expect(store).to.exist;
+  expect(store).to.be.an("object");
+  expect(store.debugMode).to.exist;
+});
+
+Scenario("locator should be importable", () => {
+  expect(locator).to.exist;
+  expect(locator.build).to.be.a("function");
+});
+
+// Secret and secret are not exported from lib/index.js in older versions, so skip them
+// Scenario("Secret should be importable", () => {
+//   expect(Secret).to.exist;
+//   expect(Secret.secret).to.be.a("function");
+// });
+
+// Scenario("secret should be importable", () => {
+//   expect(secret).to.exist;
+//   expect(secret).to.be.a("function");
+//
+//   const mySecret = secret("my-password");
+//   expect(mySecret.toString()).to.equal("my-password");
+// });

--- a/test/data/typescript-esm-exports/test.ts
+++ b/test/data/typescript-esm-exports/test.ts
@@ -1,0 +1,12 @@
+import { container } from "codeceptjs";
+import { expect } from "chai";
+
+Feature("Import container as named export");
+
+Scenario("container should be importable as named export", () => {
+  expect(container).to.exist;
+  expect(container.helpers).to.be.a("function");
+
+  const helpers = container.helpers();
+  console.log("Available helpers:", Object.keys(helpers));
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -520,86 +520,6 @@ declare namespace CodeceptJS {
   }
 
   function addStep(step: string | RegExp, fn: Function): Promise<void>
-
-  // Internal API types
-  class Container {
-    static create(config: any, opts?: any): Promise<void>
-    static actor(): any
-    static plugins(name?: string): any
-    static support(name?: string): any
-    static helpers(name?: string): any
-    static translation(): any
-    static mocha(): any
-  }
-
-  class Codecept {
-    // Codecept class methods - to be filled from JSDoc
-  }
-
-  class Config {
-    static get(): any
-    static set(key: string, value: any): void
-  }
-
-  namespace output {
-    function print(message: string): void
-    function log(message: string): void
-    function debug(message: string): void
-    function error(message: string): void
-    function info(message: string): void
-    function success(message: string): void
-    function warn(message: string): void
-  }
-
-  type event = {
-    dispatcher: any
-    on: (event: string, handler: Function) => void
-    once: (event: string, handler: Function) => void
-    removeListener: (event: string, handler: Function) => void
-    removeAllListeners: (event?: string) => void
-    emit: (event: string, ...args: any[]) => void
-  }
-
-  type recorder = {
-    (fn: () => Promise<void> | void): void
-    start: () => void
-    stop: () => void
-    add: (fn: Function) => void
-    retry: any[]
-    catch: (fn: Function) => void
-    schedule: (fn: Function) => any
-    promiseStack: any[]
-    running: boolean
-  }
-
-  type store = {
-    debugMode: boolean
-    timeouts: boolean
-    autoRetries: boolean
-    dryRun: boolean
-  }
-
-  class Secret {
-    static secret(value: string | number): Secret
-    toString(): string
-    getMasked(): string
-  }
-
-  type pause = () => void
-
-  type within = (locator: LocatorOrString) => void
-
-  class DataTable {
-    static (data: any[] | any[][]): any
-  }
-
-  class DataTableArgument {
-    static (data: any): any
-  }
-
-  class Locator {
-    static build(locator: ILocator | string): any
-  }
 }
 
 type TryTo = <T>(fn: () => Promise<T> | T) => Promise<T | false>
@@ -813,7 +733,7 @@ declare module 'codeceptjs' {
   /**
    * Create a secret value
    */
-  export const secret: typeof CodeceptJS.secret
+  export const secret: typeof CodeceptJS.Secret.secret
 }
 
 declare module '@codeceptjs/helper' {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -637,6 +637,7 @@ declare namespace Mocha {
 
 declare module 'codeceptjs' {
   export default codeceptjs
+  export const container: any
 }
 
 declare module '@codeceptjs/helper' {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -520,6 +520,86 @@ declare namespace CodeceptJS {
   }
 
   function addStep(step: string | RegExp, fn: Function): Promise<void>
+
+  // Internal API types
+  class Container {
+    static create(config: any, opts?: any): Promise<void>
+    static actor(): any
+    static plugins(name?: string): any
+    static support(name?: string): any
+    static helpers(name?: string): any
+    static translation(): any
+    static mocha(): any
+  }
+
+  class Codecept {
+    // Codecept class methods - to be filled from JSDoc
+  }
+
+  class Config {
+    static get(): any
+    static set(key: string, value: any): void
+  }
+
+  namespace output {
+    function print(message: string): void
+    function log(message: string): void
+    function debug(message: string): void
+    function error(message: string): void
+    function info(message: string): void
+    function success(message: string): void
+    function warn(message: string): void
+  }
+
+  type event = {
+    dispatcher: any
+    on: (event: string, handler: Function) => void
+    once: (event: string, handler: Function) => void
+    removeListener: (event: string, handler: Function) => void
+    removeAllListeners: (event?: string) => void
+    emit: (event: string, ...args: any[]) => void
+  }
+
+  type recorder = {
+    (fn: () => Promise<void> | void): void
+    start: () => void
+    stop: () => void
+    add: (fn: Function) => void
+    retry: any[]
+    catch: (fn: Function) => void
+    schedule: (fn: Function) => any
+    promiseStack: any[]
+    running: boolean
+  }
+
+  type store = {
+    debugMode: boolean
+    timeouts: boolean
+    autoRetries: boolean
+    dryRun: boolean
+  }
+
+  class Secret {
+    static secret(value: string | number): Secret
+    toString(): string
+    getMasked(): string
+  }
+
+  type pause = () => void
+
+  type within = (locator: LocatorOrString) => void
+
+  class DataTable {
+    static (data: any[] | any[][]): any
+  }
+
+  class DataTableArgument {
+    static (data: any): any
+  }
+
+  class Locator {
+    static build(locator: ILocator | string): any
+  }
 }
 
 type TryTo = <T>(fn: () => Promise<T> | T) => Promise<T | false>
@@ -635,9 +715,105 @@ declare namespace Mocha {
   }
 }
 
+// Internal API types
 declare module 'codeceptjs' {
   export default codeceptjs
-  export const container: any
+
+  /**
+   * Dependency Injection Container
+   * Provides access to helpers, support objects, plugins, and translation
+   */
+  export const container: typeof CodeceptJS.Container
+
+  /**
+   * Test runner class
+   */
+  export const codecept: typeof CodeceptJS.Codecept
+
+  /**
+   * Output module for printing messages
+   */
+  export const output: typeof CodeceptJS.output
+
+  /**
+   * Event dispatcher for listening to CodeceptJS events
+   */
+  export const event: CodeceptJS.event
+
+  /**
+   * Global promise chain recorder
+   */
+  export const recorder: CodeceptJS.recorder
+
+  /**
+   * Configuration module
+   */
+  export const config: typeof CodeceptJS.Config
+
+  /**
+   * Actor (I) constructor
+   */
+  export const actor: CodeceptJS.actor
+
+  /**
+   * Base Helper class
+   */
+  export const helper: typeof CodeceptJS.Helper
+
+  /**
+   * Pause execution until user input
+   */
+  export const pause: CodeceptJS.pause
+
+  /**
+   * Execute steps within specific context
+   */
+  export const within: CodeceptJS.within
+
+  /**
+   * Create data tables for data-driven tests
+   */
+  export const dataTable: typeof CodeceptJS.DataTable
+
+  /**
+   * Create data table arguments
+   */
+  export const dataTableArgument: typeof CodeceptJS.DataTableArgument
+
+  /**
+   * Shared store for test data
+   */
+  export const store: CodeceptJS.store
+
+  /**
+   * Locator builder
+   */
+  export const locator: typeof CodeceptJS.Locator
+
+  /**
+   * Auto-healing module
+   */
+  export const heal: any
+
+  /**
+   * AI assistant module
+   */
+  export const ai: any
+
+  /**
+   * Workers for parallel execution
+   */
+  export const Workers: any
+
+  /**
+   * Secret value type for sensitive data
+   */
+  export const Secret: typeof CodeceptJS.Secret
+
+  /**
+   * Create a secret value
+   */
+  export const secret: typeof CodeceptJS.secret
 }
 
 declare module '@codeceptjs/helper' {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -658,12 +658,12 @@ declare module 'codeceptjs' {
   /**
    * Event dispatcher for listening to CodeceptJS events
    */
-  export const event: CodeceptJS.event
+  export const event: typeof CodeceptJS.event
 
   /**
    * Global promise chain recorder
    */
-  export const recorder: CodeceptJS.recorder
+  export const recorder: typeof CodeceptJS.recorder
 
   /**
    * Configuration module
@@ -683,12 +683,12 @@ declare module 'codeceptjs' {
   /**
    * Pause execution until user input
    */
-  export const pause: CodeceptJS.pause
+  export const pause: typeof CodeceptJS.pause
 
   /**
    * Execute steps within specific context
    */
-  export const within: CodeceptJS.within
+  export const within: typeof CodeceptJS.within
 
   /**
    * Create data tables for data-driven tests
@@ -703,7 +703,7 @@ declare module 'codeceptjs' {
   /**
    * Shared store for test data
    */
-  export const store: CodeceptJS.store
+  export const store: typeof CodeceptJS.store
 
   /**
    * Locator builder

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -663,7 +663,7 @@ declare module 'codeceptjs' {
   /**
    * Global promise chain recorder
    */
-  export const recorder: typeof CodeceptJS.recorder
+  export const recorder: CodeceptJS.recorder
 
   /**
    * Configuration module


### PR DESCRIPTION
## Problem
  TypeScript cannot import `container` in ESM: https://github.com/codeceptjs/CodeceptJS/issues/5320

## Solution
  Added named export in typings/index.d.ts

