### PR TITLE
Correct TypeScript type definitions for effect functions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -522,9 +522,9 @@ declare namespace CodeceptJS {
   function addStep(step: string | RegExp, fn: Function): Promise<void>
 }
 
-type TryTo = <T>(fn: () => Promise<T> | T) => Promise<T | false>
-type HopeThat = <T>(fn: () => Promise<T> | T) => Promise<T | false>
-type RetryTo = <T>(fn: () => Promise<T> | T, retries?: number) => Promise<T>
+type TryTo = (fn: () => void) => Promise<boolean>
+type HopeThat = (fn: () => void) => Promise<boolean>
+type RetryTo = (fn: (tries: number) => Promise<void> | void, maxTries: number, pollInterval?: number) => Promise<boolean>
 
 // Globals
 declare const codecept_dir: string


### PR DESCRIPTION
https://github.com/codeceptjs/CodeceptJS/issues/5205

 ## Changes:
   - TryTo: now correctly returns Promise<boolean> instead of Promise<T | false>
   - HopeThat: now correctly returns Promise<boolean> instead of Promise<T | false>
   - RetryTo: now accepts (fn: (tries: number) => Promise<void> | void, maxTries: number, pollInterval?: number) and returns Promise<boolean>