### PR TITLE
fix: process hangs when _beforeSuite helper hook throws

### DIFF
--- a/lib/command/check.js
+++ b/lib/command/check.js
@@ -135,6 +135,7 @@ export default async function (options) {
   printCheck('plugins', checks['plugins'], Object.keys(Container.plugins()).join(', '))
 
   if (Object.keys(helpers).length) {
+    store.dryRun = false
     const suite = Container.mocha().suite
     const test = createTest('test', () => {})
     checks.setup = true
@@ -166,6 +167,7 @@ export default async function (options) {
     }
 
     printCheck('Helpers After', checks['teardown'], standardActingHelpers.some(h => Object.keys(helpers).includes(h)) ? 'Closing browser' : '')
+    store.dryRun = true
   }
 
   try {

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -30,11 +30,13 @@ export default function () {
   event.dispatcher.on(event.suite.before, suite => {
     // if (suite.parent) return; // only for root suite
     runAsyncHelpersHook('_beforeSuite', suite, true)
+    recorder.catch()
   })
 
   event.dispatcher.on(event.suite.after, suite => {
     // if (suite.parent) return; // only for root suite
     runAsyncHelpersHook('_afterSuite', suite, true)
+    recorder.catch()
   })
 
   event.dispatcher.on(event.test.started, test => {


### PR DESCRIPTION
## Summary

- **Add `recorder.catch()` for suite-level hook events** in `lib/listener/helpers.js`. The `event.suite.before` and `event.suite.after` listeners were missing error catch handlers — unlike every other hook event (`test.before`, `test.after`, `test.passed`, `test.failed`, `test.started`). When a helper's `_beforeSuite()` threw (e.g., Playwright browser not installed), the rejected promise was unhandled, mocha's `done` callback was never called, and the process hung indefinitely.
- **Enable browser launch during `codeceptjs check`** by temporarily disabling `store.dryRun` around the helper setup/teardown verification in `lib/command/check.js`. Previously, Playwright skipped browser launch in dryRun mode, so `check` couldn't detect missing browser installations.

## Root cause

In 3.x, suite hooks were wrapped via `injectHook()` which called `recorder.catch()` after event emission. In the 4.x ESM rewrite, `suiteSetup()` sets `recorder.errHandler(doneFn)` but no `.catch()` was appended to the promise chain to invoke it — so errors in `_beforeSuite` were silently swallowed.

## Test plan

- [ ] Run acceptance tests with Playwright — verify browser starts, tests execute, and process exits cleanly
- [ ] Run `codeceptjs check` — verify it now actually launches/closes the browser (HELPERS BEFORE / HELPERS AFTER pass)
- [ ] Verify that when Playwright browsers are not installed, `codeceptjs check` reports the error instead of passing silently
- [ ] Verify that when `_beforeSuite` fails during a real test run, the error is reported and the process exits instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)