### PR TITLE
Add seeCurrentPathEquals method to ignore query strings

### DIFF
--- a/docs/webapi/dontSeeCurrentPathEquals.mustache
+++ b/docs/webapi/dontSeeCurrentPathEquals.mustache
@@ -1,0 +1,10 @@
+Checks that current URL path does NOT match the expected path.
+Query strings and URL fragments are ignored.
+
+```js
+I.dontSeeCurrentPathEquals('/form'); // fails for '/form', '/form?user=1', '/form#section'
+I.dontSeeCurrentPathEquals('/'); // fails for '/', '/?user=ok', '/#top'
+```
+
+@param {string} path value to check.
+@returns {void} automatically synchronized promise through #recorder

--- a/docs/webapi/seeCurrentPathEquals.mustache
+++ b/docs/webapi/seeCurrentPathEquals.mustache
@@ -1,0 +1,10 @@
+Checks that current URL path matches the expected path.
+Query strings and URL fragments are ignored.
+
+```js
+I.seeCurrentPathEquals('/info'); // passes for '/info', '/info?user=1', '/info#section'
+I.seeCurrentPathEquals('/'); // passes for '/', '/?user=ok', '/#top'
+```
+
+@param {string} path value to check.
+@returns {void} automatically synchronized promise through #recorder

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2416,6 +2416,16 @@ class Playwright extends Helper {
   }
 
   /**
+   * {{> dontSeeCurrentPathEquals }}
+   */
+  async dontSeeCurrentPathEquals(path) {
+    const currentUrl = await this._getPageUrl()
+    const baseUrl = this.options.url || 'http://localhost'
+    const actualPath = new URL(currentUrl, baseUrl).pathname
+    return equals('url path').negate(path, actualPath)
+  }
+
+  /**
    * {{> see }}
    *
    *

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2406,6 +2406,16 @@ class Playwright extends Helper {
   }
 
   /**
+   * {{> seeCurrentPathEquals }}
+   */
+  async seeCurrentPathEquals(path) {
+    const currentUrl = await this._getPageUrl()
+    const baseUrl = this.options.url || 'http://localhost'
+    const actualPath = new URL(currentUrl, baseUrl).pathname
+    return equals('url path').assert(path, actualPath)
+  }
+
+  /**
    * {{> see }}
    *
    *

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1695,6 +1695,16 @@ class Puppeteer extends Helper {
   }
 
   /**
+   * {{> dontSeeCurrentPathEquals }}
+   */
+  async dontSeeCurrentPathEquals(path) {
+    const currentUrl = await this._getPageUrl()
+    const baseUrl = this.options.url || 'http://localhost'
+    const actualPath = new URL(currentUrl, baseUrl).pathname
+    return equals('url path').negate(path, actualPath)
+  }
+
+  /**
    * {{> see }}
    *
    * {{ react }}

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1685,6 +1685,16 @@ class Puppeteer extends Helper {
   }
 
   /**
+   * {{> seeCurrentPathEquals }}
+   */
+  async seeCurrentPathEquals(path) {
+    const currentUrl = await this._getPageUrl()
+    const baseUrl = this.options.url || 'http://localhost'
+    const actualPath = new URL(currentUrl, baseUrl).pathname
+    return equals('url path').assert(path, actualPath)
+  }
+
+  /**
    * {{> see }}
    *
    * {{ react }}

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1845,6 +1845,16 @@ class WebDriver extends Helper {
   }
 
   /**
+   * {{> seeCurrentPathEquals }}
+   */
+  async seeCurrentPathEquals(path) {
+    const currentUrl = await this.browser.getUrl()
+    const baseUrl = this.options.url || 'http://localhost'
+    const actualPath = new URL(currentUrl, baseUrl).pathname
+    return assert.equal(path, actualPath, `expected url path to be ${path}, but found ${actualPath}`)
+  }
+
+  /**
    * Wraps [execute](http://webdriver.io/api/protocol/execute.html) command.
    *
    * {{> executeScript }}

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1855,6 +1855,18 @@ class WebDriver extends Helper {
   }
 
   /**
+   * {{> dontSeeCurrentPathEquals }}
+   */
+  async dontSeeCurrentPathEquals(path) {
+    const currentUrl = await this.browser.getUrl()
+    const baseUrl = this.options.url || 'http://localhost'
+    const actualPath = new URL(currentUrl, baseUrl).pathname
+    const errorMessage = `expected url path not to be ${path}, but found ${actualPath}`
+    const isEqual = path === actualPath
+    if (isEqual) throw new Error(errorMessage)
+  }
+
+  /**
    * Wraps [execute](http://webdriver.io/api/protocol/execute.html) command.
    *
    * {{> executeScript }}

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -1851,7 +1851,7 @@ class WebDriver extends Helper {
     const currentUrl = await this.browser.getUrl()
     const baseUrl = this.options.url || 'http://localhost'
     const actualPath = new URL(currentUrl, baseUrl).pathname
-    return assert.equal(path, actualPath, `expected url path to be ${path}, but found ${actualPath}`)
+    return equals('url path').assert(path, actualPath)
   }
 
   /**
@@ -1861,9 +1861,7 @@ class WebDriver extends Helper {
     const currentUrl = await this.browser.getUrl()
     const baseUrl = this.options.url || 'http://localhost'
     const actualPath = new URL(currentUrl, baseUrl).pathname
-    const errorMessage = `expected url path not to be ${path}, but found ${actualPath}`
-    const isEqual = path === actualPath
-    if (isEqual) throw new Error(errorMessage)
+    return equals('url path').negate(path, actualPath)
   }
 
   /**

--- a/test/data/app/glue.php
+++ b/test/data/app/glue.php
@@ -44,7 +44,7 @@
         static function stick ($urls) {
 
             $method = strtoupper($_SERVER['REQUEST_METHOD']);
-            $path = $_SERVER['REQUEST_URI'];
+            $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 
             $found = false;
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -75,6 +75,45 @@ export function tests() {
       const url = await I.grabCurrentUrl()
       assert.equal(url, `${siteUrl}/info`)
     })
+
+    it('should check for equality with query strings', async () => {
+      await I.amOnPage('/info?user=test')
+      // Query strings matter for exact equality
+      await I.seeCurrentUrlEquals('/info?user=test')
+      await I.dontSeeCurrentUrlEquals('/info')
+      // But substring check works
+      await I.seeInCurrentUrl('/info')
+      await I.seeInCurrentUrl('user=test')
+    })
+
+    it('should handle root path with query strings', async () => {
+      await I.amOnPage('/?user=ok')
+      // Query strings matter - exact equality requires query string
+      await I.seeCurrentUrlEquals('/?user=ok')
+      await I.dontSeeCurrentUrlEquals('/')
+      // But substring check works for path fragment
+      await I.seeInCurrentUrl('/')
+    })
+
+    it('should check path equality ignoring query strings', async () => {
+      await I.amOnPage('/info?user=test')
+      // Path equality ignores query strings
+      await I.seeCurrentPathEquals('/info')
+      await I.dontSeeCurrentPathEquals('/form')
+      await I.dontSeeCurrentPathEquals('/info?user=test')
+    })
+
+    it('should check root path equality ignoring query strings', async () => {
+      await I.amOnPage('/?user=ok')
+      await I.seeCurrentPathEquals('/')
+      await I.dontSeeCurrentPathEquals('/info')
+    })
+
+    it('should check path equality ignoring hash fragments', async () => {
+      await I.amOnPage('/info#section')
+      await I.seeCurrentPathEquals('/info')
+      await I.dontSeeCurrentPathEquals('/info#section')
+    })
   })
 
   describe('#waitInUrl, #waitUrlEquals', () => {


### PR DESCRIPTION
Adds new assertion method to check URL path equality while ignoring query parameters and URL fragments.

## Usage

```js
I.seeCurrentPathEquals('/info'); // passes for '/info', '/info?user=1', '/info#section'
I.seeCurrentPathEquals('/');     // passes for '/', '/?user=ok', '/#top'
```

## Implementation

- Uses native `URL` class for pathname extraction
- Added to Playwright, Puppeteer, and WebDriver helpers
- Includes tests and documentation

Closes #{add-issue-number-if-any}