### PR TITLE
release 3.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.7.7
+
+❤️ Thanks all to those who contributed to make this release! ❤️
+
+🐛 *Bug Fixes*
+* fix: `run-workers --by suite` parallelization broken by test file sorting (#5412) (#5419) - by @mirao
+* fix: support Playwright 1.58+ output format in `codeceptjs info` (#5423) - by @mirao
+
+📖 *Documentation*
+* doc: fix playwright link to external device list (#5450) - by @gimler
+
+## 🧹 Chores & Maintenance
+- chore(deps): keep dependencies in sync (#5494, #5490, #5488, #5477, #5472, #5467, #5463, #5458, #5448) - by @thomashohn
+
 ## 3.7.6
 
 ❤️ Thanks all to those who contributed to make this release! ❤️

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "description": "Supercharged End 2 End Testing Framework for NodeJS",
   "keywords": [
     "acceptance",


### PR DESCRIPTION
## 3.7.7

❤️ Thanks all to those who contributed to make this release! ❤️

🐛 *Bug Fixes*
* fix: `run-workers --by suite` parallelization broken by test file sorting (#5412) (#5419) - by @mirao
* fix: support Playwright 1.58+ output format in `codeceptjs info` (#5423) - by @mirao

📖 *Documentation*
* doc: fix playwright link to external device list (#5450) - by @gimler

## 🧹 Chores & Maintenance
- chore(deps): keep dependencies in sync (#5494, #5490, #5488, #5477, #5472, #5467, #5463, #5458, #5448) - by @thomashohn