### PR TITLE
feat: Within() with begin/end pattern

### DIFF
--- a/docs/effects.md
+++ b/docs/effects.md
@@ -12,11 +12,7 @@ Effects are functions that can modify scenario flow. They provide ways to handle
 Effects can be imported directly from CodeceptJS:
 
 ```js
-// ESM
-import { tryTo, retryTo, within } from 'codeceptjs/effects'
-
-// CommonJS
-const { tryTo, retryTo, within } = require('codeceptjs/effects')
+import { tryTo, retryTo, Within } from 'codeceptjs/effects'
 ```
 
 > 📝 Note: Prior to v3.7, `tryTo` and `retryTo` were available globally via plugins. This behavior is deprecated and will be removed in v4.0.
@@ -80,71 +76,38 @@ await retryTo(tries => {
 }, 3)
 ```
 
-## within
+## Within
 
-The `within` effect scopes all actions inside it to a specific element on the page — useful when working with repeated UI components or narrowing interaction to a specific section.
-
-```js
-import { within } from 'codeceptjs/effects'
-
-// inside a test...
-await within('.js-signup-form', () => {
-  I.fillField('user[login]', 'User')
-  I.fillField('user[email]', 'user@user.com')
-  I.fillField('user[password]', 'user@user.com')
-  I.click('button')
-})
-I.see('There were problems creating your account.')
-```
-
-> ⚠ `within` can cause problems when used incorrectly. If you see unexpected behavior, refactor to use the context parameter on individual actions instead (e.g. `I.click('Login', '.nav')`). Keep `within` for the simplest cases.
-
-> ⚠ Since `within` returns a Promise, always `await` it when you need its return value.
-
-### IFrames
-
-Use a `frame` locator to scope actions inside an iframe:
+The `Within` effect scopes actions to a specific element or iframe. It supports both a begin/end pattern and a callback pattern:
 
 ```js
-await within({ frame: '#editor' }, () => {
-  I.see('Page')
-  I.fillField('Body', 'Hello world')
+import { Within } from 'codeceptjs/effects'
+
+// Begin/end pattern
+Within('.modal')
+I.see('Modal title')
+I.click('Close')
+Within()
+
+// Callback pattern
+Within('.modal', () => {
+  I.see('Modal title')
+  I.click('Close')
 })
 ```
 
-Nested iframes _(WebDriver & Puppeteer only)_:
+See the full [Within documentation](/within) for details on iframes, page objects, and `await` usage.
 
-```js
-await within({ frame: ['.content', '#editor'] }, () => {
-  I.see('Page')
-})
-```
-
-> ℹ IFrames can also be accessed via `I.switchTo` command.
-
-### Returning Values
-
-`within` can return a value for use in the scenario:
-
-```js
-const val = await within('#sidebar', () => {
-  return I.grabTextFrom({ css: 'h1' })
-})
-I.fillField('Description', val)
-```
-
-When running steps inside a `within` block, they will be shown indented in the output.
+> The lowercase `within()` is deprecated. Use `Within` instead.
 
 ## Usage with TypeScript
 
 Effects are fully typed and work well with TypeScript:
 
 ```ts
-import { tryTo, retryTo, within } from 'codeceptjs/effects'
+import { tryTo, retryTo, Within } from 'codeceptjs/effects'
 
 const success = await tryTo(async () => {
   await I.see('Element')
 })
 ```
-
-This documentation covers the main effects functionality while providing practical examples and important notes about deprecation and future changes. Let me know if you'd like me to expand any section or add more examples!

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -12,7 +12,7 @@ Effects are functions that can modify scenario flow. They provide ways to handle
 Effects can be imported directly from CodeceptJS:
 
 ```js
-import { tryTo, retryTo, Within } from 'codeceptjs/effects'
+import { tryTo, retryTo, within } from 'codeceptjs/effects'
 ```
 
 > 📝 Note: Prior to v3.7, `tryTo` and `retryTo` were available globally via plugins. This behavior is deprecated and will be removed in v4.0.
@@ -76,36 +76,34 @@ await retryTo(tries => {
 }, 3)
 ```
 
-## Within
+## within
 
-The `Within` effect scopes actions to a specific element or iframe. It supports both a begin/end pattern and a callback pattern:
+The `within` effect scopes actions to a specific element or iframe. It supports both a begin/leave pattern and a callback pattern:
 
 ```js
-import { Within } from 'codeceptjs/effects'
+import { within } from 'codeceptjs/effects'
 
-// Begin/end pattern
-Within('.modal')
+// Begin/leave pattern
+const area = within('.modal')
 I.see('Modal title')
 I.click('Close')
-Within()
+area.leave()
 
 // Callback pattern
-Within('.modal', () => {
+within('.modal', () => {
   I.see('Modal title')
   I.click('Close')
 })
 ```
 
-See the full [Within documentation](/within) for details on iframes, page objects, and `await` usage.
-
-> The lowercase `within()` is deprecated. Use `Within` instead.
+See the full [within documentation](/within) for details on iframes, page objects, and `await` usage.
 
 ## Usage with TypeScript
 
 Effects are fully typed and work well with TypeScript:
 
 ```ts
-import { tryTo, retryTo, Within } from 'codeceptjs/effects'
+import { tryTo, retryTo, within } from 'codeceptjs/effects'
 
 const success = await tryTo(async () => {
   await I.see('Element')

--- a/docs/within.md
+++ b/docs/within.md
@@ -5,51 +5,223 @@ title: Within
 
 # Within
 
-`within` scopes all actions inside it to a specific element on the page — useful when working with repeated UI components or narrowing interaction to a specific section.
+`Within` narrows the execution context to a specific element or iframe on the page. All actions called inside a `Within` block are scoped to the matched element.
 
 ```js
-within('.js-signup-form', () => {
-  I.fillField('user[login]', 'User')
-  I.fillField('user[email]', 'user@user.com')
-  I.fillField('user[password]', 'user@user.com')
-  I.click('button')
-})
-I.see('There were problems creating your account.')
+import { Within } from 'codeceptjs/effects'
 ```
 
-> ⚠ `within` can cause problems when used incorrectly. If you see unexpected behavior, refactor to use the context parameter on individual actions instead (e.g. `I.click('Login', '.nav')`). Keep `within` for the simplest cases.
-> Since `within` returns a Promise, always `await` it when you need its return value.
+## Begin / End Pattern
 
-## IFrames
-
-Use a `frame` locator to scope actions inside an iframe:
+The simplest way to use `Within` is the begin/end pattern. Call `Within` with a locator to start, perform actions, then call `Within()` with no arguments to end:
 
 ```js
-within({ frame: '#editor' }, () => {
-  I.see('Page')
-  I.fillField('Body', 'Hello world')
-})
+Within('.signup-form')
+I.fillField('Email', 'user@example.com')
+I.fillField('Password', 'secret')
+I.click('Sign Up')
+Within()
 ```
 
-Nested iframes _(WebDriver & Puppeteer only)_:
+Steps between `Within('.signup-form')` and `Within()` are scoped to `.signup-form`. After `Within()`, the context resets to the full page.
+
+### Auto-end previous context
+
+Starting a new `Within` automatically ends the previous one:
 
 ```js
-within({ frame: ['.content', '#editor'] }, () => {
-  I.see('Page')
-})
+Within('.sidebar')
+I.click('Dashboard')
+
+Within('.main-content') // ends .sidebar, begins .main-content
+I.see('Welcome')
+Within()
 ```
 
-> ℹ IFrames can also be accessed via `I.switchTo` command.
+### Forgetting to close
 
-## Returning Values
+If you forget to call `Within()` at the end, the context is automatically cleaned up when the test finishes. However, it is good practice to always close it explicitly.
 
-`within` can return a value for use in the scenario:
+## Callback Pattern
+
+The callback pattern wraps actions in a function. The context is automatically closed when the function returns:
 
 ```js
-const val = await within('#sidebar', () => {
-  return I.grabTextFrom({ css: 'h1' })
+Within('.signup-form', () => {
+  I.fillField('Email', 'user@example.com')
+  I.fillField('Password', 'secret')
+  I.click('Sign Up')
 })
-I.fillField('Description', val)
+I.see('Account created')
 ```
 
-When running steps inside a `within` block, they will be shown indented in the output.
+### Returning values
+
+The callback pattern supports returning values. Use `await` on both the `Within` call and the inner action:
+
+```js
+const text = await Within('#sidebar', async () => {
+  return await I.grabTextFrom('h1')
+})
+I.fillField('Search', text)
+```
+
+## When to use `await`
+
+**Begin/end pattern** does not need `await`:
+
+```js
+Within('.form')
+I.fillField('Name', 'John')
+Within()
+```
+
+**Callback pattern** needs `await` when:
+
+- The callback is `async`
+- You need a return value from `Within`
+
+```js
+// async callback — await required
+await Within('.form', async () => {
+  await I.click('Submit')
+  await I.waitForText('Done')
+})
+```
+
+```js
+// sync callback — no await needed
+Within('.form', () => {
+  I.fillField('Name', 'John')
+  I.click('Submit')
+})
+```
+
+## Working with IFrames
+
+Use the `frame` locator to scope actions inside an iframe:
+
+```js
+// Begin/end
+Within({ frame: 'iframe' })
+I.fillField('Email', 'user@example.com')
+I.click('Submit')
+Within()
+
+// Callback
+Within({ frame: '#editor-frame' }, () => {
+  I.see('Page content')
+})
+```
+
+### Nested IFrames
+
+Pass an array of selectors to reach nested iframes:
+
+```js
+Within({ frame: ['.wrapper', '#content-frame'] }, () => {
+  I.fillField('Name', 'John')
+  I.see('Sign in!')
+})
+```
+
+Each selector in the array navigates one level deeper into the iframe hierarchy.
+
+### switchTo auto-disables Within
+
+If you call `I.switchTo()` while inside a `Within` context, the within context is automatically ended. This prevents conflicts between the two scoping mechanisms:
+
+```js
+Within('.sidebar')
+I.click('Open editor')
+I.switchTo('#editor-frame') // automatically ends Within('.sidebar')
+I.fillField('content', 'Hello')
+I.switchTo() // exits iframe
+```
+
+## Usage in Page Objects
+
+In page objects, import `Within` directly:
+
+```js
+// pages/Login.js
+import { Within } from 'codeceptjs/effects'
+
+export default {
+  loginForm: '.login-form',
+
+  fillCredentials(email, password) {
+    Within(this.loginForm)
+    I.fillField('Email', email)
+    I.fillField('Password', password)
+    Within()
+  },
+
+  submitLogin(email, password) {
+    this.fillCredentials(email, password)
+    I.click('Log In')
+  },
+}
+```
+
+```js
+// tests/login_test.js
+Scenario('user can log in', ({ I, loginPage }) => {
+  I.amOnPage('/login')
+  loginPage.submitLogin('user@example.com', 'password')
+  I.see('Dashboard')
+})
+```
+
+The callback pattern also works in page objects:
+
+```js
+// pages/Checkout.js
+import { Within } from 'codeceptjs/effects'
+
+export default {
+  async getTotal() {
+    return await Within('.order-summary', async () => {
+      return await I.grabTextFrom('.total')
+    })
+  },
+}
+```
+
+## Deprecated: lowercase `within`
+
+The lowercase `within()` is still available as a global function for backward compatibility, but it is deprecated:
+
+```js
+// deprecated — still works, shows a one-time warning
+within('.form', () => {
+  I.fillField('Name', 'John')
+})
+
+// recommended
+import { Within } from 'codeceptjs/effects'
+Within('.form', () => {
+  I.fillField('Name', 'John')
+})
+```
+
+The global `within` only supports the callback pattern. For the begin/end pattern, you must import `Within`.
+
+## Output
+
+When running steps inside a `Within` block, the output shows them indented under the context:
+
+```
+  Within ".signup-form"
+    I fill field "Email", "user@example.com"
+    I fill field "Password", "secret"
+    I click "Sign Up"
+  I see "Account created"
+```
+
+## Tips
+
+- Prefer the begin/end pattern for simple linear flows — it's more readable.
+- Use the callback pattern when you need return values or want guaranteed cleanup.
+- Avoid deeply nesting `Within` blocks. If you find yourself needing nested contexts, consider restructuring your test.
+- `Within` cannot be used inside a `session`. Use `session` at the top level and `Within` inside it, not the other way around.

--- a/docs/within.md
+++ b/docs/within.md
@@ -1,53 +1,61 @@
 ---
 permalink: /within
-title: Within
+title: within
 ---
 
-# Within
+# within
 
-`Within` narrows the execution context to a specific element or iframe on the page. All actions called inside a `Within` block are scoped to the matched element.
+`within` narrows the execution context to a specific element or iframe on the page. All actions called inside a `within` block are scoped to the matched element.
 
 ```js
-import { Within } from 'codeceptjs/effects'
+import { within } from 'codeceptjs/effects'
 ```
 
-## Begin / End Pattern
+## Begin / Leave Pattern
 
-The simplest way to use `Within` is the begin/end pattern. Call `Within` with a locator to start, perform actions, then call `Within()` with no arguments to end:
+The simplest way to use `within` is the begin/leave pattern. Call `within` with a locator to start — it returns a context object. Call `.leave()` on it when done:
 
 ```js
-Within('.signup-form')
+const area = within('.signup-form')
 I.fillField('Email', 'user@example.com')
 I.fillField('Password', 'secret')
 I.click('Sign Up')
-Within()
+area.leave()
 ```
 
-Steps between `Within('.signup-form')` and `Within()` are scoped to `.signup-form`. After `Within()`, the context resets to the full page.
+Steps between `within('.signup-form')` and `area.leave()` are scoped to `.signup-form`. After `leave()`, the context resets to the full page.
+
+You can also end a context by calling `within()` with no arguments:
+
+```js
+within('.signup-form')
+I.fillField('Email', 'user@example.com')
+within()
+```
 
 ### Auto-end previous context
 
-Starting a new `Within` automatically ends the previous one:
+Starting a new `within` automatically ends the previous one:
 
 ```js
-Within('.sidebar')
+within('.sidebar')
 I.click('Dashboard')
 
-Within('.main-content') // ends .sidebar, begins .main-content
+within('.main-content') // ends .sidebar, begins .main-content
 I.see('Welcome')
-Within()
+within()
 ```
 
 ### Forgetting to close
 
-If you forget to call `Within()` at the end, the context is automatically cleaned up when the test finishes. However, it is good practice to always close it explicitly.
+If you forget to call `leave()` or `within()` at the end, the context is automatically cleaned up when the test finishes. However, it is good practice to always close it explicitly.
 
 ## Callback Pattern
 
 The callback pattern wraps actions in a function. The context is automatically closed when the function returns:
 
 ```js
-Within('.signup-form', () => {
+within('.signup-form', () => {
   I.fillField('Email', 'user@example.com')
   I.fillField('Password', 'secret')
   I.click('Sign Up')
@@ -57,10 +65,10 @@ I.see('Account created')
 
 ### Returning values
 
-The callback pattern supports returning values. Use `await` on both the `Within` call and the inner action:
+The callback pattern supports returning values. Use `await` on both the `within` call and the inner action:
 
 ```js
-const text = await Within('#sidebar', async () => {
+const text = await within('#sidebar', async () => {
   return await I.grabTextFrom('h1')
 })
 I.fillField('Search', text)
@@ -68,22 +76,22 @@ I.fillField('Search', text)
 
 ## When to use `await`
 
-**Begin/end pattern** does not need `await`:
+**Begin/leave pattern** does not need `await`:
 
 ```js
-Within('.form')
+const area = within('.form')
 I.fillField('Name', 'John')
-Within()
+area.leave()
 ```
 
 **Callback pattern** needs `await` when:
 
 - The callback is `async`
-- You need a return value from `Within`
+- You need a return value from `within`
 
 ```js
 // async callback — await required
-await Within('.form', async () => {
+await within('.form', async () => {
   await I.click('Submit')
   await I.waitForText('Done')
 })
@@ -91,7 +99,7 @@ await Within('.form', async () => {
 
 ```js
 // sync callback — no await needed
-Within('.form', () => {
+within('.form', () => {
   I.fillField('Name', 'John')
   I.click('Submit')
 })
@@ -102,14 +110,14 @@ Within('.form', () => {
 Use the `frame` locator to scope actions inside an iframe:
 
 ```js
-// Begin/end
-Within({ frame: 'iframe' })
+// Begin/leave
+const area = within({ frame: 'iframe' })
 I.fillField('Email', 'user@example.com')
 I.click('Submit')
-Within()
+area.leave()
 
 // Callback
-Within({ frame: '#editor-frame' }, () => {
+within({ frame: '#editor-frame' }, () => {
   I.see('Page content')
 })
 ```
@@ -119,7 +127,7 @@ Within({ frame: '#editor-frame' }, () => {
 Pass an array of selectors to reach nested iframes:
 
 ```js
-Within({ frame: ['.wrapper', '#content-frame'] }, () => {
+within({ frame: ['.wrapper', '#content-frame'] }, () => {
   I.fillField('Name', 'John')
   I.see('Sign in!')
 })
@@ -127,34 +135,34 @@ Within({ frame: ['.wrapper', '#content-frame'] }, () => {
 
 Each selector in the array navigates one level deeper into the iframe hierarchy.
 
-### switchTo auto-disables Within
+### switchTo auto-disables within
 
-If you call `I.switchTo()` while inside a `Within` context, the within context is automatically ended. This prevents conflicts between the two scoping mechanisms:
+If you call `I.switchTo()` while inside a `within` context, the within context is automatically ended. This prevents conflicts between the two scoping mechanisms:
 
 ```js
-Within('.sidebar')
+const area = within('.sidebar')
 I.click('Open editor')
-I.switchTo('#editor-frame') // automatically ends Within('.sidebar')
+I.switchTo('#editor-frame') // automatically ends within('.sidebar')
 I.fillField('content', 'Hello')
 I.switchTo() // exits iframe
 ```
 
 ## Usage in Page Objects
 
-In page objects, import `Within` directly:
+In page objects, import `within` directly:
 
 ```js
 // pages/Login.js
-import { Within } from 'codeceptjs/effects'
+import { within } from 'codeceptjs/effects'
 
 export default {
   loginForm: '.login-form',
 
   fillCredentials(email, password) {
-    Within(this.loginForm)
+    const area = within(this.loginForm)
     I.fillField('Email', email)
     I.fillField('Password', password)
-    Within()
+    area.leave()
   },
 
   submitLogin(email, password) {
@@ -177,39 +185,20 @@ The callback pattern also works in page objects:
 
 ```js
 // pages/Checkout.js
-import { Within } from 'codeceptjs/effects'
+import { within } from 'codeceptjs/effects'
 
 export default {
   async getTotal() {
-    return await Within('.order-summary', async () => {
+    return await within('.order-summary', async () => {
       return await I.grabTextFrom('.total')
     })
   },
 }
 ```
 
-## Deprecated: lowercase `within`
-
-The lowercase `within()` is still available as a global function for backward compatibility, but it is deprecated:
-
-```js
-// deprecated — still works, shows a one-time warning
-within('.form', () => {
-  I.fillField('Name', 'John')
-})
-
-// recommended
-import { Within } from 'codeceptjs/effects'
-Within('.form', () => {
-  I.fillField('Name', 'John')
-})
-```
-
-The global `within` only supports the callback pattern. For the begin/end pattern, you must import `Within`.
-
 ## Output
 
-When running steps inside a `Within` block, the output shows them indented under the context:
+When running steps inside a `within` block, the output shows them indented under the context:
 
 ```
   Within ".signup-form"
@@ -221,7 +210,7 @@ When running steps inside a `Within` block, the output shows them indented under
 
 ## Tips
 
-- Prefer the begin/end pattern for simple linear flows — it's more readable.
+- Prefer the begin/leave pattern for simple linear flows — it's more readable.
 - Use the callback pattern when you need return values or want guaranteed cleanup.
-- Avoid deeply nesting `Within` blocks. If you find yourself needing nested contexts, consider restructuring your test.
-- `Within` cannot be used inside a `session`. Use `session` at the top level and `Within` inside it, not the other way around.
+- Avoid deeply nesting `within` blocks. If you find yourself needing nested contexts, consider restructuring your test.
+- `within` cannot be used inside a `session`. Use `session` at the top level and `within` inside it, not the other way around.

--- a/lib/effects.js
+++ b/lib/effects.js
@@ -81,6 +81,11 @@ function Within(context, fn) {
 }
 
 let withinDeprecationWarned = false
+/**
+ * @param {CodeceptJS.LocatorOrString}  context
+ * @param {Function}  fn
+ * @return {Promise<*> | undefined}
+ */
 function within(context, fn) {
   if (!withinDeprecationWarned) {
     withinDeprecationWarned = true

--- a/lib/effects.js
+++ b/lib/effects.js
@@ -6,7 +6,12 @@ import container from './container.js'
 import { isAsyncFunction } from './utils.js'
 import { WithinContext, WithinStep } from './step/within.js'
 
-function Within(context, fn) {
+/**
+ * @param {CodeceptJS.LocatorOrString}  context
+ * @param {Function}  fn
+ * @return {Promise<*> | undefined}
+ */
+function within(context, fn) {
   if (!context && !fn) {
     WithinContext.endCurrent()
     return
@@ -15,7 +20,7 @@ function Within(context, fn) {
   if (context && !fn) {
     const ctx = new WithinContext(context)
     ctx.start()
-    return
+    return ctx
   }
 
   const helpers = store.dryRun ? {} : container.helpers()
@@ -78,20 +83,6 @@ function Within(context, fn) {
     false,
     false,
   )
-}
-
-let withinDeprecationWarned = false
-/**
- * @param {CodeceptJS.LocatorOrString}  context
- * @param {Function}  fn
- * @return {Promise<*> | undefined}
- */
-function within(context, fn) {
-  if (!withinDeprecationWarned) {
-    withinDeprecationWarned = true
-    output.print('  [deprecated] within() is deprecated. Use Within() from "codeceptjs/effects" instead.')
-  }
-  return Within(context, fn)
 }
 
 /**
@@ -306,12 +297,12 @@ async function tryTo(callback) {
   )
 }
 
-export { hopeThat, retryTo, tryTo, within, Within }
+export { hopeThat, retryTo, tryTo, within, within as Within }
 
 export default {
   hopeThat,
   retryTo,
   tryTo,
   within,
-  Within,
+  Within: within,
 }

--- a/lib/effects.js
+++ b/lib/effects.js
@@ -3,22 +3,28 @@ import output from './output.js'
 import store from './store.js'
 import event from './event.js'
 import container from './container.js'
-import MetaStep from './step/meta.js'
 import { isAsyncFunction } from './utils.js'
+import { WithinContext, WithinStep } from './step/within.js'
 
-/**
- * @param {CodeceptJS.LocatorOrString}  context
- * @param {Function}  fn
- * @return {Promise<*> | undefined}
- */
-function within(context, fn) {
+function Within(context, fn) {
+  if (!context && !fn) {
+    WithinContext.endCurrent()
+    return
+  }
+
+  if (context && !fn) {
+    const ctx = new WithinContext(context)
+    ctx.start()
+    return
+  }
+
   const helpers = store.dryRun ? {} : container.helpers()
   const locator = typeof context === 'object' ? JSON.stringify(context) : context
 
   return recorder.add(
     'register within wrapper',
     () => {
-      const metaStep = new WithinStep(locator, fn)
+      const metaStep = new WithinStep(locator)
       const defineMetaStep = step => (step.metaStep = metaStep)
       recorder.session.start('within')
 
@@ -74,15 +80,13 @@ function within(context, fn) {
   )
 }
 
-class WithinStep extends MetaStep {
-  constructor(locator, fn) {
-    super('Within')
-    this.args = [locator]
+let withinDeprecationWarned = false
+function within(context, fn) {
+  if (!withinDeprecationWarned) {
+    withinDeprecationWarned = true
+    output.print('  [deprecated] within() is deprecated. Use Within() from "codeceptjs/effects" instead.')
   }
-
-  toString() {
-    return `${this.prefix}Within ${this.humanizeArgs()}${this.suffix}`
-  }
+  return Within(context, fn)
 }
 
 /**
@@ -297,11 +301,12 @@ async function tryTo(callback) {
   )
 }
 
-export { hopeThat, retryTo, tryTo, within }
+export { hopeThat, retryTo, tryTo, within, Within }
 
 export default {
   hopeThat,
   retryTo,
   tryTo,
   within,
+  Within,
 }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -35,6 +35,7 @@ import MultipleElementsFound from './errors/MultipleElementsFound.js'
 import RemoteBrowserConnectionRefused from './errors/RemoteBrowserConnectionRefused.js'
 import Popup from './extras/Popup.js'
 import Console from './extras/Console.js'
+import { WithinContext } from '../step/within.js'
 import { findReact, findVue, findByPlaywrightLocator } from './extras/PlaywrightReactVueLocator.js'
 import { dropFile } from './scripts/dropFile.js'
 import WebElement from '../element/WebElement.js'
@@ -3609,9 +3610,7 @@ class Playwright extends Helper {
    * {{> switchTo }}
    */
   async switchTo(locator) {
-    if (this.withinLocator) {
-      await this._withinEnd()
-    }
+    WithinContext.endCurrent()
 
     if (Number.isInteger(locator)) {
       // Select by frame index of current context

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3609,6 +3609,10 @@ class Playwright extends Helper {
    * {{> switchTo }}
    */
   async switchTo(locator) {
+    if (this.withinLocator) {
+      await this._withinEnd()
+    }
+
     if (Number.isInteger(locator)) {
       // Select by frame index of current context
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -35,6 +35,7 @@ import { isColorProperty, convertColorToRGBA } from '../colorUtils.js'
 import ElementNotFound from './errors/ElementNotFound.js'
 import MultipleElementsFound from './errors/MultipleElementsFound.js'
 import RemoteBrowserConnectionRefused from './errors/RemoteBrowserConnectionRefused.js'
+import { WithinContext } from '../step/within.js'
 import Popup from './extras/Popup.js'
 import Console from './extras/Console.js'
 import { highlightElement } from './scripts/highlightElement.js'
@@ -2674,9 +2675,7 @@ class Puppeteer extends Helper {
    * {{> switchTo }}
    */
   async switchTo(locator) {
-    if (this.withinLocator) {
-      await this._withinEnd()
-    }
+    WithinContext.endCurrent()
 
     if (Number.isInteger(locator)) {
       // Select by frame index of current context

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2674,6 +2674,10 @@ class Puppeteer extends Helper {
    * {{> switchTo }}
    */
   async switchTo(locator) {
+    if (this.withinLocator) {
+      await this._withinEnd()
+    }
+
     if (Number.isInteger(locator)) {
       // Select by frame index of current context
       let frames = []

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2799,6 +2799,10 @@ class WebDriver extends Helper {
    * {{> switchTo }}
    */
   async switchTo(locator) {
+    if (this.withinLocator) {
+      await this._withinEnd()
+    }
+
     this.browser.isInsideFrame = true
     if (!locator) {
       return this.browser.switchFrame(null)

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -32,6 +32,7 @@ import { isColorProperty, convertColorToRGBA } from '../colorUtils.js'
 import ElementNotFound from './errors/ElementNotFound.js'
 import MultipleElementsFound from './errors/MultipleElementsFound.js'
 import ConnectionRefused from './errors/ConnectionRefused.js'
+import { WithinContext } from '../step/within.js'
 import Locator from '../locator.js'
 import { highlightElement } from './scripts/highlightElement.js'
 import { focusElement } from './scripts/focusElement.js'
@@ -2799,9 +2800,7 @@ class WebDriver extends Helper {
    * {{> switchTo }}
    */
   async switchTo(locator) {
-    if (this.withinLocator) {
-      await this._withinEnd()
-    }
+    WithinContext.endCurrent()
 
     this.browser.isInsideFrame = true
     if (!locator) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ import config from './config.js'
 import actor from './actor.js'
 import helper from './helper.js'
 import pause from './pause.js'
-import { within } from './effects.js'
+import { within, Within } from './effects.js'
 import dataTable from './data/table.js'
 import dataTableArgument from './data/dataTableArgument.js'
 import store from './store.js'
@@ -49,6 +49,7 @@ export default {
   pause,
   /** @type {typeof CodeceptJS.within} */
   within,
+  Within,
   /**  @type {typeof CodeceptJS.DataTable} */
   dataTable,
   /**  @type {typeof CodeceptJS.DataTableArgument} */
@@ -70,4 +71,4 @@ export default {
 }
 
 // Named exports for ESM compatibility
-export { codecept, output, container, event, recorder, config, actor, helper, pause, within, dataTable, dataTableArgument, store, locator, heal, ai, Workers, Secret, secret }
+export { codecept, output, container, event, recorder, config, actor, helper, pause, within, Within, dataTable, dataTableArgument, store, locator, heal, ai, Workers, Secret, secret }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ import config from './config.js'
 import actor from './actor.js'
 import helper from './helper.js'
 import pause from './pause.js'
-import { within, Within } from './effects.js'
+import { within } from './effects.js'
 import dataTable from './data/table.js'
 import dataTableArgument from './data/dataTableArgument.js'
 import store from './store.js'
@@ -49,7 +49,7 @@ export default {
   pause,
   /** @type {typeof CodeceptJS.within} */
   within,
-  Within,
+  Within: within,
   /**  @type {typeof CodeceptJS.DataTable} */
   dataTable,
   /**  @type {typeof CodeceptJS.DataTableArgument} */
@@ -71,4 +71,4 @@ export default {
 }
 
 // Named exports for ESM compatibility
-export { codecept, output, container, event, recorder, config, actor, helper, pause, within, Within, dataTable, dataTableArgument, store, locator, heal, ai, Workers, Secret, secret }
+export { codecept, output, container, event, recorder, config, actor, helper, pause, within, within as Within, dataTable, dataTableArgument, store, locator, heal, ai, Workers, Secret, secret }

--- a/lib/step/within.js
+++ b/lib/step/within.js
@@ -1,0 +1,78 @@
+import MetaStep from './meta.js'
+import event from '../event.js'
+import recorder from '../recorder.js'
+import output from '../output.js'
+import store from '../store.js'
+import container from '../container.js'
+
+let currentWithin
+
+class WithinStep extends MetaStep {
+  constructor(locator) {
+    super('Within')
+    this.args = [locator]
+  }
+
+  toString() {
+    return `${this.prefix}Within ${this.humanizeArgs()}${this.suffix}`
+  }
+}
+
+class WithinContext {
+  constructor(locator) {
+    this.locator = locator
+    this.locatorString = typeof locator === 'object' ? JSON.stringify(locator) : locator
+    this.metaStep = new WithinStep(this.locatorString)
+    this.attachMetaStep = step => {
+      if (currentWithin !== this) return
+      if (!step) return
+      step.metaStep = this.metaStep
+    }
+  }
+
+  start() {
+    if (currentWithin) currentWithin.end()
+    currentWithin = this
+
+    const helpers = store.dryRun ? {} : container.helpers()
+
+    event.dispatcher.prependListener(event.step.before, this.attachMetaStep)
+    event.dispatcher.once(event.test.finished, () => this.end())
+
+    Object.keys(helpers).forEach(helper => {
+      if (helpers[helper]._withinBegin) {
+        recorder.add(`[${helper}] start within`, () => helpers[helper]._withinBegin(this.locator))
+      }
+    })
+  }
+
+  end() {
+    if (currentWithin !== this) return
+    currentWithin = null
+
+    const helpers = store.dryRun ? {} : container.helpers()
+
+    Object.keys(helpers).forEach(helper => {
+      if (helpers[helper]._withinEnd) {
+        recorder.add(`[${helper}] finish within`, () => helpers[helper]._withinEnd())
+      }
+    })
+
+    recorder.add('finish within', () => {
+      output.stepShift = 1
+    })
+
+    event.dispatcher.removeListener(event.step.before, this.attachMetaStep)
+  }
+
+  static current() {
+    return currentWithin
+  }
+
+  static endCurrent() {
+    if (currentWithin) currentWithin.end()
+  }
+}
+
+export { WithinContext, WithinStep }
+export default WithinContext

--- a/lib/step/within.js
+++ b/lib/step/within.js
@@ -65,6 +65,10 @@ class WithinContext {
     event.dispatcher.removeListener(event.step.before, this.attachMetaStep)
   }
 
+  leave() {
+    this.end()
+  }
+
   static current() {
     return currentWithin
   }

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import { devices } from 'playwright'
-import { within } from 'codeceptjs/effects'
+import { within } from '../../lib/effects.js'
 import event from 'codeceptjs'
 
 const output_dir = global.output_dir || './output'

--- a/test/acceptance/within_test.js
+++ b/test/acceptance/within_test.js
@@ -1,3 +1,5 @@
+import { Within } from '../../lib/effects.js'
+
 Feature('within', { retries: 3 })
 
 Scenario('within with locate().at().find() should scope XPath @Playwright', async ({ I }) => {
@@ -124,3 +126,46 @@ Scenario('should return a value @WebDriverIO @Puppeteer @Playwright', async ({ I
   I.pressKey('Enter')
   I.see('[rus] => First')
 }).retry(0)
+
+Scenario('Within begin/end on form @Playwright', ({ I }) => {
+  I.amOnPage('/form/bug1467')
+  I.see('TEST TEST')
+  Within({ css: '[name=form2]' })
+  I.checkOption('Yes')
+  I.seeCheckboxIsChecked({ css: 'input[name=first_test_radio]' })
+  Within()
+  I.seeCheckboxIsChecked({ css: 'form[name=form2] input[name=first_test_radio]' })
+  I.dontSeeCheckboxIsChecked({ css: 'form[name=form1] input[name=first_test_radio]' })
+})
+
+Scenario('Within begin/end on iframe @Playwright', ({ I }) => {
+  I.amOnPage('/iframe')
+  Within({ frame: 'iframe' })
+  I.fillField('rus', 'Updated')
+  I.see('Sign in!')
+  Within()
+  I.see('Iframe test')
+  I.dontSee('Sign in!')
+})
+
+Scenario('Within auto-end previous context @Playwright', ({ I }) => {
+  I.amOnPage('/form/bug1467')
+  Within({ css: '[name=form2]' })
+  I.checkOption('Yes')
+  Within({ css: '[name=form1]' })
+  I.checkOption('Yes')
+  Within()
+  I.seeCheckboxIsChecked({ css: 'form[name=form2] input[name=first_test_radio]' })
+  I.seeCheckboxIsChecked({ css: 'form[name=form1] input[name=first_test_radio]' })
+})
+
+Scenario('Within callback with uppercase @Playwright', async ({ I }) => {
+  I.amOnPage('/form/bug1467')
+  I.see('TEST TEST')
+  await Within({ css: '[name=form2]' }, async () => {
+    await I.checkOption('Yes')
+    await I.seeCheckboxIsChecked({ css: 'input[name=first_test_radio]' })
+  })
+  I.seeCheckboxIsChecked({ css: 'form[name=form2] input[name=first_test_radio]' })
+  I.dontSeeCheckboxIsChecked({ css: 'form[name=form1] input[name=first_test_radio]' })
+})

--- a/test/acceptance/within_test.js
+++ b/test/acceptance/within_test.js
@@ -1,4 +1,4 @@
-import { Within } from '../../lib/effects.js'
+import { within } from '../../lib/effects.js'
 
 Feature('within', { retries: 3 })
 
@@ -127,42 +127,42 @@ Scenario('should return a value @WebDriverIO @Puppeteer @Playwright', async ({ I
   I.see('[rus] => First')
 }).retry(0)
 
-Scenario('Within begin/end on form @Playwright', ({ I }) => {
+Scenario('within begin/leave on form @Playwright', ({ I }) => {
   I.amOnPage('/form/bug1467')
   I.see('TEST TEST')
-  Within({ css: '[name=form2]' })
+  const area = within({ css: '[name=form2]' })
   I.checkOption('Yes')
   I.seeCheckboxIsChecked({ css: 'input[name=first_test_radio]' })
-  Within()
+  area.leave()
   I.seeCheckboxIsChecked({ css: 'form[name=form2] input[name=first_test_radio]' })
   I.dontSeeCheckboxIsChecked({ css: 'form[name=form1] input[name=first_test_radio]' })
 })
 
-Scenario('Within begin/end on iframe @Playwright', ({ I }) => {
+Scenario('within begin/leave on iframe @Playwright', ({ I }) => {
   I.amOnPage('/iframe')
-  Within({ frame: 'iframe' })
+  const area = within({ frame: 'iframe' })
   I.fillField('rus', 'Updated')
   I.see('Sign in!')
-  Within()
+  area.leave()
   I.see('Iframe test')
   I.dontSee('Sign in!')
 })
 
-Scenario('Within auto-end previous context @Playwright', ({ I }) => {
+Scenario('within auto-end previous context @Playwright', ({ I }) => {
   I.amOnPage('/form/bug1467')
-  Within({ css: '[name=form2]' })
+  within({ css: '[name=form2]' })
   I.checkOption('Yes')
-  Within({ css: '[name=form1]' })
+  within({ css: '[name=form1]' })
   I.checkOption('Yes')
-  Within()
+  within()
   I.seeCheckboxIsChecked({ css: 'form[name=form2] input[name=first_test_radio]' })
   I.seeCheckboxIsChecked({ css: 'form[name=form1] input[name=first_test_radio]' })
 })
 
-Scenario('Within callback with uppercase @Playwright', async ({ I }) => {
+Scenario('within callback @Playwright', async ({ I }) => {
   I.amOnPage('/form/bug1467')
   I.see('TEST TEST')
-  await Within({ css: '[name=form2]' }, async () => {
+  await within({ css: '[name=form2]' }, async () => {
     await I.checkOption('Yes')
     await I.seeCheckboxIsChecked({ css: 'input[name=first_test_radio]' })
   })

--- a/test/runner/within_test.js
+++ b/test/runner/within_test.js
@@ -29,7 +29,7 @@ describe('CodeceptJS within', function () {
       const withoutGeneratorList = grepLines(lines, 'Check within without generator', 'Check within with generator. Yield is first in order')
       testStatus = withoutGeneratorList.find(line => line.includes('OK'))
       testStatus.should.include('OK')
-      const stepsList = withoutGeneratorList.filter(line => !line.includes('OK') && !line.includes('[deprecated]'))
+      const stepsList = withoutGeneratorList.filter(line => !line.includes('OK'))
       stepsList.should.eql(
         ['Scenario()', 'I small promise ', 'I small promise was finished ', 'I hey! i am within begin. i get blabla ', 'Within "blabla"', 'I small promise ', 'I small promise was finished ', 'I oh! i am within end( '],
         'check steps execution order',

--- a/test/runner/within_test.js
+++ b/test/runner/within_test.js
@@ -29,7 +29,7 @@ describe('CodeceptJS within', function () {
       const withoutGeneratorList = grepLines(lines, 'Check within without generator', 'Check within with generator. Yield is first in order')
       testStatus = withoutGeneratorList.find(line => line.includes('OK'))
       testStatus.should.include('OK')
-      const stepsList = withoutGeneratorList.filter(line => !line.includes('OK'))
+      const stepsList = withoutGeneratorList.filter(line => !line.includes('OK') && !line.includes('[deprecated]'))
       stepsList.should.eql(
         ['Scenario()', 'I small promise ', 'I small promise was finished ', 'I hey! i am within begin. i get blabla ', 'Within "blabla"', 'I small promise ', 'I small promise was finished ', 'I oh! i am within end( '],
         'check steps execution order',


### PR DESCRIPTION
## Summary

- Refactors `within()` into `Within()` with three calling patterns:
  - **Begin/end**: `Within('.ctx')` ... `Within()` — new, no callback needed
  - **Auto-end previous**: calling `Within('.new')` auto-ends any active context
  - **Callback**: `Within('.ctx', () => { ... })` — existing behavior preserved
- Lowercase `within()` kept as deprecated global alias with one-time console warning
- `Within` must be imported: `import { Within } from 'codeceptjs/effects'` (no global registration)
- `switchTo()` in Playwright, Puppeteer, and WebDriver auto-ends any active Within context
- New `WithinContext` class in `lib/step/within.js` (modeled on `Section`)
- Full documentation at `docs/within.md` with examples for iframes, page objects, await usage

### Files changed

| File | Change |
|------|--------|
| `lib/step/within.js` | **NEW** — `WithinContext` class + `WithinStep` |
| `lib/effects.js` | `Within` with 3 signatures, deprecated `within` alias |
| `lib/index.js` | Export `Within` |
| `lib/helper/Playwright.js` | Auto-disable within in `switchTo()` |
| `lib/helper/Puppeteer.js` | Auto-disable within in `switchTo()` |
| `lib/helper/WebDriver.js` | Auto-disable within in `switchTo()` |
| `docs/within.md` | **NEW** — full Within documentation |
| `docs/effects.md` | Updated Within section |
| `test/acceptance/within_test.js` | 4 new test scenarios |

## Test plan

- [x] All 15 existing + new within acceptance tests pass with Playwright
- [x] Deprecated `within()` shows one-time warning and still works
- [x] Begin/end pattern works with CSS selectors and iframes
- [x] Auto-end previous context works correctly
- [x] Callback pattern works with uppercase `Within`
- [ ] Verify nested iframe tests still pass
- [ ] Verify WebDriver/Puppeteer helpers (switchTo auto-disable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)