### PR TITLE
restore autocompletion for page objects in TypeScript

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -230,12 +230,7 @@ function getImportString(testsPath, targetFolderPath, pathsToType, pathsToValue)
 
   for (const name in pathsToType) {
     const relativePath = getPath(pathsToType[name], targetFolderPath, testsPath)
-    // Page objects and other support modules are exported as plain objects, not as default exports
-    if (relativePath.endsWith('.ts')) {
-      importStrings.push(`type ${name} = typeof import('${relativePath}')['default'];`)
-    } else {
-      importStrings.push(`type ${name} = typeof import('${relativePath}');`)
-    }
+    importStrings.push(`type ${name} = typeof import('${relativePath}');`)
   }
 
   for (const name in pathsToValue) {

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -230,8 +230,8 @@ function getImportString(testsPath, targetFolderPath, pathsToType, pathsToValue)
 
   for (const name in pathsToType) {
     const relativePath = getPath(pathsToType[name], targetFolderPath, testsPath)
-    // For ESM modules with default exports, we need to access the default export type
-    if (relativePath.endsWith('.js')) {
+    // Page objects and other support modules are exported as plain objects, not as default exports
+    if (relativePath.endsWith('.ts')) {
       importStrings.push(`type ${name} = typeof import('${relativePath}')['default'];`)
     } else {
       importStrings.push(`type ${name} = typeof import('${relativePath}');`)

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -229,8 +229,15 @@ function getImportString(testsPath, targetFolderPath, pathsToType, pathsToValue)
   const importStrings = []
 
   for (const name in pathsToType) {
-    const relativePath = getPath(pathsToType[name], targetFolderPath, testsPath)
-    importStrings.push(`type ${name} = typeof import('${relativePath}');`)
+    const originalPath = pathsToType[name]
+    const relativePath = getPath(originalPath, targetFolderPath, testsPath)
+    // For .js files with plain object exports, access .default to allow TypeScript to extract properties
+    // For .ts files, the default export is handled differently by TypeScript
+    if (originalPath.endsWith('.js')) {
+      importStrings.push(`type ${name} = typeof import('${relativePath}').default;`)
+    } else {
+      importStrings.push(`type ${name} = typeof import('${relativePath}');`)
+    }
   }
 
   for (const name in pathsToValue) {

--- a/test/runner/definitions_test.js
+++ b/test/runner/definitions_test.js
@@ -108,8 +108,8 @@ describe('Definitions', function () {
       const extend = definitionFile.getFullText()
 
       // Page objects are exported as plain objects in .js files
-      // Use typeof import() without ['default'] to allow TypeScript to infer the object type
-      extend.should.include("type CurrentPage = typeof import('./po/custom_steps.js');")
+      // Access .default to allow TypeScript to extract properties for autocompletion
+      extend.should.include("type CurrentPage = typeof import('./po/custom_steps.js').default;")
       assert(!err)
       done()
     })

--- a/test/runner/definitions_test.js
+++ b/test/runner/definitions_test.js
@@ -107,7 +107,9 @@ describe('Definitions', function () {
       const definitionFile = types.getSourceFileOrThrow(`${codecept_dir}/steps.d.ts`)
       const extend = definitionFile.getFullText()
 
-      extend.should.include("type CurrentPage = typeof import('./po/custom_steps.js')['default'];")
+      // Page objects are exported as plain objects, not classes
+      // So they should not have ['default'] to allow autocompletion
+      extend.should.include("type CurrentPage = typeof import('./po/custom_steps.js');")
       assert(!err)
       done()
     })

--- a/test/runner/definitions_test.js
+++ b/test/runner/definitions_test.js
@@ -107,8 +107,8 @@ describe('Definitions', function () {
       const definitionFile = types.getSourceFileOrThrow(`${codecept_dir}/steps.d.ts`)
       const extend = definitionFile.getFullText()
 
-      // Page objects are exported as plain objects, not classes
-      // So they should not have ['default'] to allow autocompletion
+      // Page objects are exported as plain objects in .js files
+      // Use typeof import() without ['default'] to allow TypeScript to infer the object type
       extend.should.include("type CurrentPage = typeof import('./po/custom_steps.js');")
       assert(!err)
       done()


### PR DESCRIPTION
  Changed type generation for .js page objects to use .default accessor (dot notation) instead of removing it completely. This allows TypeScript to extract properties from plain object exports     
  while maintaining compatibility with custom helpers.

  Key change: Check originalPath.endsWith('.js') before getPath() processing, then use dot notation: typeof import('./file.js').default
  
  https://github.com/codeceptjs/CodeceptJS/issues/5363