### PR TITLE
feat: detect unfocused element before type() and pressKey()

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -7,7 +7,7 @@ import promiseRetry from 'promise-retry'
 import Locator from '../locator.js'
 import recorder from '../recorder.js'
 import store from '../store.js'
-import { checkFocusBeforeType } from './extras/focusCheck.js'
+import { checkFocusBeforeType, checkFocusBeforePressKey } from './extras/focusCheck.js'
 import { includes as stringIncludes } from '../assert/include.js'
 import { urlEquals, equals } from '../assert/equal.js'
 import { empty } from '../assert/empty.js'
@@ -2246,6 +2246,7 @@ class Playwright extends Helper {
     } else {
       key = getNormalizedKey.call(this, key)
     }
+    await checkFocusBeforePressKey(this, modifiers, key)
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier)
     }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -7,6 +7,7 @@ import promiseRetry from 'promise-retry'
 import Locator from '../locator.js'
 import recorder from '../recorder.js'
 import store from '../store.js'
+import { checkFocusBeforeType } from './extras/focusCheck.js'
 import { includes as stringIncludes } from '../assert/include.js'
 import { urlEquals, equals } from '../assert/equal.js'
 import { empty } from '../assert/empty.js'
@@ -2259,6 +2260,8 @@ class Playwright extends Helper {
    * {{> type }}
    */
   async type(keys, delay = null) {
+    await checkFocusBeforeType(this)
+
     // Always use page.keyboard.type for any string (including single character and national characters).
     if (!Array.isArray(keys)) {
       keys = keys.toString()

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2232,6 +2232,7 @@ class Playwright extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
+    await checkFocusBeforePressKey(this, key)
     const modifiers = []
     if (Array.isArray(key)) {
       for (let k of key) {
@@ -2246,7 +2247,6 @@ class Playwright extends Helper {
     } else {
       key = getNormalizedKey.call(this, key)
     }
-    await checkFocusBeforePressKey(this, modifiers, key)
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier)
     }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -8,7 +8,7 @@ import promiseRetry from 'promise-retry'
 import Locator from '../locator.js'
 import recorder from '../recorder.js'
 import store from '../store.js'
-import { checkFocusBeforeType } from './extras/focusCheck.js'
+import { checkFocusBeforeType, checkFocusBeforePressKey } from './extras/focusCheck.js'
 import { includes as stringIncludes } from '../assert/include.js'
 import { urlEquals, equals } from '../assert/equal.js'
 import { empty } from '../assert/empty.js'
@@ -1562,6 +1562,7 @@ class Puppeteer extends Helper {
     } else {
       key = getNormalizedKey.call(this, key)
     }
+    await checkFocusBeforePressKey(this, modifiers, key)
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier)
     }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -8,6 +8,7 @@ import promiseRetry from 'promise-retry'
 import Locator from '../locator.js'
 import recorder from '../recorder.js'
 import store from '../store.js'
+import { checkFocusBeforeType } from './extras/focusCheck.js'
 import { includes as stringIncludes } from '../assert/include.js'
 import { urlEquals, equals } from '../assert/equal.js'
 import { empty } from '../assert/empty.js'
@@ -1575,6 +1576,8 @@ class Puppeteer extends Helper {
    * {{> type }}
    */
   async type(keys, delay = null) {
+    await checkFocusBeforeType(this)
+
     if (!Array.isArray(keys)) {
       keys = keys.toString()
       keys = keys.split('')

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1548,6 +1548,7 @@ class Puppeteer extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
+    await checkFocusBeforePressKey(this, key)
     const modifiers = []
     if (Array.isArray(key)) {
       for (let k of key) {
@@ -1562,7 +1563,6 @@ class Puppeteer extends Helper {
     } else {
       key = getNormalizedKey.call(this, key)
     }
-    await checkFocusBeforePressKey(this, modifiers, key)
     for (const modifier of modifiers) {
       await this.page.keyboard.down(modifier)
     }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -10,6 +10,7 @@ import promiseRetry from 'promise-retry'
 import { includes as stringIncludes } from '../assert/include.js'
 import { urlEquals, equals } from '../assert/equal.js'
 import store from '../store.js'
+import { checkFocusBeforeType } from './extras/focusCheck.js'
 import output from '../output.js'
 const { debug } = output
 import { empty } from '../assert/empty.js'
@@ -2283,6 +2284,8 @@ class WebDriver extends Helper {
    * {{> type }}
    */
   async type(keys, delay = null) {
+    await checkFocusBeforeType(this)
+
     if (!Array.isArray(keys)) {
       keys = keys.toString()
       keys = keys.split('')

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -10,7 +10,7 @@ import promiseRetry from 'promise-retry'
 import { includes as stringIncludes } from '../assert/include.js'
 import { urlEquals, equals } from '../assert/equal.js'
 import store from '../store.js'
-import { checkFocusBeforeType } from './extras/focusCheck.js'
+import { checkFocusBeforeType, checkFocusBeforePressKey } from './extras/focusCheck.js'
 import output from '../output.js'
 const { debug } = output
 import { empty } from '../assert/empty.js'
@@ -2252,6 +2252,7 @@ class WebDriver extends Helper {
     } else {
       key = getNormalizedKey.call(this, key)
     }
+    await checkFocusBeforePressKey(this, modifiers, key)
     for (const modifier of modifiers) {
       await this.pressKeyDown(modifier)
     }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2238,6 +2238,7 @@ class WebDriver extends Helper {
    * {{> pressKeyWithKeyNormalization }}
    */
   async pressKey(key) {
+    await checkFocusBeforePressKey(this, key)
     const modifiers = []
     if (Array.isArray(key)) {
       for (let k of key) {
@@ -2252,7 +2253,6 @@ class WebDriver extends Helper {
     } else {
       key = getNormalizedKey.call(this, key)
     }
-    await checkFocusBeforePressKey(this, modifiers, key)
     for (const modifier of modifiers) {
       await this.pressKeyDown(modifier)
     }

--- a/lib/helper/errors/NonFocusedType.js
+++ b/lib/helper/errors/NonFocusedType.js
@@ -1,9 +1,6 @@
 class NonFocusedType extends Error {
-  constructor() {
-    super(
-      'No element is in focus. Use I.click() or I.focus() to activate an element before calling I.type(). '
-      + 'This error is thrown because strict mode is enabled.',
-    )
+  constructor(message) {
+    super(message)
     this.name = 'NonFocusedType'
   }
 }

--- a/lib/helper/errors/NonFocusedType.js
+++ b/lib/helper/errors/NonFocusedType.js
@@ -1,0 +1,11 @@
+class NonFocusedType extends Error {
+  constructor() {
+    super(
+      'No element is in focus. Use I.click() or I.focus() to activate an element before calling I.type(). '
+      + 'This error is thrown because strict mode is enabled.',
+    )
+    this.name = 'NonFocusedType'
+  }
+}
+
+export default NonFocusedType

--- a/lib/helper/extras/focusCheck.js
+++ b/lib/helper/extras/focusCheck.js
@@ -1,0 +1,20 @@
+import store from '../../store.js'
+import NonFocusedType from '../errors/NonFocusedType.js'
+
+export async function checkFocusBeforeType(helper) {
+  const isStrict = helper.options.strict
+  if (!isStrict && !store.debugMode) return
+
+  const noFocus = await helper.executeScript(() => {
+    const ae = document.activeElement
+    return !ae || ae === document.documentElement || (ae === document.body && !ae.isContentEditable)
+  })
+
+  if (!noFocus) return
+
+  if (isStrict) {
+    throw new NonFocusedType()
+  }
+
+  helper.debugSection('Warning', 'No element is in focus. Use I.click() or I.focus() to activate an element before typing.')
+}

--- a/lib/helper/extras/focusCheck.js
+++ b/lib/helper/extras/focusCheck.js
@@ -1,20 +1,34 @@
 import store from '../../store.js'
 import NonFocusedType from '../errors/NonFocusedType.js'
 
-export async function checkFocusBeforeType(helper) {
-  const isStrict = helper.options.strict
-  if (!isStrict && !store.debugMode) return
+const EDITING_KEYS = new Set(['a', 'c', 'x', 'v', 'z', 'y'])
 
-  const noFocus = await helper.executeScript(() => {
+async function isNoElementFocused(helper) {
+  return helper.executeScript(() => {
     const ae = document.activeElement
     return !ae || ae === document.documentElement || (ae === document.body && !ae.isContentEditable)
   })
+}
 
-  if (!noFocus) return
+export async function checkFocusBeforeType(helper) {
+  if (!helper.options.strict && !store.debugMode) return
+  if (!await isNoElementFocused(helper)) return
 
-  if (isStrict) {
-    throw new NonFocusedType()
-  }
+  const message = 'No element is in focus. Use I.click() or I.focus() to activate an element before typing.'
+  if (helper.options.strict) throw new NonFocusedType(message)
+  helper.debugSection('Warning', message)
+}
 
-  helper.debugSection('Warning', 'No element is in focus. Use I.click() or I.focus() to activate an element before typing.')
+export async function checkFocusBeforePressKey(helper, modifiers, key) {
+  if (!helper.options.strict && !store.debugMode) return
+
+  const hasCtrlOrMeta = modifiers.some(m => m === 'Control' || m === 'Meta'
+    || m === 'ControlLeft' || m === 'ControlRight' || m === 'MetaLeft' || m === 'MetaRight')
+  if (!hasCtrlOrMeta || !EDITING_KEYS.has(key.toLowerCase())) return
+
+  if (!await isNoElementFocused(helper)) return
+
+  const message = `No element is in focus. Key combination with "${key}" may not work as expected. Use I.click() or I.focus() first.`
+  if (helper.options.strict) throw new NonFocusedType(message)
+  helper.debugSection('Warning', message)
 }

--- a/lib/helper/extras/focusCheck.js
+++ b/lib/helper/extras/focusCheck.js
@@ -1,6 +1,7 @@
 import store from '../../store.js'
 import NonFocusedType from '../errors/NonFocusedType.js'
 
+const MODIFIER_PATTERN = /^(control|ctrl|meta|cmd|command|commandorcontrol|ctrlorcommand)/i
 const EDITING_KEYS = new Set(['a', 'c', 'x', 'v', 'z', 'y'])
 
 async function isNoElementFocused(helper) {
@@ -19,16 +20,24 @@ export async function checkFocusBeforeType(helper) {
   helper.debugSection('Warning', message)
 }
 
-export async function checkFocusBeforePressKey(helper, modifiers, key) {
+export async function checkFocusBeforePressKey(helper, originalKey) {
   if (!helper.options.strict && !store.debugMode) return
+  if (!Array.isArray(originalKey)) return
 
-  const hasCtrlOrMeta = modifiers.some(m => m === 'Control' || m === 'Meta'
-    || m === 'ControlLeft' || m === 'ControlRight' || m === 'MetaLeft' || m === 'MetaRight')
-  if (!hasCtrlOrMeta || !EDITING_KEYS.has(key.toLowerCase())) return
+  let hasCtrlOrMeta = false
+  let actionKey = null
+  for (const k of originalKey) {
+    if (MODIFIER_PATTERN.test(k)) {
+      hasCtrlOrMeta = true
+    } else {
+      actionKey = k
+    }
+  }
+  if (!hasCtrlOrMeta || !actionKey || !EDITING_KEYS.has(actionKey.toLowerCase())) return
 
   if (!await isNoElementFocused(helper)) return
 
-  const message = `No element is in focus. Key combination with "${key}" may not work as expected. Use I.click() or I.focus() first.`
+  const message = `No element is in focus. Key combination with "${originalKey.join('+')}" may not work as expected. Use I.click() or I.focus() first.`
   if (helper.options.strict) throw new NonFocusedType(message)
   helper.debugSection('Warning', message)
 }

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -2344,7 +2344,6 @@ export function tests() {
       expect(err).to.exist
       expect(err.constructor.name).to.equal('NonFocusedType')
       expect(err.message).to.include('No element is in focus')
-      expect(err.message).to.include('strict mode')
     })
 
     it('should not throw NonFocusedType when element is focused', async () => {
@@ -2353,6 +2352,33 @@ export function tests() {
       await I.click('Name')
       await I.type('test')
       await I.seeInField('Name', 'test')
+    })
+
+    it('should throw NonFocusedType for Ctrl+A without focus', async () => {
+      await I.amOnPage('/form/field')
+      I.options.strict = true
+      let err
+      try {
+        await I.pressKey(['Control', 'A'])
+      } catch (e) {
+        err = e
+      }
+      expect(err).to.exist
+      expect(err.constructor.name).to.equal('NonFocusedType')
+      expect(err.message).to.include('No element is in focus')
+    })
+
+    it('should not throw for Escape without focus', async () => {
+      await I.amOnPage('/form/field')
+      I.options.strict = true
+      await I.pressKey('Escape')
+    })
+
+    it('should not throw for Ctrl+A when element is focused', async () => {
+      await I.amOnPage('/form/field')
+      I.options.strict = true
+      await I.click('Name')
+      await I.pressKey(['Control', 'A'])
     })
   })
 

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -2331,6 +2331,29 @@ export function tests() {
       expect(err.message).to.include('/html')
       expect(err.message).to.include('Use a more specific locator')
     })
+
+    it('should throw NonFocusedType error when typing without focus', async () => {
+      await I.amOnPage('/form/field')
+      I.options.strict = true
+      let err
+      try {
+        await I.type('test')
+      } catch (e) {
+        err = e
+      }
+      expect(err).to.exist
+      expect(err.constructor.name).to.equal('NonFocusedType')
+      expect(err.message).to.include('No element is in focus')
+      expect(err.message).to.include('strict mode')
+    })
+
+    it('should not throw NonFocusedType when element is focused', async () => {
+      await I.amOnPage('/form/field')
+      I.options.strict = true
+      await I.click('Name')
+      await I.type('test')
+      await I.seeInField('Name', 'test')
+    })
   })
 
   describe('#elementIndex step option', () => {


### PR DESCRIPTION
## Summary
- `type()` and `pressKey()` use `page.keyboard` which silently drops keystrokes when no element has focus. This adds shared focus checks in `lib/helper/extras/focusCheck.js`:
  - **`type()`**: always checks focus before typing
  - **`pressKey()`**: checks focus only for editing combos: Ctrl/Meta + A, C, X, V, Z, Y (handles `CommandOrControl` → `Meta` on macOS)
  - **Debug mode**: logs a warning via `debugSection`
  - **Strict mode** (`strict: true`): throws `NonFocusedType` error with actionable message
- Applied to all three helpers: Playwright, Puppeteer, WebDriver
- Handles `<body contenteditable>` (full-page editors) — no false positive
- Navigation keys (Escape, Tab, Enter, arrows) are never flagged

## Test plan
- [x] Strict mode throws `NonFocusedType` when typing without focus
- [x] Strict mode allows typing when element is focused
- [x] Strict mode throws `NonFocusedType` for Ctrl+A without focus
- [x] Escape without focus does not throw
- [x] Ctrl+A with focused element does not throw
- [x] Existing acceptance tests pass (61 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)