### PR TITLE
Fix for stepByStepReport: cheerio ESM import and missing screenshot capture

### DIFF
--- a/lib/plugin/stepByStepReport.js
+++ b/lib/plugin/stepByStepReport.js
@@ -4,7 +4,7 @@ import figures from 'figures'
 import fs from 'fs'
 import { mkdirp } from 'mkdirp'
 import path from 'path'
-import cheerio from 'cheerio'
+import * as cheerio from 'cheerio'
 
 import Container from '../container.js'
 import recorder from '../recorder.js'
@@ -198,7 +198,7 @@ export default function (config) {
     // Ignore steps from BeforeSuite function
     if (scenarioFailed && config.disableScreenshotOnFail) return
     if (step.metaStep && step.metaStep.name === 'BeforeSuite') return
-    if (!step.test) return // Ignore steps from AfterSuite
+    if (!currentTest) return // Ignore steps from AfterSuite
 
     const fileName = `${pad.substring(0, pad.length - stepNum.toString().length) + stepNum.toString()}.png`
     if (step.status === 'failed') {


### PR DESCRIPTION
## Summary

Fix two bugs in `stepByStepReport` plugin that made it completely non-functional in v4.x (ESM):

- **cheerio ESM import:** `import cheerio from 'cheerio'` fails because cheerio 1.x removed the default export. Changed to `import * as cheerio from 'cheerio'`
- **Screenshots never captured:** `if (!step.test) return` in `persistStep()` always returned early because `step.test` property doesn't exist on the `Step` class. Replaced with `if (!currentTest) return` which correctly checks the plugin's existing `currentTest` variable

## How it was tested

- Enabled plugin with `{ enabled: true, deleteSuccessful: false }`
- Ran a UI test with multiple steps (clicks, navigation, form fills)
- Result: 55 PNG screenshots captured + working HTML slideshow report

Relates to #5351