### PR TITLE
Improve waitUrlEquals error message to include actual error

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3546,27 +3546,23 @@ class Playwright extends Helper {
       expectedUrl = baseUrl + urlPart
     }
 
-    return this.page
-      .waitForURL(
-        url => {
-          const currUrl = decodeURIComponent(window.location.href)
-          return currUrl.indexOf(url) > -1
-        },
-        expectedUrl,
+    try {
+      await this.page.waitForURL(
+        url => url.href.includes(expectedUrl),
         { timeout: waitTimeout },
       )
-      .catch(async e => {
-        const currUrl = await this._getPageUrl()
-        if (/Timeout/i.test(e.message)) {
-          if (!currUrl.includes(expectedUrl)) {
-            throw new Error(`expected url to be ${expectedUrl}, but found ${currUrl}`)
-          } else {
-            throw new Error(`expected url not loaded, error message: ${e.message}`)
-          }
+    } catch (e) {
+      const currUrl = await this._getPageUrl()
+      if (/Timeout/i.test(e.message)) {
+        if (!currUrl.includes(expectedUrl)) {
+          throw new Error(`expected url to be ${expectedUrl}, but found ${currUrl}`)
         } else {
-          throw e
+          throw new Error(`expected url not loaded, error message: ${e.message}`)
         }
-      })
+      } else {
+        throw e
+      }
+    }
   }
 
   /**

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3557,7 +3557,11 @@ class Playwright extends Helper {
       .catch(async e => {
         const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
         if (/Timeout/i.test(e.message)) {
-          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          if (urlPart !== currUrl) {
+            throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          } else {
+            throw new Error(`expected url not loaded, error message: ${e.message}`)
+          }
         } else {
           throw e
         }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3541,24 +3541,25 @@ class Playwright extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
     const baseUrl = this.options.url
+    let expectedUrl = urlPart
     if (urlPart.indexOf('http') < 0) {
-      urlPart = baseUrl + urlPart
+      expectedUrl = baseUrl + urlPart
     }
 
     return this.page
-      .waitForFunction(
-        urlPart => {
-          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
-          return currUrl.indexOf(urlPart) > -1
+      .waitForURL(
+        url => {
+          const currUrl = decodeURIComponent(window.location.href)
+          return currUrl.indexOf(url) > -1
         },
-        urlPart,
+        expectedUrl,
         { timeout: waitTimeout },
       )
       .catch(async e => {
-        const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
+        const currUrl = await this._getPageUrl()
         if (/Timeout/i.test(e.message)) {
-          if (urlPart !== currUrl) {
-            throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          if (!currUrl.includes(expectedUrl)) {
+            throw new Error(`expected url to be ${expectedUrl}, but found ${currUrl}`)
           } else {
             throw new Error(`expected url not loaded, error message: ${e.message}`)
           }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2451,24 +2451,25 @@ class Puppeteer extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
 
     const baseUrl = this.options.url
+    let expectedUrl = urlPart
     if (urlPart.indexOf('http') < 0) {
-      urlPart = baseUrl + urlPart
+      expectedUrl = baseUrl + urlPart
     }
 
     return this.page
       .waitForFunction(
-        urlPart => {
-          const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
-          return currUrl.indexOf(urlPart) > -1
+        url => {
+          const currUrl = decodeURIComponent(window.location.href)
+          return currUrl.indexOf(url) > -1
         },
         { timeout: waitTimeout },
-        urlPart,
+        expectedUrl,
       )
       .catch(async e => {
-        const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
+        const currUrl = await this._getPageUrl()
         if (/Waiting failed/i.test(e.message) || /failed: timeout/i.test(e.message)) {
-          if (urlPart !== currUrl) {
-            throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          if (!currUrl.includes(expectedUrl)) {
+            throw new Error(`expected url to be ${expectedUrl}, but found ${currUrl}`)
           } else {
             throw new Error(`expected url not loaded, error message: ${e.message}`)
           }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2467,7 +2467,11 @@ class Puppeteer extends Helper {
       .catch(async e => {
         const currUrl = await this._getPageUrl() // Required because the waitForFunction can't return data.
         if (/Waiting failed/i.test(e.message) || /failed: timeout/i.test(e.message)) {
-          throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          if (urlPart !== currUrl) {
+            throw new Error(`expected url to be ${urlPart}, but found ${currUrl}`)
+          } else {
+            throw new Error(`expected url not loaded, error message: ${e.message}`)
+          }
         } else {
           throw e
         }


### PR DESCRIPTION
## Problem
  When `waitUrlEquals` times out but expected URL matches current URL:  https://github.com/codeceptjs/CodeceptJS/issues/5208

## Solution
  Check if URLs match. If yes, show the actual error message